### PR TITLE
Translate `ReflectionFunctionAbstract` methods

### DIFF
--- a/reference/reflection/reflectionfunctionabstract/getattributes.xml
+++ b/reference/reflection/reflectionfunctionabstract/getattributes.xml
@@ -1,0 +1,233 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: fadab82e11cf93c08eb214cf9d67e9e5ac586a30 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="reflectionfunctionabstract.getattributes" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>ReflectionFunctionAbstract::getAttributes</refname>
+  <refpurpose>Renvoie les attributs</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="ReflectionFunctionAbstract">
+   <modifier>public</modifier> <type>array</type><methodname>ReflectionFunctionAbstract::getAttributes</methodname>
+   <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>name</parameter><initializer>&null;</initializer></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>0</initializer></methodparam>
+  </methodsynopsis>
+  <para>
+   Renvoie tous les attributs déclarés sur cette fonction ou méthode sous forme d'un tableau de <type>ReflectionAttribute</type>.
+  </para>
+
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   &reflection.getattributes.param.name;
+   &reflection.getattributes.param.flags;
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Un tableau d'attributs, sous forme d'objet <classname>ReflectionAttribute</classname>.
+  </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example>
+    <title>Utilisation basique avec une méthode de classe</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+#[Attribute]
+class Fruit {
+}
+
+#[Attribute]
+class Red {
+}
+
+class Factory {
+    #[Fruit]
+    #[Red]
+    public function makeApple(): string
+    {
+        return 'apple';
+    }
+}
+
+$method = new ReflectionMethod('Factory', 'makeApple');
+$attributes = $method->getAttributes();
+print_r(array_map(fn($attribute) => $attribute->getName(), $attributes));
+?>
+]]>
+    </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+Array
+(
+    [0] => Fruit
+    [1] => Red
+)
+]]>
+    </screen>
+   </example>
+  </para>
+  <para>
+   <example>
+    <title>Utilisation basique avec une fonction</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+#[Attribute]
+class Fruit {
+}
+
+#[Attribute]
+class Red {
+}
+
+#[Fruit]
+#[Red]
+function makeApple(): string
+{
+    return 'apple';
+}
+
+$function = new ReflectionFunction('makeApple');
+$attributes = $function->getAttributes();
+print_r(array_map(fn($attribute) => $attribute->getName(), $attributes));
+?>
+]]>
+    </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+Array
+(
+    [0] => Fruit
+    [1] => Red
+)
+]]>
+    </screen>
+   </example>
+  </para>
+  <para>
+   <example>
+    <title>Résultats filtrés par nom de classe</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+#[Attribute]
+class Fruit {
+}
+
+#[Attribute]
+class Red {
+}
+
+#[Fruit]
+#[Red]
+function makeApple(): string
+{
+    return 'apple';
+}
+
+$function = new ReflectionFunction('makeApple');
+$attributes = $function->getAttributes('Fruit');
+print_r(array_map(fn($attribute) => $attribute->getName(), $attributes));
+?>
+]]>
+    </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+Array
+(
+    [0] => Fruit
+)
+]]>
+    </screen>
+   </example>
+  </para>
+  <para>
+   <example>
+    <title>Résultats filtrés par nom de classe, avec héritage</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+interface Color {
+}
+
+#[Attribute]
+class Fruit {
+}
+
+#[Attribute]
+class Red implements Color {
+}
+
+#[Fruit]
+#[Red]
+function makeApple(): string
+{
+    return 'apple';
+}
+
+$function = new ReflectionFunction('makeApple');
+$attributes = $function->getAttributes('Color', ReflectionAttribute::IS_INSTANCEOF);
+print_r(array_map(fn($attribute) => $attribute->getName(), $attributes));
+?>
+]]>
+    </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+Array
+(
+    [0] => Red
+)
+]]>
+    </screen>
+   </example>
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><methodname>ReflectionClass::getAttributes</methodname></member>
+    <member><methodname>ReflectionClassConstant::getAttributes</methodname></member>
+    <member><methodname>ReflectionParameter::getAttributes</methodname></member>
+    <member><methodname>ReflectionProperty::getAttributes</methodname></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/reflection/reflectionfunctionabstract/getclosureusedvariables.xml
+++ b/reference/reflection/reflectionfunctionabstract/getclosureusedvariables.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: ec2fe9a592f794978114ef5021db9f1d00c2e05d Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="reflectionfunctionabstract.getclosureusedvariables" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>ReflectionFunctionAbstract::getClosureUsedVariables</refname>
+  <refpurpose>Renvoie un tableau des variables utilisées dans la Closure</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="ReflectionFunctionAbstract">
+   <modifier>public</modifier> <type>array</type><methodname>ReflectionFunctionAbstract::getClosureUsedVariables</methodname>
+   <void/>
+  </methodsynopsis>
+  <para>
+   Renvoie un &array; des variables utilisées dans la <classname>Closure</classname>.
+  </para>
+
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Renvoie un &array; des variables utilisées dans la <classname>Closure</classname>.
+  </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example>
+    <title>Exemple de <methodname>ReflectionFunctionAbstract::getClosureUsedVariables</methodname></title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+
+$one = 1;
+$two = 2;
+
+$function = function() use ($one, $two) {
+    static $three = 3;
+};
+
+$reflector = new ReflectionFunction($function);
+
+var_dump($reflector->getClosureUsedVariables());
+?>
+]]>
+    </programlisting>
+    &example.outputs.similar;
+    <screen>
+<![CDATA[
+array(2) {
+  ["one"]=>
+  int(1)
+  ["two"]=>
+  int(2)
+}
+]]>
+    </screen>
+   </example>
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>ReflectionFunctionAbstract::getClosureScopeClass</function></member>
+    <member><function>ReflectionFunctionAbstract::getClosureThis</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/reflection/reflectionfunctionabstract/gettentativereturntype.xml
+++ b/reference/reflection/reflectionfunctionabstract/gettentativereturntype.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: ec2fe9a592f794978114ef5021db9f1d00c2e05d Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="reflectionfunctionabstract.gettentativereturntype" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>ReflectionFunctionAbstract::getTentativeReturnType</refname>
+  <refpurpose>Renvoie le type de retour provisoire associé avec cette fonction</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="ReflectionFunctionAbstract">
+   <modifier>public</modifier> <type class="union"><type>ReflectionType</type><type>null</type></type><methodname>ReflectionFunctionAbstract::getTentativeReturnType</methodname>
+   <void/>
+  </methodsynopsis>
+  <para>
+   Renvoie le type de retour provisoire associé avec cette fonction.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Renvoie un objet <classname>ReflectionType</classname> si un type de retour provisoire est
+   spécifié, sinon &null;. 
+  </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example>
+    <title>Exemple de <methodname>ReflectionFunctionAbstract::getTentativeReturnType</methodname></title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+
+$method = new ReflectionMethod(\ArrayAccess::class, 'offsetGet');
+var_dump($method->getTentativeReturnType());
+]]>
+    </programlisting>
+    &example.outputs.similar;
+    <screen>
+<![CDATA[
+object(ReflectionNamedType)#2 (0) {
+}
+]]>
+    </screen>
+   </example>
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><methodname>ReflectionFunctionAbstract::getReturnType</methodname></member>
+    <member><methodname>ReflectionFunctionAbstract::hasTentativeReturnType</methodname></member>
+    <member><link linkend="language.oop5.inheritance.internal-classes">Compatibilité des types de retour avec les classes internes</link></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/reflection/reflectionfunctionabstract/hastentativereturntype.xml
+++ b/reference/reflection/reflectionfunctionabstract/hastentativereturntype.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: ec2fe9a592f794978114ef5021db9f1d00c2e05d Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="reflectionfunctionabstract.hastentativereturntype" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>ReflectionFunctionAbstract::hasTentativeReturnType</refname>
+  <refpurpose>Renvoie si la fonction a un type de retour provisoire</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="ReflectionFunctionAbstract">
+   <modifier>public</modifier> <type>bool</type><methodname>ReflectionFunctionAbstract::hasTentativeReturnType</methodname>
+   <void/>
+  </methodsynopsis>
+  <para>
+   Renvoie si la fonction a un type de retour provisoire.
+  </para>
+
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Renvoie &true; si la fonction a un type de retour provisoire, sinon &false;.
+  </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example>
+    <title>Exemple de <methodname>ReflectionFunctionAbstract::hasTentativeReturnType</methodname></title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+
+$method = new ReflectionMethod(\ArrayAccess::class, 'offsetGet');
+var_dump($method->hasTentativeReturnType());
+]]>
+    </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+bool(true)
+]]>
+    </screen>
+   </example>
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><methodname>ReflectionFunctionAbstract::getTentativeReturnType</methodname></member>
+    <member><methodname>ReflectionFunctionAbstract::hasReturnType</methodname></member>
+    <member><link linkend="language.oop5.inheritance.internal-classes">Compatibilité des types de retour avec les classes internes</link></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
Here is the translation of missing `ReflectionFunctionAbstract` methods

- `ReflectionFunctionAbstract::getAttributes()`
- `ReflectionFunctionAbstract::getClosureUsedVariables()`
- `ReflectionFunctionAbstract::getTentativeReturnType()`
- `ReflectionFunctionAbstract::hasTentativeReturnType()`