### PR TITLE
Add translation of missing reflection classes

### DIFF
--- a/reference/reflection/reflectionattribute.xml
+++ b/reference/reflection/reflectionattribute.xml
@@ -62,7 +62,8 @@
       <term><constant>ReflectionAttribute::IS_INSTANCEOF</constant></term>
       <listitem>
        <para>
-        Renvoie les attributs avec une vérification <parameter>instanceof</parameter>.
+        Renvoie les attributs avec une
+        vérification <parameter>instanceof</parameter>.
        </para>
       </listitem>
      </varlistentry>

--- a/reference/reflection/reflectionattribute.xml
+++ b/reference/reflection/reflectionattribute.xml
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: Fan2Shrek : ready -->
+<phpdoc:classref xml:id="class.reflectionattribute" xmlns:phpdoc="http://php.net/ns/phpdoc" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+
+ <title>La classe ReflectionAttribute</title>
+ <titleabbrev>ReflectionAttribute</titleabbrev>
+
+ <partintro>
+
+<!-- {{{ ReflectionAttribute intro -->
+  <section xml:id="reflectionattribute.intro">
+   &reftitle.intro;
+   <para>
+    La classe <classname>ReflectionAttribute</classname> apporte des informations sur
+    un <link linkend="language.attributes">Attribut</link>.
+   </para>
+  </section>
+<!-- }}} -->
+
+  <section xml:id="reflectionattribute.synopsis">
+   &reftitle.classsynopsis;
+
+<!-- {{{ Synopsis -->
+   <classsynopsis class="class">
+    <ooclass>
+     <classname>ReflectionAttribute</classname>
+    </ooclass>
+
+    <oointerface>
+     <modifier>implements</modifier>
+     <interfacename>Reflector</interfacename>
+    </oointerface>
+
+    <classsynopsisinfo role="comment">&Constants;</classsynopsisinfo>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="reflectionattribute.constants.is-instanceof">ReflectionAttribute::IS_INSTANCEOF</varname>
+    </fieldsynopsis>
+
+    <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionattribute')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='ReflectionAttribute'])">
+     <xi:fallback/>
+    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionattribute')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ReflectionAttribute'])">
+     <xi:fallback/>
+    </xi:include>
+   </classsynopsis>
+<!-- }}} -->
+
+  </section>
+
+  <!-- {{{ ReflectionAttribute constants -->
+  <section xml:id="reflectionattribute.constants">
+   &reftitle.constants;
+   <section xml:id="reflectionattribute.constants.flags">
+    <title>Drapeaux ReflectionAttribute</title>
+    <variablelist>
+
+     <varlistentry xml:id="reflectionattribute.constants.is-instanceof">
+      <term><constant>ReflectionAttribute::IS_INSTANCEOF</constant></term>
+      <listitem>
+       <para>
+        Renvoie les attributs avec une vérification <parameter>instanceof</parameter>.
+       </para>
+      </listitem>
+     </varlistentry>
+
+    </variablelist>
+    <note>
+     <para>
+      Les valeurs de ces constantes peuvent changer entre les versions de PHP.
+      Il est recommandé d'utiliser toujours les constantes et de ne pas se fier aux valeurs directement.
+     </para>
+    </note>
+   </section>
+  </section>
+  <!-- }}} -->
+
+ </partintro>
+
+ &reference.reflection.entities.reflectionattribute;
+
+</phpdoc:classref>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/reflection/reflectionenum.xml
+++ b/reference/reflection/reflectionenum.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: Fan2Shrek : ready -->
+<phpdoc:classref xml:id="class.reflectionenum" xmlns:phpdoc="http://php.net/ns/phpdoc" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+
+ <title>La classe ReflectionEnum</title>
+ <titleabbrev>ReflectionEnum</titleabbrev>
+
+ <partintro>
+
+  <!-- {{{ ReflectionEnum intro -->
+  <section xml:id="reflectionenum.intro">
+   &reftitle.intro;
+   <para>
+    La classe <classname>ReflectionEnum</classname> apporte
+    des informations à propos d'une énumération.
+   </para>
+  </section>
+  <!-- }}} -->
+
+  <section xml:id="reflectionenum.synopsis">
+   &reftitle.classsynopsis;
+
+   <!-- {{{ Synopsis -->
+   <classsynopsis class="class">
+    <ooclass>
+     <classname>ReflectionEnum</classname>
+    </ooclass>
+
+    <ooclass>
+     <modifier>extends</modifier>
+     <classname>ReflectionClass</classname>
+    </ooclass>
+
+    <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionclass')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
+     <xi:fallback/>
+    </xi:include>
+
+    <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionclass')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
+     <xi:fallback/>
+    </xi:include>
+
+    <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionenum')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='ReflectionEnum'])">
+     <xi:fallback/>
+    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionenum')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ReflectionEnum'])">
+     <xi:fallback/>
+    </xi:include>
+
+    <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionclass')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ReflectionClass'])">
+     <xi:fallback/>
+    </xi:include>
+   </classsynopsis>
+   <!-- }}} -->
+
+  </section>
+
+  <section role="seealso" xml:id="reflectionenum.seealso">
+   &reftitle.seealso;
+   <para>
+    <simplelist>
+     <member><link linkend="language.enumerations">Enumerations</link></member>
+    </simplelist>
+   </para>
+  </section>
+
+ </partintro>
+
+ &reference.reflection.entities.reflectionenum;
+
+</phpdoc:classref>
+<!-- Keep this comment at the end of the file
+ Local variables:
+ mode: sgml
+ sgml-omittag:t
+ sgml-shorttag:t
+ sgml-minimize-attributes:nil
+ sgml-always-quote-attributes:t
+ sgml-indent-step:1
+ sgml-indent-data:t
+ indent-tabs-mode:nil
+ sgml-parent-document:nil
+ sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+ sgml-exposed-tags:nil
+ sgml-local-catalogs:nil
+ sgml-local-ecat-files:nil
+ End:
+ vim600: syn=xml fen fdm=syntax fdl=2 si
+ vim: et tw=78 syn=sgml
+ vi: ts=1 sw=1
+ -->

