### PR TITLE
Fix a typo in description of array_diff

### DIFF
--- a/reference/array/functions/array-diff.xml
+++ b/reference/array/functions/array-diff.xml
@@ -20,7 +20,7 @@
   <para>
    <function>array_diff</function> compare le tableau 
    <parameter>array</parameter> avec un ou plusieurs tableaux
-   et retourne les valeurs du tableau <parameter>array1</parameter>
+   et retourne les valeurs du tableau <parameter>array</parameter>
    qui ne sont pas présentes dans les autres tableaux.
   </para>
  </refsect1>


### PR DESCRIPTION
Replaced a reference to **array1** by correct reference to **array** in description.

Fixes https://github.com/php/doc-fr/issues/148