### PR TITLE
Fix domchildnode.replacewith parsing errors

### DIFF
--- a/reference/dom/domchildnode/replacewith.xml
+++ b/reference/dom/domchildnode/replacewith.xml
@@ -6,7 +6,7 @@
   <refname>DOMChildNode::replaceWith</refname>
   <refpurpose>Remplace le nœud par de nouveaux nœuds</refpurpose>
  </refnamediv>
- 
+
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis role="DOMChildNode">
@@ -18,7 +18,7 @@
    Une combinaison de <methodname>DOMChildNode::remove</methodname> et <methodname>DOMChildNode::append</methodname>.
   </para>
  </refsect1>
- 
+
  <refsect1 role="parameters">
   &reftitle.parameters;
   <para>
@@ -34,12 +34,20 @@
    </variablelist>
   </para>
  </refsect1>
- 
+
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
    &return.void;
   </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <variablelist>
+   &dom.errors.hierarchy.parent;
+   &dom.errors.wrong_document;
+  </variablelist>
  </refsect1>
 
  <refsect1 role="changelog">


### PR DESCRIPTION
Add errors section to DOMChildNode's replaceWith method to fix parsing errors.