### PR TITLE
Fix some typos

### DIFF
--- a/features/gc.xml
+++ b/features/gc.xml
@@ -182,7 +182,7 @@ a: (refcount=1, is_ref=0)=array (
     </para>
     <para>
      <example>
-      <title>Ajout d'un élément déja existant au tableau</title>
+      <title>Ajout d'un élément déjà existant au tableau</title>
       <programlisting role="php">
 <![CDATA[
 <?php
@@ -446,7 +446,7 @@ a: (refcount=2, is_ref=1)=array (
   <sect1 xml:id="features.gc.performance-considerations">
    <title>Considerations sur les performances</title>
    <para>
-    Nous avons déja vu dans les sections précédentes que la collecte des racines probables
+    Nous avons déjà vu dans les sections précédentes que la collecte des racines probables
     avait un impact très léger sur les performances, mais c'est lorsque l'on compare PHP 5.2 à
     PHP 5.3. Même si l'enregistrement des racines probables est plus lent que de ne pas les
     enregistrer du tout, comme dans PHP 5.2, d'autres améliorations apportées par PHP 5.3

--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -2086,7 +2086,7 @@ des extensions PECL</link>. D&#39;autres informations comme les notes sur les no
  Quand <parameter>connection</parameter> est pas spécifié, la connexion par défaut est utilisé.
  La connexion par défaut est la dernière connexion faite par
  <function>pg_connect</function> ou <function>pg_pconnect</function>
- <warning><simpara>À partir de PHP 8.1.0, utiliser la connection par défaut est obsolète.</simpara></warning>
+ <warning><simpara>À partir de PHP 8.1.0, utiliser la connexion par défaut est obsolète.</simpara></warning>
 </para>'>
 
 <!ENTITY pgsql.parameter.connection-with-nullable-default '<para xmlns="http://docbook.org/ns/docbook">
@@ -2094,7 +2094,7 @@ des extensions PECL</link>. D&#39;autres informations comme les notes sur les no
  Quand <parameter>connection</parameter> est &null;, la connexion par défaut est utilisé.
  La connexion par défaut est la dernière connexion faite par
  <function>pg_connect</function> ou <function>pg_pconnect</function>
- <warning><simpara>À partir de PHP 8.1.0, utiliser la connection par défaut est obsolète.</simpara></warning>
+ <warning><simpara>À partir de PHP 8.1.0, utiliser la connexion par défaut est obsolète.</simpara></warning>
  </para>'>
 
 <!ENTITY pgsql.parameter.result '<para xmlns="http://docbook.org/ns/docbook">

--- a/reference/curl/functions/curl-getinfo.xml
+++ b/reference/curl/functions/curl-getinfo.xml
@@ -274,7 +274,7 @@
         </listitem>
         <listitem>
          <simpara>
-          <constant>CURLINFO_APPCONNECT_TIME</constant> - Temps en seconde qu'il ait fallu depuis le début jusqu'à ce que la connexion/handshake SSL/SSH à l'hôte distant a été complété.
+          <constant>CURLINFO_APPCONNECT_TIME</constant> - Temps en seconde qu'il ait fallu depuis le début jusqu'à ce que la connexion/poignée de main SSL/SSH à l'hôte distant a été complété.
          </simpara>
         </listitem>
         <listitem>
@@ -379,7 +379,7 @@
         <listitem>
          <simpara>
           <constant>CURLINFO_APPCONNECT_TIME_T</constant> - Temps, en microseconde,
-          qu'il a prit entre le début jusqu'à ce que la connexion/handshake
+          qu'il a prit entre le début jusqu'à ce que la connexion/poignée de main
           SSL/SSH à l'hôte distant a été complété
          </simpara>
         </listitem>

--- a/reference/curl/functions/curl-getinfo.xml
+++ b/reference/curl/functions/curl-getinfo.xml
@@ -379,14 +379,14 @@
         <listitem>
          <simpara>
           <constant>CURLINFO_APPCONNECT_TIME_T</constant> - Temps, en microseconde,
-          qu'il a prit entre le début jusqu'à ce que la connection/handshake
+          qu'il a prit entre le début jusqu'à ce que la connexion/handshake
           SSL/SSH à l'hôte distant a été complété
          </simpara>
         </listitem>
         <listitem>
          <simpara>
           <constant>CURLINFO_CONNECT_TIME_T</constant> - Temps total pris, en
-          microsecondes, depuis le début jusqu'à ce que la connection à l'hôte
+          microsecondes, depuis le début jusqu'à ce que la connexion à l'hôte
           distant (ou proxy) a été complété
          </simpara>
         </listitem>
@@ -430,7 +430,7 @@
         <listitem>
          <simpara>
           <constant>CURLINFO_TOTAL_TIME_T</constant> - Temps total en microsecondes
-          pour le transfer précédent, incluant la résolution de nom, connection
+          pour le transfer précédent, incluant la résolution de nom, connexion
           TCP, etc.
          </simpara>
         </listitem>

--- a/reference/curl/functions/curl-share-setopt.xml
+++ b/reference/curl/functions/curl-share-setopt.xml
@@ -88,7 +88,7 @@
            <entry valign="top"><constant>CURL_LOCK_DATA_SSL_SESSION</constant></entry>
            <entry valign="top">
             Identifiants de session partagés SSL, réduisant le temps passé
-            sur la négociation SSL lors d'une reconnection sur le même serveur.
+            sur la négociation SSL lors d'une reconnexion sur le même serveur.
             Notez que les identifiants de session SSL sont ré-utilisés
             dans le même gestionnaire par défaut.
            </entry>

--- a/reference/event/eventbufferevent/connect.xml
+++ b/reference/event/eventbufferevent/connect.xml
@@ -131,7 +131,7 @@ if (!$output->add(
     exit("Echec lors de l'ajout de la demande dans le tampon de sortie\n");
 }
 
-/* Connection à l'hôte de façon asynchrone.
+/* Connexion à l'hôte de façon asynchrone.
  * Nous connaissons l'IP, et donc, nous n'avons pas besoin de résolution DNS. */
 if (!$bev->connect("127.0.0.1:80")) {
     exit("Impossible de se connecter à l'hôte\n");

--- a/reference/image/functions/imageaffinematrixget.xml
+++ b/reference/image/functions/imageaffinematrixget.xml
@@ -38,7 +38,7 @@
       Si <parameter>type</parameter> est <constant>IMG_AFFINE_TRANSLATE</constant>
       ou <constant>IMG_AFFINE_SCALE</constant>,
       <parameter>options</parameter> doit être un <type>array</type> avec 
-      les clées <literal>x</literal>
+      les clés <literal>x</literal>
       et <literal>y</literal>, les deux étant des valeurs <type>float</type>.
      </para>
      <para>

--- a/reference/memcache/memcache/add.xml
+++ b/reference/memcache/memcache/add.xml
@@ -22,7 +22,7 @@
   <para>
    <function>Memcache::add</function> stocke la variable
    <parameter>var</parameter> avec la clé <parameter>key</parameter> seulement si cette clé
-   n'existe pas déja dans le serveur. La fonction <function>memcache_add</function> exécute la
+   n'existe pas déjà dans le serveur. La fonction <function>memcache_add</function> exécute la
    même action.
   </para>
 
@@ -77,7 +77,7 @@
   &reftitle.returnvalues;
   <para>
    &return.success;
-   Retourne &false; si la clé existe déja. Pour le reste, le comportement de
+   Retourne &false; si la clé existe déjà. Pour le reste, le comportement de
    <function>Memcache::add</function> est le même que
    <function>Memcache::set</function>.
   </para>

--- a/reference/oci8/functions/oci-connect.xml
+++ b/reference/oci8/functions/oci-connect.xml
@@ -23,7 +23,7 @@
   </para>
   <para>
    Pour les performances, la plupart des applications devraient utiliser les
-   connections persistentes avec <function>oci_pconnect</function> au lieu de
+   connexions persistentes avec <function>oci_pconnect</function> au lieu de
    <function>oci_connect</function>.
    Voir la section sur <link linkend="oci8.connection">la gestion des connexions</link>
    pour des informations générales sur la gestion des connexions et le

--- a/reference/phar/PharData/setSignatureAlgorithm.xml
+++ b/reference/phar/PharData/setSignatureAlgorithm.xml
@@ -42,7 +42,7 @@
      <term><parameter>privateKey</parameter></term>
      <listitem>
       <para>
-       Le contenue d'une clée privée OpenSSL, comme extraite depuis un
+       Le contenue d'une clé privée OpenSSL, comme extraite depuis un
        certificat ou un fichier de clé OpenSSL :
        <programlisting role="php">
 <![CDATA[

--- a/reference/session/functions/session-create-id.xml
+++ b/reference/session/functions/session-create-id.xml
@@ -43,7 +43,7 @@
         Si <parameter>prefix</parameter> est spécifié, le nouvel ID de session
         est préfixé par <parameter>prefix</parameter>. Pas tous
         les caractères sont autorisés dans l'ID de session. Les caractères
-        parmis <literal>a-z A-Z 0-9 , (virgule) et -
+        parmi <literal>a-z A-Z 0-9 , (virgule) et -
         (moins)</literal> sont autorisés..
        </para> 
       </listitem>

--- a/reference/yaf/yaf-router.xml
+++ b/reference/yaf/yaf-router.xml
@@ -26,7 +26,7 @@
     les fonctionnalités similaires au mod_rewrite en utilisant des structures PHP.
     Ces structures sont basés sur le routage en Ruby on Rails et ne nécessitent
     aucun connaissance en ré-écriture d'URL de serveur web. Elles sont prévues pour fonctionner
-    avec une seule règle Apache mod_rewrite (une parmis) :
+    avec une seule règle Apache mod_rewrite (une parmi) :
     <example>
      <title>Règle de ré-écriture pour Apache</title>
      <programlisting role="conf">


### PR DESCRIPTION
Hi, fixed some typos:

déja => déjà
connection => connexion
clée => clé
parmi => parmis

Quick question, in `reference/curl/functions/curl-getinfo.xml` should we translate "handshake" ? (I saw "poignée de main" in 2 other files but it looks kinda weird)