### PR TITLE
Types Array: fix 2 grammatical typos

### DIFF
--- a/language/types/array.xml
+++ b/language/types/array.xml
@@ -625,7 +625,7 @@ echo $foo[bar];
    <para>
     C'est incorrect, mais ça fonctionne. La raison est que ce code a une constante
     indéfinie (<literal>bar</literal>) plutôt qu'une &string;
-    (<literal>'bar'</literal> - noter les guillemets).
+    (<literal>'bar'</literal> - notez les guillemets).
     Cela fonctionne car PHP convertit automatiquement une <emphasis>chaîne nue</emphasis>
     (une chaîne sans guillemets qui ne correspond à aucun symbole connu) en une chaîne
     qui la contient. Actuellement, s'il n'y a aucune constante nommée <constant>bar</constant>,
@@ -829,7 +829,7 @@ $error_descriptions[8] = "This is just an informal notice";
       Pour être plus clair, dans une chaîne entourée de guillemets doubles,
       il est valide de ne pas entourer les indexes d'un tableau avec des
       guillemets, et donc, <literal>"$foo[bar]"</literal> est valide. Voir
-      les exemples ci-dessous pour plus détails mais aussi la section sur
+      les exemples ci-dessous pour plus de détails mais aussi la section sur
       l'<link linkend="language.types.string.parsing">analyse des variables
       dans les chaînes</link>.
      </simpara>


### PR DESCRIPTION
Two typos from manual page: https://www.php.net/manual/fr/language.types.array.php:

> La raison est que ce code a une constante indéfinie (bar) plutôt qu'une chaîne de caractères ('bar' - noter les guillemets).

Should be:
La raison est que ce code a une constante indéfinie (bar) plutôt qu'une chaîne de caractères ('bar' - notez les guillemets).

And
> Voir les exemples ci-dessous pour plus détails mais aussi la section sur l'analyse des variables dans les chaînes.

Should be:
Voir les exemples ci-dessus pour plus de détails mais aussi la section sur l'analyse des variables dans les chaînes.