### PR TITLE
Reference strings functions strcasecmp

### DIFF
--- a/reference/strings/functions/str-getcsv.xml
+++ b/reference/strings/functions/str-getcsv.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: e095023e408c8cb6378ae16bb6870343a3946919 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 7d93e0fe5eabef4325e6fc33abc329d1d370be86 Maintainer: yannick Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="function.str-getcsv" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -47,7 +47,7 @@
      <term><parameter>separator</parameter></term>
      <listitem>
       <para>
-       Le délimiteur de champ (un seul caractère).
+       Le délimiteur de champ (un seul caractère d'un octet).
       </para>
      </listitem>
     </varlistentry>
@@ -55,7 +55,7 @@
      <term><parameter>enclosure</parameter></term>
      <listitem>
       <para>
-       Le caractère d'encadrement (un seul caractère).
+       Le caractère d'encadrement (un seul caractère d'un octet).
       </para>
      </listitem>
     </varlistentry>
@@ -63,7 +63,7 @@
      <term><parameter>escape</parameter></term>
      <listitem>
       <para>
-       Le caractère de protection (au plus un caractère). Par défaut, c'est 
+       Le caractère de protection (au plus un caractère d'un octet). Par défaut, c'est
        l'antislash. (<literal>\</literal>)
        Une &string; vide (<literal>""</literal>) désactive le mécanisme d'échappement propriétaire.
       </para>

--- a/reference/strings/functions/strcasecmp.xml
+++ b/reference/strings/functions/strcasecmp.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: c44475e1fafcbee203ed4935a6d5d7a01379fcdc Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 5dcdcf32f847c297f1fe174aea802a489cecaf1d Maintainer: yannick Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="function.strcasecmp" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -17,6 +17,8 @@
   </methodsynopsis>
   <para>
    Comparaison insensible à la casse de chaînes binaires.
+   La comparaison ne tient pas compte des paramètres régionaux; seules les lettres ASCII
+   sont comparées de manière insensible à la casse.
   </para>
  </refsect1>
 


### PR DESCRIPTION
Based on diff: http://doc.php.net/revcheck.php?p=plain&lang=fr&hbp=c44475e1fafcbee203ed4935a6d5d7a01379fcdc&f=reference/strings/functions/strcasecmp.xml&c=on