### PR TITLE
Updated to en-revision

### DIFF
--- a/reference/gmp/functions/gmp-export.xml
+++ b/reference/gmp/functions/gmp-export.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 039ab719e695141ee54409d26ad828337ec31d6e Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 574a644f1de7086fdd7d2c2d1b4b2af80bc295df Maintainer: yannick Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.gmp-export" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -47,7 +47,7 @@
      <term><parameter>flags</parameter></term>
      <listitem>
       <para>
-       La valeur par défaut est GMP_MSW_FIRST | GMP_NATIVE_ENDIAN.
+       La valeur par défaut est <constant>GMP_MSW_FIRST</constant> | <constant>GMP_NATIVE_ENDIAN</constant>.
       </para>
      </listitem>
     </varlistentry>   

--- a/reference/gmp/functions/gmp-import.xml
+++ b/reference/gmp/functions/gmp-import.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 039ab719e695141ee54409d26ad828337ec31d6e Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 574a644f1de7086fdd7d2c2d1b4b2af80bc295df Maintainer: yannick Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.gmp-import" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -46,7 +46,7 @@
      <term><parameter>flags</parameter></term>
      <listitem>
       <para>
-       La valeur par défaut est GMP_MSW_FIRST | GMP_NATIVE_ENDIAN.
+       La valeur par défaut est <constant>GMP_MSW_FIRST</constant> | <constant>GMP_NATIVE_ENDIAN</constant>.
       </para>
      </listitem>
     </varlistentry>   

--- a/reference/gmp/functions/gmp-testbit.xml
+++ b/reference/gmp/functions/gmp-testbit.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 039ab719e695141ee54409d26ad828337ec31d6e Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 574a644f1de7086fdd7d2c2d1b4b2af80bc295df Maintainer: yannick Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.gmp-testbit" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -46,7 +46,7 @@
   &reftitle.returnvalues;
   <para>
    Retourne &true; si l'octet est défini dans la ressource
-   <parameter>$a</parameter>, &false; sinon.
+   <parameter>num</parameter>, &false; sinon.
   </para>
  </refsect1>
 

--- a/reference/phar/book.xml
+++ b/reference/phar/book.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: dff279a1fb1cefe17b594d2058741b308e420a36 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 562a216c8108885a492cbfb66e2d5734847fa19d Maintainer: yannick Status: ready -->
 <!-- Reviewed: no -->
 
 <book xml:id="book.phar" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -32,7 +32,7 @@
   <para>
    Phar implémente cette fonctionnalité via <link linkend="book.stream">un 
    flux</link>.  Normalement, pour utiliser un fichier externe à partir d'un script PHP, vous
-   devez utiliser la fonction <function>include</function>.
+   devez utiliser la fonction <function>include</function>:
   </para>
   <para>
    <example>
@@ -136,7 +136,7 @@
   </para>
   <para>
    Si vous utilisez des applications phar, il y a des astuces très utiles dans
-   <link linkend="phar.using">Comment utiliser des archives Phar</link>
+   <link linkend="phar.using">Comment utiliser des archives Phar</link>.
   </para>
   <para>
    Le mot <literal>phar</literal> est la contraction de <literal>PHP</literal> et de

--- a/reference/phpdbg/reference.xml
+++ b/reference/phpdbg/reference.xml
@@ -1,10 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 68c2c871505aadf983f16113c5b077b335ce8d76 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: c7378721ff88a52e66023f98d69b7fd69c997a46 Maintainer: yannick Status: ready -->
 <!-- Reviewed: no -->
 
 <reference xml:id="ref.phpdbg" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
- <?phpdoc extension-membership="bundled" ?>
  <title>phpdbg &Functions;</title>
 
  &reference.phpdbg.entities.functions;

--- a/reference/rar/setup.xml
+++ b/reference/rar/setup.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 5699ed7b6111312f90618f08b7678061da6c7ccf Maintainer: yannick Status: ready -->
+<!-- EN-Revision: d3ad869d16be772d43d85a8c982592b4a57a085a Maintainer: yannick Status: ready -->
 <!-- Reviewed: no -->
 
 <chapter xml:id="rar.setup" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -59,7 +59,7 @@ phpize
   <para>
    Cette extension enregistre 3 classes internes :
    La représentation de l'archive retournée par la fonction
