### PR TITLE
Fix missing closing bracket

### DIFF
--- a/reference/pdo_mysql/constants.xml
+++ b/reference/pdo_mysql/constants.xml
@@ -30,6 +30,7 @@ $pdo->setAttribute(PDO::MYSQL_ATTR_USE_BUFFERED_QUERY, false);
 $unbufferedResult = $pdo->query("SELECT Name FROM City");
 foreach ($unbufferedResult as $row) {
     echo $row['Name'] . PHP_EOL;
+}
 ?>
 ]]>
       </programlisting>


### PR DESCRIPTION
In constants.xml used in https://www.php.net/manual/fr/ref.pdo-mysql.php, in the 'Exemple #1 Activation du mode non mis en cache de MySQL'section.A closing bracket is missing for the foreach loop, it may cause missing understanding for beginner in PHP.