### PR TITLE
Add appendices migration81

### DIFF
--- a/appendices/migration80.xml
+++ b/appendices/migration80.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: d7a2a4e3f7114ec8f0a71da90ed7e55b70fb77ec Maintainer: happytodev Status: ready -->
+
+<appendix xml:id="migration80" xmlns="http://docbook.org/ns/docbook" xmlns:phd="http://www.php.net/ns/phd">
+ <title>Migration de PHP 7.4.x vers PHP 8.0.x</title>
+
+ &appendices.migration80.new-features;
+ &appendices.migration80.incompatible;
+ &appendices.migration80.deprecated;
+ &appendices.migration80.other-changes;
+
+ <sect1 phd:chunk="false" xml:id="migration80.intro">
+  <para>
+   Cette nouvelle version majeure apporte avec elle un certain nombre de
+   <link linkend="migration80.new-features">nouvelles fonctionnalités</link> et
+   <link linkend="migration80.incompatible">quelques incompatibilités</link>
+   qui devraient être testées avant de changer de version de PHP dans des
+   environnements de production.
+  </para>
+
+  <para>
+   &manual.migration.seealso;
+   <link linkend="migration70">7.0.x</link>,
+   <link linkend="migration71">7.1.x</link>,
+   <link linkend="migration72">7.2.x</link>,
+   <link linkend="migration73">7.3.x</link>.
+   <link linkend="migration74">7.4.x</link>.
+  </para>
+ </sect1>
+</appendix>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/appendices/migration81.xml
+++ b/appendices/migration81.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 4d2479dcf35d82aca39ee61f8ab36ceed78a869c Maintainer: happytodev Status: ready -->
+
+<appendix xml:id="migration81" xmlns="http://docbook.org/ns/docbook" xmlns:phd="http://www.php.net/ns/phd">
+ <title>Migration de PHP 8.0.x vers PHP 8.1.x</title>
+
+ &appendices.migration81.new-features;
+ &appendices.migration81.new-classes;
+ &appendices.migration81.new-functions;
+ &appendices.migration81.constants;
+ &appendices.migration81.incompatible;
+ &appendices.migration81.deprecated;
+ &appendices.migration81.other-changes;
+
+ <sect1 phd:chunk="false" xml:id="migration81.intro">
+  <para>
+   Cette nouvelle version mineure apporte avec elle un certain nombre de
+   <link linkend="migration81.new-features">nouvelles fonctionnalités</link> et
+   <link linkend="migration81.incompatible">quelques incompatibilités</link>
+   qui devraient être testées avant de changer de version de PHP dans des
+   environnements de production.
+  </para>
+
+  <para>
+   &manual.migration.seealso;
+   <link linkend="migration71">7.1.x</link>,
+   <link linkend="migration72">7.2.x</link>,
+   <link linkend="migration73">7.3.x</link>,
+   <link linkend="migration74">7.4.x</link>,
+   <link linkend="migration80">8.0.x</link>.
+  </para>
+ </sect1>
+</appendix>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
I tried many things to avoid to have commit from previous PR ('Add migration help file for PHP8.0') even with help of @Girgias (probably became crazy thanks to me). I delete and recreate many times but impossible to have only the commit for migration81.xml, with my knoledge level of Git.

if someone has an explanation, I enjoy to read it.

Don't hesitate to contact me if necessary.