--- a/reference/reflection/reflectionenumbackedcase.xml
+++ b/reference/reflection/reflectionenumbackedcase.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: Fan2Shrek : ready -->
+<phpdoc:classref xml:id="class.reflectionenumbackedcase" xmlns:phpdoc="http://php.net/ns/phpdoc" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+
+ <title>La classe ReflectionEnumBackedCase</title>
+ <titleabbrev>ReflectionEnumBackedCase</titleabbrev>
+
+ <partintro>
+
+<!-- {{{ ReflectionEnumBackedCase intro -->
+  <section xml:id="reflectionenumbackedcase.intro">
+   &reftitle.intro;
+   <para>
+    La classe <classname>ReflectionEnumBackedCase</classname> apporte
+    des informations à propos d'un cas d'énumération soutenue, qui a un scalaire équivalent.
+   </para>
+  </section>
+<!-- }}} -->
+
+  <section xml:id="reflectionenumbackedcase.synopsis">
+   &reftitle.classsynopsis;
+
+<!-- {{{ Synopsis -->
+   <classsynopsis class="class">
+    <ooclass>
+     <classname>ReflectionEnumBackedCase</classname>
+    </ooclass>
+
+    <ooclass>
+     <modifier>extends</modifier>
+     <classname>ReflectionEnumUnitCase</classname>
+    </ooclass>
+
+    <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionclassconstant')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
+     <xi:fallback/>
+    </xi:include>
+
+    <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionclassconstant')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
+     <xi:fallback/>
+    </xi:include>
+
+    <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionenumbackedcase')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='ReflectionEnumBackedCase'])">
+     <xi:fallback/>
+    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionenumbackedcase')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ReflectionEnumBackedCase'])">
+     <xi:fallback/>
+    </xi:include>
+
+    <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionenumunitcase')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ReflectionEnumUnitCase'])">
+     <xi:fallback/>
+    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionclassconstant')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ReflectionClassConstant'])">
+     <xi:fallback/>
+    </xi:include>
+   </classsynopsis>
+<!-- }}} -->
+
+  </section>
+
+  <section role="seealso" xml:id="reflectionenumbackedcase.seealso">
+   &reftitle.seealso;
+   <para>
+    <simplelist>
+     <member><link linkend="language.enumerations">Enumerations</link></member>
+     <member><classname>ReflectionEnumUnitCase</classname></member>
+    </simplelist>
+   </para>
+  </section>
+
+ </partintro>
+
+ &reference.reflection.entities.reflectionenumbackedcase;
+
+</phpdoc:classref>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/reflection/reflectionenumunitcase.xml
+++ b/reference/reflection/reflectionenumunitcase.xml
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: Fan2Shrek : ready -->
+<phpdoc:classref xml:id="class.reflectionenumunitcase" xmlns:phpdoc="http://php.net/ns/phpdoc" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+
+ <title>La classe ReflectionEnumUnitCase</title>
+ <titleabbrev>ReflectionEnumUnitCase</titleabbrev>
+
+ <partintro>
+
+<!-- {{{ ReflectionEnumUnitCase intro -->
+  <section xml:id="reflectionenumunitcase.intro">
+   &reftitle.intro;
+   <para>
+    La classe <classname>ReflectionEnumUnitCase</classname> apporte
+    des informations à propos d'un cas d'énumération unitaire, qui n'a pas d'équivalent scalaire.
+   </para>
+  </section>
+<!-- }}} -->
+
+  <section xml:id="reflectionenumunitcase.synopsis">
+   &reftitle.classsynopsis;
+
+<!-- {{{ Synopsis -->
+   <classsynopsis class="class">
+    <ooclass>
+     <classname>ReflectionEnumUnitCase</classname>
+    </ooclass>
+
+    <ooclass>
+     <modifier>extends</modifier>
+     <classname>ReflectionClassConstant</classname>
+    </ooclass>
+
+    <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionclassconstant')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
+     <xi:fallback/>
+    </xi:include>
+
+    <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionclassconstant')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
+     <xi:fallback/>
+    </xi:include>
+
+    <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionenumunitcase')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='ReflectionEnumUnitCase'])">
+     <xi:fallback/>
+    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionenumunitcase')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ReflectionEnumUnitCase'])">
+     <xi:fallback/>
+    </xi:include>
+
+    <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionclassconstant')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ReflectionClassConstant'])">
+     <xi:fallback/>
+    </xi:include>
+   </classsynopsis>
+<!-- }}} -->
+
+  </section>
+
+  <section role="seealso" xml:id="reflectionenumunitcase.seealso">
+   &reftitle.seealso;
+   <para>
+    <simplelist>
+     <member><link linkend="language.enumerations">Enumerations</link></member>
+     <member><classname>ReflectionEnumBackedCase</classname></member>
+    </simplelist>
+   </para>
+  </section>
+
+ </partintro>
+
+ &reference.reflection.entities.reflectionenumunitcase;
+
+</phpdoc:classref>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/reflection/reflectionreference.xml
+++ b/reference/reflection/reflectionreference.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: Fan2Shrek : ready -->
+<phpdoc:classref xml:id="class.reflectionreference" xmlns:phpdoc="http://php.net/ns/phpdoc" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+
+ <title>La classe ReflectionReference</title>
+ <titleabbrev>ReflectionReference</titleabbrev>
+
+ <partintro>
+
+<!-- {{{ ReflectionReference intro -->
+  <section xml:id="reflectionreference.intro">
+   &reftitle.intro;
+   <para>
+    La classe <classname>ReflectionReference</classname> apporte
+    des informations à propos d'une référence.
+   </para>
+  </section>
+<!-- }}} -->
+
+  <section xml:id="reflectionreference.synopsis">
+   &reftitle.classsynopsis;
+
+<!-- {{{ Synopsis -->
+   <classsynopsis class="class">
+    <ooclass>
+     <modifier>final</modifier>
+     <classname>ReflectionReference</classname>
+    </ooclass>
+
+    <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionreference')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='ReflectionReference'])">
+     <xi:fallback/>
+    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.reflectionreference')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ReflectionReference'])">
+     <xi:fallback/>
+    </xi:include>
+   </classsynopsis>
+<!-- }}} -->
+
+  </section>
+
+ </partintro>
+
+ &reference.reflection.entities.reflectionreference;
+
+</phpdoc:classref>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
Here is my translation for the missing reflection classes : 

- `ReflectionAttribute`
- `ReflectionEnum`
- `ReflectionEnumBackedCase`
- `ReflectionEnumUnitCase`
- `ReflectionReference`