### PR TITLE
Translate date classes

### DIFF
--- a/reference/datetime/dateerror.xml
+++ b/reference/datetime/dateerror.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 696b6b9e32d8d4ef4cfd874caf677a47a6cbadb4 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<phpdoc:exceptionref xml:id="class.dateerror" xmlns:phpdoc="http://php.net/ns/phpdoc" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+ <title>La classe DateError</title>
+ <titleabbrev>DateError</titleabbrev>
+
+ <partintro>
+
+<!-- {{{ DateError intro -->
+  <section xml:id="dateerror.intro">
+   &reftitle.intro;
+   <para>
+    Lancée quand la base de données des fuseaux horaires n'est pas trouvée, ou contient des données invalides.
+   </para>
+   <para>
+    Cette erreur ne devrait jamais se produire, et ne dépend pas du code. Il y a deux
+    exceptions enfants (<exceptionname>DateObjectError</exceptionname> et
+    <exceptionname>DateRangeError</exceptionname>) qui sont lancées en fonction
+    des erreurs du développeur ou des problèmes de plage.
+   </para>
+  </section>
+<!-- }}} -->
+
+  <section xml:id="dateerror.synopsis">
+   &reftitle.classsynopsis;
+
+<!-- {{{ Synopsis -->
+   <classsynopsis class="class">
+    <ooexception>
+     <exceptionname>DateError</exceptionname>
+    </ooexception>
+
+    <ooclass>
+     <modifier>extends</modifier>
+     <classname>Error</classname>
+    </ooclass>
+
+    <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
+     <xi:fallback/>
+    </xi:include>
+
+    <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Error'])">
+     <xi:fallback/>
+    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Error'])">
+     <xi:fallback/>
+    </xi:include>
+   </classsynopsis>
+<!-- }}} -->
+
+  </section>
+
+  <section role="seealso">
+   &reftitle.seealso;
+   <simplelist>
+    <member><exceptionname>DateObjectError</exceptionname></member>
+    <member><exceptionname>DateRangeError</exceptionname></member>
+   </simplelist>
+  </section>
+ </partintro>
+
+</phpdoc:exceptionref>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/datetime/dateexception.xml
+++ b/reference/datetime/dateexception.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 696b6b9e32d8d4ef4cfd874caf677a47a6cbadb4 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<phpdoc:exceptionref xml:id="class.dateexception" xmlns:phpdoc="http://php.net/ns/phpdoc" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+ <title>La classe DateException</title>
+ <titleabbrev>DateException</titleabbrev>
+
+ <partintro>
+
+<!-- {{{ DateException intro -->
+  <section xml:id="dateexception.intro">
+   &reftitle.intro;
+   <para>
+    Classe parente de toutes les exceptions Date/Time, pour les problèmes qui sont liés
+    aux entrées utilisateur, ou aux arguments textuels libres qui doivent être analysés.
+   </para>
+   <para>
+    Les exceptions enfants suivantes sont lancées par l'extension :
+    <itemizedlist>
+     <listitem><simpara><exceptionname>DateInvalidOperationException</exceptionname></simpara></listitem>
+     <listitem><simpara><exceptionname>DateInvalidTimezoneException</exceptionname></simpara></listitem>
+     <listitem><simpara><exceptionname>DateMalformedIntervalStringException</exceptionname></simpara></listitem>
+     <listitem><simpara><exceptionname>DateMalformedPeriodStringException</exceptionname></simpara></listitem>
+     <listitem><simpara><exceptionname>DateMalformedStringException</exceptionname></simpara></listitem>
+    </itemizedlist>
+   </para>
+  </section>
+<!-- }}} -->
+
+  <section xml:id="dateexception.synopsis">
+   &reftitle.classsynopsis;
+
+<!-- {{{ Synopsis -->
+   <classsynopsis class="class">
+    <ooexception>
+     <exceptionname>DateException</exceptionname>
+    </ooexception>
+
+    <ooclass>
+     <modifier>extends</modifier>
+     <classname>Exception</classname>
+    </ooclass>
+
+    <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
+     <xi:fallback/>
+    </xi:include>
+
+    <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])">
+     <xi:fallback/>
+    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])">
+     <xi:fallback/>
+    </xi:include>
+   </classsynopsis>
+<!-- }}} -->
+
+  </section>
+
+ </partintro>
+
+</phpdoc:exceptionref>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/datetime/dateinvalidoperationexception.xml
+++ b/reference/datetime/dateinvalidoperationexception.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 696b6b9e32d8d4ef4cfd874caf677a47a6cbadb4 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<phpdoc:exceptionref xml:id="class.dateinvalidoperationexception" xmlns:phpdoc="http://php.net/ns/phpdoc" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+ <title>La classe DateInvalidOperationException</title>
+ <titleabbrev>DateInvalidOperationException</titleabbrev>
+
+ <partintro>
+
+<!-- {{{ DateInvalidOperationException intro -->
+  <section xml:id="dateinvalidoperationexception.intro">
+   &reftitle.intro;
+   <para>
+    Lancée par <methodname>DateTimeImmutable::sub</methodname> et
+    <methodname>DateTime::sub</methodname> lorsqu'une operation non supportée est
+    tentée.
+   </para>
+   <para>
+    Un exemple d'opération non supportée est l'utilisation d'un objet
+    <classname>DateInterval</classname> représentant des spécifications de temps
+    tel que <literal>next weekday</literal>, car aucune déclaration logique inversée ne
+    peut être construite.
+   </para>
+  </section>
+<!-- }}} -->
+
+  <section xml:id="dateinvalidoperationexception.synopsis">
+   &reftitle.classsynopsis;
+
+<!-- {{{ Synopsis -->
+   <classsynopsis class="class">
+    <ooexception>
+     <exceptionname>DateInvalidOperationException</exceptionname>
+    </ooexception>
+
+    <ooclass>
+     <modifier>extends</modifier>
+     <classname>DateException</classname>
+    </ooclass>
+
+    <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
+     <xi:fallback/>
+    </xi:include>
+
+    <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])">
+     <xi:fallback/>
+    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])">
+     <xi:fallback/>
+    </xi:include>
+   </classsynopsis>
+<!-- }}} -->
+
+  </section>
+
+ </partintro>
+
+</phpdoc:exceptionref>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/datetime/dateinvalidtimezoneexception.xml
+++ b/reference/datetime/dateinvalidtimezoneexception.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 696b6b9e32d8d4ef4cfd874caf677a47a6cbadb4 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<phpdoc:exceptionref xml:id="class.dateinvalidtimezoneexception" xmlns:phpdoc="http://php.net/ns/phpdoc" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+ <title>La classe DateInvalidTimeZoneException</title>
+ <titleabbrev>DateInvalidTimeZoneException</titleabbrev>
+
+ <partintro>
+
+<!-- {{{ DateInvalidTimeZoneException intro -->
+  <section xml:id="dateinvalidtimezoneexception.intro">
+   &reftitle.intro;
+   <para>
+    Lancée lorsqu'une valeur incorrecte est passée à
+    <methodname>DateTimeZone::__construct</methodname>.
+   </para>
+  </section>
+<!-- }}} -->
+
+  <section xml:id="dateinvalidtimezoneexception.synopsis">
+   &reftitle.classsynopsis;
+
+<!-- {{{ Synopsis -->
+   <classsynopsis class="class">
+    <ooexception>
+     <exceptionname>DateInvalidTimeZoneException</exceptionname>
+    </ooexception>
+
+    <ooclass>
+     <modifier>extends</modifier>
+     <classname>DateException</classname>
+    </ooclass>
+
+    <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
+     <xi:fallback/>
+    </xi:include>
+
+    <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])">
+     <xi:fallback/>
+    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])">
+     <xi:fallback/>
+    </xi:include>
+   </classsynopsis>
+<!-- }}} -->
+
+  </section>
+
+ </partintro>
+
+</phpdoc:exceptionref>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/datetime/datemalformedintervalstringexception.xml
+++ b/reference/datetime/datemalformedintervalstringexception.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 696b6b9e32d8d4ef4cfd874caf677a47a6cbadb4 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<phpdoc:exceptionref xml:id="class.datemalformedintervalstringexception" xmlns:phpdoc="http://php.net/ns/phpdoc" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+ <title>La classe DateMalformedIntervalStringException</title>
+ <titleabbrev>DateMalformedIntervalStringException</titleabbrev>
+
+ <partintro>
+
+<!-- {{{ DateMalformedIntervalStringException intro -->
+  <section xml:id="datemalformedintervalstringexception.intro">
+   &reftitle.intro;
+   <para>
+    Lancée lorsqu'un argument <parameter>duration</parameter> invalide est passé à
+    <methodname>DateInterval::__construct</methodname>.
+   </para>
+  </section>
+<!-- }}} -->
+
+  <section xml:id="datemalformedintervalstringexception.synopsis">
+   &reftitle.classsynopsis;
+
+<!-- {{{ Synopsis -->
+   <classsynopsis class="class">
+    <ooexception>
+     <exceptionname>DateMalformedIntervalStringException</exceptionname>
+    </ooexception>
+
+    <ooclass>
+     <modifier>extends</modifier>
+     <classname>DateException</classname>
+    </ooclass>
+
+    <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
+     <xi:fallback/>
+    </xi:include>
+
+    <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])">
+     <xi:fallback/>
+    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])">
+     <xi:fallback/>
+    </xi:include>
+   </classsynopsis>
+<!-- }}} -->
+
+  </section>
+
+ </partintro>
+
+</phpdoc:exceptionref>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/datetime/datemalformedperiodstringexception.xml
+++ b/reference/datetime/datemalformedperiodstringexception.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 696b6b9e32d8d4ef4cfd874caf677a47a6cbadb4 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<phpdoc:exceptionref xml:id="class.datemalformedperiodstringexception" xmlns:phpdoc="http://php.net/ns/phpdoc" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+ <title>La classe DateMalformedPeriodStringException</title>
+ <titleabbrev>DateMalformedPeriodStringException</titleabbrev>
+
+ <partintro>
+
+<!-- {{{ DateMalformedPeriodStringException intro -->
+  <section xml:id="datemalformedperiodstringexception.intro">
+   &reftitle.intro;
+   <para>
+    Lancée lorqu'un argument <parameter>isostr</parameter> invalide est passé à
+    <methodname>DatePeriod::__construct</methodname>.
+   </para>
+  </section>
+<!-- }}} -->
+
+  <section xml:id="datemalformedperiodstringexception.synopsis">
+   &reftitle.classsynopsis;
+
+<!-- {{{ Synopsis -->
+   <classsynopsis class="class">
+    <ooexception>
+     <exceptionname>DateMalformedPeriodStringException</exceptionname>
+    </ooexception>
+
+    <ooclass>
+     <modifier>extends</modifier>
+     <classname>DateException</classname>
+    </ooclass>
+
+    <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
+     <xi:fallback/>
+    </xi:include>
+
+    <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])">
+     <xi:fallback/>
+    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])">
+     <xi:fallback/>
+    </xi:include>
+   </classsynopsis>
+<!-- }}} -->
+
+  </section>
+
+ </partintro>
+
+</phpdoc:exceptionref>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/datetime/datemalformedstringexception.xml
+++ b/reference/datetime/datemalformedstringexception.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 696b6b9e32d8d4ef4cfd874caf677a47a6cbadb4 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<phpdoc:exceptionref xml:id="class.datemalformedstringexception" xmlns:phpdoc="http://php.net/ns/phpdoc" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+ <title>La classe DateMalformedStringException</title>
+ <titleabbrev>DateMalformedStringException</titleabbrev>
+
+ <partintro>
+
+<!-- {{{ DateMalformedStringException intro -->
+  <section xml:id="datemalformedstringexception.intro">
+   &reftitle.intro;
+   <para>
+    Lancée lorsqu'une chaîne de Date/Heure invalide est détectée.
+   </para>
+   <para>
+    Cela peut être une valeur passée à
+    <methodname>DateTimeImmutable::__construct</methodname>,
+    <methodname>DateTimeImmutable::modify</methodname>,
+    <methodname>DateTime::__construct</methodname>, ou
+    <methodname>DateTime::modify</methodname>.
+   </para>
+  </section>
+<!-- }}} -->
+
+  <section xml:id="datemalformedstringexception.synopsis">
+   &reftitle.classsynopsis;
+
+<!-- {{{ Synopsis -->
+   <classsynopsis class="class">
+    <ooexception>
+     <exceptionname>DateMalformedStringException</exceptionname>
+    </ooexception>
+
+    <ooclass>
+     <modifier>extends</modifier>
+     <classname>DateException</classname>
+    </ooclass>
+
+    <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
+     <xi:fallback/>
+    </xi:include>
+
+    <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])">
+     <xi:fallback/>
+    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])">
+     <xi:fallback/>
+    </xi:include>
+   </classsynopsis>
+<!-- }}} -->
+
+  </section>
+
+ </partintro>
+
+</phpdoc:exceptionref>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/datetime/dateobjecterror.xml
+++ b/reference/datetime/dateobjecterror.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 696b6b9e32d8d4ef4cfd874caf677a47a6cbadb4 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<phpdoc:exceptionref xml:id="class.dateobjecterror" xmlns:phpdoc="http://php.net/ns/phpdoc" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+ <title>La classe DateObjectError</title>
+ <titleabbrev>DateObjectError</titleabbrev>
+
+ <partintro>
+
+<!-- {{{ DateObjectError intro -->
+  <section xml:id="dateobjecterror.intro">
+   &reftitle.intro;
+   <para>
+    Lancée lorsqu'une des classes Date/Heure n'a pas été correctement
+    initialisée.
+   </para>
+   <para>
+    Parce que les classes Date/Heure ne sont pas finales, ces classes peuvent être héritées.
+    Quand le constructeur parent n'est pas appelé, cette erreur est lancée. C'est
+    toujours une erreur de programmation.
+   </para>
+  </section>
+<!-- }}} -->
+
+  <section xml:id="dateobjecterror.synopsis">
+   &reftitle.classsynopsis;
+
+<!-- {{{ Synopsis -->
+   <classsynopsis class="class">
+    <ooexception>
+     <exceptionname>DateObjectError</exceptionname>
+    </ooexception>
+
+    <ooclass>
+     <modifier>extends</modifier>
+     <classname>DateError</classname>
+    </ooclass>
+
+    <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
+     <xi:fallback/>
+    </xi:include>
+
+    <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Error'])">
+     <xi:fallback/>
+    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Error'])">
+     <xi:fallback/>
+    </xi:include>
+   </classsynopsis>
+<!-- }}} -->
+
+  </section>
+
+  <section role="seealso">
+   &reftitle.seealso;
+   <simplelist>
+    <member><exceptionname>DateError</exceptionname></member>
+    <member><exceptionname>DateRangeError</exceptionname></member>
+   </simplelist>
+  </section>
+
+ </partintro>
+
+</phpdoc:exceptionref>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/datetime/daterangeerror.xml
+++ b/reference/datetime/daterangeerror.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 696b6b9e32d8d4ef4cfd874caf677a47a6cbadb4 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<phpdoc:exceptionref xml:id="class.daterangeerror" xmlns:phpdoc="http://php.net/ns/phpdoc" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+ <title>La classe DateRangeError</title>
+ <titleabbrev>DateRangeError</titleabbrev>
+
+ <partintro>
+
+<!-- {{{ DateRangeError intro -->
+  <section xml:id="daterangeerror.intro">
+   &reftitle.intro;
+   <para>
+    Lancée par <methodname>DateTime::getTimestamp</methodname>,
+    <methodname>DateTimeImmutable::getTimestamp</methodname>, et
+    <function>date_timestamp_get</function>, sur les plateformes 32 bits si l'objet
+    date représente une date en dehors de la plage signée 32 bits.
+   </para>
+  </section>
+<!-- }}} -->
+
+  <section xml:id="daterangeerror.synopsis">
+   &reftitle.classsynopsis;
+
+<!-- {{{ Synopsis -->
+   <classsynopsis class="class">
+    <ooexception>
+     <exceptionname>DateRangeError</exceptionname>
+    </ooexception>
+
+    <ooclass>
+     <modifier>extends</modifier>
+     <classname>DateError</classname>
+    </ooclass>
+
+    <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
+     <xi:fallback/>
+    </xi:include>
+
+    <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Error'])">
+     <xi:fallback/>
+    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Error'])">
+     <xi:fallback/>
+    </xi:include>
+   </classsynopsis>
+<!-- }}} -->
+
+  </section>
+
+  <section role="seealso">
+   &reftitle.seealso;
+   <simplelist>
+    <member><exceptionname>DateError</exceptionname></member>
+    <member><exceptionname>DateObjectError</exceptionname></member>
+   </simplelist>
+  </section>
+
+ </partintro>
+
+</phpdoc:exceptionref>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
Here is the translation of missing date classes:

- `dateError`
- `dateException`
- `dateInvalidOperationException`
- `dateInvalidTimeZoneException`
- `dateMalformedIntervalStringException`
- `dateMalformedPeriodStringException`
- `dateMalformedStringException`
- `dateObjectError`
- `dateRangeError`