### PR TITLE
Small Typo fix

### DIFF
--- a/reference/phar/using.xml
+++ b/reference/phar/using.xml
@@ -212,7 +212,7 @@ $a->stopBuffering();
   Le flux Phar supporte totalement <function>fopen</function> pour les
   lectures/écritures (pas les concaténations), <function>unlink</function>, <function>stat</function>,
   <function>fstat</function>, <function>fseek</function>, <function>rename</function>,
-  et le opérations de flux sur les répertoires <function>opendir</function>, et <function>rmdir</function>
+  et les opérations de flux sur les répertoires <function>opendir</function>, et <function>rmdir</function>
   et <function>mkdir</function>.
  </para>
  <para>


### PR DESCRIPTION
fixing missing plural in phrase : 
previously : 
> Le flux Phar supporte totalement <function>fopen</function> pour les
  lectures/écritures (pas les concaténations), <function>unlink</function>, <function>stat</function>,
  <function>fstat</function>, <function>fseek</function>, <function>rename</function>,
  et *le opérations* de flux sur les répertoires <function>opendir</function>, et <function>rmdir</function>
  et <function>mkdir</function>.

Now :
> Le flux Phar supporte totalement <function>fopen</function> pour les
  lectures/écritures (pas les concaténations), <function>unlink</function>, <function>stat</function>,
  <function>fstat</function>, <function>fseek</function>, <function>rename</function>,
  et *les opérations* de flux sur les répertoires <function>opendir</function>, et <function>rmdir</function>
  et <function>mkdir</function>.