### PR TITLE
Fixing typo in references.xml

### DIFF
--- a/language/references.xml
+++ b/language/references.xml
@@ -19,7 +19,7 @@
    Notez qu'en PHP, le nom d'une variable et son contenu sont deux
    notions distinctes, ce qui fait que l'on peut donner
    plusieurs noms au même contenu.
-   On peut faire l'analogie avec les fichiers sous Unix, et leur noms :
+   On peut faire l'analogie avec les fichiers sous Unix, et leurs noms :
    les noms des variables sont les entrées dans un répertoire, tandis
    que le contenu de la variable est le fichier en lui-même.
    Les références en PHP peuvent alors être considérées comme semblables
@@ -33,7 +33,7 @@
    Il existe trois principales utilisations des références :
    l'<link linkend="language.references.whatdo.assign">assignation par
    référence</link>, le <link linkend="language.references.whatdo.pass">passage
-   par référence</link>,
+   par référence</link>
    et le <link linkend="language.references.whatdo.return">retour par
    référence</link>. Cette section va introduire ces opérations, avec des liens
    vers plus de précisions.
@@ -108,7 +108,7 @@ $foo =& find_var($bar);
     retourne par référence génèrera une erreur, comme l'utiliser avec le
     résultat de l'opérateur <link linkend="language.oop5.basic.new">new</link>.
     Tant bien que les objets sont passés comme des pointeurs, ceci n'est pas
-    identique au références comm expliqué dans la section les
+    identique aux références comme expliqué dans la section les
     <link linkend="language.oop5.references">Objets et références</link>.
    </para>
    <warning>


### PR DESCRIPTION
- Add plural for _"leur**s** noms"_ and _"au**x** références"_
- remove _","_ According to me, we don't have _","_ before _"et"_ when we enumarate things. That was what I learn. It's maybe wrong ?
- Fix typo _"comm**e** expliqué"_