### PR TITLE
Translate missing `ReflectionClassConstant` methods

### DIFF
--- a/reference/reflection/reflectionclassconstant/getattributes.xml
+++ b/reference/reflection/reflectionclassconstant/getattributes.xml
@@ -1,0 +1,188 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: fadab82e11cf93c08eb214cf9d67e9e5ac586a30 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="reflectionclassconstant.getattributes" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>ReflectionClassConstant::getAttributes</refname>
+  <refpurpose>Vérifie les attributs</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="ReflectionClassConstant">
+   <modifier>public</modifier> <type>array</type><methodname>ReflectionClassConstant::getAttributes</methodname>
+   <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>name</parameter><initializer>&null;</initializer></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>0</initializer></methodparam>
+  </methodsynopsis>
+  <para>
+   Vérifie tous les attributs déclarés sur cette constante de classe sous forme d'un tableau de <type>ReflectionAttribute</type>.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   &reflection.getattributes.param.name;
+   &reflection.getattributes.param.flags;
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Un tableau d'attributs, sous forme d'objets <classname>ReflectionAttribute</classname>.
+  </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example>
+    <title>Utilisation simple</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+#[Attribute]
+class Fruit {
+}
+
+#[Attribute]
+class Red {
+}
+
+class Basket {
+    #[Fruit]
+    #[Red]
+    public const APPLE = 'apple';
+}
+
+$classConstant = new ReflectionClassConstant('Basket', 'APPLE');
+$attributes = $classConstant->getAttributes();
+print_r(array_map(fn($attribute) => $attribute->getName(), $attributes));
+?>
+]]>
+    </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+Array
+(
+    [0] => Fruit
+    [1] => Red
+)
+]]>
+    </screen>
+   </example>
+  </para>
+  <para>
+   <example>
+    <title>Résultats filtrés par nom de classe</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+#[Attribute]
+class Fruit {
+}
+
+#[Attribute]
+class Red {
+}
+
+class Basket {
+    #[Fruit]
+    #[Red]
+    public const APPLE = 'apple';
+}
+
+$classConstant = new ReflectionClassConstant('Basket', 'APPLE');
+$attributes = $classConstant->getAttributes('Fruit');
+print_r(array_map(fn($attribute) => $attribute->getName(), $attributes));
+?>
+]]>
+    </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+Array
+(
+    [0] => Fruit
+)
+]]>
+    </screen>
+   </example>
+  </para>
+  <para>
+   <example>
+    <title>Résultats filtrés par nom de classe, avec héritage</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+interface Color {
+}
+
+#[Attribute]
+class Fruit {
+}
+
+#[Attribute]
+class Red implements Color {
+}
+
+class Basket {
+    #[Fruit]
+    #[Red]
+    public const APPLE = 'apple';
+}
+
+$classConstant = new ReflectionClassConstant('Basket', 'APPLE');
+$attributes = $classConstant->getAttributes('Color', ReflectionAttribute::IS_INSTANCEOF);
+print_r(array_map(fn($attribute) => $attribute->getName(), $attributes));
+?>
+]]>
+    </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+Array
+(
+    [0] => Red
+)
+]]>
+    </screen>
+   </example>
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><methodname>ReflectionClass::getAttributes</methodname></member>
+    <member><methodname>ReflectionFunctionAbstract::getAttributes</methodname></member>
+    <member><methodname>ReflectionParameter::getAttributes</methodname></member>
+    <member><methodname>ReflectionProperty::getAttributes</methodname></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/reflection/reflectionclassconstant/isenumcase.xml
+++ b/reference/reflection/reflectionclassconstant/isenumcase.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: ec2fe9a592f794978114ef5021db9f1d00c2e05d Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="reflectionclassconstant.isenumcase" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>ReflectionClassConstant::isEnumCase</refname>
+  <refpurpose>Vérifie si la constante de classe est un cas d'énumération</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="ReflectionClassConstant">
+   <modifier>public</modifier> <type>bool</type><methodname>ReflectionClassConstant::isEnumCase</methodname>
+   <void/>
+  </methodsynopsis>
+  <para>
+   Vérifie si la constante de classe est un cas <link linkend="language.enumerations">énumération</link>.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &true; si la constante de classe est une énumération ; sinon &false;.
+  </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="reflectionclassconstant.isenumcase.example.basic">
+   <title>Exemple de <methodname>ReflectionClassConstant::isEnumCase</methodname></title>
+   <para>
+     Distingue entre les cas d'énumération et les constantes de classe régulières.
+   </para>
+   <programlisting role="php">
+<![CDATA[
+<?php
+enum Status
+{
+    const BORING_CONSTANT = 'test';
+    const ENUM_VALUE = Status::PUBLISHED;
+
+    case DRAFT;
+    case PUBLISHED;
+    case ARCHIVED;
+}
+
+$reflection = new ReflectionEnum(Status::class);
+foreach ($reflection->getReflectionConstants() as $constant) {
+    echo "{$constant->name} is ",
+        $constant->isEnumCase() ? "an enum case" : "a regular class constant",
+        PHP_EOL;
+}
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+BORING_CONSTANT is a regular class constant
+ENUM_VALUE is a regular class constant
+DRAFT is an enum case
+PUBLISHED is an enum case
+ARCHIVED is an enum case
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><classname>ReflectionEnum</classname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:s
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/reflection/reflectionclassconstant/isfinal.xml
+++ b/reference/reflection/reflectionclassconstant/isfinal.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: ec2fe9a592f794978114ef5021db9f1d00c2e05d Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="reflectionclassconstant.isfinal" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>ReflectionClassConstant::isFinal</refname>
+  <refpurpose>Vérifie si la constante de classe est finale</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="ReflectionClassConstant">
+   <modifier>public</modifier> <type>bool</type><methodname>ReflectionClassConstant::isFinal</methodname>
+   <void/>
+  </methodsynopsis>
+  <para>
+   Vérifie si la constante de classe est finale.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &true; si la constante de classe est finale, sinon &false;
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><methodname>ReflectionClassConstant::isPublic</methodname></member>
+    <member><methodname>ReflectionClassConstant::isPrivate</methodname></member>
+    <member><methodname>ReflectionClassConstant::isProtected</methodname></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
Here is the translation of missing `ReflectionClassContant` methods
- `ReflectionClassContant::getAttributes()`
- `ReflectionClassContant::isEnumCase()`
- `ReflectionClassContant::isFinal()`