### PR TITLE
Fix socket-create-pair example, missing ')'

### DIFF
--- a/reference/sockets/functions/socket-create-pair.xml
+++ b/reference/sockets/functions/socket-create-pair.xml
@@ -133,7 +133,7 @@ if (socket_create_pair($domain, SOCK_STREAM, 0, $sockets) === false) {
 if (socket_write($sockets[0], "ABCdef123\n", strlen("ABCdef123\n")) === false) {
     echo "socket_write() a échoué. Raison : ".socket_strerror(socket_last_error($sockets[0]));
 }
-if (($data = socket_read($sockets[1], strlen("ABCdef123\n"), PHP_BINARY_READ) === false) {
+if (($data = socket_read($sockets[1], strlen("ABCdef123\n"), PHP_BINARY_READ)) === false) {
     echo "socket_read() a échoué. Raison : ".socket_strerror(socket_last_error($sockets[1]));
 }
 var_dump($data);


### PR DESCRIPTION
PS : L'exemple dans la doc anglaise est déjà bon.