### PR TITLE
Translate the apcu extension in French

### DIFF
--- a/reference/apcu/apcuiterator.xml
+++ b/reference/apcu/apcuiterator.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: e9366ee458b2900c53a503b1ad97664e1d9a8859 Maintainer: moradZahid Status:  -->
+<!-- Reviewed: no -->
+<phpdoc:classref xml:id="class.apcuiterator" xmlns:phpdoc="http://php.net/ns/phpdoc" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+
+ <title>The APCUIterator class</title>
+ <titleabbrev>APCUIterator</titleabbrev>
+
+ <partintro>
+
+<!-- {{{ APCUIterator intro -->
+  <section xml:id="apcuiterator.intro">
+   &reftitle.intro;
+   <para>
+    La classe <classname>APCUIterator</classname> facilite le parcours des  
+    caches APCu de grandes tailles. Cela est utile car il permet de les parcourir
+    par étapes, tout en récupérant un nombre défini d'entrées par instance de 
+    verrouillage. Ainsi cela libère les verrous de cache pour d'autres activités
+    au lieu de bloquer tout le cache pour récupérer 100 entrées (par défaut). 
+    D'autre part, le filtrage par expressions régulières est plus efficace 
+    car leur manipulation a été déplacée au niveau du C.
+   </para>
+  </section>
+<!-- }}} -->
+
+  <section xml:id="apcuiterator.synopsis">
+   &reftitle.classsynopsis;
+
+<!-- {{{ Synopsis -->
+   <classsynopsis>
+    <ooclass><classname>APCUIterator</classname></ooclass>
+
+<!-- {{{ Class synopsis -->
+    <classsynopsisinfo>
+     <ooclass>
+      <classname>APCUIterator</classname>
+     </ooclass>
+     
+     <oointerface>
+      <interfacename>Iterator</interfacename>
+     </oointerface>
+
+    </classsynopsisinfo>
+<!-- }}} -->
+    
+    <classsynopsisinfo role="comment">Méthodes</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.apcuiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
+   </classsynopsis>
+<!-- }}} -->
+
+  </section>
+
+ </partintro>
+
+ &reference.apcu.entities.apcuiterator;
+
+</phpdoc:classref>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/apcu/apcuiterator/construct.xml
+++ b/reference/apcu/apcuiterator/construct.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: cc664c831ab8090ce8fa5e6d65010332b9805189 Maintainer: moradZahid Status:  -->
+<!-- EN-Revision: c44e9cb68b9b65771f9c45db2c07a06c63d71359 Maintainer: moradZahid Status:  -->
 <!-- Reviewed: no -->
 <refentry xml:id="apcuiterator.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -10,13 +10,13 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis>
+  <constructorsynopsis>
    <modifier>public</modifier> <methodname>APCUIterator::__construct</methodname>
    <methodparam choice="opt"><type class="union"><type>array</type><type>string</type><type>null</type></type><parameter>search</parameter><initializer>&null;</initializer></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>format</parameter><initializer>APC_ITER_ALL</initializer></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>chunk_size</parameter><initializer>100</initializer></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>list</parameter><initializer>APC_LIST_ACTIVE</initializer></methodparam>
-  </methodsynopsis>
+  </constructorsynopsis>
   <para>
    Construit un <type>objet</type> de la classe <classname>APCUIterator</classname>.
   </para>
@@ -64,14 +64,6 @@
     </listitem>
    </varlistentry>
   </variablelist>
- </refsect1>
-
- <refsect1 role="returnvalues">
-  &reftitle.returnvalues;
-  <para>
-   Retourne un <type>objet</type> de la classe <classname>APCUIterator</classname> en cas
-   de succès ou bien &null; en cas d'échec.
-  </para>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/apcu/apcuiterator/construct.xml
+++ b/reference/apcu/apcuiterator/construct.xml
@@ -1,0 +1,125 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: cc664c831ab8090ce8fa5e6d65010332b9805189 Maintainer: moradZahid Status:  -->
+<!-- Reviewed: no -->
+<refentry xml:id="apcuiterator.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>APCUIterator::__construct</refname>
+  <refpurpose>Construit un objet itérateur de la classe APCUIterator</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>public</modifier> <methodname>APCUIterator::__construct</methodname>
+   <methodparam choice="opt"><type class="union"><type>array</type><type>string</type><type>null</type></type><parameter>search</parameter><initializer>&null;</initializer></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>format</parameter><initializer>APC_ITER_ALL</initializer></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>chunk_size</parameter><initializer>100</initializer></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>list</parameter><initializer>APC_LIST_ACTIVE</initializer></methodparam>
+  </methodsynopsis>
+  <para>
+   Construit un <type>objet</type> de la classe <classname>APCUIterator</classname>.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>search</parameter></term>
+    <listitem>
+     <para>
+      Soit une expression régulière <link linkend="book.pcre">PCRE</link> qui
+      filtre le nom des clés APCu, donnée sous la forme d'une &string;.
+      Soit un &array; de &string; contenant des noms de clés APCu.
+      Ou, bien éventuellement, la valeur &null;, pour sauter l'étape de recherche.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>format</parameter></term>
+    <listitem>
+     <para>
+      Le format souhaité, configuré avec une ou plusieurs des constantes prédéfinies
+      <link linkend="apcu.constants">APC_ITER_*</link>.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>chunk_size</parameter></term>
+    <listitem>
+     <para>
+      La taille d'un tronçon. La valeur de ce paramètre doit être plus grand que 0.
+      La valeur par défaut est 100.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>list</parameter></term>
+    <listitem>
+     <para>
+      Le type de liste. Le paramètre peut prendre soit la valeur <constant>APC_LIST_ACTIVE</constant>
+      ou bien la valeur <constant>APC_LIST_DELETED</constant>.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Retourne un <type>objet</type> de la classe <classname>APCUIterator</classname> en cas
+   de succès ou bien &null; en cas d'échec.
+  </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example>
+    <title>Un exemple avec <function>APCUIterator::__construct</function></title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+foreach (new APCUIterator('/^counter\./') as $counter) {
+    echo "$counter[key]: $counter[value]\n";
+    apc_dec($counter['key'], $counter['value']);
+}
+?>
+]]>
+    </programlisting>
+   </example>
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>apcu_exists</function></member>
+   <member><function>apcu_cache_info</function></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/apcu/apcuiterator/current.xml
+++ b/reference/apcu/apcuiterator/current.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: e9366ee458b2900c53a503b1ad97664e1d9a8859 Maintainer: moradZahid Status:  -->
+<!-- Reviewed: no -->
+<refentry xml:id="apcuiterator.current" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>APCUIterator::current</refname>
+  <refpurpose>Retourne l'élément courant</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>public</modifier> <type>mixed</type><methodname>APCUIterator::current</methodname>
+   <void />
+  </methodsynopsis>
+  <para>
+   Retourne l'élément courant de la liste de <classname>APCUIterator</classname>.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Retourne l'élément courant en cas de succès ou bien la valeur &false; si l'un des 
+   trois cas suivants se produit: le pointeur a dépassé le dernier élément, il n'y 
+   a pas d'élément dans la liste ou la fonction a échouée.
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>APCUIterator::next</methodname></member>
+   <member><methodname>Iterator::current</methodname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/apcu/apcuiterator/gettotalcount.xml
+++ b/reference/apcu/apcuiterator/gettotalcount.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 6ad0b03b45bb3055c03f79eb0647ede0876f8b36 Maintainer: moradZahid Status:  -->
+<!-- Reviewed: no -->
+<refentry xml:id="apcuiterator.gettotalcount" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>APCUIterator::getTotalCount</refname>
+  <refpurpose>Retourne le compte total</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>public</modifier> <type>int</type><methodname>APCUIterator::getTotalCount</methodname>
+   <void />
+  </methodsynopsis>
+  <para>
+   Retourne le compte total.
+  </para>
+
+  &warn.undocumented.func;
+
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Le compte total.
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>APCUIterator::getTotalHits</methodname></member>
+   <member><methodname>APCUIterator::getTotalSize</methodname></member>
+   <member><function>apcu_cache_info</function></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/apcu/apcuiterator/gettotalhits.xml
+++ b/reference/apcu/apcuiterator/gettotalhits.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: e41806c30bf6975e452c0d4ce35ab0984c2fa68c Maintainer: moradZahid Status:  -->
+<!-- Reviewed: no -->
+<refentry xml:id="apcuiterator.gettotalhits" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>APCUIterator::getTotalHits</refname>
+  <refpurpose>Retourne le nombre total d'accès au cache</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>public</modifier> <type>int</type><methodname>APCUIterator::getTotalHits</methodname>
+   <void />
+  </methodsynopsis>
+  <para>
+   Retourne le nombre total d'accès au cache.
+  </para>
+
+  &warn.undocumented.func;
+
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Retourne le nombre total d'accès au cache en cas de succès
+   ou &false; en cas d'échec.
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>APCUIterator::getTotalCount</methodname></member>
+   <member><methodname>APCUIterator::getTotalSize</methodname></member>
+   <member><function>apcu_cache_info</function></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/apcu/apcuiterator/gettotalsize.xml
+++ b/reference/apcu/apcuiterator/gettotalsize.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: e9366ee458b2900c53a503b1ad97664e1d9a8859 Maintainer: moradZahid Status:  -->
+<!-- Reviewed: no -->
+<refentry xml:id="apcuiterator.gettotalsize" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>APCUIterator::getTotalSize</refname>
+  <refpurpose>Retourne la taille totale du cache</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>public</modifier> <type>int</type><methodname>APCUIterator::getTotalSize</methodname>
+   <void />
+  </methodsynopsis>
+  <para>
+   Retourne la taille totale du cache.
+  </para>
+
+  &warn.undocumented.func;
+
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   La taille totale du cache.
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>APCUIterator::getTotalCount</methodname></member>
+   <member><methodname>APCUIterator::getTotalHits</methodname></member>
+   <member><function>apc_cache_info</function></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/apcu/apcuiterator/key.xml
+++ b/reference/apcu/apcuiterator/key.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 4754397753fd79f1c846868b66a2448babab1c54 Maintainer: moradZahid Status:  -->
+<!-- Reviewed: no -->
+<refentry xml:id="apcuiterator.key" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>APCUIterator::key</refname>
+  <refpurpose>Retourne la clé de l'élément courant</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>public</modifier> <type>string</type><methodname>APCUIterator::key</methodname>
+   <void />
+  </methodsynopsis>
+  <para>
+   Retourne la clé de l'élément courant.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Retourne la clé en cas de succès ou &false; en cas d'échec.
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>APCUIterator::current</methodname></member>
+   <member><methodname>Iterator::key</methodname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/apcu/apcuiterator/next.xml
+++ b/reference/apcu/apcuiterator/next.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: ad7884c477b77c9a523ceef5ad7dffeaf11a4246 Maintainer: moradZahid Status:  -->
+<!-- Reviewed: no -->
+<refentry xml:id="apcuiterator.next" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>APCUIterator::next</refname>
+  <refpurpose>Déplace le pointeur sur l'élément suivant</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>public</modifier> <type>bool</type><methodname>APCUIterator::next</methodname>
+   <void />
+  </methodsynopsis>
+  <para>
+   Déplace le pointeur de l'itérateur sur l'élément suivant.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &return.success;
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>APCUIterator::current</methodname></member>
+   <member><methodname>APCUIterator::rewind</methodname></member>
+   <member><methodname>Iterator::next</methodname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/apcu/apcuiterator/rewind.xml
+++ b/reference/apcu/apcuiterator/rewind.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: e9366ee458b2900c53a503b1ad97664e1d9a8859 Maintainer: moradZahid Status:  -->
+<!-- Reviewed: no -->
+<refentry xml:id="apcuiterator.rewind" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>APCUIterator::rewind</refname>
+  <refpurpose>Replace l'itérateur sur le premier élément</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>public</modifier> <type>void</type><methodname>APCUIterator::rewind</methodname>
+   <void />
+  </methodsynopsis>
+  <para>
+   Replace l'itérateur sur le premier élément.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &return.void;
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>APCUIterator::next</methodname></member>
+   <member><methodname>Iterator::next</methodname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/apcu/apcuiterator/valid.xml
+++ b/reference/apcu/apcuiterator/valid.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: ad7884c477b77c9a523ceef5ad7dffeaf11a4246 Maintainer: moradZahid Status:  -->
+<!-- Reviewed: no -->
+<refentry xml:id="apcuiterator.valid" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>APCUIterator::valid</refname>
+  <refpurpose>Vérifie si la position courante est valide</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>public</modifier> <type>bool</type><methodname>APCUIterator::valid</methodname>
+   <void />
+  </methodsynopsis>
+  <para>
+   Vérifie si la position courante de l'itérateur est valide.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Retourne la valeur &true; si la position courante de l'itérateur est valide, sinon
+   retourne &false;.
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>APCUIterator::current</methodname></member>
+   <member><methodname>Iterator::valid</methodname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/apcu/book.xml
+++ b/reference/apcu/book.xml
@@ -18,7 +18,7 @@
    APCu, c'est APC sans la mise en cache du code opération.
   </para>
   <para>
