### PR TITLE
Fix translation for array_slice length parameter

### DIFF
--- a/reference/array/functions/array-slice.xml
+++ b/reference/array/functions/array-slice.xml
@@ -70,7 +70,7 @@
       </para>
       <para>
        Si <parameter>length</parameter> est fourni et négatif, alors
-       la séquence contiendra autant d'éléments de la fin du &array;.
+       la séquence exclura autant d'éléments de la fin du &array;.
       </para>
       <para>
        Si il est omis, la séquence aura tout


### PR DESCRIPTION
Although [last modification](https://github.com/php/doc-fr/commit/92ef1bfefc5ab464334909295f82bf8034b85d66) simplified the sentence to describe the behaviour of `array_slice` with `$length <0`, it changed its meaning.

> la séquence contiendra autant d'éléments de la fin du &array;

This is the opposite, the array will NOT contain elements at then end of the array! 

[Corresponding English documentation](https://github.com/php/doc-en/blob/9f30ccc6aa0dabe411c52305202fe85209ddc06b/reference/array/functions/array-slice.xml#L67-L68)

> the sequence will stop that many elements from the end of the array.

Nevertheless, I think this is a good idea to not translate literally here, so I propose to just replace `contiendra` by a verb with opposite sense: `exclura` (`exclude`) (but could also be `omettra` (`omit`) ...)

Thanks for your amazing work on the French documentation 🙂 