### PR TITLE
[80797] Fix mysqli_fetch_fields is missing the "s"

### DIFF
--- a/reference/mysqli/mysqli_result/fetch-fields.xml
+++ b/reference/mysqli/mysqli_result/fetch-fields.xml
@@ -13,12 +13,12 @@
   &reftitle.description;
   <para>&style.oop;</para>
   <methodsynopsis role="oop">
-   <modifier>public</modifier> <type>object</type><methodname>mysqli_result::fetch_field</methodname>
+   <modifier>public</modifier> <type>array</type><methodname>mysqli_result::fetch_fields</methodname>
    <void/>
   </methodsynopsis>
   <para>&style.procedural;</para>
   <methodsynopsis role="procedural">
-   <type>object</type><methodname>mysqli_fetch_field</methodname>
+   <type>array</type><methodname>mysqli_fetch_fields</methodname>
    <methodparam><type>mysqli_result</type><parameter>result</parameter></methodparam>
   </methodsynopsis>
 


### PR DESCRIPTION
This PR closes the bug report ([80797](https://bugs.php.net/bug.php?id=80797)) and fixes the issues of the `mysqli_fetch_fields` signature being out-of-order since the a9a52c5 commit.

This is my first PR to a translation so not 100% if this is the right way to go about it, but with this PR the document should be up-to-date with the current revision.
