### PR TITLE
Fix misleading (wrong) translation

### DIFF
--- a/reference/dom/domnode/insertbefore.xml
+++ b/reference/dom/domnode/insertbefore.xml
@@ -6,7 +6,7 @@
  <refnamediv>
   <refname>DOMNode::insertBefore</refname>
   <refpurpose>
-   Ajoute un nouveau fils avant le nœud référencé
+   Ajoute un nouveau fils avant un nœud de référence.
   </refpurpose>
  </refnamediv>
  <refsect1 role="description">
@@ -22,7 +22,7 @@
    devez utiliser le nœud retourné.
   </para>
   <para>
-   Lors de l'utilisation d'un nœud existant, il sera supprimé.
+   Lors de l'utilisation d'un nœud existant, il sera déplacé.
   </para>
  </refsect1>
  <refsect1 role="parameters">


### PR DESCRIPTION
Line 9: 
EN version reads:
> a **reference** node

(not "**referenced** node")

Line 25:
EN version reads:
> When using an existing node it will be **moved**

(not **removed**)
