### PR TITLE
Apply php/doc-en@bc0556b

### DIFF
--- a/reference/mysqli/functions/mysqli-execute.xml
+++ b/reference/mysqli/functions/mysqli-execute.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: dd09ee01d80dff959114e4d5890861af40dd93b4 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: bc0556b65588379cb86511d5a0ff8ab4684e1d33 Maintainer: yannick Status: ready -->
 <!-- Reviewed: yes -->
 
 <refentry xml:id="function.mysqli-execute" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>mysqli_execute</refname>
-  <refpurpose>Alias de <function>mysqli_stmt_execute</function></refpurpose>
+  <refpurpose>&Alias; <function>mysqli_stmt_execute</function></refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/solr/solrdocument/reset.xml
+++ b/reference/solr/solrdocument/reset.xml
@@ -1,12 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 734ddd27ada5fdc8fbd2724e4c9e08881649dec1 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: bc0556b65588379cb86511d5a0ff8ab4684e1d33 Maintainer: yannick Status: ready -->
 <!-- Reviewed: no -->
-
 <refentry xml:id="solrdocument.reset" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>SolrDocument::reset</refname>
-  <refpurpose>Alias de SolrDocument::clear()</refpurpose>
+  <refpurpose>&Alias; <methodname>SolrDocument::clear</methodname></refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/solr/solrinputdocument/reset.xml
+++ b/reference/solr/solrinputdocument/reset.xml
@@ -1,12 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 734ddd27ada5fdc8fbd2724e4c9e08881649dec1 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: bc0556b65588379cb86511d5a0ff8ab4684e1d33 Maintainer: yannick Status: ready -->
 <!-- Reviewed: no -->
-
 <refentry xml:id="solrinputdocument.reset" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>SolrInputDocument::reset</refname>
-  <refpurpose>Alias de SolrInputDocument::clear</refpurpose>
+  <refpurpose>&Alias; <methodname>SolrInputDocument::clear</methodname></refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/solr/solrparams/add.xml
+++ b/reference/solr/solrparams/add.xml
@@ -1,12 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 734ddd27ada5fdc8fbd2724e4c9e08881649dec1 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: bc0556b65588379cb86511d5a0ff8ab4684e1d33 Maintainer: yannick Status: ready -->
 <!-- Reviewed: no -->
-
 <refentry xml:id="solrparams.add" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>SolrParams::add</refname>
-  <refpurpose>Alias de SolrParams::addParam</refpurpose>
+  <refpurpose>&Alias; <methodname>SolrParams::addParam</methodname></refpurpose>
  </refnamediv>
  
  <refsect1 role="description">

--- a/reference/solr/solrparams/get.xml
+++ b/reference/solr/solrparams/get.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 734ddd27ada5fdc8fbd2724e4c9e08881649dec1 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: bc0556b65588379cb86511d5a0ff8ab4684e1d33 Maintainer: yannick Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="solrparams.get" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>SolrParams::get</refname>
-  <refpurpose>Alias de SolrParams::getParam</refpurpose>
+  <refpurpose>&Alias; <methodname>SolrParams::getParam</methodname></refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/solr/solrparams/set.xml
+++ b/reference/solr/solrparams/set.xml
@@ -1,12 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 734ddd27ada5fdc8fbd2724e4c9e08881649dec1  Maintainer: yannick Status: ready -->
+<!-- EN-Revision: bc0556b65588379cb86511d5a0ff8ab4684e1d33  Maintainer: yannick Status: ready -->
 <!-- Reviewed: no -->
-
 <refentry xml:id="solrparams.set" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>SolrParams::set</refname>
-  <refpurpose>Alias de SolrParams::setParam</refpurpose>
+  <refpurpose>&Alias; <methodname>SolrParams::setParam</methodname></refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/xdiff/functions/xdiff-file-diff-binary.xml
+++ b/reference/xdiff/functions/xdiff-file-diff-binary.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14af302c9c0e561fa6f9cdd956268758ba9a89c5 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: bc0556b65588379cb86511d5a0ff8ab4684e1d33 Maintainer: yannick Status: ready -->
 <!-- Reviewed: yes -->
 
 <refentry xml:id="function.xdiff-file-diff-binary" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>xdiff_file_diff_binary</refname>
-  <refpurpose>Créé un diff binaire de deux fichier</refpurpose>
+  <refpurpose>&Alias; <function>xdiff_file_bdiff</function></refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/xdiff/functions/xdiff-file-patch-binary.xml
+++ b/reference/xdiff/functions/xdiff-file-patch-binary.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14af302c9c0e561fa6f9cdd956268758ba9a89c5 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: bc0556b65588379cb86511d5a0ff8ab4684e1d33 Maintainer: yannick Status: ready -->
 <!-- Reviewed: yes -->
 
 <refentry xml:id="function.xdiff-file-patch-binary" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>xdiff_file_patch_binary</refname>
-  <refpurpose>Alias de xdiff_file_bpatch</refpurpose>
+  <refpurpose>&Alias; <function>xdiff_file_bpatch</function></refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/xdiff/functions/xdiff-string-diff-binary.xml
+++ b/reference/xdiff/functions/xdiff-string-diff-binary.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 4754397753fd79f1c846868b66a2448babab1c54 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: bc0556b65588379cb86511d5a0ff8ab4684e1d33 Maintainer: yannick Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="function.xdiff-string-diff-binary" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>xdiff_string_diff_binary</refname>
-  <refpurpose>Alias de xdiff_string_bdiff</refpurpose>
+  <refpurpose>&Alias; <function>xdiff_string_bdiff</function></refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/xdiff/functions/xdiff-string-patch-binary.xml
+++ b/reference/xdiff/functions/xdiff-string-patch-binary.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: e41806c30bf6975e452c0d4ce35ab0984c2fa68c Maintainer: yannick Status: ready -->
+<!-- EN-Revision: bc0556b65588379cb86511d5a0ff8ab4684e1d33 Maintainer: yannick Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="function.xdiff-string-patch-binary" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>xdiff_string_patch_binary</refname>
-  <refpurpose>Alias de xdiff_string_bpatch</refpurpose>
+  <refpurpose>&Alias; <function>xdiff_string_bpatch</function></refpurpose>
  </refnamediv>
 
  <refsect1 role="description">


### PR DESCRIPTION
Minor changes, but I'm not sure about `reference/xdiff/functions/xdiff-file-diff-binary.xml`:

there was not `Alias de xdiff_file_bdiff` as expected, 
otherwise, the file seems to be up-to-date ([French](https://github.com/php/doc-fr/blob/master/reference/xdiff/functions/xdiff-file-diff-binary.xml) and [English](https://github.com/php/doc-en/blob/master/reference/xdiff/functions/xdiff-file-diff-binary.xml)) 🤔 