### PR TITLE
Translate `MongoDB\BSON\Document`

### DIFF
--- a/reference/mongodb/bson/document/construct.xml
+++ b/reference/mongodb/bson/document/construct.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 52c3812df42c03188138c6930e49ecd7188f0e86 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="mongodb-bson-document.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>MongoDB\BSON\Document::__construct</refname>
+  <refpurpose>Construit un nouveau document BSON (inutilisée)</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>final</modifier> <modifier>private</modifier> <methodname>MongoDB\BSON\Document::__construct</methodname>
+   <void/>
+  </methodsynopsis>
+  <para>
+   Les objets <classname>MongoDB\BSON\Document</classname> sont crées à travers
+   des méthodes de fabrique statiques et ne peuvent pas être instanciés directement.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>MongoDB\BSON\Document::fromPHP</methodname></member>
+   <member><methodname>MongoDB\BSON\Document::fromBSON</methodname></member>
+   <member><methodname>MongoDB\BSON\Document::fromJSON</methodname></member>
+   <member><link xlink:href="&url.mongodb.docs.bson;">Types BSON</link></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mongodb/bson/document/frombson.xml
+++ b/reference/mongodb/bson/document/frombson.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 52c3812df42c03188138c6930e49ecd7188f0e86 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="mongodb-bson-document.frombson" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>MongoDB\BSON\Document::fromBSON</refname>
+  <refpurpose>Construit une nouvelle instance de document depuis une chaine de charactère BSON</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>final</modifier> <modifier>static</modifier> <modifier>public</modifier> <type>MongoDB\BSON\Document</type><methodname>MongoDB\BSON\Document::fromBSON</methodname>
+   <methodparam><type>string</type><parameter>bson</parameter></methodparam>
+  </methodsynopsis>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>bson</parameter> (<type>string</type>)</term>
+    <listitem>
+     <para>
+      Une chaine de charactères contenant un document au format BSON.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simplelist>
+   &mongodb.throws.argumentparsing;
+   <member>Lance une <classname>MongoDB\Driver\Exception\UnexpectedValueException</classname> si <parameter>bson</parameter> est une chaine de charactères invalide ou contenant plus d'un seul document</member>
+  </simplelist>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>MongoDB\BSON\Document::fromPHP</methodname></member>
+   <member><methodname>MongoDB\BSON\Document::fromJSON</methodname></member>
+   <member><link xlink:href="&url.mongodb.docs.bson;">BSON Types</link></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mongodb/bson/document/fromjson.xml
+++ b/reference/mongodb/bson/document/fromjson.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 52c3812df42c03188138c6930e49ecd7188f0e86 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="mongodb-bson-document.fromjson" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>MongoDB\BSON\Document::fromJSON</refname>
+  <refpurpose>Construit une nouvelle instance de document depuis une chaine de charactère JSON</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>final</modifier> <modifier>static</modifier> <modifier>public</modifier> <type>MongoDB\BSON\Document</type><methodname>MongoDB\BSON\Document::fromJSON</methodname>
+   <methodparam><type>string</type><parameter>json</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Convertie une chaine de charactères
+   <link xlink:href="&url.mongodb.docs.extendedjson;">JSON étendue</link>
+   en sa représentation BSON.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>json</parameter> (<type>string</type>)</term>
+    <listitem>
+     <para>
+      La valeur JSON à convertir.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simplelist>
+   &mongodb.throws.argumentparsing;
+   <member>Lance une <classname>MongoDB\Driver\Exception\UnexpectedValueException</classname> si <parameter>json</parameter> n'est pas un document valide.</member>
+  </simplelist>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>MongoDB\BSON\Document::fromPHP</methodname></member>
+   <member><methodname>MongoDB\BSON\Document::fromBSON</methodname></member>
+   <member><function>MongoDB\BSON\fromJSON</function></member>
+   <member><link xlink:href="&url.mongodb.docs.extendedjson;">MongoDB JSON étendu</link></member>
+   <member><link xlink:href="&url.mongodb.docs.bson;">Type BSON</link></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mongodb/bson/document/fromphp.xml
+++ b/reference/mongodb/bson/document/fromphp.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 52c3812df42c03188138c6930e49ecd7188f0e86 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="mongodb-bson-document.fromphp" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>MongoDB\BSON\Document::fromPHP</refname>
+  <refpurpose>Construit une nouvelle instance de document depuis des données PHP</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>final</modifier> <modifier>static</modifier> <modifier>public</modifier> <type>MongoDB\BSON\Document</type><methodname>MongoDB\BSON\Document::fromPHP</methodname>
+   <methodparam><type class="union"><type>object</type><type>array</type></type><parameter>value</parameter></methodparam>
+  </methodsynopsis>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>value</parameter> (<type class="union"><type>object</type><type>array</type></type>)</term>
+    <listitem>
+     <para>
+      Un objet PHP ou un tableau contenant le document. Lorsque vous passez un
+      tableau avec des clés numériques, les valeurs numériques sont converties
+      en chaînes de charactères et utilisées comme clés de document.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simplelist>
+   &mongodb.throws.argumentparsing;
+  </simplelist>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>MongoDB\BSON\Document::fromBSON</methodname></member>
+   <member><methodname>MongoDB\BSON\Document::fromJSON</methodname></member>
+   <member><function>MongoDB\BSON\fromPHP</function></member>
+   <member><link xlink:href="&url.mongodb.docs.bson;">Types BSON</link></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mongodb/bson/document/get.xml
+++ b/reference/mongodb/bson/document/get.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 52c3812df42c03188138c6930e49ecd7188f0e86 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="mongodb-bson-document.get" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>MongoDB\BSON\Document::get</refname>
+  <refpurpose>Retourne la valeur d'une clé dans un document</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>final</modifier> <modifier>public</modifier> <type>mixed</type><methodname>MongoDB\BSON\Document::get</methodname>
+   <methodparam><type>string</type><parameter>key</parameter></methodparam>
+  </methodsynopsis>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>key</parameter> (<type>string</type>)</term>
+    <listitem>
+     <para>
+      La clé à récupérer dans le document.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Renvoie la valeur associée à la clé donnée. Si la clé n'est pas présente dans
+   le document, une exception est lancée.
+  </para>
+  <note>
+   <simpara>
+    Lorsqu'une valeur encodée en tant qu'entier 64 bits est rencontrée dans le document BSON,
+    la valeur de retour de cette méthode sera une 
+    instance de <classname>MongoDB\BSON\Int64</classname>.
+   </simpara>
+  </note>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simplelist>
+   &mongodb.throws.argumentparsing;
+   <member>Lance une <classname>MongoDB\Driver\Exception\RuntimeException</classname> si la clé n'est pas présente dans le document.</member>
+  </simplelist>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>MongoDB\BSON\Document::has</methodname></member>
+   <member><link xlink:href="&url.mongodb.docs.bson;">Types BSON</link></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mongodb/bson/document/getiterator.xml
+++ b/reference/mongodb/bson/document/getiterator.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 52c3812df42c03188138c6930e49ecd7188f0e86 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="mongodb-bson-document.getiterator" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>MongoDB\BSON\Document::getIterator</refname>
+  <refpurpose>Renvoie un itérateur pour le document BSON</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>final</modifier> <modifier>public</modifier> <type>MongoDB\BSON\Iterator</type><methodname>MongoDB\BSON\Document::getIterator</methodname>
+   <void/>
+  </methodsynopsis>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Renvoie une instance de <classname>MongoDB\BSON\Iterator</classname> qui peut être
+    utilisée pour itérer sur toutes les clés du document.
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simplelist>
+   &mongodb.throws.argumentparsing;
+   <member>Lance une <classname>MongoDB\Driver\Exception\UnexpectedValueException</classname> l'itérateur BSON ne peut pas initialisé.</member>
+  </simplelist>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><link xlink:href="&url.mongodb.docs.bson;">Types BSON</link></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mongodb/bson/document/has.xml
+++ b/reference/mongodb/bson/document/has.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 52c3812df42c03188138c6930e49ecd7188f0e86 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="mongodb-bson-document.has" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>MongoDB\BSON\Document::has</refname>
+  <refpurpose>Renvoie si une clé est présente dans le document</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>final</modifier> <modifier>public</modifier> <type>bool</type><methodname>MongoDB\BSON\Document::has</methodname>
+   <methodparam><type>string</type><parameter>key</parameter></methodparam>
+  </methodsynopsis>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>key</parameter> (<type>string</type>)</term>
+    <listitem>
+     <para>
+      La clé à rechercher dans le document.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Renvoie &true; si la clé est présente dans le document sinon &false;.
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simplelist>
+   &mongodb.throws.argumentparsing;
+  </simplelist>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>MongoDB\BSON\Document::get</methodname></member>
+   <member><link xlink:href="&url.mongodb.docs.bson;">Types BSON</link></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mongodb/bson/document/offsetexists.xml
+++ b/reference/mongodb/bson/document/offsetexists.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 87a1b45a66c1ecc435dedd4e295f3c7140959e4b Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="mongodb-bson-document.offsetexists" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>MongoDB\BSON\Document::offsetExists</refname>
+  <refpurpose>Renvoie si une clé est présente dans le document</refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="MongoDB\BSON\Document">
+   <modifier>final</modifier> <modifier>public</modifier> <type>bool</type><methodname>MongoDB\BSON\Document::offsetExists</methodname>
+   <methodparam><type>mixed</type><parameter>key</parameter></methodparam>
+  </methodsynopsis>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>key</parameter></term>
+     <listitem>
+      <para>
+       La clé à rechercher dans le document.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Renvoie &true; si la clé est présente dans le document sinon &false;.
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><methodname>ArrayAccess::offsetExists</methodname></member>
+    <member><methodname>MongoDB\BSON\Document::has</methodname></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-Document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mongodb/bson/document/offsetget.xml
+++ b/reference/mongodb/bson/document/offsetget.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 87a1b45a66c1ecc435dedd4e295f3c7140959e4b Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="mongodb-bson-document.offsetget" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>MongoDB\BSON\Document::offsetGet</refname>
+  <refpurpose>Retourne la valeur d'une clé dans un document</refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="MongoDB\BSON\Document">
+   <modifier>final</modifier> <modifier>public</modifier> <type>mixed</type><methodname>MongoDB\BSON\Document::offsetGet</methodname>
+   <methodparam><type>mixed</type><parameter>key</parameter></methodparam>
+  </methodsynopsis>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>key</parameter></term>
+     <listitem>
+      <para>
+       La clé à récupérer dans le document.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Renvoie la valeur associée à la clé donnée. Si la clé n'est pas présente dans
+   le document, une exception est lancée.
+  </para>
+  <note>
+   <simpara>
+    Lorsqu'une valeur encodée en tant qu'entier 64 bits est rencontrée dans le document BSON,
+    la valeur de retour de cette méthode sera une 
+    instance de <classname>MongoDB\BSON\Int64</classname>.
+   </simpara>
+  </note>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simplelist>
+   &mongodb.throws.argumentparsing;
+   <member>Lance une <classname>MongoDB\Driver\Exception\RuntimeException</classname> si la clé n'est pas présente dans le document.</member>
+  </simplelist>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><methodname>ArrayAccess::offsetGet</methodname></member>
+    <member><methodname>MongoDB\BSON\Document::get</methodname></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mongodb/bson/document/offsetset.xml
+++ b/reference/mongodb/bson/document/offsetset.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 87a1b45a66c1ecc435dedd4e295f3c7140959e4b Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="mongodb-bson-document.offsetset" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>MongoDB\BSON\Document::offsetSet</refname>
+  <refpurpose>Implémentation d'<type>ArrayAccess</type></refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="MongoDB\BSON\Document">
+   <modifier>final</modifier> <modifier>public</modifier> <type>void</type><methodname>MongoDB\BSON\Document::offsetSet</methodname>
+   <methodparam><type>mixed</type><parameter>key</parameter></methodparam>
+   <methodparam><type>mixed</type><parameter>value</parameter></methodparam>
+  </methodsynopsis>
+
+  <para>
+   Change la valeur à la <parameter>key</parameter> spécifiée pour <parameter>value</parameter>.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>key</parameter></term>
+     <listitem>
+      <para>
+       L'index à définir.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>value</parameter></term>
+     <listitem>
+      <para>
+       La nouvelle valeur pour la <parameter>key</parameter>.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &return.void;
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simplelist>
+   <member>Lance toujours une <classname>MongoDB\Driver\Exception\LogicException</classname>.</member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mongodb/bson/document/offsetunset.xml
+++ b/reference/mongodb/bson/document/offsetunset.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 87a1b45a66c1ecc435dedd4e295f3c7140959e4b Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="mongodb-bson-document.offsetunset" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>MongoDB\BSON\Document::offsetUnset</refname>
+  <refpurpose>Implémentation d'<type>ArrayAccess</type></refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="MongoDB\BSON\Document">
+   <modifier>final</modifier> <modifier>public</modifier> <type>void</type><methodname>MongoDB\BSON\Document::offsetUnset</methodname>
+   <methodparam><type>mixed</type><parameter>key</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Retire la valeur à l'index spécifié.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>key</parameter></term>
+     <listitem>
+      <para>
+       L'index à retirer.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &return.void;
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simplelist>
+   <member>Lance toujours une <classname>MongoDB\Driver\Exception\LogicException</classname>.</member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mongodb/bson/document/serialize.xml
+++ b/reference/mongodb/bson/document/serialize.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 52c3812df42c03188138c6930e49ecd7188f0e86 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="mongodb-bson-document.serialize" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>MongoDB\BSON\Document::serialize</refname>
+  <refpurpose>Sérialise un document</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>final</modifier> <modifier>public</modifier> <type>string</type><methodname>MongoDB\BSON\Document::serialize</methodname>
+   <void />
+  </methodsynopsis>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Retourne la représentation sérialisée du
+   <classname>MongoDB\BSON\Document</classname>.
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simplelist>
+   &mongodb.throws.argumentparsing;
+  </simplelist>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>MongoDB\BSON\Document::unserialize</methodname></member>
+   <member><function>serialize</function></member>
+   <member><link linkend="language.oop5.serialization">Sérialisation d'objets</link></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mongodb/bson/document/tocanonicalextendedjson.xml
+++ b/reference/mongodb/bson/document/tocanonicalextendedjson.xml
@@ -1,0 +1,132 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 52c3812df42c03188138c6930e49ecd7188f0e86 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="mongodb-bson-document.tocanonicalextendedjson" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>MongoDB\BSON\Document::toCanonicalExtendedJSON</refname>
+  <refpurpose>Renvoie la représentation Canonique Etendue JSON du document BSON</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>final</modifier> <modifier>public</modifier> <type>string</type><methodname>MongoDB\BSON\Document::toCanonicalExtendedJSON</methodname>
+   <void/>
+  </methodsynopsis>
+  <para>
+   Convertit le document BSON en sa
+   representation <link xlink:href="&url.mongodb.specs.extendedjson;#canonical-extended-json-example">Canonique Etendue JSON</link>.
+   Le format canonique préfère la fidélité des types au détriment de
+   la sortie concise et est le plus adapté pour produire une sortie qui peut être convertie
+   en BSON sans perte d'informations de type (par exemple, les types numériques 
+   resteront différenciés).
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Exemple de <methodname>MongoDB\BSON\Document::toCanonicalExtendedJSON</methodname></title>
+   <programlisting role="php">
+    <![CDATA[
+<?php
+
+$documents = [
+    [ 'null' => null ],
+    [ 'boolean' => true ],
+    [ 'string' => 'foo' ],
+    [ 'int32' => 123 ],
+    [ 'int64' => 4294967295 ],
+    [ 'double' => 1.0, ],
+    [ 'nan' => NAN ],
+    [ 'pos_inf' => INF ],
+    [ 'neg_inf' => -INF ],
+    [ 'array' => [ 'foo', 'bar' ]],
+    [ 'document' => [ 'foo' => 'bar' ]],
+    [ 'oid' => new MongoDB\BSON\ObjectId('56315a7c6118fd1b920270b1') ],
+    [ 'dec128' => new MongoDB\BSON\Decimal128('1234.5678') ],
+    [ 'binary' => new MongoDB\BSON\Binary('foo', MongoDB\BSON\Binary::TYPE_GENERIC) ],
+    [ 'date' => new MongoDB\BSON\UTCDateTime(1445990400000) ],
+    [ 'timestamp' => new MongoDB\BSON\Timestamp(1234, 5678) ],
+    [ 'regex' => new MongoDB\BSON\Regex('pattern', 'i') ],
+    [ 'code' => new MongoDB\BSON\Javascript('function() { return 1; }') ],
+    [ 'code_ws' => new MongoDB\BSON\Javascript('function() { return a; }', ['a' => 1]) ],
+    [ 'minkey' => new MongoDB\BSON\MinKey ],
+    [ 'maxkey' => new MongoDB\BSON\MaxKey ],
+];
+
+foreach ($documents as $document) {
+    $bson = MongoDB\BSON\Document::fromPHP($document);
+    echo $bson->toCanonicalExtendedJSON(), "\n";
+}
+
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+    <![CDATA[
+{ "null" : null }
+{ "boolean" : true }
+{ "string" : "foo" }
+{ "int32" : { "$numberInt" : "123" } }
+{ "int64" : { "$numberLong" : "4294967295"} }
+{ "double" : { "$numberDouble" : "1.0" } }
+{ "nan" : { "$numberDouble" : "NaN" } }
+{ "pos_inf" : { "$numberDouble" : "Infinity" } }
+{ "neg_inf" : { "$numberDouble" : "-Infinity" } }
+{ "array" : [ "foo", "bar" ] }
+{ "document" : { "foo" : "bar" } }
+{ "oid" : { "$oid" : "56315a7c6118fd1b920270b1" } }
+{ "dec128" : { "$numberDecimal" : "1234.5678" } }
+{ "binary" : { "$binary" : { "base64": "Zm9v", "subType" : "00" } } }
+{ "date" : { "$date" : { "$numberLong" : "1445990400000" } } }
+{ "timestamp" : { "$timestamp" : { "t" : 5678, "i" : 1234 } } }
+{ "regex" : { "$regularExpression" : { "pattern" : "pattern", "options" : "i" } } }
+{ "code" : { "$code" : "function() { return 1; }" } }
+{ "code_ws" : { "$code" : "function() { return a; }", "$scope" : { "a" : { "$numberInt" : "1" } } } }
+{ "minkey" : { "$minKey" : 1 } }
+{ "maxkey" : { "$maxKey" : 1 } }
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>MongoDB\BSON\Document::fromJSON</methodname></member>
+   <member><methodname>MongoDB\BSON\Document::toRelaxedExtendedJSON</methodname></member>
+   <member><function>MongoDB\BSON\toCanonicalExtendedJSON</function></member>
+   <member><link xlink:href="&url.mongodb.specs.extendedjson;">Canonique Etendue JSON</link></member>
+   <member><link xlink:href="&url.mongodb.docs.bson;">Types BSON</link></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mongodb/bson/document/tophp.xml
+++ b/reference/mongodb/bson/document/tophp.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 52c3812df42c03188138c6930e49ecd7188f0e86 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="mongodb-bson-document.tophp" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>MongoDB\BSON\Document::toPHP</refname>
+  <refpurpose>Renvoie la représentation PHP du document BSON</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>final</modifier> <modifier>public</modifier> <type class="union"><type>array</type><type>object</type></type><methodname>MongoDB\BSON\Document::toPHP</methodname>
+   <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>typeMap</parameter><initializer>&null;</initializer></methodparam>
+  </methodsynopsis>
+  <para>
+   Désérialise le document BSON en sa représentation PHP. Le paramètre
+   <parameter>typeMap</parameter> peut être utilisé pour contrôler les types PHP
+   utilisés pour convertir les tableaux et documents BSON (racine et intégrés).
+  </para>
+  &mongodb.warning.duplicate-keys;
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   &mongodb.parameter.typeMap;
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   La valeur décodée PHP.
+  </para>
+  <note>
+   <simpara>
+    Lorsqu'une valeur encodée en tant qu'entier 64 bits est rencontrée dans le document BSON,
+    la valeur de retour de cette méthode sera une
+    instance de <classname>MongoDB\BSON\Int64</classname>. 
+   </simpara>
+  </note>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simplelist>
+   <member>
+    Lance une 
+    <classname>MongoDB\Driver\Exception\InvalidArgumentException</classname> si
+    un type dans la carte de type ne peut pas être instancié ou n'implémente pas
+    <interfacename>MongoDB\BSON\Unserializable</interfacename>.
+   </member>
+  </simplelist>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>MongoDB\BSON\toPHP</function></member>
+   <member><link xlink:href="&url.mongodb.docs.bson;">Types BSON</link></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mongodb/bson/document/torelaxedextendedjson.xml
+++ b/reference/mongodb/bson/document/torelaxedextendedjson.xml
@@ -1,0 +1,131 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 52c3812df42c03188138c6930e49ecd7188f0e86 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="mongodb-bson-document.torelaxedextendedjson" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>MongoDB\BSON\Document::toRelaxedExtendedJSON</refname>
+  <refpurpose>Renvoie la représentation rélaxée étendue JSON du document BSON</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>final</modifier> <modifier>public</modifier> <type>string</type><methodname>MongoDB\BSON\Document::toRelaxedExtendedJSON</methodname>
+   <void/>
+  </methodsynopsis>
+  <para>
+   Convertit le document BSON en sa représentation
+   <link xlink:href="&url.mongodb.specs.extendedjson;#relaxed-extended-json-example">Rélaxée Etendue JSON</link>.
+    Le format rélaxé préfère l'utilisation des primitives de type JSON au 
+    détriment de la fidélité des types et est le plus adapté pour produire une sortie qui peut être 
+    facilement consommée par les API web et les humains.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Exemple de <methodname>MongoDB\BSON\Document::toRelaxedExtendedJSON</methodname></title>
+   <programlisting role="php">
+    <![CDATA[
+<?php
+
+$documents = [
+    [ 'null' => null ],
+    [ 'boolean' => true ],
+    [ 'string' => 'foo' ],
+    [ 'int32' => 123 ],
+    [ 'int64' => 4294967295 ],
+    [ 'double' => 1.0, ],
+    [ 'nan' => NAN ],
+    [ 'pos_inf' => INF ],
+    [ 'neg_inf' => -INF ],
+    [ 'array' => [ 'foo', 'bar' ]],
+    [ 'document' => [ 'foo' => 'bar' ]],
+    [ 'oid' => new MongoDB\BSON\ObjectId('56315a7c6118fd1b920270b1') ],
+    [ 'dec128' => new MongoDB\BSON\Decimal128('1234.5678') ],
+    [ 'binary' => new MongoDB\BSON\Binary('foo', MongoDB\BSON\Binary::TYPE_GENERIC) ],
+    [ 'date' => new MongoDB\BSON\UTCDateTime(1445990400000) ],
+    [ 'timestamp' => new MongoDB\BSON\Timestamp(1234, 5678) ],
+    [ 'regex' => new MongoDB\BSON\Regex('pattern', 'i') ],
+    [ 'code' => new MongoDB\BSON\Javascript('function() { return 1; }') ],
+    [ 'code_ws' => new MongoDB\BSON\Javascript('function() { return a; }', ['a' => 1]) ],
+    [ 'minkey' => new MongoDB\BSON\MinKey ],
+    [ 'maxkey' => new MongoDB\BSON\MaxKey ],
+];
+
+foreach ($documents as $document) {
+    $bson = MongoDB\BSON\Document::fromPHP($document);
+    echo $bson->toRelaxedExtendedJSON(), "\n";
+}
+
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+    <![CDATA[
+{ "null" : null }
+{ "boolean" : true }
+{ "string" : "foo" }
+{ "int32" : 123 }
+{ "int64" : 4294967295 }
+{ "double" : 1.0 }
+{ "nan" : { "$numberDouble" : "NaN" } }
+{ "pos_inf" : { "$numberDouble" : "Infinity" } }
+{ "neg_inf" : { "$numberDouble" : "-Infinity" } }
+{ "array" : [ "foo", "bar" ] }
+{ "document" : { "foo" : "bar" } }
+{ "oid" : { "$oid" : "56315a7c6118fd1b920270b1" } }
+{ "dec128" : { "$numberDecimal" : "1234.5678" } }
+{ "binary" : { "$binary" : { "base64": "Zm9v", "subType" : "00" } } }
+{ "date" : { "$date" : "2015-10-28T00:00:00Z" } }
+{ "timestamp" : { "$timestamp" : { "t" : 5678, "i" : 1234 } } }
+{ "regex" : { "$regularExpression" : { "pattern" : "pattern", "options" : "i" } } }
+{ "code" : { "$code" : "function() { return 1; }" } }
+{ "code_ws" : { "$code" : "function() { return a; }", "$scope" : { "a" : 1 } } }
+{ "minkey" : { "$minKey" : 1 } }
+{ "maxkey" : { "$maxKey" : 1 } }
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>MongoDB\BSON\Document::fromJSON</methodname></member>
+   <member><methodname>MongoDB\BSON\Document::toCanonicalExtendedJSON</methodname></member>
+   <member><function>MongoDB\BSON\toRelaxedExtendedJSON</function></member>
+   <member><link xlink:href="&url.mongodb.specs.extendedjson;">Spécification JSON étendue</link></member>
+   <member><link xlink:href="&url.mongodb.docs.bson;">Types BSON</link></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mongodb/bson/document/tostring.xml
+++ b/reference/mongodb/bson/document/tostring.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 52c3812df42c03188138c6930e49ecd7188f0e86 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="mongodb-bson-document.tostring" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>MongoDB\BSON\Document::__toString</refname>
+  <refpurpose>Renvoie la représentation en chaine de charactères de ce document BSON</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>final</modifier> <modifier>public</modifier> <type>string</type><methodname>MongoDB\BSON\Document::__toString</methodname>
+   <void />
+  </methodsynopsis>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Renvoie la représentation en chaine de charactères de ce document BSON.
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><link xlink:href="&url.mongodb.docs.bson;">Types BSON</link></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mongodb/bson/document/unserialize.xml
+++ b/reference/mongodb/bson/document/unserialize.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 52c3812df42c03188138c6930e49ecd7188f0e86 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="mongodb-bson-document.unserialize" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>MongoDB\BSON\Document::unserialize</refname>
+  <refpurpose>Désérialise un document BSON</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>final</modifier> <modifier>public</modifier> <type>void</type><methodname>MongoDB\BSON\Document::unserialize</methodname>
+   <methodparam><type>string</type><parameter>data</parameter></methodparam>
+  </methodsynopsis>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>data</parameter></term>
+     <listitem>
+      <para>
+       Le <classname>MongoDB\BSON\Document</classname> sérialisé.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &return.void;
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simplelist>
+   &mongodb.throws.argumentparsing;
+   <member>Lance une <classname>MongoDB\Driver\Exception\UnexpectedValueException</classname> si les propriétés ne peuvent pas être désérialisées (par exemple <parameter>data</parameter> était mal formé).</member>
+   <member>Lance une <classname>MongoDB\Driver\Exception\InvalidArgumentException</classname> si les propriétés sont invalides (par exemple champs oublié, ou valeur invalide).</member>
+  </simplelist>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>MongoDB\BSON\Document::serialize</methodname></member>
+    <member><function>unserialize</function></member>
+    <member><link linkend="language.oop5.serialization">Sérializer des Objets</link></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
Here is the translation of missing `MongoDB\BSON\Document` methods

- `MongoDB\BSON\Document::__construct()`
- `MongoDB\BSON\Document::fromBSON()`
- `MongoDB\BSON\Document::fromJSON()`
- `MongoDB\BSON\Document::fromPHP()`
- `MongoDB\BSON\Document::get()`
- `MongoDB\BSON\Document::geIterator()`
- `MongoDB\BSON\Document::gas()`
- `MongoDB\BSON\Document::offsetExists()`
- `MongoDB\BSON\Document::offsetSet()`
- `MongoDB\BSON\Document::offetUnset()`
- `MongoDB\BSON\Document::serialize()`
- `MongoDB\BSON\Document::toCanonicalExtendedJson()`
- `MongoDB\BSON\Document::toPHP()`
- `MongoDB\BSON\Document::toRelaxedExtendedJson()`
- `MongoDB\BSON\Document::toString()`
- `MongoDB\BSON\Document::unserialize()`