### PR TITLE
Update reference/var/functions/is-callable to English revision

### DIFF
--- a/reference/var/functions/is-callable.xml
+++ b/reference/var/functions/is-callable.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 4807f1a19e7fafc1d9fa0ac49a2beb368c6206fa Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 83a17a7324c2597bd6385148abf19f76127229f5 Maintainer: yannick Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="function.is-callable" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -160,12 +160,14 @@ bool(false)
   <simplelist>
    <member>
     Un object est tout le temps appelable s'il implémente
-    <function>__invoke()</function>, et que la méthode est visible
+    <link linkend="object.invoke">__invoke()</link>, et que la méthode est visible
     dans le portée courante.
    </member>
-   <member>Un nom de classe est appelable si elle implémente <function>__callStatic()</function></member>
+   <member>Un nom de classe est appelable si elle implémente
+    <link linkend="object.callstatic">__callStatic()</link>
+   </member>
    <member>
-    Si un object implémente <function>__call()</function>, alors cette fonction
+    Si un object implémente <link linkend="object.call">__call()</link>, alors cette fonction
     retournera &true; pour n'importe quelle méthode sur cet object, même si
     la méthode n'est pas définie.
    </member>


### PR DESCRIPTION
Based on this diff :http://doc.php.net/revcheck.php?p=plain&lang=fr&hbp=4807f1a19e7fafc1d9fa0ac49a2beb368c6206fa&f=reference/var/functions/is-callable.xml&c=on

This only changes `function` tag to `link`. The text remains the same.