-   <function>rar_open</function> – <type>RarArchive</type> –,
+   <function>rar_open</function> – <type>RarArchive</type>,
    la représentation des entrées retournée par
    les fonctions <function>rar_list</function> et
    <function>rar_entry_get</function> – <type>RarEntry</type>

--- a/reference/reflection/reflectionproperty/isdefault.xml
+++ b/reference/reflection/reflectionproperty/isdefault.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: d6d57b5f931f2607219688c4175a4865358a964a Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 67a54da71fc48bc32082fe63abd38856bc05943f Maintainer: yannick Status: ready -->
 <!-- Reviewed: yes -->
 
 <refentry xml:id="reflectionproperty.isdefault" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/reference/rrd/functions/rrd-first.xml
+++ b/reference/rrd/functions/rrd-first.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 4754397753fd79f1c846868b66a2448babab1c54 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 42d9fe8494fe8cf37f50d4777b335b330c7ec5c1 Maintainer: yannick Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="function.rrd-first" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -47,7 +47,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Timestamp unix, ou &false; si une erreur survient.
+   Timestamp unix,&return.falseforfailure;.
   </para>
  </refsect1>
  

--- a/reference/rrd/functions/rrd-graph.xml
+++ b/reference/rrd/functions/rrd-graph.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 4754397753fd79f1c846868b66a2448babab1c54 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 42d9fe8494fe8cf37f50d4777b335b330c7ec5c1 Maintainer: yannick Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="function.rrd-graph" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -51,8 +51,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Tableau contenant les informations sur l'image générée, ou &false; si une
-   erreur survient.
+   Tableau contenant les informations sur l'image générée,&return.falseforfailure;.
   </para>
  </refsect1>
 </refentry>

--- a/reference/rrd/functions/rrd-info.xml
+++ b/reference/rrd/functions/rrd-info.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 4754397753fd79f1c846868b66a2448babab1c54 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 42d9fe8494fe8cf37f50d4777b335b330c7ec5c1 Maintainer: yannick Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="function.rrd-info" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -37,8 +37,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Tableau contenant les informations sur le fichier RRD demandé, ou &false;
-   si une erreur survient.
+   Tableau contenant les informations sur le fichier RRD demandé,&return.falseforfailure;.
   </para>
  </refsect1>
 

--- a/reference/rrd/functions/rrd-lastupdate.xml
+++ b/reference/rrd/functions/rrd-lastupdate.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 4754397753fd79f1c846868b66a2448babab1c54 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 42d9fe8494fe8cf37f50d4777b335b330c7ec5c1 Maintainer: yannick Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="function.rrd-lastupdate" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -38,8 +38,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Tableau d'informations sur la dernière mise à jour, ou &false;
-   si une erreur survient.
+   Tableau d'informations sur la dernière mise à jour,&return.falseforfailure;.
   </para>
  </refsect1>
 </refentry>

--- a/reference/rrd/functions/rrd-restore.xml
+++ b/reference/rrd/functions/rrd-restore.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: dd07341fae2c414adc1f700be0890ff32e8daab4 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 42d9fe8494fe8cf37f50d4777b335b330c7ec5c1 Maintainer: yannick Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="function.rrd-restore" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -56,7 +56,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Retourne &true; en cas de succès, &false; sinon.
+   &return.success;
   </para>
  </refsect1>
 </refentry>

--- a/reference/rrd/functions/rrd-tune.xml
+++ b/reference/rrd/functions/rrd-tune.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: dd07341fae2c414adc1f700be0890ff32e8daab4 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 42d9fe8494fe8cf37f50d4777b335b330c7ec5c1 Maintainer: yannick Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="function.rrd-tune" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -49,7 +49,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Retourne &true; en cas de succès, &false; sinon.
+   &return.success;
   </para>
  </refsect1>
  

--- a/reference/rrd/functions/rrd-update.xml
+++ b/reference/rrd/functions/rrd-update.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: dd07341fae2c414adc1f700be0890ff32e8daab4 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 42d9fe8494fe8cf37f50d4777b335b330c7ec5c1 Maintainer: yannick Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="function.rrd-update" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -50,7 +50,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Retourne &true; en cas de succès, ou &false; si une erreur survient.
+   &return.success;
   </para>
  </refsect1>
 </refentry>

