### PR TITLE
Fixi goto description

### DIFF
--- a/language/control-structures/goto.xml
+++ b/language/control-structures/goto.xml
@@ -25,7 +25,7 @@
   qu'il n'est pas possible de changer de méthode ou de fonction,
   ni de se rendre dans une autre fonction. Il est de même impossible d'entrer
   dans une structure de boucle ou un <literal>switch</literal>.
-  Vous pouvez néanmoins en sortir, et l'utilisation courante est alors de se servir de
+  Il est néanmoins possible d'en sortir, et l'utilisation courante est alors de se servir de
   <literal>goto</literal> comme un <literal>break</literal>. 
  </para>
  <para>

--- a/language/control-structures/goto.xml
+++ b/language/control-structures/goto.xml
@@ -23,8 +23,9 @@
   suivie de ce label. <literal>goto</literal> n'est pas totalement sans limitations.
   L'étiquette cible doit être dans le même contexte et fichier, ce qui signifie
   qu'il n'est pas possible de changer de méthode ou de fonction,
-  ni de se rendre dans une autre fonction. Vous pouvez sortir d'une
-  fonction, et l'utilisation courante est alors de se servir de
+  ni de se rendre dans une autre fonction. Il est de même impossible d'entrer
+  dans une structure de boucle ou un <literal>switch</literal>.
+  Vous pouvez néanmoins en sortir, et l'utilisation courante est alors de se servir de
   <literal>goto</literal> comme un <literal>break</literal>. 
  </para>
  <para>


### PR DESCRIPTION
Bonjour :wave: :slightly_smiling_face: ,

The description of the `goto` is wrong, mainly because a part of the original english text is missing.
https://github.com/php/doc-en/blob/2ef411d8ef4f8e3ecbcb9c23fbb8017061e44501/language/control-structures/goto.xml#L21-L26
```
The target
  label must be within the same file and context, meaning that you cannot jump
  out of a function or method, nor can you jump into one.  You also
  cannot jump into any sort of loop or switch structure.  You may jump
  out of these, and a common use is to use a <literal>goto</literal>
  in place of a multi-level <literal>break</literal>.
  ```
  
Previous version was suggesting that it's possible to jump out of a function with a `goto`.
I did my best to propose something else :sweat_smile: 

Thanks for your amazing work on this documentation :bow: 