### PR TITLE
Correction of example 2, terrible crypto error

### DIFF
--- a/reference/openssl/functions/openssl-encrypt.xml
+++ b/reference/openssl/functions/openssl-encrypt.xml
@@ -181,7 +181,7 @@ $plaintext = "message to be encrypted";
 $ivlen = openssl_cipher_iv_length($cipher="AES-128-CBC");
 $iv = openssl_random_pseudo_bytes($ivlen);
 $ciphertext_raw = openssl_encrypt($plaintext, $cipher, $key, $options=OPENSSL_RAW_DATA, $iv);
-$hmac = hash_hmac('sha256', $ciphertext_raw, $key, $as_binary=true);
+$hmac = hash_hmac('sha256', $iv.$ciphertext_raw, $key, $as_binary=true);
 $ciphertext = base64_encode( $iv.$hmac.$ciphertext_raw );
 
 // déchiffrer plus tard ...
@@ -191,7 +191,7 @@ $iv = substr($c, 0, $ivlen);
 $hmac = substr($c, $ivlen, $sha2len=32);
 $ciphertext_raw = substr($c, $ivlen+$sha2len);
 $original_plaintext = openssl_decrypt($ciphertext_raw, $cipher, $key, $options=OPENSSL_RAW_DATA, $iv);
-$calcmac = hash_hmac('sha256', $ciphertext_raw, $key, $as_binary=true);
+$calcmac = hash_hmac('sha256', $iv.$ciphertext_raw, $key, $as_binary=true);
 if (hash_equals($hmac, $calcmac))// timing attack safe comparison
 {
     echo $original_plaintext."\n";


### PR DESCRIPTION
L'IV doit absolument être dans le calcul du MAC !
C'est une erreur classique.
Sans ça, il est possible de modifier l'IV et donc le premier bloc sans que la modification ne soit repérée. L'intégrité n'est donc plus assurée. Tout XOR fait sur l'IV sera reporté directement sur les données claires.
Ceci est une vulnérabilité dans l'exemple.