--- a/reference/rrd/functions/rrd-xport.xml
+++ b/reference/rrd/functions/rrd-xport.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 4754397753fd79f1c846868b66a2448babab1c54 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 42d9fe8494fe8cf37f50d4777b335b330c7ec5c1 Maintainer: yannick Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="function.rrd-xport" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -41,8 +41,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Tableau contenant les informations du fichier de base de données RRD,
-   ou &false; si une erreur survient.
+   Tableau contenant les informations du fichier de base de données RRD,&return.falseforfailure;.
   </para>
  </refsect1>
  

--- a/reference/rrd/rrdcreator/construct.xml
+++ b/reference/rrd/rrdcreator/construct.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: c5aae9ac7901fd461befee6e1eb72360ae938bbc Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 42d9fe8494fe8cf37f50d4777b335b330c7ec5c1 Maintainer: yannick Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="rrdcreator.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -18,7 +18,7 @@
    <methodparam choice="opt"><type>int</type><parameter>step</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
   <para>
-   Crée une nouvelle instance RRDCreator.
+   Crée une nouvelle instance <classname>RRDCreator</classname>.
   </para>
  </refsect1>
 

--- a/reference/rrd/rrdgraph/construct.xml
+++ b/reference/rrd/rrdgraph/construct.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: c5aae9ac7901fd461befee6e1eb72360ae938bbc Maintainer: yannick Status: ready -->
+<!-- EN-Revision: eedb2334027e62f88e233472a14d19020317d752 Maintainer: yannick Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="rrdgraph.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -16,7 +16,7 @@
    <methodparam><type>string</type><parameter>path</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Crée une nouvelle instance RRDGraph. Cette instance est responsable
+   Crée une nouvelle instance <classname>RRDGraph</classname>. Cette instance est responsable
    du rendu du résultat de la requête à la base de données RRD dans l'image.
   </para>
  </refsect1>

--- a/reference/rrd/rrdgraph/save.xml
+++ b/reference/rrd/rrdgraph/save.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 4754397753fd79f1c846868b66a2448babab1c54 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: eedb2334027e62f88e233472a14d19020317d752 Maintainer: yannick Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="rrdgraph.save" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -30,8 +30,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Retourne un tableau contenant les informations sur l'image générée,
-   ou &false; si une erreur survient.
+   Retourne un tableau contenant les informations sur l'image générée,&return.falseforfailure;.
   </para>
  </refsect1>
 </refentry>

--- a/reference/rrd/rrdupdater/update.xml
+++ b/reference/rrd/rrdupdater/update.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 4b7f1ad3b9a465d97574bd73c7a5679cb8e85171 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 42d9fe8494fe8cf37f50d4777b335b330c7ec5c1 Maintainer: yannick Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="rrdupdater.update" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/reference/rrd/setup.xml
+++ b/reference/rrd/setup.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 184f3f7bd45643cb80f828d0bb001991ec3a5fad Maintainer: yannick Status: ready -->
+<!-- EN-Revision: e83ad8ecd4d98c6df0003a5f091322e7ef1de54c Maintainer: yannick Status: ready -->
 <!-- Reviewed: no -->
 
 <chapter xml:id="rrd.setup" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/reference/session/sessionhandlerinterface/gc.xml
+++ b/reference/session/sessionhandlerinterface/gc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 151e61773c016edcae8fd4989ad9a86ffd03c283 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 04a6d30dc15d2c794ec3b82a4c78dd8bf4101903 Maintainer: yannick Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="sessionhandlerinterface.gc" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -11,7 +11,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier>abstract</modifier> <modifier>public</modifier> <type class="union"><type>int</type><type>bool</type></type><methodname>SessionHandlerInterface::gc</methodname>
+   <modifier>abstract</modifier> <modifier>public</modifier> <type class="union"><type>int</type><type>false</type></type><methodname>SessionHandlerInterface::gc</methodname>
    <methodparam><type>int</type><parameter>max_lifetime</parameter></methodparam>
   </methodsynopsis>
   <para>

--- a/reference/snmp/functions/snmp-get-valueretrieval.xml
+++ b/reference/snmp/functions/snmp-get-valueretrieval.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 9f7b578adf85bcbc94397c11a7a813d1d3d0cc56 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 64bab6321fe7aec300303dcedfddfcb31fb053c2 Maintainer: yannick Status: ready -->
 <!-- Reviewed: yes -->
 
 <refentry xml:id="function.snmp-get-valueretrieval" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -37,7 +37,7 @@
   &reftitle.examples;
   <para>
    <example>
