### PR TITLE
Translate `MongoDB\BSON`

### DIFF
--- a/reference/mongodb/bson/binaryinterface.xml
+++ b/reference/mongodb/bson/binaryinterface.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<reference xml:id="class.mongodb-bson-binaryinterface" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+
+ <title>L'interface MongoDB\BSON\BinaryInterface</title>
+ <titleabbrev>MongoDB\BSON\BinaryInterface</titleabbrev>
+
+ <partintro>
+  <section xml:id="mongodb-bson-binaryinterface.intro">
+   &reftitle.intro;
+   <para>
+    Cette interface est implémentée par <classname>MongoDB\BSON\Binary</classname>
+    pour être utilisée comme type de paramètre, de retour ou de propriété dans les classes utilisateurs.
+   </para>
+  </section>
+
+  <section xml:id="mongodb-bson-binaryinterface.synopsis">
+   &reftitle.classsynopsis;
+   <classsynopsis>
+    <ooclass><classname>MongoDB\BSON\BinaryInterface</classname></ooclass>
+    <classsynopsisinfo>
+     <ooclass>
+      <classname>MongoDB\BSON\BinaryInterface</classname>
+     </ooclass>
+    </classsynopsisinfo>
+    <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.mongodb-bson-binaryinterface')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])" />
+   </classsynopsis>
+  </section>
+
+  <section role="changelog">
+   &reftitle.changelog;
+   <para>
+    <informaltable>
+     <tgroup cols="2">
+      <thead>
+       <row>
+        <entry>&Version;</entry>
+        <entry>&Description;</entry>
+       </row>
+      </thead>
+      <tbody>
+       &mongodb.changelog.tentative-return-types;
+      </tbody>
+     </tgroup>
+    </informaltable>
+   </para>
+  </section>
+ </partintro>
+
+ &reference.mongodb.bson.entities.binaryinterface;
+
+</reference>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mongodb/bson/dbpointer.xml
+++ b/reference/mongodb/bson/dbpointer.xml
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<reference xml:id="class.mongodb-bson-dbpointer" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+
+ <title>La classe MongoDB\BSON\DBPointer (dépréciée)</title>
+ <titleabbrev>MongoDB\BSON\DBPointer</titleabbrev>
+
+ <partintro>
+
+<!-- {{{ MongoDB\BSON\DBPointer intro -->
+  <section xml:id="mongodb-bson-dbpointer.intro">
+   &reftitle.intro;
+   <para>
+    Le type BSON pour le type "DBPointer". Ce type BSON est déprécié, et cette
+    classe ne peut pas être instanciée. Elle sera créée à partir d'un type BSON DBPointer
+    lors de la conversion BSON en PHP, et peut également être convertie en
+    BSON lors du stockage de documents dans la base de données.
+   </para>
+  </section>
+<!-- }}} -->
+
+  <section xml:id="mongodb-bson-dbpointer.synopsis">
+   &reftitle.classsynopsis;
+
+<!-- {{{ Synopsis -->
+   <classsynopsis>
+    <ooclass><classname>MongoDB\BSON\DBPointer</classname></ooclass>
+
+<!-- {{{ Class synopsis -->
+    <classsynopsisinfo>
+     <modifier>final</modifier>
+     <ooclass>
+      <classname>MongoDB\BSON\DBPointer</classname>
+     </ooclass>
+
+     <oointerface>
+      <interfacename>MongoDB\BSON\Type</interfacename>
+     </oointerface>
+
+     <oointerface>
+      <interfacename>Serializable</interfacename>
+     </oointerface>
+
+     <oointerface>
+      <interfacename>JsonSerializable</interfacename>
+     </oointerface>
+
+     <oointerface>
+      <interfacename>Stringable</interfacename>
+     </oointerface>
+    </classsynopsisinfo>
+<!-- }}} -->
+    
+    <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.mongodb-bson-dbpointer')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])" />
+   </classsynopsis>
+<!-- }}} -->
+
+  </section>
+
+  <section role="changelog">
+   &reftitle.changelog;
+   <para>
+    <informaltable>
+     <tgroup cols="2">
+      <thead>
+       <row>
+        <entry>&Version;</entry>
+        <entry>&Description;</entry>
+       </row>
+      </thead>
+      <tbody>
+       <row>
+        <entry>PECL mongodb 1.12.0</entry>
+        <entry>
+         Implémente <interfacename>Stringable</interfacename> pour PHP 8.0+.
+        </entry>
+       </row>
+      </tbody>
+     </tgroup>
+    </informaltable>
+   </para>
+  </section>
+
+ </partintro>
+  
+ &reference.mongodb.bson.entities.dbpointer;
+
+</reference>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mongodb/bson/decimal128.xml
+++ b/reference/mongodb/bson/decimal128.xml
@@ -1,0 +1,136 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<reference xml:id="class.mongodb-bson-decimal128" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+
+ <title>La classe MongoDB\BSON\Decimal128</title>
+ <titleabbrev>MongoDB\BSON\Decimal128</titleabbrev>
+
+ <partintro>
+
+<!-- {{{ MongoDB\BSON\Decimal128 intro -->
+  <section xml:id="mongodb-bson-decimal128.intro">
+   &reftitle.intro;
+   <para>
+    Type BSON pour le
+    <link xlink:href="&url.mongodb.wiki.decimal128;">format à virgule flottatne Decimal128</link>,
+    qui supporte les nombres avec jusqu'à 34 chiffres décimaux (i.e. chiffres
+    significatifs) et une plage d'exposants de −6143 à +6144.
+   </para>
+   <para>
+    Contrairement au type BSON double (i.e. <type>float</type> en PHP), qui ne
+    stocke qu'une approximation des valeurs décimales, le type de données décimal stocke
+    la valeur exacte. Par exemple, <literal>MongoDB\BSON\Decimal128('9.99')</literal>
+    a une valeur précise de 9.99 alors qu'un double 9.99 aurait une valeur 
+    approximative de 9.9900000000000002131628….
+   </para>
+   &mongodb.note.decimal128;
+  </section>
+<!-- }}} -->
+
+  <section xml:id="mongodb-bson-decimal128.synopsis">
+   &reftitle.classsynopsis;
+
+<!-- {{{ Synopsis -->
+   <classsynopsis>
+    <ooclass><classname>MongoDB\BSON\Decimal128</classname></ooclass>
+
+<!-- {{{ Class synopsis -->
+    <classsynopsisinfo>
+     <modifier>final</modifier>
+     <ooclass>
+      <classname>MongoDB\BSON\Decimal128</classname>
+     </ooclass>
+
+     <oointerface>
+      <interfacename>MongoDB\BSON\Decimal128Interface</interfacename>
+     </oointerface>
+
+     <oointerface>
+      <interfacename>MongoDB\BSON\Type</interfacename>
+     </oointerface>
+
+     <oointerface>
+      <interfacename>Serializable</interfacename>
+     </oointerface>
+
+     <oointerface>
+      <interfacename>JsonSerializable</interfacename>
+     </oointerface>
+
+     <oointerface>
+      <interfacename>Stringable</interfacename>
+     </oointerface>
+    </classsynopsisinfo>
+<!-- }}} -->
+
+    <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.mongodb-bson-decimal128')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])" />
+   </classsynopsis>
+<!-- }}} -->
+
+  </section>
+
+  <section role="changelog">
+   &reftitle.changelog;
+   <para>
+    <informaltable>
+     <tgroup cols="2">
+      <thead>
+       <row>
+        <entry>&Version;</entry>
+        <entry>&Description;</entry>
+       </row>
+      </thead>
+      <tbody>
+       <row>
+        <entry>PECL mongodb 1.12.0</entry>
+        <entry>
+         Implémente <interfacename>Stringable</interfacename> pour PHP 8.0+.
+        </entry>
+       </row>
+       <row>
+        <entry>PECL mongodb 1.3.0</entry>
+        <entry>
+         Implémente <interfacename>MongoDB\BSON\Decimal128Interface</interfacename>.
+        </entry>
+       </row>
+       <row>
+        <entry>PECL mongodb 1.2.0</entry>
+        <entry>
+         Implémente <interfacename>Serializable</interfacename> et
+         <interfacename>JsonSerializable</interfacename>.
+        </entry>
+       </row>
+      </tbody>
+     </tgroup>
+    </informaltable>
+   </para>
+  </section>
+
+ </partintro>
+
+ &reference.mongodb.bson.entities.decimal128;
+
+</reference>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mongodb/bson/decimal128interface.xml
+++ b/reference/mongodb/bson/decimal128interface.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<reference xml:id="class.mongodb-bson-decimal128interface" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+
+ <title>L'interface MongoDB\BSON\Decimal128Interface</title>
+ <titleabbrev>MongoDB\BSON\Decimal128Interface</titleabbrev>
+
+ <partintro>
+  <section xml:id="mongodb-bson-decimal128interface.intro">
+   &reftitle.intro;
+   <para>
+    Cette interface est implémentée par
+    <classname>MongoDB\BSON\Decimal128</classname> pour être utilisée comme type de paramètre,
+    de retour ou de propriété dans les classes utilisateurs.
+   </para>
+  </section>
+
+  <section xml:id="mongodb-bson-decimal128interface.synopsis">
+   &reftitle.classsynopsis;
+   <classsynopsis>
+    <ooclass><classname>MongoDB\BSON\Decimal128Interface</classname></ooclass>
+    <classsynopsisinfo>
+     <ooclass>
+      <classname>MongoDB\BSON\Decimal128Interface</classname>
+     </ooclass>
+    </classsynopsisinfo>
+    <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.mongodb-bson-decimal128interface')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])" />
+   </classsynopsis>
+  </section>
+  <section role="changelog">
+   &reftitle.changelog;
+   <para>
+    <informaltable>
+     <tgroup cols="2">
+      <thead>
+       <row>
+        <entry>&Version;</entry>
+        <entry>&Description;</entry>
+       </row>
+      </thead>
+      <tbody>
+       &mongodb.changelog.tentative-return-types;
+      </tbody>
+     </tgroup>
+    </informaltable>
+   </para>
+  </section>
+ </partintro>
+
+ &reference.mongodb.bson.entities.decimal128interface;
+
+</reference>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mongodb/bson/document.xml
+++ b/reference/mongodb/bson/document.xml
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<reference xml:id="class.mongodb-bson-document" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+
+ <title>la classe MongoDB\BSON\Document</title>
+ <titleabbrev>MongoDB\BSON\Document</titleabbrev>
+
+ <partintro>
+
+<!-- {{{ MongoDB\BSON\Document intro -->
+  <section xml:id="mongodb-bson-document.intro">
+   &reftitle.intro;
+   <para>
+    Représente un document BSON. Cette classe est utilisée lors de la lecture de données en tant que BSON brut
+    et ne peut pas être modifiée.
+   </para>
+  </section>
+<!-- }}} -->
+
+  <section xml:id="mongodb-bson-document.synopsis">
+   &reftitle.classsynopsis;
+
+<!-- {{{ Synopsis -->
+   <classsynopsis>
+    <ooclass><classname>MongoDB\BSON\Document</classname></ooclass>
+
+<!-- {{{ Class synopsis -->
+    <classsynopsisinfo>
+     <modifier>final</modifier>
+     <ooclass>
+      <classname>MongoDB\BSON\Document</classname>
+     </ooclass>
+
+     <oointerface>
+      <interfacename>MongoDB\BSON\Type</interfacename>
+     </oointerface>
+
+     <oointerface>
+      <interfacename>ArrayAccess</interfacename>
+     </oointerface>
+
+     <oointerface>
+      <interfacename>IteratorAggregate</interfacename>
+     </oointerface>
+
+     <oointerface>
+      <interfacename>Serializable</interfacename>
+     </oointerface>
+    </classsynopsisinfo>
+<!-- }}} -->
+
+    <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.mongodb-bson-document')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])" />
+   </classsynopsis>
+<!-- }}} -->
+
+  </section>
+
+  <section role="changelog">
+   &reftitle.changelog;
+   <para>
+    <informaltable>
+     <tgroup cols="2">
+      <thead>
+       <row>
+        <entry>&Version;</entry>
+        <entry>&Description;</entry>
+       </row>
+      </thead>
+      <tbody>
+       <row>
+        <entry>PECL mongodb 1.17.0</entry>
+        <entry>
+         Implémente <interfacename>MongoDB\BSON\Type</interfacename>.
+        </entry>
+       </row>
+      </tbody>
+     </tgroup>
+    </informaltable>
+   </para>
+  </section>
+
+ </partintro>
+
+ &reference.mongodb.bson.entities.document;
+
+</reference>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mongodb/bson/int64.xml
+++ b/reference/mongodb/bson/int64.xml
@@ -1,0 +1,134 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<reference xml:id="class.mongodb-bson-int64" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+
+ <title>La classe MongoDB\BSON\Int64</title>
+ <titleabbrev>MongoDB\BSON\Int64</titleabbrev>
+
+ <partintro>
+
+<!-- {{{ MongoDB\BSON\Int64 intro -->
+  <section xml:id="mongodb-bson-int64.intro">
+   &reftitle.intro;
+   <para>
+    Type BSON pour un entier 64 bits. Lors du décodage BSON en données PHP, cette classe
+    est utilisée lorsqu'un entier 64 bits ne peut pas être représenté en tant qu'entier PHP sur
+    des plateformes 32 bits. Ces objets supportent les opérateurs
+    <link linkend="language.operators.arithmetic">arithmétiques</link>,
+    <link linkend="language.operators.bitwise">bit à bit</link>, et
+    <link linkend="language.operators.comparison">comparaison</link> surchargés.
+   </para>
+   <para>
+    Lors du travail avec des données BSON brutes à travers les classes
+    <classname>MongoDB\BSON\Document</classname>,
+    <classname>MongoDB\BSON\PackedArray</classname>, et
+    <classname>MongoDB\BSON\Iterator</classname>, tout entier 64 bits 
+    sera retourné en tant qu'instance de cette classe, indépendamment de la plateforme et
+    de la possibilité de représenter la valeur en tant qu'entier PHP. Cela garantit que
+    les valeurs peuvent être parcourues sans changer le type.
+   </para>
+   <para>
+    Lors de l'encodage BSON, les objets de cette classe seront convertis en un type entier
+    64 bits, même lorsque la valeur pourrait tenir dans un entier 32 bits. Cela
+    permet de stocker explicitement des valeurs en tant qu'entiers 64 bits dans BSON.
+   </para>
+  </section>
+<!-- }}} -->
+
+  <section xml:id="mongodb-bson-int64.synopsis">
+   &reftitle.classsynopsis;
+
+<!-- {{{ Synopsis -->
+   <classsynopsis>
+    <ooclass><classname>MongoDB\BSON\Int64</classname></ooclass>
+
+<!-- {{{ Class synopsis -->
+    <classsynopsisinfo>
+     <modifier>final</modifier>
+     <ooclass>
+      <classname>MongoDB\BSON\Int64</classname>
+     </ooclass>
+
+     <oointerface>
+      <interfacename>MongoDB\BSON\Type</interfacename>
+     </oointerface>
+
+     <oointerface>
+      <interfacename>Serializable</interfacename>
+     </oointerface>
+
+     <oointerface>
+      <interfacename>JsonSerializable</interfacename>
+     </oointerface>
+
+     <oointerface>
+      <interfacename>Stringable</interfacename>
+     </oointerface>
+    </classsynopsisinfo>
+<!-- }}} -->
+
+    <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.mongodb-bson-int64')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])" />
+   </classsynopsis>
+<!-- }}} -->
+
+  </section>
+
+  <section role="changelog">
+   &reftitle.changelog;
+   <para>
+    <informaltable>
+     <tgroup cols="2">
+      <thead>
+       <row>
+        <entry>&Version;</entry>
+        <entry>&Description;</entry>
+       </row>
+      </thead>
+      <tbody>
+       <row>
+        <entry>PECL mongodb 1.16.0</entry>
+        <entry>
+         Cette classe peut maintenant être instanciée sur toutes les plateformes. Ajout du support pour
+         les opérateurs arithmétiques, bit à bit, et de comparaison surchargés.
+        </entry>
+       </row>
+       <row>
+        <entry>PECL mongodb 1.12.0</entry>
+        <entry>
+         Implémente <interfacename>Stringable</interfacename> pour PHP 8.0+.
+        </entry>
+       </row>
+      </tbody>
+     </tgroup>
+    </informaltable>
+   </para>
+  </section>
+
+ </partintro>
+
+ &reference.mongodb.bson.entities.int64;
+
+</reference>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mongodb/bson/iterator.xml
+++ b/reference/mongodb/bson/iterator.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<reference xml:id="class.mongodb-bson-iterator" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+
+ <title>La classe MongoDB\BSON\Iterator</title>
+ <titleabbrev>MongoDB\BSON\Iterator</titleabbrev>
+
+ <partintro>
+
+<!-- {{{ MongoDB\BSON\Iterator intro -->
+  <section xml:id="mongodb-bson-iterator.intro">
+   &reftitle.intro;
+   <para>
+    Itérateur utilisé pour parcourir un document ou un tableau BSON.
+   </para>
+  </section>
+<!-- }}} -->
+
+  <section xml:id="mongodb-bson-iterator.synopsis">
+   &reftitle.classsynopsis;
+
+<!-- {{{ Synopsis -->
+   <classsynopsis>
+    <ooclass><classname>MongoDB\BSON\Iterator</classname></ooclass>
+
+<!-- {{{ Class synopsis -->
+    <classsynopsisinfo>
+     <modifier>final</modifier>
+     <ooclass>
+      <classname>MongoDB\BSON\Iterator</classname>
+     </ooclass>
+
+     <oointerface>
+      <interfacename>Iterator</interfacename>
+     </oointerface>
+    </classsynopsisinfo>
+<!-- }}} -->
+
+    <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.mongodb-bson-iterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])" />
+   </classsynopsis>
+<!-- }}} -->
+
+  </section>
+
+ </partintro>
+
+ &reference.mongodb.bson.entities.iterator;
+
+</reference>
+
+        <!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mongodb/bson/javascriptinterface.xml
+++ b/reference/mongodb/bson/javascriptinterface.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<reference xml:id="class.mongodb-bson-javascriptinterface" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+
+ <title>L'interface MongoDB\BSON\JavascriptInterface</title>
+ <titleabbrev>MongoDB\BSON\JavascriptInterface</titleabbrev>
+
+ <partintro>
+  <section xml:id="mongodb-bson-javascriptinterface.intro">
+   &reftitle.intro;
+   <para>
+    Cette interface est implémentée par
+    <classname>MongoDB\BSON\Javascript</classname> pour être utilisée comme type de paramètre,
+    de retour ou de propriété dans les classes utilisateurs.
+   </para>
+  </section>
+
+  <section xml:id="mongodb-bson-javascriptinterface.synopsis">
+   &reftitle.classsynopsis;
+   <classsynopsis>
+    <ooclass><classname>MongoDB\BSON\JavascriptInterface</classname></ooclass>
+    <classsynopsisinfo>
+     <ooclass>
+      <classname>MongoDB\BSON\JavascriptInterface</classname>
+     </ooclass>
+    </classsynopsisinfo>
+    <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.mongodb-bson-javascriptinterface')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])" />
+   </classsynopsis>
+  </section>
+
+  <section role="changelog">
+   &reftitle.changelog;
+   <para>
+    <informaltable>
+     <tgroup cols="2">
+      <thead>
+       <row>
+        <entry>&Version;</entry>
+        <entry>&Description;</entry>
+       </row>
+      </thead>
+      <tbody>
+       &mongodb.changelog.tentative-return-types;
+      </tbody>
+     </tgroup>
+    </informaltable>
+   </para>
+  </section>
+ </partintro>
+
+ &reference.mongodb.bson.entities.javascriptinterface;
+
+</reference>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mongodb/bson/maxkeyinterface.xml
+++ b/reference/mongodb/bson/maxkeyinterface.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<reference xml:id="class.mongodb-bson-maxkeyinterface" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+
+ <title>L'interface MongoDB\BSON\MaxKeyInterface</title>
+ <titleabbrev>MongoDB\BSON\MaxKeyInterface</titleabbrev>
+
+ <partintro>
+  <section xml:id="mongodb-bson-maxkeyinterface.intro">
+   &reftitle.intro;
+   <para>
+    Cette interface est implémentée par <classname>MongoDB\BSON\MaxKey</classname>
+    pour être utilisée comme type de paramètre, de retour ou de propriété dans les classes utilisateurs.
+   </para>
+  </section>
+
+  <section xml:id="mongodb-bson-maxkeyinterface.synopsis">
+   &reftitle.classsynopsis;
+   <classsynopsis>
+    <ooclass><classname>MongoDB\BSON\MaxKeyInterface</classname></ooclass>
+    <classsynopsisinfo>
+     <ooclass>
+      <classname>MongoDB\BSON\MaxKeyInterface</classname>
+     </ooclass>
+    </classsynopsisinfo>
+   </classsynopsis>
+
+   <para>
+    Cette interface ne contient pas de méthodes.
+   </para>
+  </section>
+ </partintro>
+
+</reference>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mongodb/bson/minkeyinterface.xml
+++ b/reference/mongodb/bson/minkeyinterface.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<reference xml:id="class.mongodb-bson-minkeyinterface" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+
+ <title>L'interface MongoDB\BSON\MinKeyInterface</title>
+ <titleabbrev>MongoDB\BSON\MinKeyInterface</titleabbrev>
+
+ <partintro>
+  <section xml:id="mongodb-bson-minkeyinterface.intro">
+   &reftitle.intro;
+   <para>
+    Cette interface est implémentée par <classname>MongoDB\BSON\MinKey</classname>
+    pour être utilisée comme type de paramètre, de retour ou de propriété dans les classes utilisateurs.
+   </para>
+  </section>
+
+  <section xml:id="mongodb-bson-minkeyinterface.synopsis">
+   &reftitle.classsynopsis;
+   <classsynopsis>
+    <ooclass><classname>MongoDB\BSON\MinKeyInterface</classname></ooclass>
+    <classsynopsisinfo>
+     <ooclass>
+      <classname>MongoDB\BSON\MinKeyInterface</classname>
+     </ooclass>
+    </classsynopsisinfo>
+   </classsynopsis>
+
+   <para>
+    Cette interface ne contient pas de méthodes.
+   </para>
+  </section>
+ </partintro>
+
+</reference>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mongodb/bson/objectidinterface.xml
+++ b/reference/mongodb/bson/objectidinterface.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<reference xml:id="class.mongodb-bson-objectidinterface" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+
+ <title>L'interface MongoDB\BSON\ObjectIdInterface</title>
+ <titleabbrev>MongoDB\BSON\ObjectIdInterface</titleabbrev>
+
+ <partintro>
+  <section xml:id="mongodb-bson-objectidinterface.intro">
+   &reftitle.intro;
+   <para>
+    Cette interface est implémentée par
+    <classname>MongoDB\BSON\ObjectId</classname> pour être utilisée comme type de paramètre,
+    de retour ou de propriété dans les classes utilisateurs.
+   </para>
+  </section>
+
+  <section xml:id="mongodb-bson-objectidinterface.synopsis">
+   &reftitle.classsynopsis;
+   <classsynopsis>
+    <ooclass><classname>MongoDB\BSON\ObjectIdInterface</classname></ooclass>
+    <classsynopsisinfo>
+     <ooclass>
+      <classname>MongoDB\BSON\ObjectIdInterface</classname>
+     </ooclass>
+    </classsynopsisinfo>
+    <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.mongodb-bson-objectidinterface')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])" />
+   </classsynopsis>
+  </section>
+
+  <section role="changelog">
+   &reftitle.changelog;
+   <para>
+    <informaltable>
+     <tgroup cols="2">
+      <thead>
+       <row>
+        <entry>&Version;</entry>
+        <entry>&Description;</entry>
+       </row>
+      </thead>
+      <tbody>
+       &mongodb.changelog.tentative-return-types;
+      </tbody>
+     </tgroup>
+    </informaltable>
+   </para>
+  </section>
+ </partintro>
+
+ &reference.mongodb.bson.entities.objectidinterface;
+
+</reference>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mongodb/bson/packedarray.xml
+++ b/reference/mongodb/bson/packedarray.xml
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<reference xml:id="class.mongodb-bson-packedarray" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+
+ <title>La classe MongoDB\BSON\PackedArray</title>
+ <titleabbrev>MongoDB\BSON\PackedArray</titleabbrev>
+
+ <partintro>
+
+<!-- {{{ MongoDB\BSON\PackedArray intro -->
+  <section xml:id="mongodb-bson-packedarray.intro">
+   &reftitle.intro;
+   <para>
+    Représente un tableau BSON. Cette classe est utilisée lors de la lecture de données en tant que BSON brut
+    et ne peut pas être modifiée.
+   </para>
+  </section>
+<!-- }}} -->
+
+  <section xml:id="mongodb-bson-packedarray.synopsis">
+   &reftitle.classsynopsis;
+
+<!-- {{{ Synopsis -->
+   <classsynopsis>
+    <ooclass><classname>MongoDB\BSON\PackedArray</classname></ooclass>
+
+<!-- {{{ Class synopsis -->
+    <classsynopsisinfo>
+     <modifier>final</modifier>
+     <ooclass>
+      <classname>MongoDB\BSON\PackedArray</classname>
+     </ooclass>
+
+     <oointerface>
+      <interfacename>MongoDB\BSON\Type</interfacename>
+     </oointerface>
+
+     <oointerface>
+      <interfacename>ArrayAccess</interfacename>
+     </oointerface>
+
+     <oointerface>
+      <interfacename>IteratorAggregate</interfacename>
+     </oointerface>
+
+     <oointerface>
+      <interfacename>Serializable</interfacename>
+     </oointerface>
+    </classsynopsisinfo>
+<!-- }}} -->
+
+    <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.mongodb-bson-packedarray')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])" />
+   </classsynopsis>
+<!-- }}} -->
+
+  </section>
+
+  <section role="changelog">
+   &reftitle.changelog;
+   <para>
+    <informaltable>
+     <tgroup cols="2">
+      <thead>
+       <row>
+        <entry>&Version;</entry>
+        <entry>&Description;</entry>
+       </row>
+      </thead>
+      <tbody>
+       <row>
+        <entry>PECL mongodb 1.17.0</entry>
+        <entry>
+         Implémente <interfacename>MongoDB\BSON\Type</interfacename>.
+        </entry>
+       </row>
+       <row>
+        <entry>PECL mongodb 1.17.0</entry>
+        <entry>
+         <classname>MongoDB\BSON\PackedArray</classname> ne peut pas être sérialisé
+         dans des contextes où un document BSON est attendu. Dans les versions précédentes,
+         le tableau BSON aurait été converti en document.
+        </entry>
+       </row>
+      </tbody>
+     </tgroup>
+    </informaltable>
+   </para>
+  </section>
+
+ </partintro>
+
+ &reference.mongodb.bson.entities.packedarray;
+
+</reference>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mongodb/bson/regexinterface.xml
+++ b/reference/mongodb/bson/regexinterface.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<reference xml:id="class.mongodb-bson-regexinterface" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+
+ <title>L'interface MongoDB\BSON\RegexInterface</title>
+ <titleabbrev>MongoDB\BSON\RegexInterface</titleabbrev>
+
+ <partintro>
+  <section xml:id="mongodb-bson-regexinterface.intro">
+   &reftitle.intro;
+   <para>
+    Cette interface est implémentée par <classname>MongoDB\BSON\Regex</classname>
+    pour être utilisée comme type de paramètre, de retour ou de propriété dans les classes utilisateurs.
+   </para>
+  </section>
+
+  <section xml:id="mongodb-bson-regexinterface.synopsis">
+   &reftitle.classsynopsis;
+   <classsynopsis>
+    <ooclass><classname>MongoDB\BSON\RegexInterface</classname></ooclass>
+    <classsynopsisinfo>
+     <ooclass>
+      <classname>MongoDB\BSON\RegexInterface</classname>
+     </ooclass>
+    </classsynopsisinfo>
+    <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.mongodb-bson-regexinterface')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])" />
+   </classsynopsis>
+  </section>
+
+  <section role="changelog">
+   &reftitle.changelog;
+   <para>
+    <informaltable>
+     <tgroup cols="2">
+      <thead>
+       <row>
+        <entry>&Version;</entry>
+        <entry>&Description;</entry>
+       </row>
+      </thead>
+      <tbody>
+       &mongodb.changelog.tentative-return-types;
+      </tbody>
+     </tgroup>
+    </informaltable>
+   </para>
+  </section>
+ </partintro>
+
+ &reference.mongodb.bson.entities.regexinterface;
+
+</reference>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mongodb/bson/symbol.xml
+++ b/reference/mongodb/bson/symbol.xml
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<reference xml:id="class.mongodb-bson-symbol" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+
+ <title>La classe MongoDB\BSON\Symbol (dépréciée)</title>
+ <titleabbrev>MongoDB\BSON\Symbol</titleabbrev>
+
+ <partintro>
+
+<!-- {{{ MongoDB\BSON\Symbol intro -->
+  <section xml:id="mongodb-bson-symbol.intro">
+   &reftitle.intro;
+   <para>
+    Type BSON pour le type "Symbol". Ce type BSON est déprécié, et cette
+    classe ne peut pas être instanciée. Elle sera créée à partir d'un type
+    symbol BSON lors de la conversion BSON en PHP, et peut également être
+    convertie en BSON lors du stockage de documents dans la base de données.
+   </para>
+  </section>
+<!-- }}} -->
+
+  <section xml:id="mongodb-bson-symbol.synopsis">
+   &reftitle.classsynopsis;
+
+<!-- {{{ Synopsis -->
+   <classsynopsis>
+    <ooclass><classname>MongoDB\BSON\Symbol</classname></ooclass>
+
+<!-- {{{ Class synopsis -->
+    <classsynopsisinfo>
+     <modifier>final</modifier>
+     <ooclass>
+      <classname>MongoDB\BSON\Symbol</classname>
+     </ooclass>
+
+     <oointerface>
+      <interfacename>MongoDB\BSON\Type</interfacename>
+     </oointerface>
+
+     <oointerface>
+      <interfacename>Serializable</interfacename>
+     </oointerface>
+
+     <oointerface>
+      <interfacename>JsonSerializable</interfacename>
+     </oointerface>
+
+     <oointerface>
+      <interfacename>Stringable</interfacename>
+     </oointerface>
+    </classsynopsisinfo>
+<!-- }}} -->
+    
+    <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.mongodb-bson-symbol')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])" />
+   </classsynopsis>
+<!-- }}} -->
+
+  </section>
+
+  <section role="changelog">
+   &reftitle.changelog;
+   <para>
+    <informaltable>
+     <tgroup cols="2">
+      <thead>
+       <row>
+        <entry>&Version;</entry>
+        <entry>&Description;</entry>
+       </row>
+      </thead>
+      <tbody>
+       <row>
+        <entry>PECL mongodb 1.12.0</entry>
+        <entry>
+         Implémente <interfacename>Stringable</interfacename> pour PHP 8.0+.
+        </entry>
+       </row>
+      </tbody>
+     </tgroup>
+    </informaltable>
+   </para>
+  </section>
+
+ </partintro>
+  
+ &reference.mongodb.bson.entities.symbol;
+
+</reference>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mongodb/bson/timestampinterface.xml
+++ b/reference/mongodb/bson/timestampinterface.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<reference xml:id="class.mongodb-bson-timestampinterface" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+
+ <title>L'interface MongoDB\BSON\TimestampInterface</title>
+ <titleabbrev>MongoDB\BSON\TimestampInterface</titleabbrev>
+
+ <partintro>
+  <section xml:id="mongodb-bson-timestampinterface.intro">
+   &reftitle.intro;
+   <para>
+    Cette interface est implémentée par <classname>MongoDB\BSON\Timestamp</classname> pour être utilisée comme type de paramètre,
+    de retour ou de propriété dans les classes utilisateurs.
+   </para>
+  </section>
+
+  <section xml:id="mongodb-bson-timestampinterface.synopsis">
+   &reftitle.classsynopsis;
+   <classsynopsis>
+    <ooclass><classname>MongoDB\BSON\TimestampInterface</classname></ooclass>
+    <classsynopsisinfo>
+     <ooclass>
+      <classname>MongoDB\BSON\TimestampInterface</classname>
+     </ooclass>
+    </classsynopsisinfo>
+    <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.mongodb-bson-timestampinterface')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])" />
+   </classsynopsis>
+  </section>
+
+  <section role="changelog">
+   &reftitle.changelog;
+   <para>
+    <informaltable>
+     <tgroup cols="2">
+      <thead>
+       <row>
+        <entry>&Version;</entry>
+        <entry>&Description;</entry>
+       </row>
+      </thead>
+      <tbody>
+       &mongodb.changelog.tentative-return-types;
+      </tbody>
+     </tgroup>
+    </informaltable>
+   </para>
+  </section>
+ </partintro>
+
+ &reference.mongodb.bson.entities.timestampinterface;
+
+</reference>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mongodb/bson/undefined.xml
+++ b/reference/mongodb/bson/undefined.xml
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<reference xml:id="class.mongodb-bson-undefined" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+
+ <title>La classe MongoDB\BSON\Undefined (dépréciée)</title>
+ <titleabbrev>MongoDB\BSON\Undefined</titleabbrev>
+
+ <partintro>
+
+<!-- {{{ MongoDB\BSON\Undefined intro -->
+  <section xml:id="mongodb-bson-undefined.intro">
+   &reftitle.intro;
+   <para>
+    Type BSON pour le type "Undefined". Ce type BSON est déprécié, et cette
+    classe ne peut pas être instanciée. Elle sera créée à partir d'un type
+    BSON undefined lors de la conversion BSON en PHP, et peut également être
+    convertie en BSON lors du stockage de documents dans la base de données.
+   </para>
+  </section>
+<!-- }}} -->
+
+  <section xml:id="mongodb-bson-undefined.synopsis">
+   &reftitle.classsynopsis;
+
+<!-- {{{ Synopsis -->
+   <classsynopsis>
+    <ooclass><classname>MongoDB\BSON\Undefined</classname></ooclass>
+
+<!-- {{{ Class synopsis -->
+    <classsynopsisinfo>
+     <modifier>final</modifier>
+     <ooclass>
+      <classname>MongoDB\BSON\Undefined</classname>
+     </ooclass>
+
+     <oointerface>
+      <interfacename>MongoDB\BSON\Type</interfacename>
+     </oointerface>
+
+     <oointerface>
+      <interfacename>Serializable</interfacename>
+     </oointerface>
+
+     <oointerface>
+      <interfacename>JsonSerializable</interfacename>
+     </oointerface>
+
+     <oointerface>
+      <interfacename>Stringable</interfacename>
+     </oointerface>
+    </classsynopsisinfo>
+<!-- }}} -->
+    
+    <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.mongodb-bson-undefined')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])" />
+   </classsynopsis>
+<!-- }}} -->
+
+  </section>
+
+  <section role="changelog">
+   &reftitle.changelog;
+   <para>
+    <informaltable>
+     <tgroup cols="2">
+      <thead>
+       <row>
+        <entry>&Version;</entry>
+        <entry>&Description;</entry>
+       </row>
+      </thead>
+      <tbody>
+       <row>
+        <entry>PECL mongodb 1.12.0</entry>
+        <entry>
+         Implémente <interfacename>Stringable</interfacename> pour PHP 8.0+.
+        </entry>
+       </row>
+      </tbody>
+     </tgroup>
+    </informaltable>
+   </para>
+  </section>
+
+ </partintro>
+  
+ &reference.mongodb.bson.entities.undefined;
+
+</reference>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mongodb/bson/utcdatetimeinterface.xml
+++ b/reference/mongodb/bson/utcdatetimeinterface.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<reference xml:id="class.mongodb-bson-utcdatetimeinterface" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+
+ <title>L'interface MongoDB\BSON\UTCDateTimeInterface</title>
+ <titleabbrev>MongoDB\BSON\UTCDateTimeInterface</titleabbrev>
+
+ <partintro>
+  <section xml:id="mongodb-bson-utcdatetimeinterface.intro">
+   &reftitle.intro;
+   <para>
+    Cette interface est implémentée par <classname>MongoDB\BSON\UTCDateTime</classname> pour être utilisée comme
+    type de paramètre, de retour ou de propriété dans les classes utilisateurs.
+   </para>
+  </section>
+
+  <section xml:id="mongodb-bson-utcdatetimeinterface.synopsis">
+   &reftitle.classsynopsis;
+   <classsynopsis>
+    <ooclass><classname>MongoDB\BSON\UTCDateTimeInterface</classname></ooclass>
+    <classsynopsisinfo>
+     <ooclass>
+      <classname>MongoDB\BSON\UTCDateTimeInterface</classname>
+     </ooclass>
+    </classsynopsisinfo>
+    <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.mongodb-bson-utcdatetimeinterface')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])" />
+   </classsynopsis>
+  </section>
+
+  <section role="changelog">
+   &reftitle.changelog;
+   <para>
+    <informaltable>
+     <tgroup cols="2">
+      <thead>
+       <row>
+        <entry>&Version;</entry>
+        <entry>&Description;</entry>
+       </row>
+      </thead>
+      <tbody>
+       &mongodb.changelog.tentative-return-types;
+      </tbody>
+     </tgroup>
+    </informaltable>
+   </para>
+  </section>
+ </partintro>
+
+ &reference.mongodb.bson.entities.utcdatetimeinterface;
+
+</reference>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
Here is the translation of missing `MongoDB\Bson` stuf

- `MongoDB\Bson\BinaryInterface`
- `MongoDB\Bson\`DBPointer`
- `MongoDB\Bson\Decimal128`
- `MongoDB\Bson\Decimal128Interface`
- `MongoDB\Bson\Document`
- `MongoDB\Bson\Int64`
- `MongoDB\Bson\Iterator`
- `MongoDB\Bson\JavascriptInterface`
- `MongoDB\Bson\MaxKeInterface`
- `MongoDB\Bson\MinKeInterface`
- `MongoDB\Bson\ObjectIdInterface`
- `MongoDB\Bson\PackedArray`
- `MongoDB\Bson\RegexInterface`
- `MongoDB\Bson\Symbol`
- `MongoDB\Bson\TimestampInterface`
- `MongoDB\Bson\Undefined`
- `MongoDB\Bson\UtcDateTimeInterface`