-   Le premier codebase a été versionné 4.0.0, ce fut un embranchement logiciel de la 
+   La première version est 4.0.0, ce fut un embranchement logiciel de la 
    tête de la branche maître d'APC de l'époque.
    La prise en charge de PHP 7 est disponible à partir de APCu 5.0.0. 
    La prise en charge de PHP 8 est disponible à partir de APCu 5.1.19.

--- a/reference/apcu/book.xml
+++ b/reference/apcu/book.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: d6eb5fda8a3c0a755b4d15cb617a09bb81d5882e Maintainer: moradZahid Status:  -->
+<!-- Reviewed: no -->
+<book xml:id="book.apcu" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <?phpdoc extension-membership="pecl" ?>
+ <title>APC User Cache</title>
+ <titleabbrev>APCu</titleabbrev>
+
+ <preface xml:id="intro.apcu">
+  &reftitle.intro;
+  <para>
+   APCu est un tableau associatif stocké en mémoire pour PHP.
+   Les clés sont de type &string; et les valeurs sont des variables PHP de tout type.
+   APCu ne gère que la mise en cache de variables de l'espace utilisateur.
+  </para>
+  <para>
+   APCu, c'est APC sans la mise en cache du code opération.
+  </para>
+  <para>
+   Le premier codebase a été versionné 4.0.0, ce fut un embranchement logiciel de la 
+   tête de la branche maître d'APC de l'époque.
+   La prise en charge de PHP 7 est disponible à partir de APCu 5.0.0. 
+   La prise en charge de PHP 8 est disponible à partir de APCu 5.1.19.
+  </para>
+ </preface>
+
+ &reference.apcu.setup;
+ &reference.apcu.constants;
+ &reference.apcu.reference;
+ &reference.apcu.apcuiterator;
+
+</book>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->
+