-    <title>Exemple avec snmp_get_valueretrieval</title>
+    <title>Exemple avec <function>snmp_get_valueretrieval</function></title>
     <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/snmp/functions/snmp-read-mib.xml
+++ b/reference/snmp/functions/snmp-read-mib.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 9f7b578adf85bcbc94397c11a7a813d1d3d0cc56 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 64bab6321fe7aec300303dcedfddfcb31fb053c2 Maintainer: yannick Status: ready -->
 <!-- Reviewed: yes -->
 
 <refentry xml:id="function.snmp-read-mib" xmlns="http://docbook.org/ns/docbook">
@@ -20,7 +20,7 @@
   <para>
    Cette fonction est utilisée pour charger des MIBs additionnelles, i.e.
    spécifiques aux fabricants, ainsi, les OIDs humainement lisibles comme
-   VENDOR-MIB::foo.1 au lieu des OIDs numériques peuvent être utilisés.
+   <literal>VENDOR-MIB::foo.1</literal> au lieu des OIDs numériques peuvent être utilisés.
   </para>
   <para>
    L'ordre de chargement des MIBs est important ; la bibliothèque Net-SNMP
@@ -44,8 +44,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Retourne &true; en cas de succès, &false; si une erreur survient pendant
-   la lecture d'un fichier <acronym>MIB</acronym>.
+   &return.success;
   </para>
  </refsect1>
  

--- a/reference/snmp/functions/snmp-set-valueretrieval.xml
+++ b/reference/snmp/functions/snmp-set-valueretrieval.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 184f3f7bd45643cb80f828d0bb001991ec3a5fad Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 64bab6321fe7aec300303dcedfddfcb31fb053c2 Maintainer: yannick Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="function.snmp-set-valueretrieval" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -46,8 +46,8 @@
           <entry>SNMP_VALUE_OBJECT</entry>
           <entry>
            Les valeurs retournées seront des objets avec les propriétés
-           "value" et "type", où la seconde est une des constantes
-           SNMP_OCTET_STR, SNMP_COUNTER etc.. La façon dont la "value"
+           <literal>value</literal> et <literal>type</literal>, où la seconde est une des constantes
+           <constant>SNMP_OCTET_STR</constant>, <constant>SNMP_COUNTER</constant> etc.. La façon dont la <literal>value</literal>
            est retournée est basée suivant l'utilisation de la constante
            <constant>SNMP_VALUE_LIBRARY</constant> ou de
            la constante <constant>SNMP_VALUE_PLAIN</constant>.

--- a/reference/sodium/setup.xml
+++ b/reference/sodium/setup.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 7edfdafc14571629a807106494e0b2f21bd4e467 Maintainer: girgias Status: ready -->
+<!-- EN-Revision: e7853a8a24fd5de419860cf00e00320905e7cb4c Maintainer: girgias Status: ready -->
 <!-- Reviewed: no -->
 
 <chapter xml:id="sodium.setup" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -55,9 +55,7 @@
 
  <section xml:id="sodium.resources">
   &reftitle.resources;
-  <para>
-
-  </para>
+  &no.resource;
  </section>
 
 </chapter>

--- a/reference/spl/cachingiterator/hasnext.xml
+++ b/reference/spl/cachingiterator/hasnext.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: af4410a7e15898c3dbe83d6ea38246745ed9c6fb Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 949123c45e46fcee7ab93a148b57ab704a23a5cf Maintainer: yannick Status: ready -->
 <!-- Reviewed: yes -->
 
 <refentry xml:id="cachingiterator.hasnext" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -12,7 +12,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier>public</modifier> <type>void</type><methodname>CachingIterator::hasNext</methodname>
+   <modifier>public</modifier> <type>bool</type><methodname>CachingIterator::hasNext</methodname>
    <void />
   </methodsynopsis>
 

--- a/reference/spl/recursivecallbackfilteriterator/construct.xml
+++ b/reference/spl/recursivecallbackfilteriterator/construct.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 5faa7a6747bca628b3bdcc9f93aec5603b65581f Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 2ec2ad2aabba737fe493e4b8228928584a7cddb5 Maintainer: yannick Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="recursivecallbackfilteriterator.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -15,7 +15,7 @@
    <modifier>public</modifier>
    <methodname>RecursiveCallbackFilterIterator::__construct</methodname>
    <methodparam><type>RecursiveIterator</type><parameter>iterator</parameter></methodparam>
