### PR TITLE
Corrected typo in implode.xml

### DIFF
--- a/reference/strings/functions/implode.xml
+++ b/reference/strings/functions/implode.xml
@@ -14,7 +14,7 @@
    <methodparam><type>string</type><parameter>separator</parameter></methodparam>
    <methodparam><type>array</type><parameter>array</parameter></methodparam>
   </methodsynopsis>
-  <simpara>Signature alternative (non supporté avec les arguments nommés) :</simpara>
+  <simpara>Signature alternative (non supportée avec les arguments nommés) :</simpara>
   <methodsynopsis>
    <type>string</type><methodname>implode</methodname>
    <methodparam><type>array</type><parameter>array</parameter></methodparam>


### PR DESCRIPTION
Added "e" at the end of the word "supporté"