### PR TITLE
Typo fix in ob-start.xml

### DIFF
--- a/reference/outcontrol/functions/ob-start.xml
+++ b/reference/outcontrol/functions/ob-start.xml
@@ -46,7 +46,7 @@
   </para>
   <para>
    Si les tampons de sortie sont encore actif quand le script se termine,
-   PHP affiche le contenue automatiquement.
+   PHP affiche le contenu automatiquement.
   </para>
  </refsect1>
 


### PR DESCRIPTION
The word "contenu" was mis-spelled "contenue" in L49.