-   <methodparam><type>string</type><parameter>callback</parameter></methodparam>
+   <methodparam><type>callable</type><parameter>callback</parameter></methodparam>
   </constructorsynopsis>
   <para>
    Crée un itérateur filtré depuis une interface

--- a/reference/ssh2/setup.xml
+++ b/reference/ssh2/setup.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: d80c8d5646c200251fe6d54d366e242ada0e3f81 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: e83ad8ecd4d98c6df0003a5f091322e7ef1de54c Maintainer: yannick Status: ready -->
 <!-- Reviewed: yes -->
 
 <chapter xml:id="ssh2.setup" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/reference/stream/streamwrapper/construct.xml
+++ b/reference/stream/streamwrapper/construct.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: af4410a7e15898c3dbe83d6ea38246745ed9c6fb Maintainer: dams Status: ready -->
+<!-- EN-Revision: bf85f2f1fcd9b63abf0bfa3675d410891c3c7b94 Maintainer: dams Status: ready -->
 <!-- Reviewed: yes -->
 
 <refentry xml:id="streamwrapper.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -12,7 +12,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <methodname>streamWrapper::__construct</methodname>
+   <modifier>public</modifier> <methodname>streamWrapper::__construct</methodname>
    <void />
   </methodsynopsis>
   <para>

--- a/reference/stream/streamwrapper/destruct.xml
+++ b/reference/stream/streamwrapper/destruct.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: adc94ff1adf53b47b02fc81497b36b87f4b84d75 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: bf85f2f1fcd9b63abf0bfa3675d410891c3c7b94 Maintainer: yannick Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="streamwrapper.destruct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -12,7 +12,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <methodname>streamWrapper::__destruct</methodname>
+   <modifier>public</modifier> <methodname>streamWrapper::__destruct</methodname>
    <void />
   </methodsynopsis>
   <para>

--- a/reference/strings/functions/chunk-split.xml
+++ b/reference/strings/functions/chunk-split.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: e095023e408c8cb6378ae16bb6870343a3946919 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: d335ba69a16f4013280de8e3e71d9ba19fe3cb3c Maintainer: yannick Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://docbook.org/ns/docbook" xml:id="function.chunk-split">
  <refnamediv>
@@ -88,7 +88,6 @@ $new_string = chunk_split(base64_encode($data));
    <simplelist>
     <member><function>str_split</function></member>
     <member><function>explode</function></member>
-    <member><function>split</function></member>
     <member><function>wordwrap</function></member>
     <member><link xlink:href="&url.rfc;2045">RFC 2045</link></member>
    </simplelist>

--- a/reference/strings/functions/parse-str.xml
+++ b/reference/strings/functions/parse-str.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 4a7ddddc27271967b616ad3400cfbe2a9b48212b Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 9d2b858bca85edbeebb83f05a1cd2e87cf90127d Maintainer: yannick Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="function.parse-str" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -154,14 +154,6 @@ echo $output['My_Value']; // Something
     la variable <varname>$_SERVER['QUERY_STRING']</varname>. En outre, vous voudrez 
     peut-être lire la section sur les 
     <link linkend="language.variables.external"> variables de sources externes</link>.
-   </para>
-  </note>
-  <note>
-   <para>
-    Le paramètre <link linkend="ini.magic-quotes-gpc">magic_quotes_gpc</link> 
-    affecte la sortie de cette fonction, car <function>parse_str</function> 
-    utilise le même mécanisme que celui utilisé par PHP pour remplir les variables 
-    <varname>$_GET</varname>, <varname>$_POST</varname>, etc.
    </para>
   </note>
  </refsect1>

--- a/reference/strings/functions/quotemeta.xml
+++ b/reference/strings/functions/quotemeta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: e095023e408c8cb6378ae16bb6870343a3946919 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: d335ba69a16f4013280de8e3e71d9ba19fe3cb3c Maintainer: yannick Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="function.quotemeta" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -63,7 +63,6 @@
     <member><function>nl2br</function></member>
     <member><function>stripslashes</function></member>
     <member><function>stripcslashes</function></member>
-    <member><function>ereg</function></member>
     <member><function>preg_quote</function></member>
    </simplelist>
   </para>

