### PR TITLE
Translate `ReflectionFiber` methods

### DIFF
--- a/reference/reflection/reflectionfiber/construct.xml
+++ b/reference/reflection/reflectionfiber/construct.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: ec2fe9a592f794978114ef5021db9f1d00c2e05d Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="reflectionfiber.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>ReflectionFiber::__construct</refname>
+  <refpurpose>Construit un objet ReflectionFiber</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <constructorsynopsis role="ReflectionFiber">
+   <modifier>public</modifier> <methodname>ReflectionFiber::__construct</methodname>
+   <methodparam><type>Fiber</type><parameter>fiber</parameter></methodparam>
+  </constructorsynopsis>
+  <para>
+   Construit un objet <classname>ReflectionFiber</classname>.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>fiber</parameter></term>
+    <listitem>
+     <para>
+      La <classname>Fiber</classname> à refléter.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/reflection/reflectionfiber/getcallable.xml
+++ b/reference/reflection/reflectionfiber/getcallable.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: ec2fe9a592f794978114ef5021db9f1d00c2e05d Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="reflectionfiber.getcallable" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>ReflectionFiber::getCallable</refname>
+  <refpurpose>Renvoie le callable utilisé pour créer la Fibre</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="ReflectionFiber">
+   <modifier>public</modifier> <type>callable</type><methodname>ReflectionFiber::getCallable</methodname>
+   <void/>
+  </methodsynopsis>
+  <para>
+   Renvoie le callable utilisé pour créer la <classname>Fiber</classname>. Si la <classname>Fiber</classname> a été terminée, une
+   <classname>Erreur</classname> est lancée.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Le callable utilisé pour créer la <classname>Fiber</classname>.
+  </para>
+ </refsect1>
+
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/reflection/reflectionfiber/getexecutingfile.xml
+++ b/reference/reflection/reflectionfiber/getexecutingfile.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: db22a7cfcbc3af221f67e228336ac3e2d62aaf2c Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="reflectionfiber.getexecutingfile" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>ReflectionFiber::getExecutingFile</refname>
+  <refpurpose>Renvoie le nom du fichier du point d'éxécution actuel</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="ReflectionFiber">
+   <modifier>public</modifier> <type class="union"><type>string</type><type>null</type></type><methodname>ReflectionFiber::getExecutingFile</methodname>
+   <void/>
+  </methodsynopsis>
+  <para>
+   Renvoie le chemin complet et le nom du fichier du point d'éxécution actuel de la <classname>Fiber</classname> reflétée.
+   Si la fibre n'a pas été démarrée ou s'est terminée, une <classname>Erreur</classname> est lancée.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Le chemin complet et le nom du fichier de la fibre reflétée.
+   Si la fibre reflétée est utilisée en dehors d'une fonction définie par l'utilisateur, &null; est renvoyé.
+  </para>
+ </refsect1>
+
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/reflection/reflectionfiber/getexecutingline.xml
+++ b/reference/reflection/reflectionfiber/getexecutingline.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: db22a7cfcbc3af221f67e228336ac3e2d62aaf2c Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="reflectionfiber.getexecutingline" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>ReflectionFiber::getExecutingLine</refname>
+  <refpurpose>Renvoie le numéro de ligne du point d'éxécution actuel</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="ReflectionFiber">
+   <modifier>public</modifier> <type class="union"><type>int</type><type>null</type></type><methodname>ReflectionFiber::getExecutingLine</methodname>
+   <void/>
+  </methodsynopsis>
+  <para>
+   Renvoie le numéro de ligne du point d'éxécution actuel de la <classname>Fiber</classname> reflétée.
+   Si la fibre reflétée est utilisée en dehors d'une fonction définie par l'utilisateur, &null; est renvoyé.
+   Si la fibre n'a pas été démarrée ou s'est terminée, une <classname>Erreur</classname> est lancée.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Le numéro de ligne du point d'éxécution actuel de la fibre.
+  </para>
+ </refsect1>
+
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/reflection/reflectionfiber/getfiber.xml
+++ b/reference/reflection/reflectionfiber/getfiber.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: ec2fe9a592f794978114ef5021db9f1d00c2e05d Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="reflectionfiber.getfiber" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>ReflectionFiber::getFiber</refname>
+  <refpurpose>Renvoie l'instance de la Fibre reflétée</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="ReflectionFiber">
+   <modifier>public</modifier> <type>Fiber</type><methodname>ReflectionFiber::getFiber</methodname>
+   <void/>
+  </methodsynopsis>
+  <para>
+   Renvoie l'instance de la <classname>Fiber</classname> reflétée.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   L'instance de la <classname>Fiber</classname> reflétée.
+  </para>
+ </refsect1>
+
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/reflection/reflectionfiber/gettrace.xml
+++ b/reference/reflection/reflectionfiber/gettrace.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: ec2fe9a592f794978114ef5021db9f1d00c2e05d Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="reflectionfiber.gettrace" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>ReflectionFiber::getTrace</refname>
+  <refpurpose>Renvoie la trace d'appels du point d'éxécution actuel</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="ReflectionFiber">
+   <modifier>public</modifier> <type>array</type><methodname>ReflectionFiber::getTrace</methodname>
+   <methodparam choice="opt"><type>int</type><parameter>options</parameter><initializer><constant>DEBUG_BACKTRACE_PROVIDE_OBJECT</constant></initializer></methodparam>
+  </methodsynopsis>
+  <para>
+   Renvoie la trace d'appels du point d'éxécution actuel de la <classname>Fiber</classname> reflétée.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>options</parameter></term>
+     <listitem>
+      <para>
+       La valeur de <parameter>options</parameter> peut être l'un des
+       drapeaux suivants.
+      </para>
+      <para>
+       <table>
+        <title>Options disponibles</title>
+        <tgroup cols="2">
+         <thead>
+          <row>
+           <entry>Option</entry>
+           <entry>&Description;</entry>
+          </row>
+         </thead>
+         <tbody>
+          <row>
+           <entry>
+            <constant>DEBUG_BACKTRACE_PROVIDE_OBJECT</constant>
+           </entry>
+           <entry>
+            Défaut.
+           </entry>
+          </row>
+          <row>
+           <entry>
+            <constant>DEBUG_BACKTRACE_IGNORE_ARGS</constant>
+           </entry>
+           <entry>
+            Ne pas inclure les informations d'argument pour les fonctions dans la trace
+            d'appels.
+           </entry>
+          </row>
+         </tbody>
+        </tgroup>
+       </table>
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   La trace d'appels du point d'éxécution actuel de la fibre.
+  </para>
+ </refsect1>
+
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
Here is the translation of missing `ReflectionFiber` methods

- `ReflectionFiber::__construct()`
- `ReflectionFiber::getCallable()`
- `ReflectionFiber::getExecutingFile()`
- `ReflectionFiber::getExecutingLine()`
- `ReflectionFiber::getFiber()`
- `ReflectionFiber::getTrace()`