### PR TITLE
Convert curl-getinfo() constant list to table

### DIFF
--- a/reference/curl/functions/curl-getinfo.xml
+++ b/reference/curl/functions/curl-getinfo.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: f3d1cec9e549e5ac7bfbb076295537668ceb0e4a Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 8b3f89ed6171cb711b00afb0fcacbea3462537b9 Maintainer: haszi Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.curl-getinfo" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>

--- a/reference/curl/functions/curl-getinfo.xml
+++ b/reference/curl/functions/curl-getinfo.xml
@@ -16,7 +16,7 @@
    <methodparam choice="opt"><type class="union"><type>int</type><type>null</type></type><parameter>option</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
   <para>
-   <function>curl_getinfo</function> lit les informations 
+   <function>curl_getinfo</function> lit les informations
    concernant le transfert <parameter>handle</parameter>.
   </para>
  </refsect1>
@@ -31,420 +31,496 @@
      <listitem>
       <para>
        Ce paramètre peut prendre l'une des valeurs suivantes :
-       <itemizedlist>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_CAINFO</constant> - Chemin d'accès par défaut du certificat CA intégré
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_CAPATH</constant> - Chaîne de chemin d'accès CA intégré par défaut
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_EFFECTIVE_URL</constant> - Dernière URL effective
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_HTTP_CODE</constant> : Le dernier code de réponse.
-          À partir de cURL 7.10.8, ceci est un alias hérité de
-          <constant>CURLINFO_RESPONSE_CODE</constant>
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_FILETIME</constant> : Date distante du document récupéré,
-          avec <constant>CURLOPT_FILETIME</constant> activé ;
-          si -1 est retourné la date du document distant est inconnue.
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_TOTAL_TIME</constant> : Durée de la transaction en
-          secondes pour le dernier transfert
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_NAMELOOKUP_TIME</constant> : Durée de résolution
-          du nom de domaine en secondes
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_CONNECT_TIME</constant> : Durée d'établissement de
-          la connexion en secondes
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_PRETRANSFER_TIME</constant> : Durée en secondes,
-          entre le début de la transaction et de début du transfert de fichiers
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_STARTTRANSFER_TIME</constant> : Durée en secondes
-          jusqu'à ce que le premier octet soit sur le point d'être transféré
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_REDIRECT_COUNT</constant> : Nombre de redirections, avec 
-          l'option <constant>CURLOPT_FOLLOWLOCATION</constant> activée
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_REDIRECT_TIME</constant> : Durée en secondes de toutes
-          les étapes de redirection avant que la transaction finale ne soit débutée,
-          avec l'option <constant>CURLOPT_FOLLOWLOCATION</constant> activée
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_REDIRECT_URL</constant> - Avec l'option 
-          <constant>CURLOPT_FOLLOWLOCATION</constant> désactivée : URL de 
-          redirection trouvée dans la dernière transaction, qui devra être 
-          interrogé manuellement par la suite. Si l'option 
-          <constant>CURLOPT_FOLLOWLOCATION</constant> est activée : cette valeur 
-          est vide. Dans ce cas, l'url de redirection est disponible dans 
-          <constant>CURLINFO_EFFECTIVE_URL</constant> 
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_PRIMARY_IP</constant> - Adresse IP de la plus 
-          récente connexion
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_PRIMARY_PORT</constant> - Port de destination de 
-          la plus récente connexion
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_LOCAL_IP</constant> - Adresse IP locale (source) de 
-          la plus récente connexion
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_LOCAL_PORT</constant> - Port local (source) de la 
-          plus récente connexion
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_SIZE_UPLOAD</constant> : Nombre total 
-          d'octets envoyés
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_SIZE_DOWNLOAD</constant> : Nombre total 
-          d'octets téléchargés
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_SPEED_DOWNLOAD</constant> : Vitesse moyenne
-          de téléchargement
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_SPEED_UPLOAD</constant> : Vitesse moyenne d'envoi
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_HEADER_SIZE</constant> : Taille des en-têtes reçus
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_HEADER_OUT</constant> : La chaîne de requête envoyée.
-          Pour que cela fonctionne, appelez <function>curl_setopt</function> avec
-          l'option <constant>CURLINFO_HEADER_OUT</constant>.
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_REFERER</constant> - L'en-tête referrer
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_REQUEST_SIZE</constant> : Taille totale des 
-          requêtes envoyées. Actuellement, uniquement pour les requêtes HTTP
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_RETRY_AFTER</constant> - L'information de l'en-tête
-          <literal>Retry-After:</literal>, ou zéro s'il n'y a pas d'en-tête valide.
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_SSL_VERIFYRESULT</constant> : Résultat de la
-          vérification de la certification SSL demandée par 
-          <constant>CURLOPT_SSL_VERIFYPEER</constant>
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_CONTENT_LENGTH_DOWNLOAD</constant> : Taille du corps
-          du téléchargement, lu dans l'en-tête 
-          <literal>Content-Length:</literal> 
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_CONTENT_LENGTH_UPLOAD</constant> : Taille spécifiée
-          de l'envoi.
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_CONTENT_TYPE</constant> : <literal>Content-Type:</literal>
-          du document demandé. &null; indique que le serveur
-          n'a pas envoyé d'en-tête <literal>Content-Type:</literal>
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_PRIVATE</constant> - Données privées associées avec
-          le gestionnaire cURL, précédement défini avec l'option 
-          <constant>CURLOPT_PRIVATE</constant> de la fonction 
-          <function>curl_setopt</function>
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_PROXY_ERROR</constant> - Le code d'erreur détaillé
-          du proxy quand le transfert le plus récent a retourné une erreur
-          <constant>CURLE_PROXY</constant>. La valeur de retour sera exactement
-          une des valeurs parmi
-          <constant>CURLPX_<replaceable>*</replaceable></constant>.
-          Le code d'erreur sera <constant>CURLPX_OK</constant> si aucun code de
-          réponse est disponible.
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_RESPONSE_CODE</constant> - Le dernier code de réponse
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_HTTP_CONNECTCODE</constant> - Le code réponse CONNECT
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_HTTPAUTH_AVAIL</constant> - Masque binaire indiquant la(/les) méthode(s) d'authentification disponbile en accord avec la réponse précédente
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_PROXYAUTH_AVAIL</constant> - Masque binaire indiquant la(/les) méthode(s) d'authentification proxy disponbile en accord avec la réponse précédente
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_OS_ERRNO</constant> - Errno depuis un échec de connexion. Le numéro est spécifique au système et à l'OP.
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_NUM_CONNECTS</constant> - Nombre de connexion curl a dû créer pour achever le transfert précédent
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_SSL_ENGINES</constant> - Moteur-crypto OpenSSL supporté
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_COOKIELIST</constant> - Tous les cookies connue
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_FTP_ENTRY_PATH</constant> - Chemin d'entrée dans un serveur FTP
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_APPCONNECT_TIME</constant> - Temps en seconde qu'il ait fallu depuis le début jusqu'à ce que la connexion/poignée de main SSL/SSH à l'hôte distant a été complété.
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_CERTINFO</constant> - Chaîne de certificats TLS
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_CONDITION_UNMET</constant> - Info sur le temps conditionel non satisfait
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_RTSP_CLIENT_CSEQ</constant> - Prochain client RTSP CSeq
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_RTSP_CSEQ_RECV</constant> - Récemment reçu CSeq
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_RTSP_SERVER_CSEQ</constant> - Prochain serveur RTSP CSeq
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_RTSP_SESSION_ID</constant> - ID de session RTSP
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_CONTENT_LENGTH_DOWNLOAD_T</constant> - Le
-          content-length du téléchargement. Cette valeur est lu depuis le champ
-          <literal>Content-Length:</literal>. -1 si la taille est inconnue
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_CONTENT_LENGTH_UPLOAD_T</constant> - La taille
-          spécifié pour le téléversment. -1 si la taille est inconnue
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_HTTP_VERSION</constant> - La version utilisé lors
-          de la dernière connexion HTTP. La valeur de retour sera l'une des
-          constantes <constant>CURL_HTTP_VERSION_*</constant> définie, ou 0 si
-          la version ne peut être déterminée
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_PROTOCOL</constant> - Le protocole utilisé lors
-          de la dernière connexion HTTP. La valeur retourné sera exactement
-          l'une des valeur <constant>CURLPROTO_*</constant>
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_PROXY_SSL_VERIFYRESULT</constant> - Le résultat
-          de la vérification de certificat qui a été demandé (utilisant l'option
-          <constant>CURLOPT_PROXY_SSL_VERIFYPEER</constant>). Utilisé seulement
-          pour les proxies HTTPS
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_SCHEME</constant> - La schéma de l'URL utilisé
-          pour la connexion la plus récente
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_SIZE_DOWNLOAD_T</constant> - Nombre total d'octets
-          qui ont été téléchargé. Le nombre est uniquement pour le dernier 
-          transfer et sera réinitiallisé denouveau pour chaque nouveau transfer
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_SIZE_UPLOAD_T</constant> - Nombre total d'octets
-          qui ont été téléversé
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_SPEED_DOWNLOAD_T</constant> - La vitesse de
-          téléchargement moyenne en octet/seconde que curl a mesuré pour le
-          téléchargement complet
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_SPEED_UPLOAD_T</constant> - La vitesse de
-          téléchargement moyenne en octet/seconde que curl a mesuré pour le
-          téléversement complet
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_APPCONNECT_TIME_T</constant> - Temps, en microseconde,
-          qu'il a prit entre le début jusqu'à ce que la connexion/poignée de main
-          SSL/SSH à l'hôte distant a été complété
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_CONNECT_TIME_T</constant> - Temps total pris, en
-          microsecondes, depuis le début jusqu'à ce que la connexion à l'hôte
-          distant (ou proxy) a été complété
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_FILETIME_T</constant> - Temps distant du document
-          récupéré (en tant qu'horodatage Unix), une alternative à
-          <constant>CURLINFO_FILETIME</constant> pour permettre aux systèmes
-          avec des variables long 32 bits d'extraire les dates en dehors de
-          l'intervalle 32bit de l'horodatage
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_NAMELOOKUP_TIME_T</constant> - Temps en microsecondes
-          depuis le début jusqu'à ce que la résolution de nom a été complété
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_PRETRANSFER_TIME_T</constant> - Temps pris depuis
-          le début jusqu'à ce que le transfer de fichier est sur le point de
-          commencer, en microsecondes
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_REDIRECT_TIME_T</constant> - Temps total, en
-          microsecondes, prit pour que toutes les étapes de redirection, incluant
-          la recherche de nom, connexion, pré-transfer et transfer avant que la
-          transaction finale a été commencé
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_STARTTRANSFER_TIME_T</constant> - Temps, en
-          microsecondes, il a prit depuis le début jusqu'à ce que le premier
-          octet a été reçu
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_TOTAL_TIME_T</constant> - Temps total en microsecondes
-          pour le transfer précédent, incluant la résolution de nom, connexion
-          TCP, etc.
-         </simpara>
-        </listitem>
-       </itemizedlist>
+       <informaltable>
+        <tgroup cols="2">
+         <thead>
+          <row>
+           <entry valign="top">Option</entry>
+           <entry valign="top">&Description;</entry>
+          </row>
+         </thead>
+         <tbody>
+          <row>
+           <entry><constant>CURLINFO_CAINFO</constant></entry>
+           <entry>
+            Chemin d'accès par défaut du certificat CA intégré
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_CAPATH</constant></entry>
+           <entry>
+            Chaîne de chemin d'accès CA intégré par défaut
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_EFFECTIVE_URL</constant></entry>
+           <entry>
+            Dernière URL effective
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_HTTP_CODE</constant></entry>
+           <entry>
+            Le dernier code de réponse.
+            À partir de cURL 7.10.8, ceci est un alias hérité de
+            <constant>CURLINFO_RESPONSE_CODE</constant>
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_FILETIME</constant></entry>
+           <entry>
+            Date distante du document récupéré,
+            avec <constant>CURLOPT_FILETIME</constant> activé ;
+            si -1 est retourné la date du document distant est inconnue.
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_TOTAL_TIME</constant></entry>
+           <entry>
+            Durée de la transaction en
+            secondes pour le dernier transfert
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_NAMELOOKUP_TIME</constant></entry>
+           <entry>
+            Durée de résolution
+            du nom de domaine en secondes
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_CONNECT_TIME</constant></entry>
+           <entry>
+            Durée d'établissement de
+            la connexion en secondes
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_PRETRANSFER_TIME</constant></entry>
+           <entry>
+            Durée en secondes,
+            entre le début de la transaction et de début du transfert de fichiers
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_STARTTRANSFER_TIME</constant></entry>
+           <entry>
+            Durée en secondes
+            jusqu'à ce que le premier octet soit sur le point d'être transféré
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_REDIRECT_COUNT</constant></entry>
+           <entry>
+            Nombre de redirections, avec
+            l'option <constant>CURLOPT_FOLLOWLOCATION</constant> activée
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_REDIRECT_TIME</constant></entry>
+           <entry>
+            Durée en secondes de toutes
+            les étapes de redirection avant que la transaction finale ne soit débutée,
+            avec l'option <constant>CURLOPT_FOLLOWLOCATION</constant> activée
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_REDIRECT_URL</constant></entry>
+           <entry>
+            Avec l'option
+            <constant>CURLOPT_FOLLOWLOCATION</constant> désactivée : URL de
+            redirection trouvée dans la dernière transaction, qui devra être
+            interrogé manuellement par la suite. Si l'option
+            <constant>CURLOPT_FOLLOWLOCATION</constant> est activée : cette valeur
+            est vide. Dans ce cas, l'url de redirection est disponible dans
+            <constant>CURLINFO_EFFECTIVE_URL</constant>
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_PRIMARY_IP</constant></entry>
+           <entry>
+            Adresse IP de la plus
+            récente connexion
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_PRIMARY_PORT</constant></entry>
+           <entry>
+            Port de destination de
+            la plus récente connexion
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_LOCAL_IP</constant></entry>
+           <entry>
+            Adresse IP locale (source) de
+            la plus récente connexion
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_LOCAL_PORT</constant></entry>
+           <entry>
+            Port local (source) de la
+            plus récente connexion
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_SIZE_UPLOAD</constant></entry>
+           <entry>
+            Nombre total
+            d'octets envoyés
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_SIZE_DOWNLOAD</constant></entry>
+           <entry>
+            Nombre total
+            d'octets téléchargés
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_SPEED_DOWNLOAD</constant></entry>
+           <entry>
+            Vitesse moyenne
+            de téléchargement
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_SPEED_UPLOAD</constant></entry>
+           <entry>
+            Vitesse moyenne d'envoi
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_HEADER_SIZE</constant></entry>
+           <entry>
+            Taille des en-têtes reçus
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_HEADER_OUT</constant></entry>
+           <entry>
+            La chaîne de requête envoyée.
+            Pour que cela fonctionne, appelez <function>curl_setopt</function> avec
+            l'option <constant>CURLINFO_HEADER_OUT</constant>.
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_REFERER</constant></entry>
+           <entry>
+            L'en-tête referrer
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_REQUEST_SIZE</constant></entry>
+           <entry>
+            Taille totale des
+            requêtes envoyées. Actuellement, uniquement pour les requêtes HTTP
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_RETRY_AFTER</constant></entry>
+           <entry>
+            L'information de l'en-tête
+            <literal>Retry-After:</literal>, ou zéro s'il n'y a pas d'en-tête valide.
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_SSL_VERIFYRESULT</constant></entry>
+           <entry>
+            Résultat de la
+            vérification de la certification SSL demandée par
+            <constant>CURLOPT_SSL_VERIFYPEER</constant>
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_CONTENT_LENGTH_DOWNLOAD</constant></entry>
+           <entry>
+            Taille du corps
+            du téléchargement, lu dans l'en-tête
+            <literal>Content-Length:</literal>
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_CONTENT_LENGTH_UPLOAD</constant></entry>
+           <entry>
+            Taille spécifiée
+            de l'envoi.
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_CONTENT_TYPE</constant></entry>
+           <entry>
+            <literal>Content-Type:</literal>
+            du document demandé. &null; indique que le serveur
+            n'a pas envoyé d'en-tête <literal>Content-Type:</literal>
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_PRIVATE</constant></entry>
+           <entry>
+            Données privées associées avec
+            le gestionnaire cURL, précédement défini avec l'option
+            <constant>CURLOPT_PRIVATE</constant> de la fonction
+            <function>curl_setopt</function>
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_PROXY_ERROR</constant></entry>
+           <entry>
+            Le code d'erreur détaillé
+            du proxy quand le transfert le plus récent a retourné une erreur
+            <constant>CURLE_PROXY</constant>. La valeur de retour sera exactement
+            une des valeurs parmi
+            <constant>CURLPX_<replaceable>*</replaceable></constant>.
+            Le code d'erreur sera <constant>CURLPX_OK</constant> si aucun code de
+            réponse est disponible.
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_RESPONSE_CODE</constant></entry>
+           <entry>
+            Le dernier code de réponse
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_HTTP_CONNECTCODE</constant></entry>
+           <entry>
+            Le code réponse CONNECT
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_HTTPAUTH_AVAIL</constant></entry>
+           <entry>
+            Masque binaire indiquant la(/les) méthode(s) d'authentification disponbile en accord avec la réponse précédente
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_PROXYAUTH_AVAIL</constant></entry>
+           <entry>
+            Masque binaire indiquant la(/les) méthode(s) d'authentification proxy disponbile en accord avec la réponse précédente
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_OS_ERRNO</constant></entry>
+           <entry>
+            Errno depuis un échec de connexion. Le numéro est spécifique au système et à l'OP.
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_NUM_CONNECTS</constant></entry>
+           <entry>
+            Nombre de connexion curl a dû créer pour achever le transfert précédent
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_SSL_ENGINES</constant></entry>
+           <entry>
+            Moteur-crypto OpenSSL supporté
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_COOKIELIST</constant></entry>
+           <entry>
+            Tous les cookies connue
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_FTP_ENTRY_PATH</constant></entry>
+           <entry>
+            Chemin d'entrée dans un serveur FTP
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_APPCONNECT_TIME</constant></entry>
+           <entry>
+            Temps en seconde qu'il ait fallu depuis le début jusqu'à ce que la connexion/poignée de main SSL/SSH à l'hôte distant a été complété.
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_CERTINFO</constant></entry>
+           <entry>
+            Chaîne de certificats TLS
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_CONDITION_UNMET</constant></entry>
+           <entry>
+            Info sur le temps conditionel non satisfait
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_RTSP_CLIENT_CSEQ</constant></entry>
+           <entry>
+            Prochain client RTSP CSeq
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_RTSP_CSEQ_RECV</constant></entry>
+           <entry>
+            Récemment reçu CSeq
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_RTSP_SERVER_CSEQ</constant></entry>
+           <entry>
+            Prochain serveur RTSP CSeq
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_RTSP_SESSION_ID</constant></entry>
+           <entry>
+            ID de session RTSP
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_CONTENT_LENGTH_DOWNLOAD_T</constant></entry>
+           <entry>
+            Le
+            content-length du téléchargement. Cette valeur est lu depuis le champ
+            <literal>Content-Length:</literal>. -1 si la taille est inconnue
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_CONTENT_LENGTH_UPLOAD_T</constant></entry>
+           <entry>
+            La taille
+            spécifié pour le téléversment. -1 si la taille est inconnue
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_HTTP_VERSION</constant></entry>
+           <entry>
+            La version utilisé lors
+            de la dernière connexion HTTP. La valeur de retour sera l'une des
+            constantes <constant>CURL_HTTP_VERSION_*</constant> définie, ou 0 si
+            la version ne peut être déterminée
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_PROTOCOL</constant></entry>
+           <entry>
+            Le protocole utilisé lors
+            de la dernière connexion HTTP. La valeur retourné sera exactement
+            l'une des valeur <constant>CURLPROTO_*</constant>
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_PROXY_SSL_VERIFYRESULT</constant></entry>
+           <entry>
+            Le résultat
+            de la vérification de certificat qui a été demandé (utilisant l'option
+            <constant>CURLOPT_PROXY_SSL_VERIFYPEER</constant>). Utilisé seulement
+            pour les proxies HTTPS
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_SCHEME</constant></entry>
+           <entry>
+            La schéma de l'URL utilisé
+            pour la connexion la plus récente
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_SIZE_DOWNLOAD_T</constant></entry>
+           <entry>
+            Nombre total d'octets
+            qui ont été téléchargé. Le nombre est uniquement pour le dernier
+            transfer et sera réinitiallisé denouveau pour chaque nouveau transfer
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_SIZE_UPLOAD_T</constant></entry>
+           <entry>
+            Nombre total d'octets
+            qui ont été téléversé
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_SPEED_DOWNLOAD_T</constant></entry>
+           <entry>
+            La vitesse de
+            téléchargement moyenne en octet/seconde que curl a mesuré pour le
+            téléchargement complet
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_SPEED_UPLOAD_T</constant></entry>
+           <entry>
+            La vitesse de
+            téléchargement moyenne en octet/seconde que curl a mesuré pour le
+            téléversement complet
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_APPCONNECT_TIME_T</constant></entry>
+           <entry>
+            Temps, en microseconde,
+            qu'il a prit entre le début jusqu'à ce que la connexion/poignée de main
+            SSL/SSH à l'hôte distant a été complété
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_CONNECT_TIME_T</constant></entry>
+           <entry>
+            Temps total pris, en
+            microsecondes, depuis le début jusqu'à ce que la connexion à l'hôte
+            distant (ou proxy) a été complété
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_FILETIME_T</constant></entry>
+           <entry>
+            Temps distant du document
+            récupéré (en tant qu'horodatage Unix), une alternative à
+            <constant>CURLINFO_FILETIME</constant> pour permettre aux systèmes
+            avec des variables long 32 bits d'extraire les dates en dehors de
+            l'intervalle 32bit de l'horodatage
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_NAMELOOKUP_TIME_T</constant></entry>
+           <entry>
+            Temps en microsecondes
+            depuis le début jusqu'à ce que la résolution de nom a été complété
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_PRETRANSFER_TIME_T</constant></entry>
+           <entry>
+            Temps pris depuis
+            le début jusqu'à ce que le transfer de fichier est sur le point de
+            commencer, en microsecondes
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_REDIRECT_TIME_T</constant></entry>
+           <entry>
+            Temps total, en
+            microsecondes, prit pour que toutes les étapes de redirection, incluant
+            la recherche de nom, connexion, pré-transfer et transfer avant que la
+            transaction finale a été commencé
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_STARTTRANSFER_TIME_T</constant></entry>
+           <entry>
+            Temps, en
+            microsecondes, il a prit depuis le début jusqu'à ce que le premier
+            octet a été reçu
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_TOTAL_TIME_T</constant></entry>
+           <entry>
+            Temps total en microsecondes
+            pour le transfer précédent, incluant la résolution de nom, connexion
+            TCP, etc.
+           </entry>
+          </row>
+         </tbody>
+        </tgroup>
+       </informaltable>
       </para>
      </listitem>
     </varlistentry>
@@ -456,7 +532,7 @@
   &reftitle.returnvalues;
   <para>
    Si <parameter>option</parameter> est fourni, la valeur sera retournée.
-   Sinon, ce sera un tableau associatif contenant les éléments suivants 
+   Sinon, ce sera un tableau associatif contenant les éléments suivants
    (qui correspond à <parameter>option</parameter>), ou &false; si une erreur survient :
    <itemizedlist>
     <listitem>
@@ -591,13 +667,13 @@
     </listitem>
     <listitem>
      <simpara>
-      "request_header" (Existe seulement si <constant>CURLINFO_HEADER_OUT</constant> 
+      "request_header" (Existe seulement si <constant>CURLINFO_HEADER_OUT</constant>
       est utilisé via un appel à <function>curl_setopt</function>)
      </simpara>
     </listitem>
    </itemizedlist>
-   Veuillez noter que les données privées ne sont pas incluses dans le tableau 
-   associatif et doivent être récupérées individuellement avec l'option 
+   Veuillez noter que les données privées ne sont pas incluses dans le tableau
+   associatif et doivent être récupérées individuellement avec l'option
    <constant>CURLINFO_PRIVATE</constant>.
   </para>
  </refsect1>
@@ -641,7 +717,7 @@
        <entry>7.3.0</entry>
        <entry>
         Ajout de <constant>CURLINFO_CONTENT_LENGTH_DOWNLOAD_T</constant>,
-        <constant>CURLINFO_CONTENT_LENGTH_UPLOAD_T</constant>, 
+        <constant>CURLINFO_CONTENT_LENGTH_UPLOAD_T</constant>,
         <constant>CURLINFO_HTTP_VERSION</constant>,
         <constant>CURLINFO_PROTOCOL</constant>,
         <constant>CURLINFO_PROXY_SSL_VERIFYRESULT</constant>,
@@ -736,7 +812,7 @@ curl_close($ch);
    </para>
   </note>
  </refsect1>
- 
+
 </refentry>
 <!-- Keep this comment at the end of the file
 Local variables:

--- a/reference/curl/functions/curl-getinfo.xml
+++ b/reference/curl/functions/curl-getinfo.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 8b3f89ed6171cb711b00afb0fcacbea3462537b9 Maintainer: haszi Status: ready -->
+<!-- EN-Revision: 8b3f89ed6171cb711b00afb0fcacbea3462537b9 Maintainer: yannick Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.curl-getinfo" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>


### PR DESCRIPTION
This PR converts the constant list for the second (`option`) parameter of `curl_getinfo()` to a table (as it was done in `doc-en` [here](https://github.com/php/doc-en/pull/3130)).