### PR TITLE
Issue #554: reword explanation of PCRE modifier "u"

### DIFF
--- a/reference/pcre/pattern.modifiers.xml
+++ b/reference/pcre/pattern.modifiers.xml
@@ -179,7 +179,7 @@
         Cette option active des fonctionnalités additionnelles de PCRE qui ne sont pas compatibles avec Perl.
         La chaîne d'entrée et le masque sont traités comme des chaînes UTF-8.
         Une chaîne d'entrée invalide aura pour conséquence une absence de correspondance dans les fonctions preg_*.
-        Un masque invalide va lever une erreur de niveau E_WARNING.
+        Un masque invalide va lever une erreur de niveau <constant>E_WARNING</constant>.
         Les séquences UTF-8 de cinq et six octets sont considérées comme invalides.
        </simpara>
       </listitem>

--- a/reference/pcre/pattern.modifiers.xml
+++ b/reference/pcre/pattern.modifiers.xml
@@ -176,12 +176,11 @@
       <term><emphasis>u</emphasis> (<literal>PCRE_UTF8</literal>)</term>
       <listitem>
        <simpara>
-        Cette option désactive les fonctionnalités additionnelles de PCRE qui 
-        ne sont pas compatibles avec Perl. Le masque et la chaîne d'entrée sont 
-        traitées comme des chaînes UTF-8. Une chaîne d'entrée invalide 
-        entrainera aucune détection par les fonctions preg_*. Un masque 
-        invalide va lever une erreur de niveau E_WARNING. Les séquences UTF-8 
-        de cinq et six octets sont invalides.
+        Cette option active des fonctionnalités additionnelles de PCRE qui ne sont pas compatibles avec Perl.
+        La chaîne d'entrée et le masque sont traités comme des chaînes UTF-8.
+        Une chaîne d'entrée invalide aura pour conséquence une absence de correspondance dans les fonctions preg_*.
+        Un masque invalide va lever une erreur de niveau E_WARNING.
+        Les séquences UTF-8 de cinq et six octets sont considérées comme invalides.
        </simpara>
       </listitem>
      </varlistentry>


### PR DESCRIPTION
As explained on #554 the current explanation for the "u" PCRE modifier says the opposite of what the modifier actually does. This rewords the whole paragraph the better to match the original english text.