### PR TITLE
Update `fopen.xml` : `a+` mode

### DIFF
--- a/reference/filesystem/functions/fopen.xml
+++ b/reference/filesystem/functions/fopen.xml
@@ -142,8 +142,8 @@ $handle = fopen("c:\\folder\\resource.txt", "r");
             Ouvre en lecture et écriture ; place le pointeur de fichier
             à la fin du fichier. Si le fichier n'existe pas, on tente
             de le créer. Dans ce mode, la fonction <function>fseek</function>
-            n'affecte que la position de lecture, les écritures surviennent
-            toujours.
+            n'affecte que la position de lecture, les écritures sont toujours 
+            ajoutées à la fin.
            </entry>
           </row>
           <row>


### PR DESCRIPTION
Translation has confusion between "happened" and "appended". Closes #546