### PR TITLE
Fix typo on setTime documentation

### DIFF
--- a/reference/datetime/datetime/settime.xml
+++ b/reference/datetime/datetime/settime.xml
@@ -32,7 +32,7 @@
    Change le temps dans l'objet <classname>DateTime</classname>.
   </para>
   <para>
-   Comme <methodname>DateTimeImmutable::setTi,e</methodname> mais fonctionne avec
+   Comme <methodname>DateTimeImmutable::setTime</methodname> mais fonctionne avec
    <classname>DateTime</classname>.
   </para>
   <para>


### PR DESCRIPTION
Seems like someone used QWERTY keyboard to write french documentation 😉