### PR TITLE
Use "exécution immédiate" instead of "exécution avide"

### DIFF
--- a/language/functions.xml
+++ b/language/functions.xml
@@ -183,7 +183,7 @@ function recursion($a)
    une fonction en utilisant une liste d'arguments, dont chaque
    expression est séparée par une virgule. Les arguments seront
    évalués depuis la gauche vers la droite, avant que la fonction soit
-   actuellement appelée (évaluation <emphasis>avide</emphasis>).
+   actuellement appelée (évaluation <emphasis>immédiate</emphasis>).
   </simpara>
   <para>
    PHP supporte le passage d'arguments par valeur (comportement par défaut), <link


### PR DESCRIPTION
This makes it clearer for the user.