### PR TITLE
Translate `ReflectionReference` methods

### DIFF
--- a/reference/reflection/reflectionreference/construct.xml
+++ b/reference/reflection/reflectionreference/construct.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: ec2fe9a592f794978114ef5021db9f1d00c2e05d Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="reflectionreference.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>ReflectionReference::__construct</refname>
+  <refpurpose>Constructeur privé pour empêcher l'instanciation directe</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <constructorsynopsis role="ReflectionReference">
+   <modifier>private</modifier> <methodname>ReflectionReference::__construct</methodname>
+   <void/>
+  </constructorsynopsis>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/reflection/reflectionreference/fromarrayelement.xml
+++ b/reference/reflection/reflectionreference/fromarrayelement.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: ec2fe9a592f794978114ef5021db9f1d00c2e05d Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="reflectionreference.fromarrayelement" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>ReflectionReference::fromArrayElement</refname>
+  <refpurpose>Créer un ReflectionReference depuis un élément d'un tableau</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="ReflectionReference">
+   <modifier>public</modifier> <modifier>static</modifier> <type class="union"><type>ReflectionReference</type><type>null</type></type><methodname>ReflectionReference::fromArrayElement</methodname>
+   <methodparam><type>array</type><parameter>array</parameter></methodparam>
+   <methodparam><type class="union"><type>int</type><type>string</type></type><parameter>key</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Créer un <classname>ReflectionReference</classname> depuis un élément d'un tableau.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>array</parameter></term>
+    <listitem>
+     <para>
+      Le &array; qui contient la référence potentielle.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>key</parameter></term>
+    <listitem>
+     <para>
+      La clé; soit un &integer; ou une &string;.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Retourne une instance de <classname>ReflectionReference</classname> si
+   <literal>$array[$key]</literal> est une référence, ou &null; sinon.
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <para>
+   Si <parameter>array</parameter> n'est pas un &array;, ou <parameter>key</parameter>
+   n'est pas un &integer; ou &string;, une <classname>TypeError</classname> est lancée.
+   Si <literal>$array[$key]</literal> n'existe pas,
+   une <classname>ReflectionException</classname> est lancée.
+  </para>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/reflection/reflectionreference/getid.xml
+++ b/reference/reflection/reflectionreference/getid.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: ec2fe9a592f794978114ef5021db9f1d00c2e05d Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="reflectionreference.getid" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>ReflectionReference::getId</refname>
+  <refpurpose>Renvoie un ID unique d'une référence</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="ReflectionReference">
+   <modifier>public</modifier> <type>string</type><methodname>ReflectionReference::getId</methodname>
+   <void/>
+  </methodsynopsis>
+  <para>
+   Renvoie un ID qui est unique pour la référence pour la durée de vie de cette référence.
+   Cet ID peut être utilisée pour comparer des référénces pour l'égalité, ou pour maintenir une carte de
+   références connues.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Renvoie une &string; de format non spécifié.
+  </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="reflectionreference.getid.example.basic">
+   <title>Utilisation basique de <methodname>ReflectionReference::getId</methodname></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$val1 = 'foo';
+$val2 = 'bar';
+$arr = [&$val1, &$val2, &$val1];
+
+$rr1 = ReflectionReference::fromArrayElement($arr, 0);
+$rr2 = ReflectionReference::fromArrayElement($arr, 1);
+$rr3 = ReflectionReference::fromArrayElement($arr, 2);
+
+var_dump($rr1->getId() === $rr2->getId());
+var_dump($rr1->getId() === $rr3->getId());
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+bool(false)
+bool(true)
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
Here is the translation of missing `ReflectionReference` methods

- `ReflectionReference::__construct()`
- `ReflectionReference::fromArrayElement()`
- `ReflectionReference::getId()`

This should be the lasts reference/reflection files :tada:  