--- a/reference/apcu/functions/apcu-add.xml
+++ b/reference/apcu/functions/apcu-add.xml
@@ -1,0 +1,158 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: e9366ee458b2900c53a503b1ad97664e1d9a8859 Maintainer: moradZahid Status:  -->
+<!-- Reviewed: no -->
+<refentry xml:id="function.apcu-add" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>apcu_add</refname>
+  <refpurpose>
+   Met en cache une nouvelle variable dans le dépôt de données
+  </refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>bool</type><methodname>apcu_add</methodname>
+   <methodparam><type>string</type><parameter>key</parameter></methodparam>
+   <methodparam><type>mixed</type><parameter>var</parameter></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>ttl</parameter><initializer>0</initializer></methodparam>
+  </methodsynopsis>
+  <methodsynopsis>
+   <type>array</type><methodname>apcu_add</methodname>
+   <methodparam><type>array</type><parameter>values</parameter></methodparam>
+   <methodparam choice="opt"><type>mixed</type><parameter>unused</parameter><initializer>NULL</initializer></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>ttl</parameter><initializer>0</initializer></methodparam>
+  </methodsynopsis>
+  <para>
+   Met en cache une variable dans le dépôt de données, seulement si elle n'a pas été déjà stockée.
+  </para>
+  <note>
+   <simpara>
+    Contrairement à de nombreux autres mécanismes dans PHP, les variables stockées
+    utilisant <function>apcu_add</function> persisteront entre les requêtes (jusqu'à ce
+    que leurs valeurs soient retirées du cache).
+   </simpara>
+  </note>
+ </refsect1>
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>key</parameter></term>
+     <listitem>
+      <para>
+       Stocke la variable en utilisant ce nom de clé. Chaque clé est unique dans le cache,
+       essayer d'utiliser <function>apcu_add</function> pour stocker une donnée avec une
+       valeur du paramètre <parameter>key</parameter> déjà existante ne va pas réécrire sur la
+       donnée mais va retourner la valeur &false;. (C'est l'unique différence entre
+       les fonctions <function>apcu_add</function> et <function>apcu_store</function>.)
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>var</parameter></term>
+     <listitem>
+      <para>
+       La variable à stocker.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>ttl</parameter></term>
+     <listitem>
+      <para>
+       Durée de vie; stocke la variable <parameter>var</parameter> dans le cache pour
+       une durée de <parameter>ttl</parameter> secondes. Après l'expiration de
+       <parameter>ttl</parameter>, la variable stockée sera retirée du cache (à la 
+       prochaine requête). Si aucune valeur n'est passée à 
+       <parameter>ttl</parameter> (ou si la valeur de <parameter>ttl</parameter> est
+       <literal>0</literal>), la variable persistera jusqu'à qu'elle soit retirée
+       manuellement du cache, ou, sinon, elle échouera à sortir du cache (lors d'un 
+       effaçage, redémarrage, etc.).
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>values</parameter></term>
+     <listitem>
+      <para>
+       Les noms sont fournis par les clés du tableau <parameter>values</parameter>,
+       les variables par les valeurs.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Retourne TRUE si une variable a effectivement été ajoutée au cache, FALSE sinon.
+   La seconde syntaxe retourne un tableau avec les clés erronées.
+  </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example>
+    <title>Un exemple avec <function>apcu_add</function></title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+$bar = 'BAR';
+apcu_add('foo', $bar);
+var_dump(apcu_fetch('foo'));
+echo "\n";
+$bar = 'NEVER GETS SET';
+apcu_add('foo', $bar);
+var_dump(apcu_fetch('foo'));
+echo "\n";
+?>
+]]>
+    </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+string(3) "BAR"
+string(3) "BAR"
+]]>
+    </screen>
+   </example>
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>apcu_store</function></member>
+    <member><function>apcu_fetch</function></member>
+    <member><function>apcu_delete</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/apcu/functions/apcu-cache-info.xml
+++ b/reference/apcu/functions/apcu-cache-info.xml
@@ -1,0 +1,165 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: b95d28e6ec86e4a71e012737d36ebdc1cf009180 Maintainer: moradZahid Status:  -->
+<!-- Reviewed: no -->
+<refentry xml:id="function.apcu-cache-info" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>apcu_cache_info</refname>
+  <refpurpose>
+   Récupère les informations mises en cache dans le dépôt de données d'APCu
+  </refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type class="union"><type>array</type><type>false</type></type><methodname>apcu_cache_info</methodname>
+   <methodparam choice="opt"><type>bool</type><parameter>limited</parameter><initializer>&false;</initializer></methodparam>
+  </methodsynopsis>
+  <para>
+   Récupère les informations et les méta-données mises en cache dans le dépôt de données d'APCu.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>limited</parameter></term>
+     <listitem>
+      <para>
+       Si la valeur de <parameter>limited</parameter> est &true;, la valeur retournée
+       exclura la liste individuelle des entrées du cache. Cela est utile lorsqu'une
+       optimisation des appels à des fins statistiques est tentée.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Tableau des données (et méta-données) mises en cache &return.falseforfailure;
+  </para>
+  <note>
+   <simpara>
+    <function>apcu_cache_info</function> émettra un avertissement s'il est
+    incapable de retrouver les données du cache APC. Cela se produit 
+    typiquement lorsqu'APC n'est pas activé.
+   </simpara>
+  </note>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>PECL apcu 3.0.11</entry>
+       <entry>
+        Le paramètre <parameter>limited</parameter> est introduit.
+       </entry>
+      </row>
+      <row>
+       <entry>PECL apcu 3.0.16</entry>
+       <entry>
+        L'option "<literal>filehits</literal>" pour le paramètre
+        <parameter>cache_type</parameter> est introduit.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example>
+    <title>Un exemple avec <function>apcu_cache_info</function></title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+print_r(apcu_cache_info());
+?>
+]]>
+    </programlisting>
+    &example.outputs.similar;
+    <screen>
+<![CDATA[
+Array
+(
+    [num_slots] => 2000
+    [ttl] => 0
+    [num_hits] => 9
+    [num_misses] => 3
+    [start_time] => 1123958803
+    [cache_list] => Array
+        (
+            [0] => Array
+                (
+                    [filename] => /path/to/apcu_test.php
+                    [device] => 29954
+                    [inode] => 1130511
+                    [type] => file
+                    [num_hits] => 1
+                    [mtime] => 1123960686
+                    [creation_time] => 1123960696
+                    [deletion_time] => 0
+                    [access_time] => 1123962864
+                    [ref_count] => 1
+                    [mem_size] => 677
+                )
+            [1] => Array (...itère pour chaque fichier mis en cache)
+)
+]]>
+    </screen>
+   </example>
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><link linkend="apcu.configuration">Directives de configuration d'APCu</link></member>
+    <member><methodname>APCUIterator::getTotalSize</methodname></member>
+    <member><methodname>APCUIterator::getTotalHits</methodname></member>
+    <member><methodname>APCUIterator::getTotalCount</methodname></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/apcu/functions/apcu-cas.xml
+++ b/reference/apcu/functions/apcu-cas.xml
@@ -1,0 +1,131 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: e9366ee458b2900c53a503b1ad97664e1d9a8859 Maintainer: moradZahid Status:  -->
+<!-- Reviewed: no -->
+<refentry xml:id="function.apcu-cas" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>apcu_cas</refname>
+  <refpurpose>Remplace une ancienne valeur par une nouvelle</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>bool</type><methodname>apcu_cas</methodname>
+   <methodparam><type>string</type><parameter>key</parameter></methodparam>
+   <methodparam><type>int</type><parameter>old</parameter></methodparam>
+   <methodparam><type>int</type><parameter>new</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   <function>apcu_cas</function> remplace une valeur entière déjà existante, si la 
+   valeur du paramètre <parameter>old</parameter> correspond à celle actuellement
+   stockée, par la valeur du paramètre <parameter>new</parameter>.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>key</parameter></term>
+    <listitem>
+     <para>
+      La clé de la valeur à remplacer.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>old</parameter></term>
+    <listitem>
+     <para>
+      L'ancienne valeur (la valeur actuellement stockée).
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>new</parameter></term>
+    <listitem>
+     <para>
+      La nouvelle valeur.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &return.success;
+  </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Un exemple avec <function>apcu_cas</function></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+apcu_store('foobar', 2);
+echo '$foobar = 2', PHP_EOL;
+echo '$foobar == 1 ? 2 : 1 = ', (apcu_cas('foobar', 1, 2) ? 'ok' : 'fail'), PHP_EOL;
+echo '$foobar == 2 ? 1 : 2 = ', (apcu_cas('foobar', 2, 1) ? 'ok' : 'fail'), PHP_EOL;
+
+echo '$foobar = ', apcu_fetch('foobar'), PHP_EOL;
+
+echo '$f__bar == 1 ? 2 : 1 = ', (apcu_cas('f__bar', 1, 2) ? 'ok' : 'fail'), PHP_EOL;
+
+apcu_store('perfection', 'xyz');
+echo '$perfection == 2 ? 1 : 2 = ', (apcu_cas('perfection', 2, 1) ? 'ok' : 'epic fail'), PHP_EOL;
+
+echo '$foobar = ', apcu_fetch('foobar'), PHP_EOL;
+?>
+]]>
+   </programlisting>
+   &example.outputs.similar;
+   <screen>
+<![CDATA[
+$foobar = 2
+$foobar == 1 ? 2 : 1 = fail
+$foobar == 2 ? 1 : 2 = ok
+$foobar = 1
+$f__bar == 1 ? 2 : 1 = fail
+$perfection == 2 ? 1 : 2 = epic fail
+$foobar = 1
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>apcu_dec</function></member>
+   <member><function>apcu_store</function></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/apcu/functions/apcu-clear-cache.xml
+++ b/reference/apcu/functions/apcu-clear-cache.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: e9366ee458b2900c53a503b1ad97664e1d9a8859 Maintainer: moradZahid Status:  -->
+<!-- Reviewed: no -->
+<refentry xml:id="function.apcu-clear-cache" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>apcu_clear_cache</refname>
+  <refpurpose>
+   Efface le cache APCu
+  </refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>bool</type><methodname>apcu_clear_cache</methodname>
+   <void/>
+  </methodsynopsis>
+  <para>
+   Efface le cache.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Retourne toujours la valeur &true;.
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>apcu_cache_info</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/apcu/functions/apcu-dec.xml
+++ b/reference/apcu/functions/apcu-dec.xml
@@ -29,7 +29,7 @@
     <term><parameter>key</parameter></term>
     <listitem>
      <para>
-      La clé de la valeur qui doit être Décrémentée.
+      La clé de la valeur qui doit être décrémentée.
      </para>
     </listitem>
    </varlistentry>
@@ -37,7 +37,7 @@
     <term><parameter>step</parameter></term>
     <listitem>
      <para>
-      Le pas de Décrémentation ou la valeur à soustraire.
+      Le pas de décrémentation ou la valeur à soustraire.
      </para>
     </listitem>
    </varlistentry>

--- a/reference/apcu/functions/apcu-dec.xml
+++ b/reference/apcu/functions/apcu-dec.xml
@@ -1,0 +1,150 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 5fabd07880ab15b0ad2cf7eb055c7c2b36d7120f Maintainer: moradZahid Status:  -->
+<!-- Reviewed: no -->
+<refentry xml:id="function.apcu-dec" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>apcu_dec</refname>
+  <refpurpose>Diminue un nombre stocké</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type class="union"><type>int</type><type>false</type></type><methodname>apcu_dec</methodname>
+   <methodparam><type>string</type><parameter>key</parameter></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>step</parameter><initializer>1</initializer></methodparam>
+   <methodparam choice="opt"><type>bool</type><parameter role="reference">success</parameter></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>ttl</parameter><initializer>0</initializer></methodparam>
+  </methodsynopsis>
+  <para>
+   Diminue une valeur entière stockée.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>key</parameter></term>
+    <listitem>
+     <para>
+      La clé de la valeur qui doit être diminuée.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>step</parameter></term>
+    <listitem>
+     <para>
+      Le pas de diminution ou la valeur à soustraire.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>success</parameter></term>
+    <listitem>
+     <para>
+      Optionnel, passe la valeur booléenne succès ou échec à la variable
+      référencée.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>ttl</parameter></term>
+    <listitem>
+     <para>
+      Durée de vie à utiliser si la fonction insère une nouvelle variable (au lieu de décrémenter
+      une variable existante).
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Retourne la valeur courante associée à la clé <parameter>key</parameter> en cas de succès,
+   &return.falseforfailure;
+  </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Un exemple avec <function>apcu_dec</function></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+echo "Let's do something with success", PHP_EOL;
+
+apcu_store('anumber', 42);
+
+echo apcu_fetch('anumber'), PHP_EOL;
+
+echo apcu_dec('anumber'), PHP_EOL;
+echo apcu_dec('anumber', 10), PHP_EOL;
+echo apcu_dec('anumber', 10, $success), PHP_EOL;
+
+var_dump($success);
+
+echo "Now, let's fail", PHP_EOL, PHP_EOL;
+
+apcu_store('astring', 'foo');
+
+$ret = apcu_dec('astring', 1, $fail);
+
+var_dump($ret);
+var_dump($fail);
+?>
+]]>
+   </programlisting>
+   &example.outputs.similar;
+   <screen>
+<![CDATA[
+Let's do something with success
+42
+41
+31
+21
+bool(true)
+Now, let's fail
+
+bool(false)
+bool(false)
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>apcu_inc</function></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/apcu/functions/apcu-dec.xml
+++ b/reference/apcu/functions/apcu-dec.xml
@@ -5,7 +5,7 @@
 <refentry xml:id="function.apcu-dec" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>apcu_dec</refname>
-  <refpurpose>Diminue un nombre stocké</refpurpose>
+  <refpurpose>Décrémente un nombre stocké</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -18,7 +18,7 @@
    <methodparam choice="opt"><type>int</type><parameter>ttl</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
   <para>
-   Diminue une valeur entière stockée.
+   Décrémente une valeur entière stockée.
   </para>
  </refsect1>
 
@@ -29,7 +29,7 @@
     <term><parameter>key</parameter></term>
     <listitem>
      <para>
-      La clé de la valeur qui doit être diminuée.
+      La clé de la valeur qui doit être Décrémentée.
      </para>
     </listitem>
    </varlistentry>
@@ -37,7 +37,7 @@
     <term><parameter>step</parameter></term>
     <listitem>
      <para>
-      Le pas de diminution ou la valeur à soustraire.
+      Le pas de Décrémentation ou la valeur à soustraire.
      </para>
     </listitem>
    </varlistentry>

--- a/reference/apcu/functions/apcu-delete.xml
+++ b/reference/apcu/functions/apcu-delete.xml
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: fcc5d68305ec9f2e3534cc0c5b4d8e09f47649f9 Maintainer: moradZahid Status:  -->
+<!-- Reviewed: no -->
+<refentry xml:id="function.apcu-delete" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>apcu_delete</refname>
+  <refpurpose>
+   Retire une variable stockée du cache
+  </refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>mixed</type><methodname>apcu_delete</methodname>
+   <methodparam><type>mixed</type><parameter>key</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Retire une variable stockée du cache.
+  </para>
+ </refsect1>
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>key</parameter></term>
+     <listitem>
+      <para>
+       Le paramètre <parameter>key</parameter> peut être soit une 
+       <type>chaîne de caractères</type> pour une seule clé,
+       soit un <type>tableau</type> de chaîne de caractères pour plusieurs clés,
+       soit un <type>objet</type> de la classe <classname>APCUIterator</classname>.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Si le paramètre <parameter>key</parameter> est un &array;, alors la valeur
+   retournée est le &array; indexé des clés.
+   Sinon la valeur &true; est retournée en cas de succès, ou &false; en cas d'échec.
+  </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example>
+    <title>Un exemple avec <function>apcu_delete</function></title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+$bar = 'BAR';
+apcu_store('foo', $bar);
+apcu_delete('foo');
+// c'est clairement inutile sous cette forme
+
+// Autrement efface plusieurs clés.
+apcu_delete(['foo', 'bar', 'baz']);
+
+// Ou utilise un Itérateur avec une expression régulière.
+apcu_delete(new APCUIterator('#^myprefix_#'));
+?>
+]]>
+    </programlisting>
+   </example>
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>apcu_store</function></member>
+    <member><function>apcu_fetch</function></member>
+    <member><function>apcu_clear_cache</function></member>
+    <member><classname>APCUIterator</classname></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/apcu/functions/apcu-enabled.xml
+++ b/reference/apcu/functions/apcu-enabled.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 1e3eecef0dd80e18405a719560119cc1bcc55435 Maintainer: moradZahid Status:  -->
+<!-- Reviewed: no -->
+<refentry xml:id="function.apcu-enabled" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>apcu_enabled</refname>
+  <refpurpose>Vérifie si APCu est utilisable dans l'environnement courant</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="procedural">
+   <type>bool</type><methodname>apcu_enabled</methodname>
+   <void />
+  </methodsynopsis>
+  <para>
+   Vérifie si APCu est utilisable dans l'environnement courant.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Retourne la valeur &true; si APCu est utilisable dans l'environnement courant, ou &false; sinon.
+  </para>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/apcu/functions/apcu-entry.xml
+++ b/reference/apcu/functions/apcu-entry.xml
@@ -1,0 +1,181 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: e9366ee458b2900c53a503b1ad97664e1d9a8859 Maintainer: moradZahid Status:  -->
+<!-- Reviewed: no -->
+<refentry xml:id="function.apcu-entry" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>apcu_entry</refname>
+  <refpurpose>
+   Récupère atomiquement ou génère une entrée de cache
+  </refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>mixed</type><methodname>apcu_entry</methodname>
+   <methodparam><type>string</type><parameter>key</parameter></methodparam>
+   <methodparam><type>callable</type><parameter>generator</parameter></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>ttl</parameter><initializer>0</initializer></methodparam>
+  </methodsynopsis>
+  <para>
+   Tente de récupérer atomiquement la valeur indexée par la clé <parameter>key</parameter>
+   dans le cache. Si elle ne peut pas être récupérée, la fonction passée à
+   <parameter>generator</parameter> est appelée, avec pour unique argument la valeur 
+   contenue dans <parameter>key</parameter>.  La valeur de retour de l'appel est 
+   ensuite mise en cache avec le paramètre optionnel <parameter>ttl</parameter>, 
+   puis rend la main.
+  </para>
+  <note>
+   <simpara>
+    Lorsque le contrôle entre dans <function>apcu_entry</function> le verrou du cache est 
+    acquis de façon exclusive. Il est libéré lorsque le contrôle quitte 
+    <function>apcu_entry</function>: Plus précisément, le corps de la fonction passée à 
+    <parameter>generator</parameter> devient une section critique, ce qui interdit à 
+    deux processus d'exécuter la même partie du code concurrentiellement. En outre, il 
+    interdit l'exécution concurrentielle de tout autre fonction APCu, puisqu'elle acquerra
+    le même verrou.
+   </simpara>
+  </note>
+  <warning>
+   <simpara>
+     La seule fonction qui peut être appelée en toute sécurité par <parameter>generator</parameter> 
+     est <function>apcu_entry</function>.
+   </simpara>
+  </warning>
+ </refsect1>
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>key</parameter></term>
+     <listitem>
+      <para>
+       Clé d'une entrée de cache.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>generator</parameter></term>
+     <listitem>
+      <para>
+       Un paramètre de type callable qui prend <parameter>key</parameter> pour unique argument
+       et retourne la valeur à mettre en cache.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>ttl</parameter></term>
+     <listitem>
+      <para>
+       Durée de vie; stocke la variable <parameter>var</parameter> dans le cache pour
+       une durée de <parameter>ttl</parameter> secondes. Après l'expiration de
+       <parameter>ttl</parameter>, la variable stockée sera retirée du cache (à la 
+       prochaine requête). Si aucune valeur n'est passée au paramètre 
+       <parameter>ttl</parameter> (ou si la valeur de <parameter>ttl</parameter> est
+       <literal>0</literal>), la variable persistera jusqu'à qu'elle soit retirée
+       manuellement du cache, ou, sinon, elle échouera à sortir du cache (lors d'un 
+       effaçage, redémarrage, etc.).
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Retourne la valeur mise en cache.
+  </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example>
+    <title>Un exemple avec <function>apcu_entry</function></title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+$config = apcu_entry("config", function($key) {
+ return [
+   "fruit" => apcu_entry("config.fruit", function($key){
+     return [
+       "apples",
+       "pears"
+     ];
+   }), 
+   "people" => apcu_entry("config.people", function($key){
+     return [
+      "bob",
+      "joe",
+      "niki"
+     ];
+   })
+ ];
+});
+
+var_dump($config);
+?>
+]]>
+    </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+array(2) {
+  ["fruit"]=>
+  array(2) {
+    [0]=>
+    string(6) "apples"
+    [1]=>
+    string(5) "pears"
+  }
+  ["people"]=>
+  array(3) {
+    [0]=>
+    string(3) "bob"
+    [1]=>
+    string(3) "joe"
+    [2]=>
+    string(4) "niki"
+  }
+}
+]]>
+    </screen>
+   </example>
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>apcu_store</function></member>
+    <member><function>apcu_fetch</function></member>
+    <member><function>apcu_delete</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/apcu/functions/apcu-exists.xml
+++ b/reference/apcu/functions/apcu-exists.xml
@@ -1,0 +1,126 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: e9366ee458b2900c53a503b1ad97664e1d9a8859 Maintainer: moradZahid Status:  -->
+<!-- Reviewed: no -->
+<refentry xml:id="function.apcu-exists" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>apcu_exists</refname>
+  <refpurpose>Vérifie si une entrée existe</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>mixed</type><methodname>apcu_exists</methodname>
+   <methodparam><type>mixed</type><parameter>keys</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Vérifie si une ou plusieurs entrées APCu existent.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>keys</parameter></term>
+    <listitem>
+     <para>
+      Une <type>chaîne de caractères</type> ou un <type>tableau</type> de
+      chaînes de caractères qui contient les clés.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Retourne la valeur &true; si la clé existe, ou &false; sinon. 
+   Ou bien, si un <type>tableau</type> a été passé à <parameter>keys</parameter>,
+   alors la valeur retournée est un tableau contenant toutes les clés
+   existantes, ou un tableau vide si aucune n'existe.
+  </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Un exemple avec <function>apcu_exists</function></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$fruit  = 'apple';
+$veggie = 'carrot';
+
+apcu_store('foo', $fruit);
+apcu_store('bar', $veggie);
+
+if (apcu_exists('foo')) {
+    echo "Foo exists: ";
+    echo apcu_fetch('foo');
+} else {
+    echo "Foo does not exist";
+}
+
+echo PHP_EOL;
+if (apcu_exists('baz')) {
+    echo "Baz exists.";
+} else {
+    echo "Baz does not exist";
+}
+
+echo PHP_EOL;
+
+$ret = apcu_exists(array('foo', 'donotexist', 'bar'));
+var_dump($ret);
+
+?>
+]]>
+   </programlisting>
+   &example.outputs.similar;
+   <screen>
+<![CDATA[
+Foo exists: apple
+Baz does not exist
+array(2) {
+  ["foo"]=>
+  bool(true)
+  ["bar"]=>
+  bool(true)
+}
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>apcu_cache_info</function></member>
+   <member><function>apcu_fetch</function></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/apcu/functions/apcu-fetch.xml
+++ b/reference/apcu/functions/apcu-fetch.xml
@@ -1,0 +1,134 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: cbac1ecf71d754707d69bdc344c4031c157eaa54 Maintainer: moradZahid Status:  -->
+<!-- Reviewed: no -->
+<refentry xml:id="function.apcu-fetch" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>apcu_fetch</refname>
+  <refpurpose>
+   Récupère une variable stockée dans le cache
+  </refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>mixed</type><methodname>apcu_fetch</methodname>
+   <methodparam><type>mixed</type><parameter>key</parameter></methodparam>
+   <methodparam choice="opt"><type>bool</type><parameter role="reference">success</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Récupère une entrée du cache.
+  </para>
+ </refsect1>
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>key</parameter></term>
+     <listitem>
+      <para>
+       La clé <parameter>key</parameter> utilisée pour stocker la valeur 
+       (avec <function>apcu_store</function>). Si un tableau est passé 
+       alors chaque élément est récupéré et retourné.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>success</parameter></term>
+     <listitem>
+      <para>
+       Définie par la valeur &true; en cas de succès et &false; en cas d'échec.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   La variable ou le tableau de variables stocké en cas de succès;
+   &false; en cas d'échec.
+  </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>PECL apcu 3.0.17</entry>
+      <entry>
+       Le paramètre <parameter>success</parameter> a été ajouté.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example>
+    <title>Un exemple avec <function>apcu_fetch</function></title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+$bar = 'BAR';
+apcu_store('foo', $bar);
+var_dump(apcu_fetch('foo'));
+?>
+]]>
+    </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+string(3) "BAR"
+]]>
+    </screen>
+   </example>
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>apcu_store</function></member>
+    <member><function>apcu_delete</function></member>
+    <member><classname>APCUIterator</classname></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/apcu/functions/apcu-inc.xml
+++ b/reference/apcu/functions/apcu-inc.xml
@@ -5,7 +5,7 @@
 <refentry xml:id="function.apcu-inc" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>apcu_inc</refname>
