### PR TITLE
Fix typos in French translation of security.xml

### DIFF
--- a/reference/session/security.xml
+++ b/reference/session/security.xml
@@ -832,9 +832,9 @@
     </para>
     <para>
      (PHP 7.1.0 &lt;) Une fonction de hachage forte va générer un identifiant
-     de session fort. Bien qu'une colision de hachage soit peu probable avec des
+     de session fort. Bien qu'une collision de hachage soit peu probable avec des
      algorithme de hachage MD5, les développeurs doivent utiliser SHA-2 ou un
-     algorithme de hachage plus fort comme sha384 etha512.
+     algorithme de hachage plus fort comme sha384 et sha512.
      Les développeurs doivent s'assurer d'une longueur suffisante de 
      l'<link linkend="ini.session.entropy-length">entropie</link> pour la 
      fonction de hachage utilisée.


### PR DESCRIPTION
I might have found what seems to be typos in French php-doc of session security.xml file. 
Trying to help the php community as much as I can.
Have a great day php core team and all of you awesome php contributors.