--- a/reference/strings/functions/str-word-count.xml
+++ b/reference/strings/functions/str-word-count.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: c73b00a6d7f799e3e5189a316efa06b7ef3c0fe6 Maintainer: dams Status: ready -->
+<!-- EN-Revision: d335ba69a16f4013280de8e3e71d9ba19fe3cb3c Maintainer: dams Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="function.str-word-count" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -192,7 +192,6 @@ Array
    <simplelist>
     <member><function>explode</function></member>
     <member><function>preg_split</function></member>
-    <member><function>split</function></member>
     <member><function>count_chars</function></member>
     <member><function>substr_count</function></member>
    </simplelist>

--- a/reference/strings/functions/strtok.xml
+++ b/reference/strings/functions/strtok.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: f1def1dea90866604da2ed230a2941778dd05802 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: d335ba69a16f4013280de8e3e71d9ba19fe3cb3c Maintainer: yannick Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.strtok" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -173,7 +173,6 @@ echo json_encode($parts),"\n";
   &reftitle.seealso;
   <para>
    <simplelist>
-    <member><function>split</function></member>
     <member><function>explode</function></member>
    </simplelist>
   </para>

--- a/reference/win32service/functions/win32-create-service.xml
+++ b/reference/win32service/functions/win32-create-service.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 4d72f13eaf9e06715ae68eac72aa3fd6ae83eb78 Maintainer: jbnahan Status: ready -->
+<!-- EN-Revision: 0d5b0198bfeee039849d521866503120351476d3 Maintainer: jbnahan Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.win32-create-service" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>

--- a/reference/win32service/functions/win32-delete-service.xml
+++ b/reference/win32service/functions/win32-delete-service.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 4d72f13eaf9e06715ae68eac72aa3fd6ae83eb78 Maintainer: jbnahan Status: ready -->
+<!-- EN-Revision: 0d5b0198bfeee039849d521866503120351476d3 Maintainer: jbnahan Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.win32-delete-service" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>

--- a/reference/win32service/functions/win32-pause-service.xml
+++ b/reference/win32service/functions/win32-pause-service.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 05568582247276cc2ee7b2b87f7df7d602e566c0 Maintainer: jbnahan Status: ready -->
+<!-- EN-Revision: 0d5b0198bfeee039849d521866503120351476d3 Maintainer: jbnahan Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="function.win32-pause-service" xmlns="http://docbook.org/ns/docbook">

--- a/reference/win32service/functions/win32-query-service-status.xml
+++ b/reference/win32service/functions/win32-query-service-status.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 16a1bdfd1c36108534b5af08dc4b751c7ac0fdaf Maintainer: jbnahan Status: ready -->
+<!-- EN-Revision: 0d5b0198bfeee039849d521866503120351476d3 Maintainer: jbnahan Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="function.win32-query-service-status" xmlns="http://docbook.org/ns/docbook">

--- a/reference/win32service/functions/win32-send-custom-control.xml
+++ b/reference/win32service/functions/win32-send-custom-control.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 05568582247276cc2ee7b2b87f7df7d602e566c0 Maintainer: jbnahan Status: ready -->
+<!-- EN-Revision: 0d5b0198bfeee039849d521866503120351476d3 Maintainer: jbnahan Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="function.win32-send-custom-control" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/reference/yaf/yaf_dispatcher/autorender.xml
+++ b/reference/yaf/yaf_dispatcher/autorender.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 37a12bad6c625be2f4df088dfadb72ded9a3389e Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 49d4fb555745d1981edac87a5a2d8ae53b5f75df Maintainer: yannick Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="yaf-dispatcher.autorender" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/reference/yaf/yaf_dispatcher/catchexception.xml
+++ b/reference/yaf/yaf_dispatcher/catchexception.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 0dc8bbd88c5e4b1d69595c03ba7451f340265db1 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 49d4fb555745d1981edac87a5a2d8ae53b5f75df Maintainer: yannick Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="yaf-dispatcher.catchexception" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/reference/yaf/yaf_dispatcher/dispatch.xml
+++ b/reference/yaf/yaf_dispatcher/dispatch.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: a023d0b2477a34b665318759194f64e4eeaa2262 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 49d4fb555745d1981edac87a5a2d8ae53b5f75df Maintainer: yannick Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="yaf-dispatcher.dispatch" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -27,7 +27,7 @@
    <member>Response</member>
   </simplelist>
    Le premier ne prend place qu'une seule fois, utilisant les valeurs de l'objet