-  <refpurpose>Augmente un nombre stocké</refpurpose>
+  <refpurpose>Incrémente un nombre stocké</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -18,7 +18,7 @@
    <methodparam choice="opt"><type>int</type><parameter>ttl</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
   <para>
-   Augmente un nombre stocké.
+   Incrémente un nombre stocké.
   </para>
  </refsect1>
 
@@ -29,7 +29,7 @@
     <term><parameter>key</parameter></term>
     <listitem>
      <para>
-      La clé de la valeur qui doit être augmentée.
+      La clé de la valeur qui doit être incrémentée.
      </para>
     </listitem>
    </varlistentry>
@@ -37,7 +37,7 @@
     <term><parameter>step</parameter></term>
     <listitem>
      <para>
-      Le pas d'augmentation ou la valeur à ajouter.
+      Le pas d'incrémentation ou la valeur à ajouter.
      </para>
     </listitem>
    </varlistentry>

--- a/reference/apcu/functions/apcu-inc.xml
+++ b/reference/apcu/functions/apcu-inc.xml
@@ -1,0 +1,149 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 5fabd07880ab15b0ad2cf7eb055c7c2b36d7120f Maintainer: moradZahid Status:  -->
+<!-- Reviewed: no -->
+<refentry xml:id="function.apcu-inc" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>apcu_inc</refname>
+  <refpurpose>Augmente un nombre stocké</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type class="union"><type>int</type><type>false</type></type><methodname>apcu_inc</methodname>
+   <methodparam><type>string</type><parameter>key</parameter></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>step</parameter><initializer>1</initializer></methodparam>
+   <methodparam choice="opt"><type>bool</type><parameter role="reference">success</parameter></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>ttl</parameter><initializer>0</initializer></methodparam>
+  </methodsynopsis>
+  <para>
+   Augmente un nombre stocké.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>key</parameter></term>
+    <listitem>
+     <para>
+      La clé de la valeur qui doit être augmentée.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>step</parameter></term>
+    <listitem>
+     <para>
+      Le pas d'augmentation ou la valeur à ajouter.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>success</parameter></term>
+    <listitem>
+     <para>
+      Optionnel, passe la valeur booléenne succès ou échec à la variable
+      référencée.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>ttl</parameter></term>
+    <listitem>
+     <para>
+      Durée de vie à utiliser si la fonction insère une nouvelle variable (au lieu d'incrémenter
+      une variable existante).
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Retourne la valeur courante associée à la clé <parameter>key</parameter> en cas de succès,
+   &return.falseforfailure;
+  </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Un exemple avec <function>apcu_inc</function></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+echo "Let's do something with success", PHP_EOL;
+
+apcu_store('anumber', 42);
+
+echo apcu_fetch('anumber'), PHP_EOL;
+
+echo apcu_inc('anumber'), PHP_EOL;
+echo apcu_inc('anumber', 10), PHP_EOL;
+echo apcu_inc('anumber', 10, $success), PHP_EOL;
+
+var_dump($success);
+
+echo "Now, let's fail", PHP_EOL, PHP_EOL;
+
+apcu_store('astring', 'foo');
+
+$ret = apcu_inc('astring', 1, $fail);
+
+var_dump($ret);
+var_dump($fail);
+?>
+]]>
+   </programlisting>
+   &example.outputs.similar;
+   <screen>
+<![CDATA[
+Let's do something with success
+42
+43
+53
+63
+bool(true)
+Now, let's fail
+
+bool(false)
+bool(false)
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>apcu_dec</function></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/apcu/functions/apcu-key-info.xml
+++ b/reference/apcu/functions/apcu-key-info.xml
@@ -1,0 +1,118 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 6c26ac2fef2d918868e3c6415b9ce2416a92b37f Maintainer: moradZahid Status:  -->
+<!-- Reviewed: no -->
+<refentry xml:id="function.apcu-key-info" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>apcu_key_info</refname>
+  <refpurpose>
+   Retourne des informations détaillées sur la clé de cache
+  </refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type class="union"><type>array</type><type>null</type></type><methodname>apcu_key_info</methodname>
+   <methodparam><type>string</type><parameter>key</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Retourne des informations détaillées sur la clé de cache.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>key</parameter></term>
+     <listitem>
+      <para>
+       Nom de la clé.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Un tableau contenant des informations détaillées sur la clé de cache, 
+   ou la valeur &null; si la clé n'existe pas.
+  </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example>
+    <title>Un exemple avec <function>apcu_key_info</function></title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+apcu_add('a','b');
+var_dump(apcu_key_info('a'));
+?>
+]]>
+    </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+array(7) {
+  ["hits"]=>
+  int(0)
+  ["access_time"]=>
+  int(1606701783)
+  ["mtime"]=>
+  int(1606701783)
+  ["creation_time"]=>
+  int(1606701783)
+  ["deletion_time"]=>
+  int(0)
+  ["ttl"]=>
+  int(0)
+  ["refs"]=>
+  int(0)
+}
+]]>
+    </screen>
+   </example>
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>apcu_store</function></member>
+    <member><function>apcu_fetch</function></member>
+    <member><function>apcu_delete</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/apcu/functions/apcu-sma-info.xml
+++ b/reference/apcu/functions/apcu-sma-info.xml
@@ -1,0 +1,122 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: ace6b151ca0bee0bb8c8f05073e361fe012c8454 Maintainer: moradZahid Status:  -->
+<!-- Reviewed: no -->
+<refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.apcu-sma-info">
+ <refnamediv>
+  <refname>apcu_sma_info</refname>
+  <refpurpose>
+   Retourne des informations sur l'Allocation de Mémoire Partagée d'APCu
+  </refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>array</type><methodname>apcu_sma_info</methodname>
+   <methodparam choice="opt"><type>bool</type><parameter>limited</parameter><initializer>&false;</initializer></methodparam>
+  </methodsynopsis>
+  <para>
+   Retourne des informations sur l'Allocation de Mémoire Partagée d'APCu.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>limited</parameter></term>
+     <listitem>
+      <para>
+       Lorsque la valeur &false; est passée (par défaut) à ce paramètre, la 
+       fonction <function>apcu_sma_info</function> retourne des informations 
+       détaillées sur chaque segment.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Un tableau de données sur l'Allocation de Mémoire Partagée;
+   &false; en cas d'échec.
+  </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example>
+    <title>Un exemple avec <function>apcu_sma_info</function></title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+print_r(apcu_sma_info());
+?>
+]]>
+    </programlisting>
+    &example.outputs.similar;
+    <screen>
+<![CDATA[
+Array
+(
+    [num_seg] => 1
+    [seg_size] => 31457280
+    [avail_mem] => 31448408
+    [block_lists] => Array
+        (
+            [0] => Array
+                (
+                    [0] => Array
+                        (
+                            [size] => 31448408
+                            [offset] => 8864
+                        )
+
+                )
+
+        )
+
+)
+]]>
+    </screen>
+   </example>
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member>
+     <link linkend="apcu.configuration">Directives de configuration d'APCu</link>
+    </member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/apcu/functions/apcu-store.xml
+++ b/reference/apcu/functions/apcu-store.xml
@@ -1,0 +1,150 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: e9366ee458b2900c53a503b1ad97664e1d9a8859 Maintainer: moradZahid Status:  -->
+<!-- Reviewed: no -->
+<refentry xml:id="function.apcu-store" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>apcu_store</refname>
+  <refpurpose>
+   Met en cache une variable dans le dépôt de données
+  </refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>bool</type><methodname>apcu_store</methodname>
+   <methodparam><type>string</type><parameter>key</parameter></methodparam>
+   <methodparam><type>mixed</type><parameter>var</parameter></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>ttl</parameter><initializer>0</initializer></methodparam>
+  </methodsynopsis>
+  <methodsynopsis>
+   <type>array</type><methodname>apcu_store</methodname>
+   <methodparam><type>array</type><parameter>values</parameter></methodparam>
+   <methodparam choice="opt"><type>mixed</type><parameter>unused</parameter><initializer>NULL</initializer></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>ttl</parameter><initializer>0</initializer></methodparam>
+  </methodsynopsis>
+  <para>
+   Met en cache une variable dans le dépôt de données.
+  </para>
+  <note>
+   <simpara>
+    Contrairement à de nombreux autres mécanismes dans PHP, les variables stockées
+    utilisant <function>apcu_store</function> persisteront entre les requêtes (jusqu'à ce
+    que leurs valeurs soient retirées du cache).
+   </simpara>
+  </note>
+ </refsect1>
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>key</parameter></term>
+     <listitem>
+      <para>
+       Stocke la variable en utilisant ce nom de clé. Chaque clé est unique dans le cache,
+       stocker une seconde valeur avec le même paramètre <parameter>key</parameter> 
+       va réécrire sur la valeur originale.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>var</parameter></term>
+     <listitem>
+      <para>
+       La variable à stocker.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>ttl</parameter></term>
+     <listitem>
+      <para>
+       Durée de vie; stocke la variable <parameter>var</parameter> dans le cache pour
+       une durée de <parameter>ttl</parameter> secondes. Après l'expiration de
+       <parameter>ttl</parameter>, la variable stockée sera retirée du cache (à la 
+       prochaine requête). Si aucune valeur n'est passée au paramètre 
+       <parameter>ttl</parameter> (ou si la valeur de <parameter>ttl</parameter> est
+       <literal>0</literal>), la variable persistera jusqu'à qu'elle soit retirée
+       manuellement du cache, ou, sinon, elle échouera à sortir du cache (lors d'un 
+       effaçage, redémarrage, etc.).
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>values</parameter></term>
+     <listitem>
+      <para>
+       Les noms sont fournis par les clés du tableau <parameter>values</parameter>,
+       les variables par les valeurs.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &return.success;
+   La seconde syntaxe retourne un tableau avec les clés erronées.
+  </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example>
+    <title>Un exemple avec <function>apcu_store</function></title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+$bar = 'BAR';
+apcu_store('foo', $bar);
+var_dump(apcu_fetch('foo'));
+?>
+]]>
+    </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+string(3) "BAR"
+]]>
+    </screen>
+   </example>
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>apcu_add</function></member>
+    <member><function>apcu_fetch</function></member>
+    <member><function>apcu_delete</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/apcu/ini.xml
+++ b/reference/apcu/ini.xml
@@ -1,0 +1,390 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 2b5c6c13ce31e8da096cca92b92e11fd4087973b Maintainer: moradZahid Status:  -->
+<!-- Reviewed: no -->
+<section xml:id="apcu.configuration" xmlns="http://docbook.org/ns/docbook">
+ &reftitle.runtime;
+ &extension.runtime;
+ <para>
+  Bien que les réglages par défaut d'APCu fonctionnent correctement sur de nombreuses 
+  installations, il est utile de penser à ajuster ces paramètres de configuration.
+ </para>
+ <para>
+  Une question importante pour la configuration d'APCu est   
+  quelle est la taille adéquate qui doit être allouée dans la mémoire à APCu.
+  La directive ini qui contrôle ce paramètre est <literal>apc.shm_size</literal>.
+  Le paragraphe ci-dessous est important pour répondre à cette question.
+ </para>
+ <para>
+  Une fois le serveur lancé, le script <literal>apc.php</literal>, disponible avec 
+  l'extension, peut être copié dans le document root et exécuté par le 
+  navigateur. Ce script fournit une analyse détaillée du fonctionnement interne
+  de APCu. Si la bibliothèque GD est activée dans PHP alors le script peut afficher
+  des graphiques pertinents. Par exemple, si APCu est en fonctionnement, le nombre
+  <literal>Cache full count</literal> (sur la gauche) indique le nombre de fois que  
+  le cache a atteint sa capacité maximale et a été obligé de supprimer toute entrée
+  qui n'a pas été appelée dans les dernières <literal>apc.ttl</literal> secondes. 
+  Ce nombre doit être le plus petit possible pour une configuration optimale.
+  Si le cache est constamment rempli, il sera obligé de libérer de l'espace ce qui 
+  aura pour conséquence de diminuer ses performances.  
+  La méthode la plus simple pour minimiser ce nombre est d'allouer plus de mémoire à
+  APCu.
+ </para>
+ <para>
+  Lorsque APCu est compilé avec mmap (Memory Mapping), il n'utilisera qu'un seul
+  segment de mémoire, contrairement au cas où APCu est construit avec
+  SHM (SysV Shared Memory) qui utilise plusieurs segments de mémoire. MMAP n'a 
+  pas de limite maximale comme SHM dans <literal>/proc/sys/kernel/shmmax</literal>.
+  En général, l'utilisation de MMAP est recommandée car il réclame la mémoire 
+  plus vite lorsque le serveur web est redémarré et réduit l'impact sur 
+  l'allocation de mémoire au démarrage.
+ </para>
+ <para>
+  <table>
+   <title>Options de configuration d'APCu</title>
+   <tgroup cols="4">
+    <thead>
+     <row>
+      <entry>&Name;</entry>
+      <entry>&Default;</entry>
+      <entry>&Changeable;</entry>
+      <entry>&Changelog;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry><link linkend="ini.apcu.enabled">apc.enabled</link></entry>
+      <entry>"1"</entry>
+      <entry>PHP_INI_SYSTEM</entry>
+      <entry></entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.apcu.shm-segments">apc.shm_segments</link></entry>
+      <entry>"1"</entry>
+      <entry>PHP_INI_SYSTEM</entry>
+      <entry></entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.apcu.shm-size">apc.shm_size</link></entry>
+      <entry>"32M"</entry>
+      <entry>PHP_INI_SYSTEM</entry>
+      <entry></entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.apcu.entries-hint">apc.entries_hint</link></entry>
+      <entry>"4096"</entry>
+      <entry>PHP_INI_SYSTEM</entry>
+      <entry></entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.apcu.ttl">apc.ttl</link></entry>
+      <entry>"0"</entry>
+      <entry>PHP_INI_SYSTEM</entry>
+      <entry></entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.apcu.gc-ttl">apc.gc_ttl</link></entry>
+      <entry>"3600"</entry>
+      <entry>PHP_INI_SYSTEM</entry>
+      <entry></entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.apcu.mmap-file-mask">apc.mmap_file_mask</link></entry>
+      <entry>NULL</entry>
+      <entry>PHP_INI_SYSTEM</entry>
+      <entry></entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.apcu.slam-defense">apc.slam_defense</link></entry>
+      <entry>"1"</entry>
+      <entry>PHP_INI_SYSTEM</entry>
+      <entry></entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.apcu.enable-cli">apc.enable_cli</link></entry>
+      <entry>"0"</entry>
+      <entry>PHP_INI_SYSTEM</entry>
+      <entry></entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.apcu.use-request-time">apc.use_request_time</link></entry>
+      <entry>"0"</entry>
+      <entry>PHP_INI_ALL</entry>
+      <entry>Antérieurement à APCu 5.1.19, la valeur par défaut était "1".</entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.apcu.serializer">apc.serializer</link></entry>
+      <entry>"php"</entry>
+      <entry>PHP_INI_SYSTEM</entry>
+      <entry>Antérieurement à APCu 5.1.15, la valeur par défaut était "default".</entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.apcu.coredump-unmap">apc.coredump_unmap</link></entry>
+      <entry>"0"</entry>
+      <entry>PHP_INI_SYSTEM</entry>
+      <entry></entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.apcu.preload-path">apc.preload_path</link></entry>
+      <entry>NULL</entry>
+      <entry>PHP_INI_SYSTEM</entry>
+      <entry></entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </table>
+  &ini.php.constants;
+ </para>
+ 
+ &ini.descriptions.title;
+ 
+ <para>
+  <variablelist>
+   <varlistentry xml:id="ini.apcu.enabled">
+    <term>
+     <parameter>apc.enabled</parameter>
+     <type>bool</type>
+    </term>
+    <listitem>
+     <para>
+      <literal>apc.enabled</literal> peut être mis à 0 pour désactiver APC. 
+      Cela peut s'avérer utile lorsqu'APC est compilé statiquement dans PHP 
+      puisqu'il n'y a pas d'autre moyen de le désactiver (lorsque APC est 
+      compilé en tant que DSO, la ligne <literal>extension</literal>
+      dans le fichier <literal>php.ini</literal> peut simplement être mise en 
+      commentaire).
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="ini.apcu.shm-segments">
+    <term>
+     <parameter>apc.shm_segments</parameter>
+     <type>int</type>
+    </term>
+    <listitem>
+     <para>
+      Le nombre de segments de mémoire partagée à allouer au cache de compilation
+      Si APC manque de mémoire partagée mais que <literal>apc.shm_size</literal> 
+      est mis à la valeur maximale autorisée par le système, alors augmenter 
+      cette valeur peut empêcher APC d'épuiser sa mémoire.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="ini.apcu.shm-size">
+    <term>
+     <parameter>apc.shm_size</parameter>
+     <type>string</type>
+    </term>
+    <listitem>
+     <para>
+      La taille de chaque segment de mémoire partagée donnée en notation abrégée
+      comme indiquée dans cette <link linkend="faq.using.shorthandbytes">FAQ</link>.
+      Par défaut, certains systèmes (dont la plus part des variants de BSD)
+      ont une limite très basse pour la taille d'un segment de mémoire partagée.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="ini.apcu.entries-hint">
+    <term>
+     <parameter>apc.entries_hint</parameter>
+     <type>int</type>
+    </term>
+    <listitem>
+     <para>
+      Un "indice" sur le nombre de variables distinctes qui peuvent être stockées.
+      Mettre à zéro ou dans le doute omettre.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="ini.apcu.ttl">
+    <term>
+     <parameter>apc.ttl</parameter>
+     <type>int</type>
+    </term>
+    <listitem>
+     <para>
+      La durée en seconde qu'une entrée de cache est autorisée à
+      rester inactive dans son emplacement, au cas où cet emplacement
+      est réclamée par une autre entrée. Laisser à zéro cette valeur 
+      signifie que potentiellement, le cache d'APC pourrait être
+      rempli par des entrées jamais appelées alors que de nouvelles
+      entrées ne seront pas mises en cache. Lorsqu'un événement signalant le manque 
+      de mémoire disponible se produit, le cache sera complètement effacé si 
+      <literal>apc.ttl</literal> est égal à 0. Sinon, lorsque 
+      <literal>apc.ttl</literal> est strictement supérieur à 0, APC tentera 
+      de retirer les entrées dont la durée de vie a expiré.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="ini.apcu.gc-ttl">
+    <term>
+     <parameter>apc.gc_ttl</parameter>
+     <type>int</type>
+    </term>
+    <listitem>
+     <para>
+      La durée en seconde qu'une entrée de cache peut rester dans la liste du 
+      ramasse-miettes. Cette valeur fournit une sûreté intégrée dans le cas
+      où un processus s'arrête pendant qu'il exécute le code d'un fichier
+      source mis en cache; si ce fichier est modifié, la mémoire allouée pour
+      l'ancienne version ne sera pas réclamée tant que la durée de vie n'est 
+      pas atteinte. Mettre à zéro pour désactiver cette fonctionnalité.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="ini.apcu.mmap-file-mask">
+    <term>
+     <parameter>apc.mmap_file_mask</parameter>
+     <type>string</type>
+    </term>
+    <listitem>
+     <para>
+      Si APCu a été compilé avec l'option MMAP en utilisant 
+      <literal>--enable-mmap</literal>, ce paramètre reçoit le masque de 
+      fichier de type mktemp-style à passer au module mmap pour déterminer
+      si la région de la mémoire utilisant mmap sera sauvegardée par le biais 
+      d'un fichier ou par celui de la mémoire partagée.
+      Dans le cas où la sauvegarde se fait par le biais d'un fichier,
+      le masque sera de la forme <literal>/tmp/apc.XXXXXX</literal>
+      (avec exactement 6 <literal>X</literal>).
+      Pour utiliser shm_open/mmap de la norme POSIX, le masque doit contenir 
+      <literal>.shm</literal>, comme dans l'exemple suivant:  
+      <literal>/apc.shm.XXXXXX</literal>. Ce paramètre peut être défini par
+      <literal>/dev/zero</literal> pour utiliser l'interface 
+      <literal>/dev/zero</literal> du noyau avec une mémoire utilisant mmap
+      anonymement. Laisser ce paramètre indéfini forcera un mmap anonyme.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="ini.apcu.slam-defense">
+    <term>
+     <parameter>apc.slam_defense</parameter>
+     <type>int</type>
+    </term>
+    <listitem>
+     <para>
+      Au démarrage ou lors de la modification d'un fichier dans un serveur
+      très occupé, plusieurs processus peuvent entrer en compétition
+      pour mettre en cache un même fichier en même temps. Cette option 
+      permet de définir la proportion des processus qui ne tenteront pas 
+      de mettre en cache le même fichier au même instant, exprimée en 
+      pourcentage. Autrement dit, elle définit la probabilité qu'un
+      seul processus n'essaie pas d'accéder au cache. Par exemple
+      définir <literal>apc.slam_defense</literal>
+      à <literal>75</literal> signifie qu'il y a 75% de chance pour
+      qu'un processus ne mette pas en cache un fichier non présent dans le 
+      cache. Donc plus cette valeur est haute et plus la protection 
+      contre le cache slam est importante. Mettre cette valeur à
+      <literal>0</literal> désactive cette option.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="ini.apcu.enable-cli">
+    <term>
+     <parameter>apc.enable_cli</parameter>
+     <type>int</type>
+    </term>
+    <listitem>
+     <para>
+      Principalement utilisé pour les tests et le débogage. Définir ce 
+      paramètre permet d'activer APC dans la version CLI de PHP.
+      En temps normal, il n'est pas idéal de créer, alimenter et 
+      détruire le cache APC à chaque requête CLI. Cependant, dans de
+      nombreux scénarios de test il est utile de pouvoir activer
+      facilement APC dans la version CLI de PHP.
+     </para>
+    </listitem>
+   </varlistentry> 
+   <varlistentry xml:id="ini.apcu.serializer">
+    <term>
+     <parameter>apc.serializer</parameter>
+     <type>string</type>
+    </term>
+    <listitem>
+     <para>
+      Ce paramètre permet à APC d'utiliser un linéariseur tiers
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="ini.apcu.coredump-unmap">
+    <term>
+     <parameter>apc.coredump_unmap</parameter>
+     <type>bool</type>
+    </term>
+    <listitem>
+     <para>
+      Active la gestion par APC de signaux, tels que SIGSEGV, qui provoquent
+      l'écriture de fichiers core dump lorsqu'ils sont reçus. Quand ces
+      signaux sont reçus, APC essaiera de désallouer le segment de mémoire
+      partagée réservé à mmap dans le but de l'exclure du fichier core
+      dump. Cette option peut améliorer la stabilité du système lorsque
+      des signaux fatals sont reçus et qu'APC est configuré avec un long
+      segment de mémoire partagée.
+     </para>
+     <warning>
+      <para>
+       Cette option est potentiellement dangereuse. Désallouer un segment de
+       mémoire partagée utilisé par mmap dans le gestionnaire de signaux 
+       fatals peut causer un comportement imprévisible si une erreur fatale
+       survient.
+      </para>
+     </warning>
+     <note>
+      <para>
+       Bien que certains noyaux peuvent fournir la possibilité d'ignorer
+       de nombreux types de mémoire partagée lorsqu'ils génèrent un fichier
+       core dump, ces implémentations peuvent aussi ignorer d'importants 
+       segments de mémoire partagée tels que le tableau de bord d'Apache.
+      </para>
+     </note>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="ini.apcu.preload-path">
+    <term>
+     <parameter>apc.preload_path</parameter>
+     <type>string</type>
+    </term>
+    <listitem>
+     <para>
+      Optionnel, définit un chemin vers le répertoire où APC chargera
+      les données du cache au démarrage.
+     </para>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry xml:id="ini.apcu.use-request-time">
+    <term>
+     <parameter>apc.use_request_time</parameter>
+     <type>bool</type>
+    </term>
+    <listitem>
+     <para>
+      Utilise la requête start time de l'interface <acronym>SAPI</acronym> 
+      pour la durée de vie (<acronym>TTL</acronym>).
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </para>
+</section>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/apcu/setup.xml
+++ b/reference/apcu/setup.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: d6eb5fda8a3c0a755b4d15cb617a09bb81d5882e Maintainer: moradZahid Status:  -->
+<!-- Reviewed: no -->
+<chapter xml:id="apcu.setup" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ &reftitle.setup;
+
+ <section xml:id="apcu.requirements">
+  &reftitle.required;
+  &no.requirement;
+ </section>
+
+ <section xml:id="apcu.installation">
+  &reftitle.install;
+  <para>
+   &pecl.info;
+   <link xlink:href="&url.pecl.package;apcu">&url.pecl.package;apcu</link>.
+  </para>
+  <tip>
+   <simpara>
+    PHP 7 a un module séparé (<link xlink:href="&url.apc.bc;">apcu-bc</link>) pour des raisons de 
+    rétrocompatibilité avec APC.
+   </simpara>
+   <para>
+    En mode rétrocompatibilité, APCu enregistre les fonctions APC applicables avec des
+    prototypes rétrocompatibles.
+   </para>
+   <para>
+    Lorsqu'une fonction APC accepte le paramètre <parameter>cache_type</parameter>, ce dernier est
+    ignoré par la version rétrocompatible de la fonction et omis du prototype de la version APCu.
+   </para>
+  </tip>
+  <warning>
+   <simpara>
+    A partir de PHP 8.0.0, apcu-bc n'est plus accepté.
+   </simpara>
+  </warning>
+  <note>
+   <simpara>
+    Avec Windows, APCu a besoin d'un chemin temporaire dans lequel le serveur web est autorisé à 
+    écrire. Il vérifie successivement les variables d'environnement TMP, TEMP et USERPROFILE dans 
+    cet ordre et termine en essayant le répertoire WINDOWS si aucune de ces variables n'a été 
+    définie.
+   </simpara>
+  </note>
+  <note>
+   <simpara>
+    Pour plus de détails techniques approfondis sur l'implémentation, confère le
+    <link xlink:href="&url.apc.technotes;">
+     fichier TECHNOTES fourni par les développeurs 
+    </link>.
+   </simpara>
+  </note>
+  <para>
+   Les sources d'APCu sont disponibles <link xlink:href="&url.git.hub;krakjoe/apcu">ici</link>.
+  </para>
+ </section>
+
+ &reference.apcu.ini;
+
+ <section xml:id="apcu.resources">
+  &reftitle.resources;
+  &no.resource;
+ </section>
+
+</chapter>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->
+


### PR DESCRIPTION
Translate apcuiterator.xml, book.xml, ini.xml and setup.xml in reference/apcu.
Translate all the files in reference/apcu/apcuiterators and reference/apcu/functions

The titles of the two first commits are not correct
The first one should be "Translate apcu/apcuiterator.xml"
The second one should be "Translate apcu/book.xml"
