### PR TITLE
FIX: Typo in preg_match.xml

### DIFF
--- a/reference/pcre/functions/preg-match.xml
+++ b/reference/pcre/functions/preg-match.xml
@@ -255,7 +255,6 @@ Array
   <para>
    <function>preg_match</function> retourne 1 si le <parameter>pattern</parameter>
    fourni correspond, 0 s'il ne correspond pas,&return.falseforfailure;.
-   survient.
   </para>
   &return.falseproblem;
  </refsect1>


### PR DESCRIPTION
Duplicate "survient" in the return value of the preg_match function documentation