### PR TITLE
Fixing errors in Exceptions documentation

### DIFF
--- a/language/exceptions.xml
+++ b/language/exceptions.xml
@@ -200,12 +200,12 @@ echo "\n\n";
    </para>
 
    <para>
-    Si une exception est lancé et que la porté courante de la fonction n'as pas
+    Si une exception est lancée et que la portée courante de la fonction n'a pas
     de block &catch;, l'exception "remontera" la pile d'appel de la fonction appelante
     jusqu'à trouver un bloc &catch; correspondant. Tous les blocs &finally; rencontrés
-    seront exécuté. Si la pile d'appel est déroulée jusqu'à la portée globale sans
+    seront exécutés. Si la pile d'appel est déroulée jusqu'à la portée globale sans
     rencontrer de bloc &catch; correspondant, le programme sera terminé avec
-    une erreur fatale sauf si un gestionnaire globale d'exception a été définie.
+    une erreur fatale sauf si un gestionnaire global d'exception a été défini.
    </para>
    <para>
     L'objet lancé doit être une instance de la classe
@@ -216,18 +216,18 @@ echo "\n\n";
    <para>
     À partir de PHP 8.0.0, le mot clé &throw; est une expression et peut être
     utilisé dans n'importe quel contexte d'expressions. Dans les versions
-    antérieures c'était une déclaration et devait être sur sa propre ligne.
+    antérieures c'était une déclaration qui devait être sur sa propre ligne.
    </para>
   </simplesect>
 
   <simplesect xml:id="language.exceptions.catch">
    <title><literal>catch</literal></title>
    <para>
-    Un bloc &catch; définie comment réagir à une exception qui a été lancé.
-    Un bloc &catch; définit un ou plusieurs type d'exception ou erreur qu'il peut
+    Un bloc &catch; définit comment réagir à une exception qui a été lancée.
+    Un bloc &catch; définit un ou plusieurs types d'exceptions ou erreurs qu'il peut
     gérer, et optionnellement une variable dans laquelle assigner l'exception.
-    (Cette variable était requis antérieur à PHP 8.0.0)
-    Le premier bloc &catch; qu'une exception our erreur lancé qui correspond au
+    (Cette variable était requise dans les versions antérieures à PHP 8.0.0)
+    Le premier bloc &catch; qu'une exception ou erreur lancée rencontre et qui correspond au
     type de l'objet lancé gérera l'objet.
    </para>
    <para>
@@ -235,7 +235,7 @@ echo "\n\n";
     classes d'exceptions. L'exécution normale (lorsqu'aucune exception n'est lancée
     dans le bloc &try;) continue après le dernier
     bloc &catch; défini dans la séquence. Les exceptions
-    peuvent être &throw; (lancé) (ou relancées) dans un bloc &catch;. Sinon,
+    peuvent être lancées (&throw;) ou relancées dans un bloc &catch;. Sinon,
     l'exécution continuera après le bloc &catch; qui a été déclenché.
    </para>
    <para>
@@ -254,7 +254,7 @@ echo "\n\n";
     de la même manière.
    </para>
    <para>
-    À partir de PHP 8.0.0, le nom de variable pour l'exception attrapé est
+    À partir de PHP 8.0.0, le nom de variable pour l'exception attrapée est
     optionnel. Si non spécifié, le bloc &catch; sera toujours exécuté mais
     n'aura pas accès à l'objet lancé.
    </para>
@@ -275,7 +275,7 @@ echo "\n\n";
     Si une déclaration &return; est rencontrée à l'intérieur des blocs &try;
     ou &catch;, le bloc &finally; sera quand même exécuté. De plus,
     la déclaration &return; est évaluée quand elle est rencontrée, mais le
-    résultat sera retourné après le bloc &finally; soit exécuté.
+    résultat sera retourné après que le bloc &finally; soit exécuté.
     Additionnellement, si le bloc &finally; contient aussi une déclaration
     &return; la valeur du bloc &finally; est retournée.
    </para>
@@ -284,8 +284,8 @@ echo "\n\n";
  <simplesect xml:id="language.exceptions.exception-handler">
   <title><literal>Global exception handler</literal></title>
   <para>
-   Si une exception est autorisé à remonter jusqu'à la portée globale, elle peut
-   être attrapée par un gestionnaire d'exception global si définie. La fonction
+   Si une exception est autorisée à remonter jusqu'à la portée globale, elle peut
+   être attrapée par un gestionnaire d'exceptions global si il a été défini. La fonction
    <function>set_exception_handler</function> peut définir une fonction qui sera
    appelée à la place d'un block &catch; si aucun autre block n'est invoqué.
    L'effet est essentiellement identique à entourer le programme entier dans un
@@ -507,7 +507,7 @@ string(11) "MyException"
    </example>
    <example>
     <title>Omettre la variable attrapé</title>
-    <para>Seulement permit dans PHP 8.0.0 et ultérieur.</para>
+    <para>Seulement permis dans PHP 8.0.0 et ultérieur.</para>
     <programlisting role="php">
 <![CDATA[
 <?php
@@ -529,7 +529,7 @@ try {
    </example>
    <example>
     <title>Throw en tant qu'expression</title>
-    <para>Seulement permit dans PHP 8.0.0 et ultérieur.</para>
+    <para>Seulement permis dans PHP 8.0.0 et ultérieur.</para>
     <programlisting role="php">
 <![CDATA[
 <?php


### PR DESCRIPTION
I noticed some errors in that documentation while reading it, quite usual French errors.

Now fixed 😉 