### PR TITLE
Fix typos in addslashes reference page

### DIFF
--- a/reference/strings/functions/addslashes.xml
+++ b/reference/strings/functions/addslashes.xml
@@ -15,7 +15,7 @@
    <methodparam><type>string</type><parameter>string</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Retourne la chaîne <parameter>str</parameter>, après avoir échappé tous
+   Retourne la chaîne <parameter>str</parameter> après avoir échappé tous
    les caractères qui doivent l'être. Ces caractères sont :
    <simplelist>
     <member>guillemets simples (<literal>'</literal>)</member>
@@ -26,7 +26,7 @@
   </para>
   <para>
    Un cas d'utilisation de <function>addslashes</function> est d'échapper les
-   caractères susmentionnés dans une &string; qui doit être évalué par PHP :
+   caractères susmentionnés dans une &string; qui doit être évaluée par PHP :
    <informalexample>
     <programlisting role="php">
 <![CDATA[
@@ -42,7 +42,7 @@ eval("echo '" . addslashes($str) . "';");
    <function>addslashes</function> est parfois utilisé incorrectement pour empêcher
    les <link linkend="security.database.sql-injection">Injections SQL</link>.
    À la place, les fonctions d'échappements spécifiques à la base de données et/ou 
-   les délcarations préparées devraient être utilisé.
+   les déclarations préparées devraient être utilisées.
   </para>
  </refsect1>
 


### PR DESCRIPTION
The reference page for the `addslashes` function contains several typos.