### PR TITLE
translation error in version changes.

### DIFF
--- a/reference/strings/functions/number-format.xml
+++ b/reference/strings/functions/number-format.xml
@@ -85,7 +85,7 @@
       <row>
        <entry>8.0.0</entry>
        <entry>
-        Avant cette version, <function>number_format</function> acceptait
+        Antérieur à cette version, <function>number_format</function> acceptait
         un, deux, ou quatre paramètres (mais pas trois).
        </entry>
       </row>

--- a/reference/strings/functions/number-format.xml
+++ b/reference/strings/functions/number-format.xml
@@ -85,7 +85,7 @@
       <row>
        <entry>8.0.0</entry>
        <entry>
-        Antérieur à cette version, <function>number_format</function> acceptée
+        Avant cette version, <function>number_format</function> acceptait
         un, deux, ou quatre paramètres (mais pas trois).
        </entry>
       </row>


### PR DESCRIPTION
*"accepted"* was translated as a past participle (*"acceptée"*) although it is a simple past (=> imparfait: *"acceptait"*).

Also, a simple *"Avant"* instead of *"Antérieur à"* makes this sentence more understandable.