### PR TITLE
Translate `PhpToken` methods

### DIFF
--- a/reference/tokenizer/phptoken/construct.xml
+++ b/reference/tokenizer/phptoken/construct.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 0e51e26bd9f0f69f1e32ff51ebc4d9223449b162 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="phptoken.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>PhpToken::__construct</refname>
+  <refpurpose>Renvoie un nouvel objet PhpToken</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <constructorsynopsis role="PhpToken">
+   <modifier>final</modifier> <modifier>public</modifier> <methodname>PhpToken::__construct</methodname>
+   <methodparam><type>int</type><parameter>id</parameter></methodparam>
+   <methodparam><type>string</type><parameter>text</parameter></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>line</parameter><initializer>-1</initializer></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>pos</parameter><initializer>-1</initializer></methodparam>
+  </constructorsynopsis>
+  <para>
+   Renvoie un nouvel objet PhpToken
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>id</parameter></term>
+    <listitem>
+     <para>
+      L'une des constantes T_* (voir <xref linkend="tokens"/>), ou un codepoint ASCII représentant un token à un seul caractère.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>text</parameter></term>
+    <listitem>
+     <para>
+      Le contenu textuel du token.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>line</parameter></term>
+    <listitem>
+     <para>
+      Le numéro de ligne (à partir de 1) du token.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>pos</parameter></term>
+    <listitem>
+     <para>
+      La position de départ (à partir de 0) dans la chaîne tokenisée (le nombre d'octets).
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>PhpToken::tokenize</function></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/tokenizer/phptoken/getTokenName.xml
+++ b/reference/tokenizer/phptoken/getTokenName.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 0e51e26bd9f0f69f1e32ff51ebc4d9223449b162 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="phptoken.gettokenname" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>PhpToken::getTokenName</refname>
+  <refpurpose>Renvoie le nom du token.</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="PhpToken">
+   <modifier>public</modifier> <type class="union"><type>string</type><type>null</type></type><methodname>PhpToken::getTokenName</methodname>
+   <void/>
+  </methodsynopsis>
+  <para>
+   Renvoie le nom du token.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Un charactère ASCII pour les tokens à un seul caractère,
+   ou une des constantes T_* pour les tokens connus (voir <xref linkend="tokens"/>),
+   ou &null; pour les tokens inconnus.
+  </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Exemple de <function>PhpToken::getTokenName</function></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+// token connu
+$token = new PhpToken(T_ECHO, 'echo');
+var_dump($token->getTokenName());   // -> string(6) "T_ECHO"
+
+// token à un seul charactère
+$token = new PhpToken(ord(';'), ';');
+var_dump($token->getTokenName());   // -> string(1) ";"
+
+// token inconnu
+$token = new PhpToken(10000 , "\0");
+var_dump($token->getTokenName());   // -> NULL
+]]>
+   </programlisting>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>PhpToken::tokenize</function></member>
+   <member><function>token_name</function></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/tokenizer/phptoken/is.xml
+++ b/reference/tokenizer/phptoken/is.xml
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 0e51e26bd9f0f69f1e32ff51ebc4d9223449b162 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="phptoken.is" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>PhpToken::is</refname>
+  <refpurpose>Indique si le token est d'un type donné.</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="PhpToken">
+   <modifier>public</modifier> <type>bool</type><methodname>PhpToken::is</methodname>
+   <methodparam><type class="union"><type>int</type><type>string</type><type>array</type></type><parameter>kind</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Indique si le token est d'un type donné.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+     <term><parameter>kind</parameter></term>
+     <listitem>
+      <para>
+       Soit une valeur unique pour correspondre à l'id ou au contenu textuel du token, soit un tableau de ces valeurs.
+      </para>
+     </listitem>
+    </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Une valeur booléenne indiquant si le token est du type donné.
+  </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Exemple de<function>PhpToken::is</function></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$token = new PhpToken(T_ECHO, 'echo');
+var_dump($token->is(T_ECHO));        // -> bool(true)
+var_dump($token->is('echo'));        // -> bool(true)
+var_dump($token->is(T_FOREACH));     // -> bool(false)
+var_dump($token->is('foreach'));     // -> bool(false)
+]]>
+   </programlisting>
+  </example>
+  <example>
+   <title>Usage with array</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+function isClassType(PhpToken $token): bool {
+    return $token->is([T_CLASS, T_INTERFACE, T_TRAIT]);
+}
+
+$interface = new PhpToken(T_INTERFACE, 'interface');
+var_dump(isClassType($interface));   // -> bool(true)
+
+$function = new PhpToken(T_FUNCTION, 'function');
+var_dump(isClassType($function));    // -> bool(false)
+]]>
+   </programlisting>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>token_name</function></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/tokenizer/phptoken/isIgnorable.xml
+++ b/reference/tokenizer/phptoken/isIgnorable.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 0e51e26bd9f0f69f1e32ff51ebc4d9223449b162 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="phptoken.isignorable" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>PhpToken::isIgnorable</refname>
+  <refpurpose>Indique si le token sera ignoré par l'analyseur PHP.</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="PhpToken">
+   <modifier>public</modifier> <type>bool</type><methodname>PhpToken::isIgnorable</methodname>
+   <void/>
+  </methodsynopsis>
+  <para>
+   Indique si le token sera ignoré par l'analyseur PHP.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Une valeur booléenne indiquant si le token sera ignoré par l'analyseur PHP (comme les espaces ou les commentaires).
+  </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Exemple de <function>PhpToken::isIgnorable</function></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$echo = new PhpToken(T_ECHO, 'echo');
+var_dump($echo->isIgnorable());   // -> bool(false)
+
+$space = new PhpToken(T_WHITESPACE, ' ');
+var_dump($space->isIgnorable());  // -> bool(true)
+]]>
+   </programlisting>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>PhpToken::tokenize</function></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/tokenizer/phptoken/toString.xml
+++ b/reference/tokenizer/phptoken/toString.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 0e51e26bd9f0f69f1e32ff51ebc4d9223449b162 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="phptoken.tostring" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>PhpToken::__toString</refname>
+  <refpurpose>Retourne le contenu textuel du token.</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="PhpToken">
+   <modifier>public</modifier> <type>string</type><methodname>PhpToken::__toString</methodname>
+   <void/>
+  </methodsynopsis>
+  <para>
+   Retourne le contenu textuel du token.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Le contenu textuel du token.
+  </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Exemple de <function>PhpToken::__toString</function></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$token = new PhpToken(T_ECHO, 'echo');
+echo $token;
+]]>
+   </programlisting>
+   &examples.outputs;
+   <screen>
+<![CDATA[
+echo
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>token_name</function></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/tokenizer/phptoken/tokenize.xml
+++ b/reference/tokenizer/phptoken/tokenize.xml
@@ -1,0 +1,136 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 0e51e26bd9f0f69f1e32ff51ebc4d9223449b162 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="phptoken.tokenize" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>PhpToken::tokenize</refname>
+  <refpurpose>Sépare le code source donné en tokens PHP, représenté par des objets PhpToken.</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="PhpToken">
+   <modifier>public</modifier> <modifier>static</modifier> <type>array</type><methodname>PhpToken::tokenize</methodname>
+   <methodparam><type>string</type><parameter>code</parameter></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>0</initializer></methodparam>
+  </methodsynopsis>
+  <para>
+   Renvoie un tableau d'objets PhpToken représentant le <parameter>code</parameter> donné.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+     <term><parameter>code</parameter></term>
+     <listitem>
+      <para>
+       Le code source PHP à analyser.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>flags</parameter></term>
+     <listitem>
+      <para>
+       Drapeaux valides :
+       <itemizedlist>
+        <listitem>
+         <simpara>
+          <constant>TOKEN_PARSE</constant> - Reconnaît la possibilité d'utiliser 
+          des mots réservés dans des contextes spécifiques.
+         </simpara>
+        </listitem>
+       </itemizedlist>
+      </para>
+     </listitem>
+    </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Un tableau de tokens PHP représenté par des instances de PhpToken ou de ses descendants.
+   Cette méthode retourne <type>static[]</type> pour que PhpToken puisse être étendu de manière transparente.
+  </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Exemple de <function>PhpToken::tokenize</function></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$tokens = PhpToken::tokenize('<?php echo; ?>');
+
+foreach ($tokens as $token) {
+    echo "Line {$token->line}: {$token->getTokenName()} ('{$token->text}')", PHP_EOL;
+}
+]]>
+   </programlisting>
+   &examples.outputs;
+   <screen>
+<![CDATA[
+Line 1: T_OPEN_TAG ('<?php ')
+Line 1: T_ECHO ('echo')
+Line 1: ; (';')
+Line 1: T_WHITESPACE (' ')
+Line 1: T_CLOSE_TAG ('?>')
+]]>
+   </screen>
+  </example>
+  <example>
+   <title>Extension de PhpToken</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+
+class MyPhpToken extends PhpToken {
+    public function getUpperText() {
+        return strtoupper($this->text);
+    }
+}
+
+$tokens = MyPhpToken::tokenize('<?php echo; ?>');
+echo "'{$tokens[0]->getUpperText()}'";
+]]>
+   </programlisting>
+   &examples.outputs;
+   <screen>
+<![CDATA[
+'<?PHP '
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>token_get_all</function></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
Here is the translation of missing `PhpToken` methods

- `PhpToken::__construct()`
- `PhpToken::getTokenName()`
- `PhpToken::is()`
- `PhpToken::isIgnorable()`
- `PhpToken::tokenize()`
- `PhpToken::toString()`