### PR TITLE
Corrected PHP mail() function arguments names in French documentation

### DIFF
--- a/reference/mail/functions/mail.xml
+++ b/reference/mail/functions/mail.xml
@@ -15,7 +15,7 @@
    <methodparam><type>string</type><parameter>to</parameter></methodparam>
    <methodparam><type>string</type><parameter>subject</parameter></methodparam>
    <methodparam><type>string</type><parameter>message</parameter></methodparam>
-   <methodparam choice="opt"><type class="union"><type>array</type><type>string</type></type><parameter>additional_params</parameter><initializer>[]</initializer></methodparam>
+   <methodparam choice="opt"><type class="union"><type>array</type><type>string</type></type><parameter>additional_headers</parameter><initializer>[]</initializer></methodparam>
    <methodparam choice="opt"><type>string</type><parameter>additional_params</parameter><initializer>""</initializer></methodparam>
   </methodsynopsis>
   <para>
@@ -86,7 +86,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>additional_params</parameter> (optionnel)</term>
+     <term><parameter>additional_headers</parameter> (optionnel)</term>
      <listitem>
       <para>
        <type>String</type> ou <type>array</type> à insérer à la fin des en-têtes du mail.
@@ -106,7 +106,7 @@
       <note>
        <para>
         Avant PHP 5.4.42 et 5.5.27, respectivement, 
-        <parameter>additional_params</parameter> n'avait pas de protection
+        <parameter>additional_headers</parameter> n'avait pas de protection
         d'injection en-tête de messagerie. Par conséquent, les utilisateurs 
         doivent s'assurer que les en-têtes spécifiés sont sûrs et contiennent 
         uniquement des en-têtes. C'est à dire ne jamais démarrer le corps du 
@@ -117,7 +117,7 @@
        <para>
         Lors de l'envoi d'un mail, le mail <emphasis>doit</emphasis>
         contenir un en-tête <literal>From</literal>. Il peut être
-        défini par le paramètre <parameter>additional_params</parameter>,
+        défini par le paramètre <parameter>additional_headers</parameter>,
         ou un par défaut peut être défini dans le &php.ini;.
        </para>
        <para>
@@ -146,10 +146,10 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>additional_parameters</parameter> (optionnel)</term>
+     <term><parameter>additional_params</parameter> (optionnel)</term>
      <listitem>
       <para>
-       Le paramètre <parameter>additional_parameters</parameter>
+       Le paramètre <parameter>additional_params</parameter>
        peut être utilisé pour passer des drapeaux additionnels comme options
        à la ligne de commande configurée pour être utilisée pour envoyer les
        mails en utilisant le paramètre de configuration <literal>sendmail_path</literal>.
@@ -211,7 +211,7 @@
       <row>
        <entry>7.2.0</entry>
        <entry>
-        Le paramètre <parameter>additional_params</parameter> accepte maintenant
+        Le paramètre <parameter>additional_headers</parameter> accepte maintenant
         les <type>array</type>.
        </entry>
       </row>
@@ -292,7 +292,7 @@ mail($to, $subject, $message, $headers);
    <example>
     <title>Envoi d'un mail avec un paramètre de ligne de commande additionnel</title>
     <para>
-     Le paramètre <parameter>additional_parameters</parameter>
+     Le paramètre <parameter>additional_params</parameter>
      peut être utilisé pour passer un paramètre additionnel au programme configuré
      à être utilisé pour envoyer les mails en utilisant <literal>sendmail_path</literal>.
     </para>


### PR DESCRIPTION
Resolved issue #134 