### PR TITLE
Fix missing en translation

### DIFF
--- a/reference/reflection/reflectionattribute.xml
+++ b/reference/reflection/reflectionattribute.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: Fan2Shrek : ready -->
+<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: Fan2Shrek Status: ready -->
 <phpdoc:classref xml:id="class.reflectionattribute" xmlns:phpdoc="http://php.net/ns/phpdoc" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>La classe ReflectionAttribute</title>

--- a/reference/reflection/reflectionenum.xml
+++ b/reference/reflection/reflectionenum.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: Fan2Shrek : ready -->
+<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: Fan2Shrek Status: ready -->
 <phpdoc:classref xml:id="class.reflectionenum" xmlns:phpdoc="http://php.net/ns/phpdoc" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>La classe ReflectionEnum</title>

--- a/reference/reflection/reflectionenumbackedcase.xml
+++ b/reference/reflection/reflectionenumbackedcase.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: Fan2Shrek : ready -->
+<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: Fan2Shrek Status: ready -->
 <phpdoc:classref xml:id="class.reflectionenumbackedcase" xmlns:phpdoc="http://php.net/ns/phpdoc" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>La classe ReflectionEnumBackedCase</title>

--- a/reference/reflection/reflectionenumunitcase.xml
+++ b/reference/reflection/reflectionenumunitcase.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: Fan2Shrek : ready -->
+<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: Fan2Shrek Status: ready -->
 <phpdoc:classref xml:id="class.reflectionenumunitcase" xmlns:phpdoc="http://php.net/ns/phpdoc" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>La classe ReflectionEnumUnitCase</title>

--- a/reference/reflection/reflectionreference.xml
+++ b/reference/reflection/reflectionreference.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: Fan2Shrek : ready -->
+<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: Fan2Shrek Status: ready -->
 <phpdoc:classref xml:id="class.reflectionreference" xmlns:phpdoc="http://php.net/ns/phpdoc" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>La classe ReflectionReference</title>


### PR DESCRIPTION
While browsing the PHP documentation tool website, I saw [this](http://doc.php.net/revcheck.php?p=misstags&lang=fr). 

This seems related to the missing `Status`.


(#800) My bad 😅