### PR TITLE
fix(assert): assert table configuration

### DIFF
--- a/reference/info/functions/assert.xml
+++ b/reference/info/functions/assert.xml
@@ -79,9 +79,9 @@
         Si &false;, <function>assert</function> ne vérifie pas l'attente
         et retourne toujours &true;, sans condition.
        </entry>
-      <entry>
-       Obsolète à partir de PHP 8.3.0.
-      </entry>
+       <entry>
+        Obsolète à partir de PHP 8.3.0.
+       </entry>
       </row>
       <row>
        <entry><link linkend="ini.assert.callback">assert.callback</link></entry>
@@ -121,9 +121,9 @@
        <entry>
         Si &true;, lancera une <classname>AssertionError</classname> si l'attente n'est pas respectée.
        </entry>
-      <entry>
-       Obsolète à partir de PHP 8.3.0.
-      </entry>
+       <entry>
+        Obsolète à partir de PHP 8.3.0.
+       </entry>
       </row>
       <row>
        <entry><link linkend="ini.assert.bail">assert.bail</link></entry>
@@ -131,10 +131,9 @@
        <entry>
         Si &true;, interrompra l'exécution du script PHP si l'attente n'est pas respectée.
        </entry>
-       <entry/>
-      <entry>
-       Obsolète à partir de PHP 8.3.0.
-      </entry>
+       <entry>
+        Obsolète à partir de PHP 8.3.0.
+       </entry>
       </row>
       <row>
        <entry><link linkend="ini.assert.warning">assert.warning</link></entry>


### PR DESCRIPTION
I did the following changes:
- re indent some `<entry>` nodes
- remove the `<entry/>` node in the assert.bail section

Note: I did not test to see if it works. If needed I can try to test it with some help.

### Screenshot
![Capture d’écran 2024-06-21 à 14 09 40](https://github.com/php/doc-fr/assets/59170365/18874984-938e-48b8-aa9c-718a51dcc130)