### PR TITLE
Translate `MongoDB\BSON\Iterator`

### DIFF
--- a/reference/mongodb/bson/iterator/construct.xml
+++ b/reference/mongodb/bson/iterator/construct.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 52c3812df42c03188138c6930e49ecd7188f0e86 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="mongodb-bson-iterator.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>MongoDB\BSON\Iterator::__construct</refname>
+  <refpurpose>Construit un nouvel itérateur BSON (inutilisée)</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>final</modifier> <modifier>private</modifier> <methodname>MongoDB\BSON\Iterator::__construct</methodname>
+   <void/>
+  </methodsynopsis>
+  <para>
+   Les objets <classname>MongoDB\BSON\Iterator</classname> sont crées en appelant
+   <methodname>MongoDB\BSON\Document::getIterator</methodname> ou
+   <methodname>MongoDB\BSON\PackedArray::getIterator</methodname> et ne peuvent pas être
+   instanciés directement.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>MongoDB\BSON\Document::getIterator</methodname></member>
+   <member><methodname>MongoDB\BSON\PackedArray::getIterator</methodname></member>
+   <member><link xlink:href="&url.mongodb.docs.bson;">Types BSON</link></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mongodb/bson/iterator/current.xml
+++ b/reference/mongodb/bson/iterator/current.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 52c3812df42c03188138c6930e49ecd7188f0e86 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="mongodb-bson-iterator.current" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>MongoDB\BSON\Iterator::current</refname>
+  <refpurpose>Renvoie l'élément actuel/courrant</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>public</modifier> <type>mixed</type><methodname>MongoDB\BSON\Iterator::current</methodname>
+   <void/>
+  </methodsynopsis>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Renvoie la valeur de l'élément actuel/courrant.
+  </para>
+  <note>
+   <simpara>
+    Lorsqu'une valeur est encodée en tant qu'entier 64 bits dans la structure BSON est rencontrée,
+    la valeur de retour de cette méthode sera une instance de
+    <classname>MongoDB\BSON\Int64</classname>.
+   </simpara>
+  </note>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simplelist>
+   &mongodb.throws.argumentparsing;
+   <member>Lance une <classname>MongoDB\Driver\Exception\LogicException</classname> si l'itérateur n'est pas valide.</member>
+  </simplelist>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Iterator::current</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mongodb/bson/iterator/key.xml
+++ b/reference/mongodb/bson/iterator/key.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 52c3812df42c03188138c6930e49ecd7188f0e86 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="mongodb-bson-iterator.key" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>MongoDB\BSON\Iterator::key</refname>
+  <refpurpose>Renvoie la clé de l'élément actuel/courrant</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>public</modifier> <type class="union"><type>string</type><type>int</type></type><methodname>MongoDB\BSON\Iterator::key</methodname>
+   <void/>
+  </methodsynopsis>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Renvoie la clé de l'élément actuel/courrant. Lors de l'itération d'un document BSON, la
+   clé sera toujours une <type>string</type>. Lors de l'itération d'un tableau BSON, la
+   clé sera un <type>int</type>.
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simplelist>
+   &mongodb.throws.argumentparsing;
+   <member>Lance une <classname>MongoDB\Driver\Exception\LogicException</classname> si l'itérateur n'est pas valide.</member>
+  </simplelist>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Iterator::key</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mongodb/bson/iterator/next.xml
+++ b/reference/mongodb/bson/iterator/next.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 52c3812df42c03188138c6930e49ecd7188f0e86 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="mongodb-bson-iterator.next" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>MongoDB\BSON\Iterator::next</refname>
+  <refpurpose>Avance l'itérateur à l'élément suivant</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>public</modifier> <type>void</type><methodname>MongoDB\BSON\Iterator::next</methodname>
+   <void/>
+  </methodsynopsis>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Iterator::next</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mongodb/bson/iterator/rewind.xml
+++ b/reference/mongodb/bson/iterator/rewind.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 52c3812df42c03188138c6930e49ecd7188f0e86 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="mongodb-bson-iterator.rewind" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>MongoDB\BSON\Iterator::rewind</refname>
+  <refpurpose>Rembobine l'itérateur à l'élément précédent</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>public</modifier> <type>void</type><methodname>MongoDB\BSON\Iterator::rewind</methodname>
+   <void/>
+  </methodsynopsis>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Iterator::rewind</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mongodb/bson/iterator/valid.xml
+++ b/reference/mongodb/bson/iterator/valid.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 52c3812df42c03188138c6930e49ecd7188f0e86 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="mongodb-bson-iterator.valid" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>MongoDB\BSON\Iterator::valid</refname>
+  <refpurpose>Vérifie si la position courrante est valide</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>public</modifier> <type>bool</type><methodname>MongoDB\BSON\Iterator::valid</methodname>
+   <void/>
+  </methodsynopsis>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Renvoie &true; si la position courrante de l'itérateur est valide, sinon &false;.
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Iterator::valid</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
Here is the translation of missing `MongoDB\BSON\Iterator` methods

- `MongoDB\BSON\Iterator::__construct()`
- `MongoDB\BSON\Iterator::current()`
- `MongoDB\BSON\Iterator::key()`
- `MongoDB\BSON\Iterator::next()`
- `MongoDB\BSON\Iterator::rewind()`
- `MongoDB\BSON\Iterator::valid()`