### PR TITLE
Switch g and h format character order

### DIFF
--- a/reference/datetime/datetime/createfromformat.xml
+++ b/reference/datetime/datetime/createfromformat.xml
@@ -146,7 +146,7 @@
           <entry><literal>am</literal> ou <literal>pm</literal></entry>
          </row>
          <row>
-          <entry><literal>h</literal> et <literal>g</literal></entry>
+          <entry><literal>g</literal> et <literal>h</literal></entry>
           <entry>L'heure au format 12-heures, avec ou sans zéro initial</entry>
           <entry>
            De <literal>1</literal> à <literal>12</literal> ou


### PR DESCRIPTION
In the french translation, the format character order (h and g) does not match the example order (De 1 à 12 ou de 01 à 12).
This pull request fix the order of format to (g and h), to match the example order, in the same way of the english original version.