### PR TITLE
fix "example" typos

### DIFF
--- a/language-defs.ent
+++ b/language-defs.ent
@@ -53,7 +53,7 @@
 <!ENTITY IndexListing      "Liste de l'index">
 <!ENTITY FunctionListing   "Liste des fonctions et des méthodes">
 <!ENTITY FunctionListingDescription   "Liste de toutes les fonctions et méthodes du manuel">
-<!ENTITY ExampleListing    "Liste d'examples">
+<!ENTITY ExampleListing    "Liste d'exemples">
 <!ENTITY ExampleListingDescription   "Liste de tous les exemples du manuel">
 <!ENTITY ChangelogListingTitle "Historique des modifications">
 <!ENTITY ChangelogListingDescription "Les modifications suivantes ont été apportées aux classes/fonctions/méthodes de cette extension.">

--- a/language/functions.xml
+++ b/language/functions.xml
@@ -709,7 +709,7 @@ array_fill(start_index: 0, count: 100, value: 50);
    </para>
 
    <example>
-    <title>Même example que ci-dessus, mais avec un ordre de paramètre différent</title>
+    <title>Même exemple que ci-dessus, mais avec un ordre de paramètre différent</title>
     <programlisting role="php">
 <![CDATA[
 <?php

--- a/language/types/string.xml
+++ b/language/types/string.xml
@@ -263,7 +263,7 @@ echo 'Les variables ne seront pas $traitees $ici';
 
 
    <example>
-    <title>Example Heredoc basique à partir de PHP 7.3.0</title>
+    <title>Exemple Heredoc basique à partir de PHP 7.3.0</title>
     <programlisting role="php">
      <![CDATA[
 <?php
@@ -371,7 +371,7 @@ PHP Parse error:  Invalid indentation - tabs and spaces cannot be mixed in examp
 
    <simpara>
     L'identifiant de fin du corps du texte n'est pas requis d'être suivi
-    d'une point virgule ou une nouvelle ligne. Par example, le code suivant
+    d'une point virgule ou une nouvelle ligne. Par exemple, le code suivant
     est autorisé à partir de PHP 7.3.0:
    </simpara>
 

--- a/language/variables.xml
+++ b/language/variables.xml
@@ -924,7 +924,7 @@ if ($_POST) {
    <note>
      <simpara>
       Si le nom d'une variable externe commence par une syntaxe valide pour un tableau, les caractères qui suivent
-      sont silencieusement ignorés. Par example : <literal>&lt;input name="foo[bar]baz"&gt;</literal>
+      sont silencieusement ignorés. Par exemple : <literal>&lt;input name="foo[bar]baz"&gt;</literal>
       deviens <literal>$_REQUEST['foo']['bar']</literal>.
      </simpara>
     </note>

--- a/reference/exec/functions/proc-open.xml
+++ b/reference/exec/functions/proc-open.xml
@@ -50,7 +50,7 @@
         de <command>cmd.exe</command>), résulatant dans du comportement
         innatendu, et potentiellement dangereux, car les messages d'erreurs de
         <command>cmd.exe</command> peuvent contenir (une partir de) la
-        <parameter>command</parameter> passé (see example below).
+        <parameter>command</parameter> passé (voir exemple ci-dessous).
        </simpara>
       </note>
       <para>

--- a/reference/imap/functions/imap-mail-compose.xml
+++ b/reference/imap/functions/imap-mail-compose.xml
@@ -37,7 +37,7 @@
        définie les en-têtes respectifs à la &string; donnée.
        Pour définir des en-têtes additionnels, la clé
        <literal>"custom_headers"</literal> est supporté, qui attend un tableau
-       de ces en-têtes, par example <code>["User-Agent: My Mail Client"]</code>.
+       de ces en-têtes, par exemple <code>["User-Agent: My Mail Client"]</code>.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/mbstring/functions/mb-detect-encoding.xml
+++ b/reference/mbstring/functions/mb-detect-encoding.xml
@@ -154,8 +154,8 @@ string(10) "ISO-8859-1"
   <para>
    Dans certain cas, la même séquences d'octet peut former une chaîne valide
    dans différents encodages de caractères, et il est impossible de déterminer
-   quelle interprétation était prévu. Par example, parmi tant d'autres,
-   séquance d'octets "\xC4\xA2" pourrait être :
+   quelle interprétation était prévu. Un exemple, parmi tant d'autres,
+   la séquence d'octets "\xC4\xA2" pourrait être :
   </para>
   <para>
    <simplelist>

--- a/reference/network/functions/setcookie.xml
+++ b/reference/network/functions/setcookie.xml
@@ -114,7 +114,7 @@
        Le (sous-)domaine pour lequel le cookie est disponible. Définir ceci à un
        sous-domaine (tel que <literal>'www.example.com'</literal>) rendra le cookie
        disponible pour ce sous-domaine ainsi que tous ses sous-domaines
-       (par example : w2.www.example.com). Pour rendre le cookie
+       (par exemple : w2.www.example.com). Pour rendre le cookie
        disponible sur tout le domaine (ainsi que tous ses sous-domaines), définissez
        simplement la valeur avec le nom de domaine (<literal>'example.com'</literal>,
        avec cet exemple).

--- a/reference/pcre/pattern.syntax.xml
+++ b/reference/pcre/pattern.syntax.xml
@@ -719,7 +719,7 @@
    caractères suivis par la chaîne littérale <literal>.$.</literal> et ancrés à la
    fin de la chaîne.
    Il est à noter que ceci ne change pas le comportement des délimiteurs ;
-   par example le masque <literal>#\Q#\E#$</literal> n'est pas valide, car
+   par exemple le masque <literal>#\Q#\E#$</literal> n'est pas valide, car
    le second <literal>#</literal> marque la fin du masque, et que
    <literal>\E#</literal> est interprété comme un modificateur invalide.
   </para>

--- a/reference/pdo/pdo/quote.xml
+++ b/reference/pdo/pdo/quote.xml
@@ -67,7 +67,7 @@
         Le type de données pour les drivers qui ont des styles particuliers
         de protection.
         Fournit un indice au type de donnée pour les pilotes qui ont un style
-        d'échappement différent. Par example <constant>PDO_PARAM_LOB</constant>
+        d'échappement différent. Par exemple <constant>PDO_PARAM_LOB</constant>
         indique au pilote d'échapper des données binaires.
        </para>
       </listitem>

--- a/reference/sqlsrv/functions/sqlsrv-close.xml
+++ b/reference/sqlsrv/functions/sqlsrv-close.xml
@@ -46,7 +46,7 @@
   &reftitle.examples;
   <para>
    <example>
-    <title>Example avec <function>sqlsrv_close</function></title>
+    <title>Exemple avec <function>sqlsrv_close</function></title>
     <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/strings/functions/strtok.xml
+++ b/reference/strings/functions/strtok.xml
@@ -49,7 +49,7 @@
     délimiteur.
     De plus, un <parameter>token</parameter> situé au début ou à la fin de la
     chaîne est ignoré.
-    Par example, si la chaîne <literal>";aaa;;bbb;"</literal> est utilisé,
+    Par exemple, si la chaîne <literal>";aaa;;bbb;"</literal> est utilisé,
     les appels successif à <function>strtok</function> avec
     <literal>";"</literal> en tant que <parameter>token</parameter> retournera
     les chaînes "aaa" et "bbb", et puis &false;.

--- a/reference/zip/ziparchive/setexternalattributesname.xml
+++ b/reference/zip/ziparchive/setexternalattributesname.xml
@@ -67,7 +67,7 @@
  <refsect1 role="examples">
   &reftitle.examples;
     <para>
-     Cet example crée une archive ZIP
+     Cet exemple crée une archive ZIP
      <filename>test.zip</filename> et ajoute
      le fichier <filename>test.txt</filename>
      ainsi que ses permissions Unix dans les attributs externes.


### PR DESCRIPTION
Hello,
I just searched all "example" typos in doc's and fixed them. Maybe i forgot some of them ?

Thanks for proofreading !