### PR TITLE
typo "default;" => "default:"

### DIFF
--- a/language/control-structures/switch.xml
+++ b/language/control-structures/switch.xml
@@ -291,7 +291,7 @@ switch($beer)
     case 'guinness';
         echo 'Bon choix';
         break;
-    default;
+    default:
         echo 'Merci de faire un choix...';
         break;
 }


### PR DESCRIPTION
Pas grand chose, mais peut être piégeant en cas de C/C