### PR TITLE
Sync various section 

### DIFF
--- a/appendices/reserved.xml
+++ b/appendices/reserved.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 0780c1316035cca19a0267e58a03c8ed3701da76 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 360928c5efa8ebd586168d2660fc48d7fc6c9ba2 Maintainer: victor-prdh Status: ready -->
 <!-- Reviewed: no -->
 <appendix xml:id="reserved" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Mots réservés en PHP</title>
@@ -358,8 +358,9 @@
      <term><classname>stdClass</classname></term>
      <listitem>
       <simpara>
-       Créé par <link linkend="language.types.object.casting">la conversion
-       en objet</link>.
+       Une classe vide générique créée à la suite du 
+       <link linkend="language.types.object.casting">transtypage
+       en objet</link> ou diverses fonctions standard.
       </simpara>
      </listitem>
     </varlistentry>

--- a/appendices/reserved.xml
+++ b/appendices/reserved.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 360928c5efa8ebd586168d2660fc48d7fc6c9ba2 Maintainer: victor-prdh Status: ready -->
+<!-- EN-Revision: 360928c5efa8ebd586168d2660fc48d7fc6c9ba2 Maintainer: yannick Status: ready -->
 <!-- Reviewed: no -->
 <appendix xml:id="reserved" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Mots réservés en PHP</title>

--- a/language/predefined/interfaces.xml
+++ b/language/predefined/interfaces.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 2c974ae7c41fefb4733acbe665ca66e568cbba59 Maintainer: girgias Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 360928c5efa8ebd586168d2660fc48d7fc6c9ba2 Maintainer: victor-prdh Status: ready -->
+<!-- Reviewed: no -->
 
 <part xml:id="reserved.interfaces" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Interfaces et Classes Prédéfinies</title>
@@ -20,6 +20,7 @@
  &language.predefined.arrayaccess;
  &language.predefined.serializable;
  &language.predefined.closure;
+ &language.predefined.stdclass;
  &language.predefined.generator;
  &language.predefined.fiber;
  &language.predefined.weakreference;

--- a/language/predefined/interfaces.xml
+++ b/language/predefined/interfaces.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 360928c5efa8ebd586168d2660fc48d7fc6c9ba2 Maintainer: victor-prdh Status: ready -->
+<!-- EN-Revision: 360928c5efa8ebd586168d2660fc48d7fc6c9ba2 Maintainer: girgias Status: ready -->
 <!-- Reviewed: no -->
 
 <part xml:id="reserved.interfaces" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/language/types/object.xml
+++ b/language/types/object.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: fddb6fb79392f87b40b1c63bc5efd0becf9caac3 Maintainer: yannick Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 4c4b82965384d55f5c3efb1ffa80615acd98a737 Maintainer: victor-prdh Status: ready -->
+<!-- Reviewed: no -->
 
 <sect1 xml:id="language.types.object">
  <title>Les objets</title>
@@ -45,7 +45,7 @@ $bar->do_foo();
   <para>
    Si un objet est converti en un objet, il ne sera pas modifié.
    Si une valeur de n'importe quel type est convertie en un objet,
-   une nouvelle instance de la classe interne <literal>stdClass</literal>
+   une nouvelle instance de la classe interne <classname>stdClass</classname>
    sera créée. Si la valeur est &null;, la nouvelle instance sera vide.
    Un <type>array</type> se convertit en <type>object</type> avec  les propriétés
    nommées au regard des clés avec leurs valeurs correspondantes. Notez que 

--- a/language/types/object.xml
+++ b/language/types/object.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 4c4b82965384d55f5c3efb1ffa80615acd98a737 Maintainer: victor-prdh Status: ready -->
+<!-- EN-Revision: 4c4b82965384d55f5c3efb1ffa80615acd98a737 Maintainer: yannick Status: ready -->
 <!-- Reviewed: no -->
 
 <sect1 xml:id="language.types.object">

--- a/reference/classobj/functions/is-a.xml
+++ b/reference/classobj/functions/is-a.xml
@@ -1,11 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: c44475e1fafcbee203ed4935a6d5d7a01379fcdc Maintainer: yannick Status: ready -->
-<!-- Reviewed: yes Maintainer: pmartin -->
+<!-- EN-Revision: 2761e65ea261c33f65a7854b567a5821cf06aaa7 Maintainer: victor-prdh Status: ready -->
+<!-- Reviewed: no Maintainer: pmartin -->
 <refentry xml:id="function.is-a" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>is_a</refname>
-  <refpurpose>Vérifie si l'objet est une instance d'une classe donnée ou a cette classe parmi ses parents</refpurpose>
+  <refpurpose>
+   Vérifie si l'objet est une instance de ce type d'objet
+   ou a ce type d'objet parmi ses parents
+  </refpurpose>
  </refnamediv>
  <refsect1 role="description">
   &reftitle.description;
@@ -16,8 +19,8 @@
    <methodparam choice="opt"><type>bool</type><parameter>allow_string</parameter><initializer>&false;</initializer></methodparam>
   </methodsynopsis>
   <para>
-   Vérifie si l'objet <parameter>object_or_class</parameter> est une instance
-   d'une classe donnée ou a cette classe comme parent.
+   Vérifie si l'objet <parameter>object_or_class</parameter> est de ce type d'objet
+   ou a cette classe comme parent.
   </para>
  </refsect1>
 

--- a/reference/info/functions/dl.xml
+++ b/reference/info/functions/dl.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 928e363675c2b64e83ac790a5ceb396b793c911e Maintainer: victor-prdh Status: ready -->
+<!-- EN-Revision: 928e363675c2b64e83ac790a5ceb396b793c911e Maintainer: yannick Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.dl" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>

--- a/reference/info/functions/dl.xml
+++ b/reference/info/functions/dl.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 7639cf87731d902f2d2dbdcd34447b80e24bb80a Maintainer: yannick Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 928e363675c2b64e83ac790a5ceb396b793c911e Maintainer: victor-prdh Status: ready -->
+<!-- Reviewed: no -->
 <refentry xml:id="function.dl" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>dl</refname>
@@ -26,8 +26,9 @@
   </para>
   <warning>
    <simpara>
-    Cette fonction a été supprimée de la plupart des SAPIs dans PHP 5.3.0, et a 
-    été supprimé de PHP-FPM dans php 7.0.0.
+    Cette fonction n'est disponible que pour les <acronym>CLI</acronym>, les <acronym>SAPI</acronym>s,
+    intégrés, les <acronym>CGI</acronym> et <acronym>SAPI</acronym> lorsqu'ils sont exécutés à 
+    partir de la ligne de commande.
    </simpara>
   </warning>
  </refsect1>


### PR DESCRIPTION
Hi, just a little question:
`reference/classobj/functions/is-a.xml` seems not very logical, even in the doc-en. It'sspeak about "object type" and "class" for the same things, it's maybe better to keep only one of those (l.17) ?

Summary: 
* Sync appendice/reserved

* Sync predefined/interfaces

* Sync types/object

* Sync classobj/functions

* Sync info/functions

Thanks for your review !