### PR TITLE
Corrected spelling mistake in french

### DIFF
--- a/language/types/type-juggling.xml
+++ b/language/types/type-juggling.xml
@@ -40,7 +40,7 @@
 
  <note>
   <simpara>
-   Quand une valeur à besoin d'être interpréter comme un type différent,
+   Quand une valeur a besoin d'être interprétée comme un type différent,
    la valeur elle-même <emphasis>ne change pas</emphasis> de type.
   </simpara>
  </note>


### PR DESCRIPTION
"à" -> "a"
"interpréter" -> "interprétée"