### PR TITLE
Typos: Deplus -> De plus

### DIFF
--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -1498,7 +1498,7 @@ fuseaux horaires supportés par PHP, qui peuvent être utilisés avec, e.g.
 <!ENTITY date.timezone.bc '<simpara xmlns="http://docbook.org/ns/docbook">
 N&#39;utilisez aucun des fuseaux horaires listés ici (excepté UTC), ils
 n&#39;existent que pour des raisons de compatibilité ascendante et leur comportement peut provoquer des erreurs.
-Deplus, ces fuseaux horaires peuvent être supprimée de la base de donnée IANA de fuseaux horaire à tout moment.
+De plus, ces fuseaux horaires peuvent être supprimée de la base de donnée IANA de fuseaux horaire à tout moment.
 </simpara>'>
 
 <!ENTITY date.timezone.posix-signs '<simpara xmlns="http://docbook.org/ns/docbook">

--- a/reference/pdo/pdo/prepare.xml
+++ b/reference/pdo/pdo/prepare.xml
@@ -49,7 +49,7 @@
    qui doivent être exécutées plusieurs fois avec différentes valeurs de
    paramètres optimisent les performances de votre application en autorisant
    le pilote à négocier coté client et/ou serveur avec le cache des requêtes
-   et les meta-informations. Deplus appeler <methodname>PDO::prepare</methodname> et
+   et les meta-informations. De plus appeler <methodname>PDO::prepare</methodname> et
    <methodname>PDOStatement::execute</methodname> aident à prévenir les attaques par
    injection SQL en éliminant le besoin de protéger les paramètres manuellement.
   </para>


### PR DESCRIPTION
I stumbled upon a "Deplus" typo on the docs, so I thought that I might at least fix it (and find if there's more). So here it is, my (small) PR that fixes 2 typos, replacing "Deplus" strings by "De plus".