### PR TITLE
Translate `MongoDB\BSON\PackedArray`

### DIFF
--- a/reference/mongodb/bson/packedarray/construct.xml
+++ b/reference/mongodb/bson/packedarray/construct.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 52c3812df42c03188138c6930e49ecd7188f0e86 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="mongodb-bson-packedarray.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>MongoDB\BSON\PackedArray::__construct</refname>
+  <refpurpose>Construit un nouveau tableau BSON (inutilisé)</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>final</modifier> <modifier>private</modifier> <methodname>MongoDB\BSON\PackedArray::__construct</methodname>
+   <void/>
+  </methodsynopsis>
+  <para>
+   Les objets <classname>MongoDB\BSON\PackedArray</classname> sont créer avec
+    des méthodes de fabrique statiques et ne peuvent pas être instanciés directement.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>MongoDB\BSON\PackedArray::fromPHP</methodname></member>
+   <member><link xlink:href="&url.mongodb.docs.bson;">Types BSON</link></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-packedarray:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mongodb/bson/packedarray/fromphp.xml
+++ b/reference/mongodb/bson/packedarray/fromphp.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: f80105b4fc1196bd8d5fecb98d686b580b1ff65d Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="mongodb-bson-packedarray.fromphp" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>MongoDB\BSON\PackedArray::fromPHP</refname>
+  <refpurpose>Construit une nouvelle instance de tableau BSON depuis des données PHP</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>final</modifier> <modifier>static</modifier> <modifier>public</modifier> <type>MongoDB\BSON\PackedArray</type><methodname>MongoDB\BSON\PackedArray::fromPHP</methodname>
+   <methodparam><type>array</type><parameter>value</parameter></methodparam>
+  </methodsynopsis>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>value</parameter> (<type>array</type>)</term>
+    <listitem>
+     <para>
+      Le tableau PHP à convertir en tableau BSON. Le tableau doit être une liste
+      (c'est-à-dire avoir des clés numériques séquentielles commençant par <literal>0</literal>).
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simplelist>
+   &mongodb.throws.argumentparsing;
+   <member>Lance une <classname>MongoDB\Driver\Exception\InvalidArgumentException</classname> si le tableau donnée n'est pas une liste (par exemple il a des séquences numériques commençant par <literal>0</literal>).</member>
+  </simplelist>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>MongoDB\BSON\fromPHP</function></member>
+   <member><link xlink:href="&url.mongodb.docs.bson;">Types BSON</link></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-packedarray:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mongodb/bson/packedarray/get.xml
+++ b/reference/mongodb/bson/packedarray/get.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 87a1b45a66c1ecc435dedd4e295f3c7140959e4b Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="mongodb-bson-packedarray.get" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>MongoDB\BSON\PackedArray::get</refname>
+  <refpurpose>Renvoie la valeur d'un index du tableau</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>final</modifier> <modifier>public</modifier> <type>mixed</type><methodname>MongoDB\BSON\PackedArray::get</methodname>
+   <methodparam><type>int</type><parameter>key</parameter></methodparam>
+  </methodsynopsis>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>key</parameter> (<type>int</type>)</term>
+    <listitem>
+     <para>
+      L'index à récupérer du tableau.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Renvoie la valeur associée à l'index donné. Si l'index n'est pas
+   présent dans le tableau, une exception est lancée.
+  </para>
+  <note>
+   <simpara>
+    Lorsqu'une valeur encodée en tant qu'entier 64 bits est rencontrée dans le tableau BSON,
+    la valeur de retour de cette méthode sera une instance de
+    <classname>MongoDB\BSON\Int64</classname>.
+   </simpara>
+  </note>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simplelist>
+   &mongodb.throws.argumentparsing;
+   <member>Lance une <classname>MongoDB\Driver\Exception\RuntimeException</classname>si l'index n'est pas présent dans le tableau.</member>
+  </simplelist>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>MongoDB\BSON\PackedArray::has</methodname></member>
+   <member><link xlink:href="&url.mongodb.docs.bson;">Types BSON</link></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-packedarray:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mongodb/bson/packedarray/getiterator.xml
+++ b/reference/mongodb/bson/packedarray/getiterator.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 52c3812df42c03188138c6930e49ecd7188f0e86 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="mongodb-bson-packedarray.getiterator" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>MongoDB\BSON\PackedArray::getIterator</refname>
+  <refpurpose>Renvoie l'itérateur pour le tableau BSON</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>final</modifier> <modifier>public</modifier> <type>MongoDB\BSON\Iterator</type><methodname>MongoDB\BSON\PackedArray::getIterator</methodname>
+   <void/>
+  </methodsynopsis>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Renvoie une instance de <classname>MongoDB\BSON\Iterator</classname> qui peut être
+   utilisée pour itérer sur tous les index du tableau.  
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simplelist>
+   &mongodb.throws.argumentparsing;
+   <member>Lance une <classname>MongoDB\Driver\Exception\UnexpectedValueException</classname> si l'itérateur BSON ne peut pas être instancié.</member>
+  </simplelist>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><link xlink:href="&url.mongodb.docs.bson;">Types BSON</link></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-packedarray:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mongodb/bson/packedarray/has.xml
+++ b/reference/mongodb/bson/packedarray/has.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 52c3812df42c03188138c6930e49ecd7188f0e86 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="mongodb-bson-packedarray.has" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>MongoDB\BSON\PackedArray::has</refname>
+  <refpurpose>Renvoie si un index est présent dans le tableau</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>final</modifier> <modifier>public</modifier> <type>bool</type><methodname>MongoDB\BSON\PackedArray::has</methodname>
+   <methodparam><type>int</type><parameter>index</parameter></methodparam>
+  </methodsynopsis>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>index</parameter> (<type>int</type>)</term>
+    <listitem>
+     <para>
+      L'index a chercher dans le tableau.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Renvoie &true; si l'index est présent dans le tableau sinon &false;.
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simplelist>
+   &mongodb.throws.argumentparsing;
+  </simplelist>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>MongoDB\BSON\PackedArray::get</methodname></member>
+   <member><link xlink:href="&url.mongodb.docs.bson;">Types BSON</link></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-packedarray:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mongodb/bson/packedarray/offsetexists.xml
+++ b/reference/mongodb/bson/packedarray/offsetexists.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 87a1b45a66c1ecc435dedd4e295f3c7140959e4b Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="mongodb-bson-packedarray.offsetexists" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>MongoDB\BSON\PackedArray::offsetExists</refname>
+  <refpurpose>RRenvoie si un index est présent dans le tableau</refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="MongoDB\BSON\PackedArray">
+   <modifier>final</modifier> <modifier>public</modifier> <type>bool</type><methodname>MongoDB\BSON\PackedArray::offsetExists</methodname>
+   <methodparam><type>mixed</type><parameter>key</parameter></methodparam>
+  </methodsynopsis>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>key</parameter></term>
+     <listitem>
+      <para>
+       L'index a chercher dans le tableau.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Renvoie &true; si l'index est présent dans le tableau sinon &false;.
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><methodname>ArrayAccess::offsetExists</methodname></member>
+    <member><methodname>MongoDB\BSON\PackedArray::has</methodname></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-packedarray:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mongodb/bson/packedarray/offsetget.xml
+++ b/reference/mongodb/bson/packedarray/offsetget.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 87a1b45a66c1ecc435dedd4e295f3c7140959e4b Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="mongodb-bson-packedarray.offsetget" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>MongoDB\BSON\PackedArray::offsetGet</refname>
+  <refpurpose>Renvoie la valeur d'un index du tableau</refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="MongoDB\BSON\PackedArray">
+   <modifier>final</modifier> <modifier>public</modifier> <type>mixed</type><methodname>MongoDB\BSON\PackedArray::offsetGet</methodname>
+   <methodparam><type>mixed</type><parameter>key</parameter></methodparam>
+  </methodsynopsis>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>key</parameter></term>
+     <listitem>
+      <para>
+        L'index à récupérer du tableau. Seulement <type>int</type> est supporté.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Renvoie la valeur associée à l'index donné. Si l'index n'est pas
+   présent dans le tableau, une exception est lancée.
+  </para>
+  <note>
+   <simpara>
+    Lorsqu'une valeur encodée en tant qu'entier 64 bits est rencontrée dans le tableau BSON,
+    la valeur de retour de cette méthode sera une instance de
+    <classname>MongoDB\BSON\Int64</classname>.
+   </simpara>
+  </note>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simplelist>
+   &mongodb.throws.argumentparsing;
+   <member>Lance une <classname>MongoDB\Driver\Exception\RuntimeException</classname>si l'index n'est pas présent dans le tableau.</member>
+  </simplelist>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><methodname>ArrayAccess::offsetGet</methodname></member>
+    <member><methodname>MongoDB\BSON\PackedArray::get</methodname></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mongodb/bson/packedarray/offsetset.xml
+++ b/reference/mongodb/bson/packedarray/offsetset.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 87a1b45a66c1ecc435dedd4e295f3c7140959e4b Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="mongodb-bson-packedarray.offsetset" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>MongoDB\BSON\PackedArray::offsetSet</refname>
+  <refpurpose>Implémentation de <type>ArrayAccess</type></refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="MongoDB\BSON\PackedArray">
+   <modifier>final</modifier> <modifier>public</modifier> <type>void</type><methodname>MongoDB\BSON\PackedArray::offsetSet</methodname>
+   <methodparam><type>mixed</type><parameter>key</parameter></methodparam>
+   <methodparam><type>mixed</type><parameter>value</parameter></methodparam>
+  </methodsynopsis>
+
+  <para>
+   Change la valeur de <parameter>key</parameter> pour <parameter>value</parameter>.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>key</parameter></term>
+     <listitem>
+      <para>
+       L'index a modifier.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>value</parameter></term>
+     <listitem>
+      <para>
+       La nouvelle valeur de <parameter>key</parameter>.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &return.void;
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simplelist>
+   <member>Lance toujours une <classname>MongoDB\Driver\Exception\LogicException</classname>.</member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mongodb/bson/packedarray/offsetunset.xml
+++ b/reference/mongodb/bson/packedarray/offsetunset.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 87a1b45a66c1ecc435dedd4e295f3c7140959e4b Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="mongodb-bson-packedarray.offsetunset" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>MongoDB\BSON\PackedArray::offsetUnset</refname>
+  <refpurpose>Implémentation de <type>ArrayAccess</type></refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="MongoDB\BSON\PackedArray">
+   <modifier>final</modifier> <modifier>public</modifier> <type>void</type><methodname>MongoDB\BSON\PackedArray::offsetUnset</methodname>
+   <methodparam><type>mixed</type><parameter>key</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Retire la valeur à l'index donné.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>key</parameter></term>
+     <listitem>
+      <para>
+       La valeur à retirer.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &return.void;
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simplelist>
+   <member>Lance toujours une <classname>MongoDB\Driver\Exception\LogicException</classname>.</member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mongodb/bson/packedarray/serialize.xml
+++ b/reference/mongodb/bson/packedarray/serialize.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 52c3812df42c03188138c6930e49ecd7188f0e86 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="mongodb-bson-packedarray.serialize" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>MongoDB\BSON\PackedArray::serialize</refname>
+  <refpurpose>Sérialise un tableau BSON</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>final</modifier> <modifier>public</modifier> <type>string</type><methodname>MongoDB\BSON\PackedArray::serialize</methodname>
+   <void />
+  </methodsynopsis>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Renvoie la représentation sérialisée de la
+    <classname>MongoDB\BSON\PackedArray</classname>.
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simplelist>
+   &mongodb.throws.argumentparsing;
+  </simplelist>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>MongoDB\BSON\PackedArray::unserialize</methodname></member>
+   <member><function>serialize</function></member>
+   <member><link linkend="language.oop5.serialization">Sérialiser des objets</link></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-packedarray:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mongodb/bson/packedarray/tophp.xml
+++ b/reference/mongodb/bson/packedarray/tophp.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 52c3812df42c03188138c6930e49ecd7188f0e86 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="mongodb-bson-packedarray.tophp" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>MongoDB\BSON\PackedArray::toPHP</refname>
+  <refpurpose>Renvoie la représentation PHP du tableau BSON</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>final</modifier> <modifier>public</modifier> <type class="union"><type>array</type><type>object</type></type><methodname>MongoDB\BSON\PackedArray::toPHP</methodname>
+   <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>typeMap</parameter><initializer>&null;</initializer></methodparam>
+  </methodsynopsis>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   &mongodb.parameter.typeMap;
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   La valeur décodée en PHP.
+  </para>
+  <note>
+   <simpara>
+    Lorsq'une valeur encodée en tant qu'entier 64 bits est rencontrée dans le tableau BSON,
+    la valeur de retour de cette méthode sera une instance de
+    <classname>MongoDB\BSON\Int64</classname>.
+   </simpara>
+  </note>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simplelist>
+   <member>
+    Lance une
+    <classname>MongoDB\Driver\Exception\InvalidArgumentException</classname> si
+    une classe dans le type map ne peut pas être instanciée ou n'implémente pas
+    <interfacename>MongoDB\BSON\Unserializable</interfacename>.
+   </member>
+  </simplelist>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>MongoDB\BSON\toPHP</function></member>
+   <member><link xlink:href="&url.mongodb.docs.bson;">Types BSON</link></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-packedarray:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mongodb/bson/packedarray/tostring.xml
+++ b/reference/mongodb/bson/packedarray/tostring.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 52c3812df42c03188138c6930e49ecd7188f0e86 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="mongodb-bson-packedarray.tostring" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>MongoDB\BSON\PackedArray::__toString</refname>
+  <refpurpose>Renvoie la représentation en chaine de charactères pour ce tableau BSON</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>final</modifier> <modifier>public</modifier> <type>string</type><methodname>MongoDB\BSON\PackedArray::__toString</methodname>
+   <void />
+  </methodsynopsis>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Renvoie la représentation en chaine de charactères de ce tableau BSON.
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><link xlink:href="&url.mongodb.docs.bson;">Types BSON</link></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-packedarray:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mongodb/bson/packedarray/unserialize.xml
+++ b/reference/mongodb/bson/packedarray/unserialize.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 99a3189143933ea9dc4749cc7e1a8a762268f138 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="mongodb-bson-packedarray.unserialize" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>MongoDB\BSON\PackedArray::unserialize</refname>
+  <refpurpose>Désérialise un tableau BSON</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>final</modifier> <modifier>public</modifier> <type>void</type><methodname>MongoDB\BSON\PackedArray::unserialize</methodname>
+   <methodparam><type>string</type><parameter>data</parameter></methodparam>
+  </methodsynopsis>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>data</parameter></term>
+     <listitem>
+      <para>
+       Le <classname>MongoDB\BSON\PackedArray</classname> sérialisé.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &return.void;
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simplelist>
+   &mongodb.throws.argumentparsing;
+   <member>Lance une <classname>MongoDB\Driver\Exception\UnexpectedValueException</classname> si les propriétés ne peuvent pas désérialisées (par exemple <parameter>data</parameter> a été mal formé).</member>
+   <member>Lance une <classname>MongoDB\Driver\Exception\InvalidArgumentException</classname> si les propriétés sont invalides (par exemple champs manquant ou valeur invalide).</member>
+  </simplelist>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>MongoDB\BSON\PackedArray::serialize</methodname></member>
+    <member><function>unserialize</function></member>
+    <member><link linkend="language.oop5.serialization">Sérialiser des objets</link></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-packedarray:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
Here is the translation of missing `MongoDB\BSON\PackedArray` methods

- `MongoDB\BSON\PackedArray::__construct()`
- `MongoDB\BSON\PackedArray::fromPHP()`
- `MongoDB\BSON\PackedArray::get()`
- `MongoDB\BSON\PackedArray::getIterator()`
- `MongoDB\BSON\PackedArray::offsetExists()`
- `MongoDB\BSON\PackedArray::offsetGet()`
- `MongoDB\BSON\PackedArray::offsetSet()`
- `MongoDB\BSON\PackedArray::offsetUnset()`
- `MongoDB\BSON\PackedArray::serialize()`
- `MongoDB\BSON\PackedArray::toPHP()`
- `MongoDB\BSON\PackedArray::toString()`
- `MongoDB\BSON\PackedArray::unserialize()`