### PR TITLE
Translate digit (which was still in English)

### DIFF
--- a/reference/math/functions/round.xml
+++ b/reference/math/functions/round.xml
@@ -61,13 +61,13 @@
        Si le paramètre <parameter>precision</parameter> est positif,
        <parameter>num</parameter> sera arrondi en utilisant le paramètre
        <parameter>precision</parameter> pour définir le nombre significatif
-       de digits après le point décimal.
+       de chiffres après le point décimal.
       </para>
       <para>
        Si le paramètre <parameter>precision</parameter> est négatif,
        <parameter>num</parameter> arrondi en utilisant le paramètre
        <parameter>precision</parameter> pour définir le nombre significatif
-       de digits avant le point décimal, i.e. le multiple le plus proche
+       de chiffres avant le point décimal, i.e. le multiple le plus proche
        de <code>pow(10, -$precision)</code>, i.e. pour une
        <parameter>precision</parameter> de -1, <parameter>num</parameter>
        sera arrondi à 10, pour une <parameter>precision</parameter> de -2 à 100, etc.


### PR DESCRIPTION
BTW, `après le point décimal` should be `après la virgule` because in French the decimal separator is `,`