### PR TITLE
type-juggling: fixes typo and litteral translation

### DIFF
--- a/language/types/type-juggling.xml
+++ b/language/types/type-juggling.xml
@@ -245,7 +245,7 @@ $bar = (bool) $foo;   // $bar is a boolean
   <caution>
    <simpara>
     Le cast <literal>(binary)</literal> et le préfixe <literal>b</literal>
-    existe uniquement pour la compatibilité ascendante. Actuellement
+    existent uniquement pour la compatibilité ascendante. Actuellement
     <literal>(binary)</literal> et <literal>(string)</literal> sont identiques,
     mais ceci peut changer : vous ne devriez pas compter dessus.
    </simpara>

--- a/language/types/type-juggling.xml
+++ b/language/types/type-juggling.xml
@@ -223,7 +223,7 @@ $bar = (bool) $foo;   // $bar is a boolean
     <literal>(binary)</literal> est un alias du cast <literal>(string)</literal>.
     <literal>(double)</literal> et <literal>(real)</literal> sont des alias du
     cast <literal>(float)</literal>.
-    Ces casts n'utilisent pas le nom de type canonique est ne sont pas recommandé.
+    Ces casts n'utilisent pas le nom de type canonique et ne sont pas recommandé.
    </para>
   </note>
 
@@ -246,8 +246,8 @@ $bar = (bool) $foo;   // $bar is a boolean
    <simpara>
     Le cast <literal>(binary)</literal> et le préfixe <literal>b</literal>
     existe uniquement pour la compatibilité ascendante. Actuellement
-    <literal>(binary)</literal> et <literal>(string)</literal> sont identique,
-    mais ceci peut changer et ne devrait pas être invoqué.
+    <literal>(binary)</literal> et <literal>(string)</literal> sont identiques,
+    mais ceci peut changer : vous ne devriez pas compter dessus.
    </simpara>
   </caution>
 
@@ -287,7 +287,7 @@ $binary = b"binary string";
   <!-- TODO Remove or move into string context section? -->
   <note>
    <simpara>
-    Au lieu de cast une variable en une <type>string</type>, il est également possible
+    Au lieu de transtyper une variable en une <type>string</type>, il est également possible
     d'entourer la variable de guillemets doubles.
    </simpara>
 
@@ -310,8 +310,8 @@ if ($fst === $str) {
   </note>
 
   <para>
-   Il n'est pas forcément évident ce qui se produira exactement lors d'un casting
-   entre certains types. Pour plus d'informations, voir ces sections :
+   Ce qui se produira exactement lors d'un transtypage entre certains types
+   n’est pas forcément évident. Pour plus d’informations, voir ces sections :
    <simplelist>
     <member><link linkend="language.types.boolean.casting">Convertir en boolean</link></member>
     <member><link linkend="language.types.integer.casting">Convertir en integer</link></member>
@@ -334,12 +334,6 @@ if ($fst === $str) {
     l'exemple suivant est valable pour toutes les versions de PHP :
    </simpara>
 
-   <para>
-    De plus, puisque PHP supporte l'indexation des chaînes de caractères
-    via des positions en utilisant la même syntaxe que pour les tableaux,
-    l'exemple suivant est vrai pour toutes les versions de PHP :
-   </para>
-
    <informalexample>
     <programlisting role="php">
 <![CDATA[
@@ -354,7 +348,7 @@ echo $a;       // bar
 
    <simpara>
     Voir la section sur l'<link linkend="language.types.string.substr">accès
-    aux chaînes par caractères</link> pour plus d'informations.
+    aux chaînes par caractère</link> pour plus d'informations.
    </simpara>
   </note>
  </simplesect>

--- a/language/types/type-juggling.xml
+++ b/language/types/type-juggling.xml
@@ -223,7 +223,7 @@ $bar = (bool) $foo;   // $bar is a boolean
     <literal>(binary)</literal> est un alias du cast <literal>(string)</literal>.
     <literal>(double)</literal> et <literal>(real)</literal> sont des alias du
     cast <literal>(float)</literal>.
-    Ces casts n'utilisent pas le nom de type canonique et ne sont pas recommandé.
+    Ces casts n'utilisent pas le nom de type canonique et ne sont pas recommandés.
    </para>
   </note>
 
@@ -311,7 +311,7 @@ if ($fst === $str) {
 
   <para>
    Ce qui se produira exactement lors d'un transtypage entre certains types
-   n’est pas forcément évident. Pour plus d’informations, voir ces sections :
+   n'est pas forcément évident. Pour plus d'informations, voir ces sections :
    <simplelist>
     <member><link linkend="language.types.boolean.casting">Convertir en boolean</link></member>
     <member><link linkend="language.types.integer.casting">Convertir en integer</link></member>


### PR DESCRIPTION
* "est ne sont pas" → "et ne sont pas"
* "sont identique" → "sont identiques"
* "et ne devrait pas être invoqué" → "vous ne devriez pas compter dessus" (rely on)
* "cast une variable" → "transtyper une variable"
* "Il n'est pas forcément évident ce qui se produira" → "Ce qui se produira n’est pas forcément évident"
* "un casting" → "un transtypage"
* "accès par caractères" → "accès par caractère" (by character, only one is possible)
* Removing of one duplicated paragraph.