### PR TITLE
Translate missing predefined files

### DIFF
--- a/language/predefined/closedgeneratorexception.xml
+++ b/language/predefined/closedgeneratorexception.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<reference xml:id="class.closedgeneratorexception" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+ <title>La classe ClosedGeneratorException</title>
+ <titleabbrev>ClosedGeneratorException</titleabbrev>
+
+ <partintro>
+
+<!-- {{{ ClosedGeneratorException intro -->
+  <section xml:id="closedgeneratorexception.intro">
+   &reftitle.intro;
+   <para>
+    Une <classname>ClosedGeneratorException</classname> est lancée lorsqu'on
+    essaie de récupérer une valeur d'un <classname>Generator</classname> fermé.
+   </para>
+  </section>
+<!-- }}} -->
+
+  <section xml:id="closedgeneratorexception.synopsis">
+   &reftitle.classsynopsis;
+
+<!-- {{{ Synopsis -->
+   <classsynopsis class="class">
+    <ooexception>
+     <exceptionname>ClosedGeneratorException</exceptionname>
+    </ooexception>
+
+    <ooclass>
+     <modifier>extends</modifier>
+     <classname>Exception</classname>
+    </ooclass>
+
+    <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
+     <xi:fallback/>
+    </xi:include>
+
+    <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])">
+     <xi:fallback/>
+    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])">
+     <xi:fallback/>
+    </xi:include>
+   </classsynopsis>
+<!-- }}} -->
+
+  </section>
+
+ </partintro>
+
+</reference>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/language/predefined/interfaces.xml
+++ b/language/predefined/interfaces.xml
@@ -29,6 +29,7 @@
  &language.predefined.unitenum;
  &language.predefined.backedenum;
  &language.predefined.sensitiveparametervalue;
+ &language.predefined.php-incomplete-class;
 
 </part>
 

--- a/language/predefined/php-incomplete-class.xml
+++ b/language/predefined/php-incomplete-class.xml
@@ -1,0 +1,126 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 26e26a95fdc3aac9b464068953ea3105dee00f14 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<reference xml:id="class.php-incomplete-class" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+
+ <title>La classe __PHP_Incomplete_Class</title>
+ <titleabbrev>__PHP_Incomplete_Class</titleabbrev>
+
+ <partintro>
+
+  <section xml:id="php-incomplete-class.intro">
+   &reftitle.intro;
+   <para>
+    Créer par <function>unserialize</function>,
+    lorsque l'on essaie de désérialiser une classe non définie
+    ou une classe non listée dans les <literal>allowed_classes</literal>
+    du tableau <parameter>options</parameter> de <function>unserialize</function>.
+   </para>
+
+   <para>
+    Avant PHP 7.2.0, utiliser <function>is_object</function> sur la
+    classe <classname>__PHP_Incomplete_Class</classname> retournait &false;.
+    À partir de PHP 7.2.0, &true; sera retourné.
+   </para>
+  </section>
+
+  <section xml:id="php-incomplete-class.synopsis">
+   &reftitle.classsynopsis;
+
+   <classsynopsis class="class">
+    <ooclass>
+     <classname>__PHP_Incomplete_Class</classname>
+    </ooclass>
+   </classsynopsis>
+
+   <para>
+    Cette classe n'a pas de propriétés ou de méthodes par défaut.
+    Lorsqu'elle est créée par <function>unserialize</function>,
+    en plus de toutes les propriétés et valeurs désérialisées
+    l'objet aura une propriété <literal>__PHP_Incomplete_Class_Name</literal>
+    qui contiendra le nom de la classe désérialisée.
+   </para>
+  </section>
+
+  <section xml:id="php-incomplete-class.examples" role="examples">
+   &reftitle.examples;
+   <example xml:id="php-incomplete-class.basic-example">
+    <title>Created by <function>unserialize</function></title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+
+class MyClass
+{
+    public string $property = "myValue";
+}
+
+$myObject = new MyClass;
+
+$foo = serialize($myObject);
+
+// désérialise tous les objet en objet __PHP_Incomplete_Class
+$disallowed = unserialize($foo, ["allowed_classes" => false]);
+
+var_dump($disallowed);
+
+// désérialise tous les objets en objet __PHP_Incomplete_Class sauf ceux des classes MyClass2 et MyClass3
+$disallowed2 = unserialize($foo, ["allowed_classes" => ["MyClass2", "MyClass3"]]);
+
+var_dump($disallowed2);
+
+// désérialise une classe non définie en objet __PHP_Incomplete_Class
+$undefinedClass = unserialize('O:16:"MyUndefinedClass":0:{}');
+
+var_dump($undefinedClass);
+]]>
+    </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+
+object(__PHP_Incomplete_Class)#2 (2) {
+  ["__PHP_Incomplete_Class_Name"]=>
+  string(7) "MyClass"
+  ["property"]=>
+  string(7) "myValue"
+}
+object(__PHP_Incomplete_Class)#3 (2) {
+  ["__PHP_Incomplete_Class_Name"]=>
+  string(7) "MyClass"
+  ["property"]=>
+  string(7) "myValue"
+}
+object(__PHP_Incomplete_Class)#4 (1) {
+  ["__PHP_Incomplete_Class_Name"]=>
+  string(16) "MyUndefinedClass"
+}
+
+]]>
+    </screen>
+   </example>
+  </section>
+
+ </partintro>
+
+</reference>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/var/functions/unserialize.xml
+++ b/reference/var/functions/unserialize.xml
@@ -63,7 +63,7 @@
         <para>
          Il est possible de définir une fonction de rappel qui sera appelée si
          une classe indéfinie est utilisée lors de la désérialisation
-         (ce qui évitera de recevoir un <type>object</type> "<literal>__PHP_Incomplete_Class</literal>").
+         (ce qui évitera de recevoir un <type>object</type> <classname>__PHP_Incomplete_Class</classname>).
          Utilisez votre &php.ini; ou le fichier &htaccess; pour définir
          <link linkend="ini.unserialize-callback-func">unserialize_callback_func</link>.
          Chaque fois qu'une classe non-définie sera instanciée, cette fonction sera


### PR DESCRIPTION
`ClosedGeneratorException` and `__PHP_Incomplete_Class`

See php/doc-en#3451 for related changes (revision checks were skipped).