-   de requête lorsque dispatch() est appelé. Le second prend place dans une boucle ;
+   de requête lorsque <function>Yaf_Dispatcher::dispatch</function> est appelé. Le second prend place dans une boucle ;
    une requête peut soit indiquer plusieurs actions à répartir, soit le controlleur
    ou un plugin peut réinitialiser l'objet de requête pour forcer des actions
    supplémentaires au répartiteur (voir <classname>Yaf_Plugin_Abstract</classname>).

--- a/reference/yaf/yaf_dispatcher/flushinstantly.xml
+++ b/reference/yaf/yaf_dispatcher/flushinstantly.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: d69ea3a807fd411a471cdee3122b0017189324b6 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 49d4fb555745d1981edac87a5a2d8ae53b5f75df Maintainer: yannick Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="yaf-dispatcher.flushinstantly" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/reference/yaf/yaf_dispatcher/getapplication.xml
+++ b/reference/yaf/yaf_dispatcher/getapplication.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: a023d0b2477a34b665318759194f64e4eeaa2262 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 49d4fb555745d1981edac87a5a2d8ae53b5f75df Maintainer: yannick Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="yaf-dispatcher.getapplication" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/reference/yaf/yaf_dispatcher/registerplugin.xml
+++ b/reference/yaf/yaf_dispatcher/registerplugin.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: a023d0b2477a34b665318759194f64e4eeaa2262 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 49d4fb555745d1981edac87a5a2d8ae53b5f75df Maintainer: yannick Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="yaf-dispatcher.registerplugin" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/reference/yaf/yaf_dispatcher/seterrorhandler.xml
+++ b/reference/yaf/yaf_dispatcher/seterrorhandler.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: ff8bbeed9c1f2c9291b59ed4ec5264c2d413b3ee Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 49d4fb555745d1981edac87a5a2d8ae53b5f75df Maintainer: yannick Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="yaf-dispatcher.seterrorhandler" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/reference/yaf/yaf_dispatcher/setview.xml
+++ b/reference/yaf/yaf_dispatcher/setview.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 7b0a4b69ba35d7f0a1ef3f50a84848126cc212e6 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 49d4fb555745d1981edac87a5a2d8ae53b5f75df Maintainer: yannick Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="yaf-dispatcher.setview" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -29,7 +29,7 @@
     <term><parameter>view</parameter></term>
     <listitem>
      <para>
-      Une instance de la classe Yaf_View_Interface.
+      Une instance de la classe <classname>Yaf_View_Interface</classname>.
      </para>
     </listitem>
    </varlistentry>

--- a/reference/yaf/yaf_dispatcher/throwexception.xml
+++ b/reference/yaf/yaf_dispatcher/throwexception.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: ff8bbeed9c1f2c9291b59ed4ec5264c2d413b3ee Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 49d4fb555745d1981edac87a5a2d8ae53b5f75df Maintainer: yannick Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="yaf-dispatcher.throwexception" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/reference/zlib/functions/gzwrite.xml
+++ b/reference/zlib/functions/gzwrite.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 02ba67b51f2bde571b6ce07026e935f4e81019af Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 9d2b858bca85edbeebb83f05a1cd2e87cf90127d Maintainer: yannick Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="function.gzwrite" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -51,15 +51,6 @@
        ou si la fin de la chaîne <parameter>data</parameter> est atteinte ;
        celui qui survient le premier.
       </para>
-      <note>
-       <para>
-        Notez que si l'argument <parameter>length</parameter>
-        est donné, alors l'option de configuration <link
-        linkend="ini.magic-quotes-runtime">magic_quotes_runtime</link>
-        sera ignoré et aucun slash ne sera supprimé de la chaîne
-        <parameter>data</parameter>.
-       </para>
-      </note>
      </listitem>
     </varlistentry>
    </variablelist>


### PR DESCRIPTION
Next commits may not have updates:

php/doc-en@49d4fb555745d1981edac87a5a2d8ae53b5f75df - fixed English typos, and added space to "... example"
php/doc-en@0d5b0198bfeee039849d521866503120351476d3 - removed `;` in English version
php/doc-en@e83ad8ecd4d98c6df0003a5f091322e7ef1de54c - `linux` to `Linux`. French version already has the right variant
php/doc-en@42d9fe8494fe8cf37f50d4777b335b330c7ec5c1 - fixed English typos
php/doc-en@eedb2334027e62f88e233472a14d19020317d752 - fixed English typos



