### PR TITLE
Fix. conjugaison in error description

### DIFF
--- a/reference/json/constants.xml
+++ b/reference/json/constants.xml
@@ -366,7 +366,7 @@
    <listitem>
     <simpara>
      Émet une <classname>JsonException</classname> si une erreur se produit
-     au lieu de régler l'état d'erreur globale qui est récupérer grâce à
+     au lieu de régler l'état d'erreur globale qui est récupéré grâce à
      <function>json_last_error</function> et <function>json_last_error_msg</function>.
      <constant>JSON_PARTIAL_OUTPUT_ON_ERROR</constant> prend la priorité par rapport à
      <constant>JSON_THROW_ON_ERROR</constant>.


### PR DESCRIPTION
Infinitive tense is used instead of conjugating the word `récupérer`.