### PR TITLE
reference/strings/functions/stripos

### DIFF
--- a/reference/strings/functions/stripos.xml
+++ b/reference/strings/functions/stripos.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: e095023e408c8cb6378ae16bb6870343a3946919 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 89a80389d474b16b8e063d058506a19beaf32db7 Maintainer: yannick Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="function.stripos" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>


### PR DESCRIPTION
The original documentation was updated with only a typo in the word "beginning", so nothing to update in French: http://doc.php.net/revcheck.php?p=plain&lang=fr&hbp=e095023e408c8cb6378ae16bb6870343a3946919&f=reference/strings/functions/stripos.xml&c=on