### PR TITLE
Make French translation clearer for array_search

### DIFF
--- a/reference/array/functions/array-search.xml
+++ b/reference/array/functions/array-search.xml
@@ -7,7 +7,7 @@
 <refentry xml:id="function.array-search" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>array_search</refname>
-  <refpurpose>Recherche dans un tableau la clé associée à la première valeur</refpurpose>
+  <refpurpose>Recherche dans un tableau la première clé associée à la valeur</refpurpose>
  </refnamediv>
  <refsect1 role="description">
   &reftitle.description;


### PR DESCRIPTION
The description was ambiguous, `array_search` return the first key corresponding to the passed value, not the key corresponding to the first value.