### PR TITLE
Translate `IntlCalendar` methods

### DIFF
--- a/reference/intl/intlcalendar/fromdatetime.xml
+++ b/reference/intl/intlcalendar/fromdatetime.xml
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 1976eae0d815797af97a1e16c5cd90ffc2868395 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="intlcalendar.fromdatetime" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>IntlCalendar::fromDateTime</refname>
+  <refpurpose>Créer un IntlCalendar depuis un objet DateTime ou une chaine de charactères</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <para>
+   &style.oop;
+  </para>
+  <methodsynopsis role="IntlCalendar">
+   <modifier>public</modifier> <modifier>static</modifier> <type class="union"><type>IntlCalendar</type><type>null</type></type><methodname>IntlCalendar::fromDateTime</methodname>
+   <methodparam><type class="union"><type>DateTime</type><type>string</type></type><parameter>datetime</parameter></methodparam>
+   <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>locale</parameter><initializer>&null;</initializer></methodparam>
+  </methodsynopsis>
+  <para>
+   &style.procedural;
+  </para>
+  <methodsynopsis>
+   <type class="union"><type>IntlCalendar</type><type>null</type></type><methodname>intlcal_from_date_time</methodname>
+   <methodparam><type class="union"><type>DateTime</type><type>string</type></type><parameter>datetime</parameter></methodparam>
+   <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>locale</parameter><initializer>&null;</initializer></methodparam>
+  </methodsynopsis>
+  <para>
+   Creer un objet <classname>IntlCalendar</classname> soit depuis un objet
+   <classname>DateTime</classname> ou depuis une chaine de charactères qui
+   peut être utilisée pour construireun objet <classname>DateTime</classname>.
+  </para>
+  <para>
+   Le nouveau calendrier représentera non seulement le même instant que le
+   <classname>DateTime</classname> donné (sous réserve de la perte de précision
+   pour les dates très anciennes ou futures), mais aussi le même fuseau horaire
+   (sous réserve de la mise en garde que différentes bases de données de fuseaux
+   horaires seront utilisées, et donc les résultats peuvent différer).
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>datetime</parameter></term>
+    <listitem>
+     <para>
+      Un objet <classname>DateTime</classname> ou une <type>string</type> qui
+      peut être passé à <function>DateTime::__construct</function>.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   L'objet <classname>IntlCalendar</classname> créé ou &null; en cas d'échec.
+   Si une <type>string</type> est passée, toute exception qui se produit
+   à l'intérieur du constructeur <classname>DateTime</classname> est propagée.
+  </para>
+ </refsect1>
+
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example>
+   <title><function>IntlCalendar::fromDateTime</function></title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+ini_set('date.timezone', 'Europe/Lisbon');
+
+//comme IntlCalendar::fromDateTime(new DateTime(...))
+$cal1 = IntlCalendar::fromDateTime('2013-02-28 00:01:02 Europe/Berlin');
+
+//A noter que la timezone est Europe/Berlin, pas celle par défaut Europe/Lisbon
+echo IntlDateFormatter::formatObject($cal1, 'yyyy MMMM d HH:mm:ss VVVV', 'de_DE'), "\n";
+
+]]>
+    </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+2013 Februar 28 00:01:02 Deutschland Zeit
+]]>
+    </screen>
+   </example>
+  </para>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/intl/intlcalendar/getactualmaximum.xml
+++ b/reference/intl/intlcalendar/getactualmaximum.xml
@@ -1,0 +1,131 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 1976eae0d815797af97a1e16c5cd90ffc2868395 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="intlcalendar.getactualmaximum" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>IntlCalendar::getActualMaximum</refname>
+  <refpurpose>La valeur maximale pour un champ, en considérant le temps actuel de l'objet</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <para>
+   &style.oop;
+  </para>
+  <methodsynopsis role="IntlCalendar">
+   <modifier>public</modifier> <type class="union"><type>int</type><type>false</type></type><methodname>IntlCalendar::getActualMaximum</methodname>
+   <methodparam><type>int</type><parameter>field</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   &style.procedural;
+  </para>
+  <methodsynopsis>
+   <type class="union"><type>int</type><type>false</type></type><methodname>intlcal_get_actual_maximum</methodname>
+   <methodparam><type>IntlCalendar</type><parameter>calendar</parameter></methodparam>
+   <methodparam><type>int</type><parameter>field</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Renvoie la valeur maximale pour un champ, en considérant le temps actuel de l'objet. La sémantique
+   exacte varie selon le champ, mais dans le cas général, c'est la valeur qui serait obtenue si on
+   fixait la valeur du champ au 
+   <link linkend="intlcalendar.getleastmaximum">plus petit maximum relatif</link> pour
+   le champ et qu'on l'incrémentait jusqu'à atteindre le 
+   <link linkend="intlcalendar.getmaximum">maximum global</link> ou que la valeur du champ
+   boucle, auquel cas la valeur retournée serait le maximum global ou la valeur avant le bouclage, respectivement.
+  </para>
+  <para>
+   Par exemple, dans le calendrier grégorien, la valeur maximale réelle pour le
+   <link linkend="intlcalendar.constants.field-day-of-month">jour du 
+   mois</link> varierait entre <literal>28</literal> et <literal>31</literal>,
+   selon le mois et l'année du temps actuel.
+  </para>
+
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>calendar</parameter></term>
+    <listitem>
+     &intl.parameter.intl-calendar;
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>field</parameter></term>
+    <listitem>
+     &reference.intl.incfieldparam;
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Un <type>int</type> représentant la valeur maximale dans les unités associées
+   au <parameter>field</parameter> donné&return.falseforfailure;.
+  </para>
+ </refsect1>
+
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example>
+   <title><function>IntlCalendar::getActualMaximum</function></title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+ini_set('date.timezone', 'Europe/Lisbon');
+
+$cal = IntlCalendar::fromDateTime('2013-02-15');
+var_dump($cal->getActualMaximum(IntlCalendar::FIELD_DAY_OF_MONTH)); //28
+
+$cal->add(IntlCalendar::FIELD_EXTENDED_YEAR, -1);
+var_dump($cal->getActualMaximum(IntlCalendar::FIELD_DAY_OF_MONTH)); //29
+]]>
+    </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+int(28)
+int(29)
+]]>
+    </screen>
+   </example>
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><methodname>IntlCalendar::getMaximum</methodname></member>
+    <member><methodname>IntlCalendar::getLeastMaximum</methodname></member>
+    <member><methodname>IntlCalendar::getActualMinimum</methodname></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/intl/intlcalendar/getactualminimum.xml
+++ b/reference/intl/intlcalendar/getactualminimum.xml
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 1976eae0d815797af97a1e16c5cd90ffc2868395 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="intlcalendar.getactualminimum" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>IntlCalendar::getActualMinimum</refname>
+  <refpurpose>La valeur minimal pour un champ, en considérant le temps actuel de l'objet</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <para>
+   &style.oop;
+  </para>
+  <methodsynopsis role="IntlCalendar">
+   <modifier>public</modifier> <type class="union"><type>int</type><type>false</type></type><methodname>IntlCalendar::getActualMinimum</methodname>
+   <methodparam><type>int</type><parameter>field</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   &style.procedural;
+  </para>
+  <methodsynopsis>
+   <type class="union"><type>int</type><type>false</type></type><methodname>intlcal_get_actual_minimum</methodname>
+   <methodparam><type>IntlCalendar</type><parameter>calendar</parameter></methodparam>
+   <methodparam><type>int</type><parameter>field</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Renvoie la valeur minimale pour un champ, en considérant le temps actuel de l'objet. La sémantique
+   exacte varie selon le champ, mais dans le cas général, c'est la valeur qui serait obtenue si on
+   fixait la valeur du champ au
+   <link linkend="intlcalendar.getgreatestminimum">plus grand minimum relatif</link> pour
+   le champ et qu'on le décrémentait jusqu'à atteindre le
+   <link linkend="intlcalendar.getminimum">minimum global</link> ou que la valeur du champ
+   boucle, auquel cas la valeur retournée serait le minimum global ou la valeur avant le bouclage, respectivement.
+  </para>
+  <para>
+   Pour le calendrier grégorien, c'est toujours la même valeur que
+   <function>IntlCalendar::getMinimum</function>.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>calendar</parameter></term>
+    <listitem>
+     &intl.parameter.intl-calendar;
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>field</parameter></term>
+    <listitem>
+     &reference.intl.incfieldparam;
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Un <type>int</type> représentant la valeur minimale dans
+   lʼunité du champ&return.falseforfailure;.
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><methodname>IntlCalendar::getMinimum</methodname></member>
+    <member><methodname>IntlCalendar::getGreatestMinimum</methodname></member>
+    <member><methodname>IntlCalendar::getActualMaximum</methodname></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/intl/intlcalendar/getavailablelocales.xml
+++ b/reference/intl/intlcalendar/getavailablelocales.xml
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 1976eae0d815797af97a1e16c5cd90ffc2868395 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="intlcalendar.getavailablelocales" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>IntlCalendar::getAvailableLocales</refname>
+  <refpurpose>Renvoie un tableau des locales pour lesquelles il y a des données</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <para>
+   &style.oop;
+  </para>
+  <methodsynopsis role="IntlCalendar">
+   <modifier>public</modifier> <modifier>static</modifier> <type>array</type><methodname>IntlCalendar::getAvailableLocales</methodname>
+   <void/>
+  </methodsynopsis>
+  <para>
+   &style.procedural;
+  </para>
+  <methodsynopsis>
+   <type>array</type><methodname>intlcal_get_available_locales</methodname>
+   <void/>
+  </methodsynopsis>
+  <para>
+   Donne la liste des locales pour lesquelles les calendriers sont installés. À partir de ICU 51,
+   c'est la liste de toutes les locales ICU installées.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Un <type>array</type> de <type>string</type>, un pour chaque locale. 
+  </para>
+ </refsect1>
+
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example>
+   <title><function>IntlCalendar::getAvailableLocales</function></title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+print_r(IntlCalendar::getAvailableLocales());
+]]>
+    </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+Array
+(
+    [0] => af
+    [1] => af_NA
+    [2] => af_ZA
+    [3] => agq
+    [4] => agq_CM
+    [5] => ak
+    [6] => ak_GH
+    [7] => am
+    [8] => am_ET
+    [9] => ar
+    [10] => ar_001
+    [11] => ar_AE
+    [12] => ar_BH
+    [13] => ar_DJ
+    … output abbreviated …
+    [595] => zh_Hant_HK
+    [596] => zh_Hant_MO
+    [597] => zh_Hant_TW
+    [598] => zu
+    [599] => zu_ZA
+)
+]]>
+    </screen>
+   </example>
+  </para>
+ </refsect1>
+
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/intl/intlcalendar/getdayofweektype.xml
+++ b/reference/intl/intlcalendar/getdayofweektype.xml
@@ -1,0 +1,154 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 1976eae0d815797af97a1e16c5cd90ffc2868395 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="intlcalendar.getdayofweektype" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>IntlCalendar::getDayOfWeekType</refname>
+  <refpurpose>Indique si un jour est un jour de la semaine, un week-end ou un jour de transition entre les deux</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <para>
+   &style.oop;
+  </para>
+  <methodsynopsis role="IntlCalendar">
+   <modifier>public</modifier> <type class="union"><type>int</type><type>false</type></type><methodname>IntlCalendar::getDayOfWeekType</methodname>
+   <methodparam><type>int</type><parameter>dayOfWeek</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   &style.procedural;
+  </para>
+  <methodsynopsis>
+   <type class="union"><type>int</type><type>false</type></type><methodname>intlcal_get_day_of_week_type</methodname>
+   <methodparam><type>IntlCalendar</type><parameter>calendar</parameter></methodparam>
+   <methodparam><type>int</type><parameter>dayOfWeek</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Renvoie si le jour passé est un jour de semaine
+   (<constant>IntlCalendar::DOW_TYPE_WEEKDAY</constant>), un jour de week-end
+   (<constant>IntlCalendar::DOW_TYPE_WEEKEND</constant>), un jour de transition
+   vers le week-end
+   (<constant>IntlCalendar::DOW_TYPE_WEEKEND_OFFSET</constant>) ou un jour de
+   transition hors du week-end
+   (<constant>IntlCalendar::DOW_TYPE_WEEKEND_CEASE</constant>).
+  </para>
+  <para>
+   Si le retour est soit
+   <constant>IntlCalendar::DOW_TYPE_WEEKEND_OFFSET</constant> ou
+   <constant>IntlCalendar::DOW_TYPE_WEEKEND_CEASE</constant>, alors
+   <function>IntlCalendar::getWeekendTransition</function> peut être appelée pour
+   obtenir le temps de la transition.
+  </para>
+  <para>
+   Cette fonction nécessite ICU 4.4 ou plus récent.
+  </para>
+
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>calendar</parameter></term>
+    <listitem>
+     &intl.parameter.intl-calendar;
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>dayOfWeek</parameter></term>
+    <listitem>
+     <para>
+      Une des constantes <constant>IntlCalendar::DOW_SUNDAY</constant>,
+      <constant>IntlCalendar::DOW_MONDAY</constant>, …,
+      <constant>IntlCalendar::DOW_SATURDAY</constant>.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Une des constantes 
+   <constant>IntlCalendar::DOW_TYPE_WEEKDAY</constant>,
+   <constant>IntlCalendar::DOW_TYPE_WEEKEND</constant>,
+   <constant>IntlCalendar::DOW_TYPE_WEEKEND_OFFSET</constant> ou
+   <constant>IntlCalendar::DOW_TYPE_WEEKEND_CEASE</constant>&return.falseforfailure;.
+  </para>
+ </refsect1>
+
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example>
+   <title><function>IntlCalendar::getDayOfWeekType</function></title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+foreach (array('en_US', 'ar_SA') as $locale) {
+    echo "Locale: ", Locale::getDisplayName($locale, "en_US"), "\n";
+
+    $cal = IntlCalendar::createInstance('UTC', $locale);
+
+    for ($i = IntlCalendar::DOW_SUNDAY; $i <= IntlCalendar::DOW_SATURDAY; $i++) {
+        $type = $cal->getDayOfWeekType($i);
+        $transition = ($type !== IntlCalendar::DOW_TYPE_WEEKDAY)
+            ? $cal->getWeekendTransition($i)
+            : '';
+        echo $i, " ", $type, " ", $transition, "\n";
+    }
+    echo "\n";
+}
+?>
+]]>
+    </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+Locale: English (United States)
+1 1 86400000
+2 0
+3 0
+4 0
+5 0
+6 0
+7 1 0
+
+Locale: Arabic (Saudi Arabia)
+1 0
+2 0
+3 0
+4 0
+5 0
+6 1 0
+7 1 86400000
+]]>
+    </screen>
+   </example>
+  </para>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/intl/intlcalendar/geterrorcode.xml
+++ b/reference/intl/intlcalendar/geterrorcode.xml
@@ -1,0 +1,140 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 1976eae0d815797af97a1e16c5cd90ffc2868395 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="intlcalendar.geterrorcode" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>IntlCalendar::getErrorCode</refname>
+  <refname>intlcal_get_error_code</refname>
+  <refpurpose>Renvoie le dernier code d'erreur sur l'objet</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <para>&style.oop; (method):</para>
+   <methodsynopsis role="IntlCalendar">
+   <modifier>public</modifier> <type class="union"><type>int</type><type>false</type></type><methodname>IntlCalendar::getErrorCode</methodname>
+   <void/>
+  </methodsynopsis>
+  <para>&style.procedural;:</para>
+  <methodsynopsis>
+   <type class="union"><type>int</type><type>false</type></type><methodname>intlcal_get_error_code</methodname>
+   <methodparam><type>IntlCalendar</type><parameter>calendar</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Renvoie le code d'erreur numérique ICU pour le dernier appel sur cet objet
+   (y compris le clonage) ou l'objet <classname>IntlCalendar</classname> donné
+   pour le paramètre <parameter>calendar</parameter> (dans la version
+   procédurale). Cela peut indiquer seulement un avertissement (code d'erreur
+   négatif) ou pas d'erreur du tout (<constant>U_ZERO_ERROR</constant>). La
+   présence réelle d'une erreur peut être testée avec <function>intl_is_failure</function>.
+  </para>
+  <para>
+   Les arguments invalides détectés du côté PHP (avant l'invocation des
+   fonctions de la bibliothèque ICU) ne sont pas enregistrés pour les besoins de cette fonction.
+  </para>
+  <para>
+   Le dernier code d'erreur qui s'est produit dans n'importe quel appel à une
+   fonction de l'extension intl, y compris les erreurs d'arguments précoces,
+   peut être obtenu avec <function>intl_get_error_code</function>. Cette
+   fonction réinitialise le code d'erreur global, mais pas le code d'erreur de l'objet.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>calendar</parameter></term>
+    <listitem>
+     <para>
+      L'objet calendrier, sur l'interface de style procédural.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Un code d'erreur ICU indiquant soit le succès, l'échec ou un avertissement.
+   Renvoie &false; en cas d'échec.
+  </para>
+ </refsect1>
+
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example>
+   <title><function>IntlCalendar::getErrorCode</function> et
+   <function>IntlCalendar::getErrorMessage</function></title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+ini_set("intl.error_level", E_WARNING);
+ini_set("intl.default_locale", "nl");
+
+$intlcal = new IntlGregorianCalendar(2012, 1, 29);
+var_dump(
+    $intlcal->getErrorCode(),
+    $intlcal->getErrorMessage()
+);
+$intlcal->fieldDifference(-1e100, IntlCalendar::FIELD_SECOND);
+
+var_dump(
+    $intlcal->getErrorCode(),
+    $intlcal->getErrorMessage()
+);
+
+]]>
+    </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+int(0)
+string(12) "U_ZERO_ERROR"
+
+Warning: IntlCalendar::fieldDifference(): intlcal_field_difference: Call to ICU method has failed in /home/glopes/php/ws/example.php on line 10
+int(1)
+string(81) "intlcal_field_difference: Call to ICU method has failed: U_ILLEGAL_ARGUMENT_ERROR"
+]]>
+    </screen>
+   </example>
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><methodname>IntlCalendar::getErrorMessage</methodname></member>
+    <member><methodname>intl_is_failure</methodname></member>
+    <member><methodname>intl_error_name</methodname></member>
+    <member><methodname>intl_get_error_code</methodname></member>
+    <member><methodname>intl_get_error_message</methodname></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/intl/intlcalendar/geterrormessage.xml
+++ b/reference/intl/intlcalendar/geterrormessage.xml
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 1976eae0d815797af97a1e16c5cd90ffc2868395 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="intlcalendar.geterrormessage" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>IntlCalendar::getErrorMessage</refname>
+  <refname>intlcal_get_error_message</refname>
+  <refpurpose>Renvoie le dernier message d'erreur sur l'objet</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <para>&style.oop; (method):</para>
+   <methodsynopsis role="IntlCalendar">
+   <modifier>public</modifier> <type class="union"><type>string</type><type>false</type></type><methodname>IntlCalendar::getErrorMessage</methodname>
+   <void/>
+  </methodsynopsis>
+  <para>&style.procedural;:</para>
+  <methodsynopsis>
+   <type class="union"><type>string</type><type>false</type></type><methodname>intlcal_get_error_message</methodname>
+   <methodparam><type>IntlCalendar</type><parameter>calendar</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Renvoie (s'il y a) le message d'erreur associé à l'erreur signalée par
+   <function>IntlCalendar::getErrorCode</function> ou
+   <function>intlcal_get_error_code</function>. S'il n'y a pas de message
+   d'erreur associé, seule la représentation de chaîne du nom de la constante
+   d'erreur sera renvoyée. Sinon, le message inclut également un message
+   défini du côté de la liaison PHP.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>calendar</parameter></term>
+    <listitem>
+     <para>
+      L'objet calendrier, sur l'interface de style procédural.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Le message d'erreur associé à la dernière erreur qui s'est produite dans un appel
+   de fonction sur cet objet, ou une chaîne indiquant la non-existence d'une erreur.
+   Renvoie &false; en cas d'échec.
+  </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example>
+   <title><function>IntlCalendar::getErrorMessage</function></title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+$cal = IntlCalendar::createInstance('UTC', 'en_US');
+var_dump($cal->getErrorMessage());
+
+$cal->getWeekendTransition(IntlCalendar::DOW_WEDNESDAY);
+var_dump($cal->getErrorMessage());
+
+]]>
+    </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+string(12) "U_ZERO_ERROR"
+string(82) "intlcal_get_weekend_transition: Error calling ICU method: U_ILLEGAL_ARGUMENT_ERROR"
+]]>
+    </screen>
+   </example>
+  </para>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/intl/intlcalendar/getfirstdayofweek.xml
+++ b/reference/intl/intlcalendar/getfirstdayofweek.xml
@@ -1,0 +1,118 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 1976eae0d815797af97a1e16c5cd90ffc2868395 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="intlcalendar.getfirstdayofweek" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>IntlCalendar::getFirstDayOfWeek</refname>
+  <refpurpose>Renvoie le premier jour de la semaine pour la locale du calendrier</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <para>
+   &style.oop;
+  </para>
+  <methodsynopsis role="IntlCalendar">
+   <modifier>public</modifier> <type class="union"><type>int</type><type>false</type></type><methodname>IntlCalendar::getFirstDayOfWeek</methodname>
+   <void/>
+  </methodsynopsis>
+  <para>
+   &style.procedural;
+  </para>
+  <methodsynopsis>
+   <type class="union"><type>int</type><type>false</type></type><methodname>intlcal_get_first_day_of_week</methodname>
+   <methodparam><type>IntlCalendar</type><parameter>calendar</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Renvoie le jour de la semaine qui est considéré comme le premier jour de la semaine, soit la valeur par défaut pour cette locale, 
+   soit la valeur définie avec
+   <function>IntlCalendar::setFirstDayOfWeek</function>.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>calendar</parameter></term>
+    <listitem>
+     &intl.parameter.intl-calendar;
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Une des constantes <constant>IntlCalendar::DOW_SUNDAY</constant>,
+    <constant>IntlCalendar::DOW_MONDAY</constant>, …,
+    <constant>IntlCalendar::DOW_SATURDAY</constant>&return.falseforfailure;.
+  </para>
+ </refsect1>
+
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example>
+   <title><function>IntlCalendar::getFirstDayOfWeek</function></title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+ini_set('date.timezone', 'UTC');
+
+$cal1 = IntlCalendar::createInstance(NULL, 'es_ES');
+var_dump($cal1->getFirstDayOfWeek()); // Lundi
+$cal1->set(2013, 1 /* February */, 3); // un dimanche
+var_dump($cal1->get(IntlCalendar::FIELD_WEEK_OF_YEAR)); // 5
+
+$cal2 = IntlCalendar::createInstance(NULL, 'en_US');
+var_dump($cal2->getFirstDayOfWeek()); // Dimanche
+$cal2->set(2013, 1 /* February */, 3); // un dimanche
+var_dump($cal2->get(IntlCalendar::FIELD_WEEK_OF_YEAR)); // 6
+]]>
+    </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+int(2)
+int(5)
+int(1)
+int(6)
+]]>
+    </screen>
+   </example>
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><methodname>IntlCalendar::setFirstDayOfWeek</methodname></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/intl/intlcalendar/getgreatestminimum.xml
+++ b/reference/intl/intlcalendar/getgreatestminimum.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 1976eae0d815797af97a1e16c5cd90ffc2868395 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="intlcalendar.getgreatestminimum" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>IntlCalendar::getGreatestMinimum</refname>
+  <refpurpose>Renvoie la plus grande valeur minimale locale pour un champ</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <para>
+   &style.oop;
+  </para>
+  <methodsynopsis role="IntlCalendar">
+   <modifier>public</modifier> <type class="union"><type>int</type><type>false</type></type><methodname>IntlCalendar::getGreatestMinimum</methodname>
+   <methodparam><type>int</type><parameter>field</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   &style.procedural;
+  </para>
+  <methodsynopsis>
+   <type class="union"><type>int</type><type>false</type></type><methodname>intlcal_get_greatest_minimum</methodname>
+   <methodparam><type>IntlCalendar</type><parameter>calendar</parameter></methodparam>
+   <methodparam><type>int</type><parameter>field</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Renvoie la plus grande valeur minimale locale pour un champ. Cela devrait être une valeur
+   plus grande ou égale à celle retournée par
+   <function>IntlCalendar::getActualMinimum</function>, qui est à son tour
+   plus grande ou égale à celle retournée par
+   <function>IntlCalendar::getMinimum</function>. Ces trois fonctions
+   retournent la même valeur pour le calendrier grégorien.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>calendar</parameter></term>
+    <listitem>
+     &intl.parameter.intl-calendar;
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>field</parameter></term>
+    <listitem>
+     &reference.intl.incfieldparam;
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Un <type>int</type> représentant une valeur de champ, dans lʼunité
+   du champ,&return.falseforfailure;.
+  </para>
+ </refsect1>
+
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/intl/intlcalendar/getkeywordvaluesforlocale.xml
+++ b/reference/intl/intlcalendar/getkeywordvaluesforlocale.xml
@@ -1,0 +1,155 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 1976eae0d815797af97a1e16c5cd90ffc2868395 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="intlcalendar.getkeywordvaluesforlocale" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>IntlCalendar::getKeywordValuesForLocale</refname>
+  <refpurpose>Renvoie l'ensemble des valeurs de mots-clés de locale</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <para>
+   &style.oop;
+  </para>
+  <methodsynopsis role="IntlCalendar">
+   <modifier>public</modifier> <modifier>static</modifier> <type class="union"><type>IntlIterator</type><type>false</type></type><methodname>IntlCalendar::getKeywordValuesForLocale</methodname>
+   <methodparam><type>string</type><parameter>keyword</parameter></methodparam>
+   <methodparam><type>string</type><parameter>locale</parameter></methodparam>
+   <methodparam><type>bool</type><parameter>onlyCommon</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   &style.procedural;
+  </para>
+  <methodsynopsis>
+   <type class="union"><type>IntlIterator</type><type>false</type></type><methodname>intlcal_get_keyword_values_for_locale</methodname>
+   <methodparam><type>string</type><parameter>keyword</parameter></methodparam>
+   <methodparam><type>string</type><parameter>locale</parameter></methodparam>
+   <methodparam><type>bool</type><parameter>onlyCommon</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Pour une clé de locale donnée, renvoie l'ensemble des valeurs pour cette clé qui entraîneraient
+   un comportement différent. Pour l'instant, seul le mot-clé <literal>'calendar'</literal>
+   est supporté.
+  </para>
+  <para>
+   Cette fonction requiert ICU 4.2 or later.
+  </para>
+
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>keyword</parameter></term>
+    <listitem>
+     <para>
+      Le mot-clé de locale pour lequel les valeurs pertinentes doivent être interrogées. Seul
+      <literal>'calendar'</literal> est supporté.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>locale</parameter></term>
+    <listitem>
+     <para>
+      La locale sur laquelle la paire mot-clé/valeur doit être ajouté.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>onlyCommon</parameter></term>
+    <listitem>
+     <para>
+      Indique s'il faut afficher uniquement les valeurs couramment utilisées pour la locale spécifiée.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Un itérateur qui renvoie des chaînes avec les valeurs de mot-clé de locale
+   &return.falseforfailure;.
+  </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example>
+   <title><function>IntlCalendar::getKeyworkValuesForLocale</function></title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+print_r(
+        iterator_to_array(
+                IntlCalendar::getKeywordValuesForLocale(
+                        'calendar', 'fa_IR', true)));
+print_r(
+        iterator_to_array(
+                IntlCalendar::getKeywordValuesForLocale(
+                        'calendar', 'fa_IR', false)));
+
+
+
+
+]]>
+    </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+Array
+(
+    [0] => persian
+    [1] => gregorian
+    [2] => islamic
+    [3] => islamic-civil
+)
+Array
+(
+    [0] => persian
+    [1] => gregorian
+    [2] => islamic
+    [3] => islamic-civil
+    [4] => japanese
+    [5] => buddhist
+    [6] => roc
+    [7] => hebrew
+    [8] => chinese
+    [9] => indian
+    [10] => coptic
+    [11] => ethiopic
+    [12] => ethiopic-amete-alem
+)
+
+]]>
+    </screen>
+   </example>
+  </para>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/intl/intlcalendar/getleastmaximum.xml
+++ b/reference/intl/intlcalendar/getleastmaximum.xml
@@ -1,0 +1,124 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 1976eae0d815797af97a1e16c5cd90ffc2868395 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="intlcalendar.getleastmaximum" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>IntlCalendar::getLeastMaximum</refname>
+  <refpurpose>Obtient le plus petit maximum local pour un champ</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <para>
+   &style.oop;
+  </para>
+  <methodsynopsis role="IntlCalendar">
+   <modifier>public</modifier> <type class="union"><type>int</type><type>false</type></type><methodname>IntlCalendar::getLeastMaximum</methodname>
+   <methodparam><type>int</type><parameter>field</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   &style.procedural;
+  </para>
+  <methodsynopsis>
+   <type class="union"><type>int</type><type>false</type></type><methodname>intlcal_get_least_maximum</methodname>
+   <methodparam><type>IntlCalendar</type><parameter>calendar</parameter></methodparam>
+   <methodparam><type>int</type><parameter>field</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Renvoie le plus petit maximum local pour un champ. Cela devrait être une valeur
+   plus petite ou égale à celle retournée par
+   <function>IntlCalendar::getActualMaxmimum</function>, qui est à son tour
+   plus petite ou égale à celle retournée par
+   <function>IntlCalendar::getMaximum</function>.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>calendar</parameter></term>
+    <listitem>
+     &intl.parameter.intl-calendar;
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>field</parameter></term>
+    <listitem>
+     &reference.intl.incfieldparam;
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Un <type>int</type> représentant une valeur de champ, dans lʼunité
+   du champ,&return.falseforfailure;.
+  </para>
+ </refsect1>
+
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example>
+   <title>Exemple de maximum</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+ini_set('date.timezone', 'UTC');
+ini_set('intl.default_locale', 'it_IT');
+
+$cal = new IntlGregorianCalendar(2013, 3 /* April */, 6);
+var_dump(
+    $cal->getLeastMaximum(IntlCalendar::FIELD_DAY_OF_MONTH),  // 28
+    $cal->getActualMaximum(IntlCalendar::FIELD_DAY_OF_MONTH), // 30
+    $cal->getMaximum(IntlCalendar::FIELD_DAY_OF_MONTH)        // 31
+);
+]]>
+    </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+int(28)
+int(30)
+int(31)
+]]>
+    </screen>
+   </example>
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><methodname>IntlCalendar::getActualMaximum</methodname></member>
+    <member><methodname>IntlCalendar::getMaximum</methodname></member>
+    <member><methodname>IntlCalendar::getGreatestMinimum</methodname></member>
+   </simplelist>
+  </para>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/intl/intlcalendar/getlocale.xml
+++ b/reference/intl/intlcalendar/getlocale.xml
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 1976eae0d815797af97a1e16c5cd90ffc2868395 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="intlcalendar.getlocale" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>IntlCalendar::getLocale</refname>
+  <refpurpose>Renvoie la locale associée à l'objet</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <para>
+   &style.oop;
+  </para>
+  <methodsynopsis role="IntlCalendar">
+   <modifier>public</modifier> <type class="union"><type>string</type><type>false</type></type><methodname>IntlCalendar::getLocale</methodname>
+   <methodparam><type>int</type><parameter>type</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   &style.procedural;
+  </para>
+  <methodsynopsis>
+   <type class="union"><type>string</type><type>false</type></type><methodname>intlcal_get_locale</methodname>
+   <methodparam><type>IntlCalendar</type><parameter>calendar</parameter></methodparam>
+   <methodparam><type>int</type><parameter>type</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Renvoie la locale utilisée par cet objet calendrier.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>calendar</parameter></term>
+    <listitem>
+     &intl.parameter.intl-calendar;
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>type</parameter></term>
+    <listitem>
+     <para>
+      Indique si la locale actuelle (la locale à partir de laquelle les données
+      du calendrier proviennent, avec <constant>Locale::ACTUAL_LOCALE</constant>)
+      ou la locale valide, c'est-à-dire la locale la plus spécifique supportée
+      par ICU relativement à la locale demandée – voir <constant>Locale::VALID_LOCALE</constant>.
+      De la plus générale à la plus spécifique, les locales sont ordonnées de
+      cette façon – locale actuel, locale valide, locale demandée.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Une chaîne de caractères représentant la locale&return.falseforfailure;.
+  </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example>
+   <title><function>IntlCalendar::getLocale</function></title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+$cal = IntlCalendar::createInstance(IntlTimeZone::getGMT(), 'en_US_CALIFORNIA');
+var_dump(
+    $cal->getLocale(Locale::ACTUAL_LOCALE),
+    $cal->getLocale(Locale::VALID_LOCALE)
+);
+]]>
+    </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+string(2) "en"
+string(5) "en_US"
+]]>
+    </screen>
+   </example>
+  </para>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/intl/intlcalendar/getmaximum.xml
+++ b/reference/intl/intlcalendar/getmaximum.xml
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 1976eae0d815797af97a1e16c5cd90ffc2868395 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="intlcalendar.getmaximum" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>IntlCalendar::getMaximum</refname>
+  <refpurpose>Obtient la valeur maximale globale pour un champ</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <para>
+   &style.oop;
+  </para>
+  <methodsynopsis role="IntlCalendar">
+   <modifier>public</modifier> <type class="union"><type>int</type><type>false</type></type><methodname>IntlCalendar::getMaximum</methodname>
+   <methodparam><type>int</type><parameter>field</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   &style.procedural;
+  </para>
+  <methodsynopsis>
+   <type class="union"><type>int</type><type>false</type></type><methodname>intlcal_get_maximum</methodname>
+   <methodparam><type>IntlCalendar</type><parameter>calendar</parameter></methodparam>
+   <methodparam><type>int</type><parameter>field</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Renvoie le maximum global pour un champ, dans ce calendrier spécifique. Cette valeur
+   est plus grande ou égale à celle retournée par
+   <function>IntlCalendar::getActualMaximum</function>, qui est à son tour
+   plus grande ou égale à celle retournée par
+   <function>IntlCalendar::getLeastMaximum</function>.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>calendar</parameter></term>
+    <listitem>
+     &intl.parameter.intl-calendar;
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>field</parameter></term>
+    <listitem>
+     &reference.intl.incfieldparam;
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Un <type>int</type> représentant une valeur de champ, dans lʼunité
+   du champ,&return.falseforfailure;.
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><methodname>IntlCalendar::getActualMaximum</methodname></member>
+    <member><methodname>IntlCalendar::getLeastMaximum</methodname></member>
+    <member><methodname>IntlCalendar::getMinimum</methodname></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/intl/intlcalendar/getminimaldaysinfirstweek.xml
+++ b/reference/intl/intlcalendar/getminimaldaysinfirstweek.xml
@@ -1,0 +1,123 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 1976eae0d815797af97a1e16c5cd90ffc2868395 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="intlcalendar.getminimaldaysinfirstweek" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>IntlCalendar::getMinimalDaysInFirstWeek</refname>
+  <refpurpose>Obtient le nombre minimal de jours que la première semaine dʼune année ou dʼun mois peut avoir</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <para>
+   &style.oop;
+  </para>
+  <methodsynopsis role="IntlCalendar">
+   <modifier>public</modifier> <type class="union"><type>int</type><type>false</type></type><methodname>IntlCalendar::getMinimalDaysInFirstWeek</methodname>
+   <void/>
+  </methodsynopsis>
+  <para>
+   &style.procedural;
+  </para>
+  <methodsynopsis>
+   <type class="union"><type>int</type><type>false</type></type><methodname>intlcal_get_minimal_days_in_first_week</methodname>
+   <methodparam><type>IntlCalendar</type><parameter>calendar</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Renvoie le plus petit nombre de jours que la première semaine dʼune année ou dʼun mois
+   doit avoir dans la nouvelle année ou le nouveau mois. Par exemple, dans le calendrier grégorien, si
+   cette valeur est 1, alors la première semaine de lʼannée inclura nécessairement
+   le 1er janvier, tandis que si cette valeur est 7, alors la semaine avec le 1er janvier sera
+   la première semaine de lʼannée seulement si le jour de la semaine pour le 1er janvier
+   correspond au jour de la semaine retourné par <function>IntlCalendar::getFirstDayOfWeek</function>; sinon ce sera
+   la dernière semaine de lʼannée précédente.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>calendar</parameter></term>
+    <listitem>
+     &intl.parameter.intl-calendar;
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Un <type>int</type> représentant un numéro de jour&return.falseforfailure;.
+  </para>
+ </refsect1>
+
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example>
+   <title><function>IntlCalendar::getMinimalDaysInFirstWeek</function></title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+ini_set('date.timezone', 'UTC');
+ini_set('intl.default_locale', 'en_US');
+
+$cal = new IntlGregorianCalendar(2013, 0 /* January */, 2);
+var_dump(IntlDateFormatter::formatObject($cal, 'cccc')); // Mercredi
+
+var_dump($cal->getMinimalDaysInFirstWeek(), // 1
+$cal->getFirstDayofWeek()); // 1 (Dimanche)
+
+// Semaine 1 de 2013
+var_dump(IntlDateFormatter::formatObject($cal, "'Week 'w' of 'Y"));
+
+$cal->setMinimalDaysInFirstWeek(4);
+// Toujours semaine 1 de 2013 (La 1st semaine a 5 jours dans la nouvelle année)
+var_dump(IntlDateFormatter::formatObject($cal, "'Week 'w' of 'Y"));
+
+$cal->setMinimalDaysInFirstWeek(6);
+// Semaine 53 de 2012
+var_dump(IntlDateFormatter::formatObject($cal, "'Week 'w' of 'Y"));
+
+]]>
+    </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+string(9) "Wednesday"
+int(1)
+int(1)
+string(14) "Week 1 of 2013"
+string(14) "Week 1 of 2013"
+string(15) "Week 53 of 2012"
+]]>
+    </screen>
+   </example>
+  </para>
+ </refsect1>
+
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/intl/intlcalendar/getminimum.xml
+++ b/reference/intl/intlcalendar/getminimum.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 1976eae0d815797af97a1e16c5cd90ffc2868395 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="intlcalendar.getminimum" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>IntlCalendar::getMinimum</refname>
+  <refpurpose>Obtient la valeur minimale globale pour un champ</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <para>
+   &style.oop;
+  </para>
+  <methodsynopsis role="IntlCalendar">
+   <modifier>public</modifier> <type class="union"><type>int</type><type>false</type></type><methodname>IntlCalendar::getMinimum</methodname>
+   <methodparam><type>int</type><parameter>field</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   &style.procedural;
+  </para>
+  <methodsynopsis>
+   <type class="union"><type>int</type><type>false</type></type><methodname>intlcal_get_minimum</methodname>
+   <methodparam><type>IntlCalendar</type><parameter>calendar</parameter></methodparam>
+   <methodparam><type>int</type><parameter>field</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Renvoie la valeur minimale globale pour un champ, dans ce calendrier spécifique. Cette valeur
+   est plus petite ou égale à celle retournée par
+   <function>IntlCalendar::getActualMinimum</function>, qui est à son tour
+   plus petite ou égale à celle retournée par
+   <function>IntlCalendar::getGreatestMinimum</function>. Pour le calendrier grégorien, ces trois fonctions
+   retournent toujours la même valeur (pour chaque
+   champ).
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>calendar</parameter></term>
+    <listitem>
+     &intl.parameter.intl-calendar;
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>field</parameter></term>
+    <listitem>
+     &reference.intl.incfieldparam;
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Un <type>int</type> représentant une valeur de champ, dans lʼunité
+   du champ,&return.falseforfailure;.
+  </para>
+ </refsect1>
+
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/intl/intlcalendar/getrepeatedwalltimeoption.xml
+++ b/reference/intl/intlcalendar/getrepeatedwalltimeoption.xml
@@ -1,0 +1,133 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 1976eae0d815797af97a1e16c5cd90ffc2868395 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="intlcalendar.getrepeatedwalltimeoption" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>IntlCalendar::getRepeatedWallTimeOption</refname>
+  <refpurpose>Obtient le comportement pour la gestion des heures murales répétées</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <para>
+   &style.oop;
+  </para>
+  <methodsynopsis role="IntlCalendar">
+   <modifier>public</modifier> <type>int</type><methodname>IntlCalendar::getRepeatedWallTimeOption</methodname>
+   <void/>
+  </methodsynopsis>
+  <para>
+   &style.procedural;
+  </para>
+  <methodsynopsis>
+   <type>int</type><methodname>intlcal_get_repeated_wall_time_option</methodname>
+   <methodparam><type>IntlCalendar</type><parameter>calendar</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Renvoie la stratégie actuelle pour la gestion des heures murales répétées
+   lorsque l'horloge est remise en arrière lors des transitions de fin d'heure d'été.
+   La valeur par défaut est <constant>IntlCalendar::WALLTIME_LAST</constant>.
+  </para>
+  <para>
+   Cette fonction requiert ICU 4.9 ou plus récent.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>calendar</parameter></term>
+    <listitem>
+     &intl.parameter.intl-calendar;
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Une des constantes <constant>IntlCalendar::WALLTIME_FIRST</constant> ou
+   <constant>IntlCalendar::WALLTIME_LAST</constant>. 
+  </para>
+ </refsect1>
+
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example>
+   <title><function>IntlCalendar::getRepeatedWallTimeOption</function></title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+ini_set('date.timezone', 'Europe/Lisbon');
+ini_set('intl.default_locale', 'en_US');
+ini_set('intl.error_level', E_WARNING);
+
+//Le 27 Octobre à 0200, l'heure reculera d'une heure de GMT+01 à GMT+00
+$cal = new IntlGregorianCalendar(2013, 9 /* October */, 27, 1, 30);
+
+var_dump($cal->getRepeatedWalltimeOption()); // 0 WALLTIME_LAST
+
+$formatter = IntlDateFormatter::create(
+    NULL,
+    IntlDateFormatter::FULL,
+    IntlDateFormatter::FULL,
+    'UTC'
+);
+var_dump($formatter->format($cal->getTime() / 1000.));
+
+$cal->setRepeatedWalltimeOption(IntlCalendar::WALLTIME_FIRST);
+var_dump($cal->getRepeatedWalltimeOption()); // 1 WALLTIME_FIRST
+$cal->set(IntlCalendar::FIELD_HOUR_OF_DAY, 1);
+
+var_dump($formatter->format($cal->getTime() / 1000.));
+]]>
+    </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+int(0)
+string(42) "Sunday, October 27, 2013 at 1:30:00 AM GMT"
+int(1)
+string(43) "Sunday, October 27, 2013 at 12:30:00 AM GMT"
+]]>
+    </screen>
+   </example>
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><methodname>IntlCalendar::getSkippedWallTimeOption</methodname></member>
+    <member><methodname>IntlCalendar::setSkippedWallTimeOption</methodname></member>
+    <member><methodname>IntlCalendar::setRepeatedWallTimeOption</methodname></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/intl/intlcalendar/getskippedwalltimeoption.xml
+++ b/reference/intl/intlcalendar/getskippedwalltimeoption.xml
@@ -1,0 +1,151 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 1976eae0d815797af97a1e16c5cd90ffc2868395 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="intlcalendar.getskippedwalltimeoption" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>IntlCalendar::getSkippedWallTimeOption</refname>
+  <refpurpose>Obtient le comportement pour la gestion des heures murales sautées</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <para>
+   &style.oop;
+  </para>
+  <methodsynopsis role="IntlCalendar">
+   <modifier>public</modifier> <type>int</type><methodname>IntlCalendar::getSkippedWallTimeOption</methodname>
+   <void/>
+  </methodsynopsis>
+  <para>
+   &style.procedural;
+  </para>
+  <methodsynopsis>
+   <type>int</type><methodname>intlcal_get_skipped_wall_time_option</methodname>
+   <methodparam><type>IntlCalendar</type><parameter>calendar</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Renvoie la stratégie actuelle pour la gestion des heures murales sautées
+   lorsque l'horloge est avancée lors des transitions de début d'heure d'été.
+   La valeur par défaut est <constant>IntlCalendar::WALLTIME_LAST</constant>.
+  </para>
+  <para>
+   Le calendrier doit être <link linkend="intlcalendar.setlenient">tolérant</link> pour que cette option ait
+   un effet, sinon tenter de définir une heure inexistante provoquera une
+   erreur.
+  </para>
+  <para>
+   Cette fonction requiert ICU 4.9 ou plus récent.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>calendar</parameter></term>
+    <listitem>
+     &intl.parameter.intl-calendar;
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Une des constantes <constant>IntlCalendar::WALLTIME_FIRST</constant>,
+   <constant>IntlCalendar::WALLTIME_LAST</constant> ou
+   <constant>IntlCalendar::WALLTIME_NEXT_VALID</constant>.
+  </para>
+ </refsect1>
+
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example>
+   <title><function>IntlCalendar::getSkippedWallTimeOption</function></title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+ini_set('date.timezone', 'Europe/Lisbon');
+ini_set('intl.default_locale', 'en_US');
+ini_set('intl.error_level', E_WARNING);
+
+//Le 31 Mars à 0100, l'horloge avancera d'une houre de GMT+00 à GMT+01
+$cal = new IntlGregorianCalendar(2013, 2 /* March */, 31, 1, 30);
+
+var_dump(
+    $cal->isLenient(),               // true
+    $cal->getSkippedWalltimeOption() // 0 WALLTIME_LAST
+);
+
+$formatter = IntlDateFormatter::create(
+    NULL,
+    IntlDateFormatter::FULL,
+    IntlDateFormatter::FULL,
+    'UTC'
+);
+var_dump($formatter->format($cal->getTime() / 1000));
+
+$cal->setSkippedWallTimeOption(IntlCalendar::WALLTIME_FIRST);
+var_dump($cal->getSkippedWalltimeOption()); // 1 WALLTIME_FIRST
+$cal->set(IntlCalendar::FIELD_HOUR_OF_DAY, 1);
+
+var_dump($formatter->format($cal->getTime() / 1000));
+
+$cal->setSkippedWallTimeOption(IntlCalendar::WALLTIME_NEXT_VALID);
+var_dump($cal->getSkippedWalltimeOption()); // 2 WALLTIME_NEXT_VALID
+$cal->set(IntlCalendar::FIELD_HOUR_OF_DAY, 1);
+
+var_dump($formatter->format($cal->getTime() / 1000));
+]]>
+    </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+bool(true)
+int(0)
+string(40) "Sunday, March 31, 2013 at 1:30:00 AM GMT"
+int(1)
+string(41) "Sunday, March 31, 2013 at 12:30:00 AM GMT"
+int(2)
+string(40) "Sunday, March 31, 2013 at 1:00:00 AM GMT"
+]]>
+    </screen>
+   </example>
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><methodname>IntlCalendar::getRepeatedWallTimeOption</methodname></member>
+    <member><methodname>IntlCalendar::setSkippedWallTimeOption</methodname></member>
+    <member><methodname>IntlCalendar::setRepeatedWallTimeOption</methodname></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/intl/intlcalendar/gettime.xml
+++ b/reference/intl/intlcalendar/gettime.xml
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 1976eae0d815797af97a1e16c5cd90ffc2868395 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="intlcalendar.gettime" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>IntlCalendar::getTime</refname>
+  <refpurpose>Obtient le temps actuellement représenté par l'objet</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <para>
+   &style.oop;
+  </para>
+  <methodsynopsis role="IntlCalendar">
+   <modifier>public</modifier> <type class="union"><type>float</type><type>false</type></type><methodname>IntlCalendar::getTime</methodname>
+   <void/>
+  </methodsynopsis>
+  <para>
+   &style.procedural;
+  </para>
+  <methodsynopsis>
+   <type class="union"><type>float</type><type>false</type></type><methodname>intlcal_get_time</methodname>
+   <methodparam><type>IntlCalendar</type><parameter>calendar</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Renvoie le temps associé à cet objet, exprimé en tant que nombre de
+   millisecondes écoulées depuis l'epoch.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>calendar</parameter></term>
+    <listitem>
+     &intl.parameter.intl-calendar;
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Un <type>float</type> représentant le nombre de millisecondes écoulées depuis le
+   temps de référence (1 Jan 1970 00:00:00 UTC),&return.falseforfailure;
+  </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example>
+   <title><function>IntlCalendar::getTime</function></title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+ini_set('date.timezone', 'Europe/Lisbon');
+ini_set('intl.default_locale', 'en_US');
+
+$cal = new IntlGregorianCalendar(2013, 4 /* May */, 1, 0, 0, 0);
+$time = $cal->getTime();
+var_dump($time, $time / 1000 == strtotime('2013-05-01 00:00:00')); //true
+]]>
+    </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+float(1367362800000)
+bool(true)
+]]>
+    </screen>
+   </example>
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><methodname>IntlCalendar::getNow</methodname></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/intl/intlcalendar/getweekendtransition.xml
+++ b/reference/intl/intlcalendar/getweekendtransition.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 1976eae0d815797af97a1e16c5cd90ffc2868395 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="intlcalendar.getweekendtransition" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>IntlCalendar::getWeekendTransition</refname>
+  <refpurpose>Obtient l'heure du jour à laquelle le week-end commence ou se termine</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <para>
+   &style.oop;
+  </para>
+  <methodsynopsis role="IntlCalendar">
+   <modifier>public</modifier> <type class="union"><type>int</type><type>false</type></type><methodname>IntlCalendar::getWeekendTransition</methodname>
+   <methodparam><type>int</type><parameter>dayOfWeek</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   &style.procedural;
+  </para>
+  <methodsynopsis>
+   <type class="union"><type>int</type><type>false</type></type><methodname>intlcal_get_weekend_transition</methodname>
+   <methodparam><type>IntlCalendar</type><parameter>calendar</parameter></methodparam>
+   <methodparam><type>int</type><parameter>dayOfWeek</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Renvoie le nombre de millisecondes écoulées depuis minuit à l'heure à laquelle le week-end
+   commence ou se termine.
+  </para>
+  <para>
+   Ceci est uniquement applicable pour les jours de la semaine pour lesquels
+   <function>IntlCalendar::getDayOfWeekType</function> retourne soit
+   <constant>IntlCalendar::DOW_TYPE_WEEKEND_OFFSET</constant> ou
+   <constant>IntlCalendar::DOW_TYPE_WEEKEND_CEASE</constant>. Appeler cette
+   fonction pour d'autres jours de la semaine est une condition d'erreur.
+  </para>
+  <para>
+   Cette fonction requiert ICU 4.4 ou plus.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>calendar</parameter></term>
+    <listitem>
+     &intl.parameter.intl-calendar;
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>dayOfWeek</parameter></term>
+    <listitem>
+     <para>
+      Une des constantes <constant>IntlCalendar::DOW_SUNDAY</constant>,
+      <constant>IntlCalendar::DOW_MONDAY</constant>, …,
+      <constant>IntlCalendar::DOW_SATURDAY</constant>.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Le nombre de millisecondes écoulées depuis minuit à l'heure à laquelle le week-end
+   commence ou se termine&return.falseforfailure;.
+  </para>
+ </refsect1>
+
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   Voir un exemple sur <function>IntlCalendar::getDayOfWeekType</function>.
+  </para>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/intl/intlcalendar/indaylighttime.xml
+++ b/reference/intl/intlcalendar/indaylighttime.xml
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 1976eae0d815797af97a1e16c5cd90ffc2868395 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="intlcalendar.indaylighttime" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>IntlCalendar::inDaylightTime</refname>
+  <refpurpose>Indique si l'objet est en heure d'été</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <para>
+   &style.oop;
+  </para>
+  <methodsynopsis role="IntlCalendar">
+   <modifier>public</modifier> <type>bool</type><methodname>IntlCalendar::inDaylightTime</methodname>
+   <void/>
+  </methodsynopsis>
+  <para>
+   &style.procedural;
+  </para>
+  <methodsynopsis>
+   <type>bool</type><methodname>intlcal_in_daylight_time</methodname>
+   <methodparam><type>IntlCalendar</type><parameter>calendar</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Si, pour l'instant représenté par cet objet et pour le fuseau horaire de cet objet, l'heure d'été est en vigueur.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>calendar</parameter></term>
+    <listitem>
+     &intl.parameter.intl-calendar;
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Renvoie &true; si la date est en heure d'été, sinon &false;.
+  </para>
+  &intl.error.intl-calendar;
+ </refsect1>
+
+
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example>
+   <title><function>IntlCalendar::inDaylightTime</function></title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+ini_set('date.timezone', 'Europe/Lisbon');
+ini_set('intl.default_locale', 'pt_PT');
+
+$cal = new IntlGregorianCalendar(2013, 6 /* July */, 1, 4, 56, 31);
+var_dump($cal->inDaylightTime()); // true
+$cal->set(IntlCalendar::FIELD_MONTH, 11 /* December */);
+var_dump($cal->inDaylightTime()); // false
+
+//Fin de l'heure d'été le 2013-10-27 à 0200 (recul d'une heure)
+$cal = new IntlGregorianCalendar(2013, 9 /* October */, 27, 1, 30, 0);
+
+var_dump($cal->inDaylightTime()); // false (default WALLTIME_LAST)
+
+$cal->setRepeatedWallTimeOption(IntlCalendar::WALLTIME_FIRST);
+$cal->set(IntlCalendar::FIELD_HOUR_OF_DAY, 1); // force time recalculation
+var_dump($cal->inDaylightTime()); // true
+
+]]>
+    </programlisting>
+   </example>
+  </para>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/intl/intlcalendar/isequivalentto.xml
+++ b/reference/intl/intlcalendar/isequivalentto.xml
@@ -1,0 +1,131 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 1976eae0d815797af97a1e16c5cd90ffc2868395 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="intlcalendar.isequivalentto" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>IntlCalendar::isEquivalentTo</refname>
+  <refpurpose>Indique si un autre calendrier est équivalent, mais pour un autre moment</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <para>
+   &style.oop;
+  </para>
+  <methodsynopsis role="IntlCalendar">
+   <modifier>public</modifier> <type>bool</type><methodname>IntlCalendar::isEquivalentTo</methodname>
+   <methodparam><type>IntlCalendar</type><parameter>other</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   &style.procedural;
+  </para>
+  <methodsynopsis>
+   <type>bool</type><methodname>intlcal_is_equivalent_to</methodname>
+   <methodparam><type>IntlCalendar</type><parameter>calendar</parameter></methodparam>
+   <methodparam><type>IntlCalendar</type><parameter>other</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Renvoie si cet objet et celui donnée sont équivalent pour tous les usages,
+   sauf pour le moment qu'ils ont défini. Les fuseaux horaires n'ont pas à correspondre,
+   tant qu'aucun changement de comportement n'en résulte. Cela inclut le <link linkend="intlcalendar.gettimezone">fuseau horaire</link>, si le
+   <link linkend="intlcalendar.islenient">mode laxiste</link> est défini,
+   les paramètres de temps de mur <link linkend="intlcalendar.getrepeatedwalltimeoption">répété</link>
+   et <link linkend="intlcalendar.getskippedwalltimeoption">sauté</link>, 
+   les <link linkend="intlcalendar.getdayofweektype">jours de la semaine où le week-end commence et cesse</link> et les <link linkend="intlcalendar.getweekendtransition">heures où de telles transitions
+   se produisent</link>. Cela peut également inclure d'autres paramètres spécifiques au calendrier, tels que
+   l'instant de transition grégorien/julien.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>calendar</parameter></term>
+    <listitem>
+     &intl.parameter.intl-calendar;
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>other</parameter></term>
+    <listitem>
+     <para>
+      L'autre calendrier par rapport auquel la comparaison doit être faite.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   En supposant qu'il n'y a pas d'erreurs d'argument, renvoie &true; si les calendriers sont
+   équivalents, sauf peut-être pour leur moment défini.
+  </para>
+ </refsect1>
+
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example>
+   <title><function>IntlCalendar::isEquivalentTo</function></title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+$cal1 = IntlCalendar::createInstance('Europe/Lisbon', 'pt_PT');
+$cal2 = IntlCalendar::createInstance('Europe/Lisbon', 'es_ES');
+$cal2->clear();
+
+var_dump($cal1->isEquivalentTo($cal2)); // true
+
+$cal3 = IntlCalendar::createInstance('Europe/Lisbon', 'en_US');
+var_dump($cal1->isEquivalentTo($cal3)); // false
+var_dump($cal1->getFirstDayOfWeek(),    // 2 (Monday)
+$cal3->getFirstDayOfWeek());            // 1 (Sunday)
+]]>
+    </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+bool(true)
+bool(false)
+int(2)
+int(1)
+]]>
+    </screen>
+   </example>
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><methodname>IntlCalendar::equals</methodname></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/intl/intlcalendar/islenient.xml
+++ b/reference/intl/intlcalendar/islenient.xml
@@ -1,0 +1,118 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 1976eae0d815797af97a1e16c5cd90ffc2868395 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="intlcalendar.islenient" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>IntlCalendar::isLenient</refname>
+  <refpurpose>Indique si l'interprétation de la date/heure est en mode tolérant</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <para>
+   &style.oop;
+  </para>
+  <methodsynopsis role="IntlCalendar">
+   <modifier>public</modifier> <type>bool</type><methodname>IntlCalendar::isLenient</methodname>
+   <void/>
+  </methodsynopsis>
+  <para>
+   &style.procedural;
+  </para>
+  <methodsynopsis>
+   <type>bool</type><methodname>intlcal_is_lenient</methodname>
+   <methodparam><type>IntlCalendar</type><parameter>calendar</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Renvoie si l'interprétation de la date/heure est en mode tolérant (le
+   mode par défaut). Si c'est le cas, certaines valeurs hors limites pour les
+   champs seront acceptées au lieu de générer une erreur.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>calendar</parameter></term>
+    <listitem>
+     &intl.parameter.intl-calendar;
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Un <type>bool</type> représentant si le calendrier est en mode tolérant.
+  </para>
+ </refsect1>
+
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example>
+   <title><function>IntlCalendar::isLenient</function></title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+ini_set('date.timezone', 'Europe/Lisbon');
+ini_set('intl.default_locale', 'pt_PT');
+ini_set('intl.use_exceptions', '1');
+
+$cal = new IntlGregorianCalendar(2013, 6 /* July */, 1);
+var_dump(IntlDateFormatter::formatObject($cal), // 01/07/2013, 00:00:00
+$cal->isLenient()); // true
+
+$cal->set(IntlCalendar::FIELD_DAY_OF_MONTH, 33);
+var_dump(IntlDateFormatter::formatObject($cal)); // 02/08/2013, 00:00:00
+
+$cal->setLenient(false);
+var_dump($cal->isLenient()); // false
+$cal->set(IntlCalendar::FIELD_DAY_OF_MONTH, 33);
+var_dump(IntlDateFormatter::formatObject($cal)); // erreur
+
+]]>
+    </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+string(20) "01/07/2013, 00:00:00"
+bool(true)
+string(20) "02/08/2013, 00:00:00"
+bool(false)
+
+Fatal error: Uncaught exception 'IntlException' with message 'datefmt_format_object: error obtaining instant from IntlCalendar' in /home/foobar/example.php:16
+Stack trace:
+#0 /home/foobar/example.php(16): IntlDateFormatter::formatObject(Object(IntlGregorianCalendar))
+#1 {main}
+  thrown in /home/foobar/example.php on line 16
+]]>
+    </screen>
+   </example>
+  </para>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/intl/intlcalendar/isset.xml
+++ b/reference/intl/intlcalendar/isset.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 1976eae0d815797af97a1e16c5cd90ffc2868395 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="intlcalendar.isset" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>IntlCalendar::isSet</refname>
+  <refpurpose>Indique si un champ est défini</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <para>
+   &style.oop;
+  </para>
+  <methodsynopsis role="IntlCalendar">
+   <modifier>public</modifier> <type>bool</type><methodname>IntlCalendar::isSet</methodname>
+   <methodparam><type>int</type><parameter>field</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   &style.procedural;
+  </para>
+  <methodsynopsis>
+   <type>bool</type><methodname>intlcal_is_set</methodname>
+   <methodparam><type>IntlCalendar</type><parameter>calendar</parameter></methodparam>
+   <methodparam><type>int</type><parameter>field</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Renvoie si un champ est défini (par opposition à <link linkend="intlcalendar.clear">effacé</link>). Les champs définis ont la priorité sur
+   les champs non définis et leurs valeurs par défaut lors du calcul de la date/heure.
+   Les champs définis plus tard ont la priorité sur les champs définis plus tôt.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>calendar</parameter></term>
+    <listitem>
+     &intl.parameter.intl-calendar;
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>field</parameter></term>
+    <listitem>
+     &reference.intl.incfieldparam;
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   En supposant qu'il n'y a pas d'erreurs d'arguments, renvoie &true; si le champ est défini.
+  </para>
+ </refsect1>
+
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   Voir un exemple sur <function>IntlCalendar::clear</function>.
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><methodname>IntlCalendar::clear</methodname></member>
+    <member><methodname>IntlCalendar::set</methodname></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/intl/intlcalendar/isweekend.xml
+++ b/reference/intl/intlcalendar/isweekend.xml
@@ -1,0 +1,123 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 1976eae0d815797af97a1e16c5cd90ffc2868395 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="intlcalendar.isweekend" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>IntlCalendar::isWeekend</refname>
+  <refpurpose>Indique si une date/heure est un week-end</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <para>
+   &style.oop;
+  </para>
+  <methodsynopsis role="IntlCalendar">
+   <modifier>public</modifier> <type>bool</type><methodname>IntlCalendar::isWeekend</methodname>
+   <methodparam choice="opt"><type class="union"><type>float</type><type>null</type></type><parameter>timestamp</parameter><initializer>&null;</initializer></methodparam>
+  </methodsynopsis>
+  <para>
+   &style.procedural;
+  </para>
+  <methodsynopsis>
+   <type>bool</type><methodname>intlcal_is_weekend</methodname>
+   <methodparam><type>IntlCalendar</type><parameter>calendar</parameter></methodparam>
+   <methodparam choice="opt"><type class="union"><type>float</type><type>null</type></type><parameter>timestamp</parameter><initializer>&null;</initializer></methodparam>
+  </methodsynopsis>
+  <para>
+   Renvoie si l'heure actuelle de l'objet ou le timestamp fourni
+   se produit pendant un week-end dans le système de calendrier de cet objet.
+  </para>
+  <para>
+   Cette fonction nécessite ICU 4.4 ou plus récent.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>calendar</parameter></term>
+    <listitem>
+     &intl.parameter.intl-calendar;
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>timestamp</parameter></term>
+    <listitem>
+     <para>
+      Un timestamp optionnel représentant le nombre de millisecondes écoulées
+      depuis l'epoch, excluant les secondes intercalaires. Si &null;, le temps
+      actuel de cet objet est utilisé à la place.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Un <type>bool</type> indiquant si le temps donné ou celui de cet objet
+   se produit pendant un week-end.
+  </para>
+  &intl.error.intl-calendar;
+ </refsect1>
+
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example>
+   <title><function>IntlCalendar::isWeekend</function></title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+ini_set('date.timezone', 'Europe/Lisbon');
+
+$cal = new IntlGregorianCalendar(NULL, 'en_US');
+$cal->set(2013, 6 /* July */, 7); // un dimanche 
+
+var_dump($cal->isWeekend()); // true
+var_dump($cal->isWeekend(strtotime('2013-07-01 00:00:00'))); // false, Monday
+
+$cal = new IntlGregorianCalendar(NULL, 'ar_SA');
+$cal->set(2013, 6 /* July */, 7); // un dimanche 
+var_dump($cal->isWeekend()); // false, dimanche n'est pas dans le week-end sur ce calendrier
+]]>
+    </programlisting>
+   </example>
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><methodname>IntlCalendar::getDayOfWeekType</methodname></member>
+    <member><methodname>IntlCalendar::getWeekendTransition</methodname></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/intl/intlcalendar/roll.xml
+++ b/reference/intl/intlcalendar/roll.xml
@@ -1,0 +1,133 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 1976eae0d815797af97a1e16c5cd90ffc2868395 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="intlcalendar.roll" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>IntlCalendar::roll</refname>
+  <refpurpose>Ajoute une valeur à un champ sans la reporter sur les champs plus significatifs</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <para>
+   &style.oop;
+  </para>
+  <methodsynopsis role="IntlCalendar">
+   <modifier>public</modifier> <type>bool</type><methodname>IntlCalendar::roll</methodname>
+   <methodparam><type>int</type><parameter>field</parameter></methodparam>
+   <methodparam><type class="union"><type>int</type><type>bool</type></type><parameter>value</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   &style.procedural;
+  </para>
+  <methodsynopsis>
+   <type>bool</type><methodname>intlcal_roll</methodname>
+   <methodparam><type>IntlCalendar</type><parameter>calendar</parameter></methodparam>
+   <methodparam><type>int</type><parameter>field</parameter></methodparam>
+   <methodparam><type class="union"><type>int</type><type>bool</type></type><parameter>value</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Ajoute une valeur (signée) à un champ. La différence avec
+   <function>IntlCalendar::add</function> est que lorsque la valeur du champ
+   déborde, elle ne se reporte pas sur les champs plus significatifs.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>calendar</parameter></term>
+    <listitem>
+     &intl.parameter.intl-calendar;
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>field</parameter></term>
+    <listitem>
+     &reference.intl.incfieldparam;
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>value</parameter></term>
+    <listitem>
+     <para>
+      La valeur (signée) à ajouter au champ, &true; pour aller vers le haut
+      (ajoutant <literal>1</literal>), ou &false; pour aller vers le bas
+      (soustrayant <literal>1</literal>).
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Renvoie &true; en cas de succès ou &false; en cas d'échec.
+  </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example>
+   <title><function>IntlCalendar::roll</function></title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+ini_set('date.timezone', 'Europe/Lisbon');
+ini_set('intl.default_locale', 'pt_PT');
+
+$cal = new IntlGregorianCalendar(2013, 5 /* June */, 30);
+
+$cal->add(IntlCalendar::FIELD_DAY_OF_MONTH, 1);
+var_dump(IntlDateFormatter::formatObject($cal)); // "01/07/2013, 00:00:00"
+
+$cal->set(2013, 5 /* June */, 30);
+$cal->roll(IntlCalendar::FIELD_DAY_OF_MONTH, true); // aller en up, comme rouler +1
+var_dump(IntlDateFormatter::formatObject($cal)); // "01/06/2013, 00:00:00"
+]]>
+    </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+string(20) "01/07/2013, 00:00:00"
+string(20) "01/06/2013, 00:00:00"
+]]>
+    </screen>
+   </example>
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><methodname>IntlCalendar::add</methodname></member>
+    <member><methodname>IntlCalendar::set</methodname></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/intl/intlcalendar/set.xml
+++ b/reference/intl/intlcalendar/set.xml
@@ -1,0 +1,236 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 2ca090342977839edca2f7f4e52305a1b5da6095 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+
+<refentry xml:id="intlcalendar.set" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>IntlCalendar::set</refname>
+  <refpurpose>Définit un champ de temps ou plusieurs champs communs en une seule fois</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <para>
+   &style.oop;
+  </para>
+  <methodsynopsis role="IntlCalendar">
+   <modifier>public</modifier> <type>true</type><methodname>IntlCalendar::set</methodname>
+   <methodparam><type>int</type><parameter>field</parameter></methodparam>
+   <methodparam><type>int</type><parameter>value</parameter></methodparam>
+  </methodsynopsis>
+  <methodsynopsis role="IntlCalendar">
+   <modifier>public</modifier> <type>true</type><methodname>IntlCalendar::set</methodname>
+   <methodparam><type>int</type><parameter>year</parameter></methodparam>
+   <methodparam><type>int</type><parameter>month</parameter></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>dayOfMonth</parameter><initializer>NULL</initializer></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>hour</parameter><initializer>NULL</initializer></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>minute</parameter><initializer>NULL</initializer></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>second</parameter><initializer>NULL</initializer></methodparam>
+  </methodsynopsis>
+  <para>
+   &style.procedural;
+  </para>
+  <methodsynopsis>
+   <type>true</type><methodname>intlcal_set</methodname>
+   <methodparam><type>IntlCalendar</type><parameter>cal</parameter></methodparam>
+   <methodparam><type>int</type><parameter>field</parameter></methodparam>
+   <methodparam><type>int</type><parameter>value</parameter></methodparam>
+  </methodsynopsis>
+  <methodsynopsis>
+   <type>bool</type><methodname>intlcal_set</methodname>
+   <methodparam><type>IntlCalendar</type><parameter>cal</parameter></methodparam>
+   <methodparam><type>int</type><parameter>year</parameter></methodparam>
+   <methodparam><type>int</type><parameter>month</parameter></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>dayOfMonth</parameter><initializer>NULL</initializer></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>hour</parameter><initializer>NULL</initializer></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>minute</parameter><initializer>NULL</initializer></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>second</parameter><initializer>NULL</initializer></methodparam>
+  </methodsynopsis>
+  <para>
+   Définit soit un champ spécifique à la valeur donnée, soit définit en une seule fois
+   plusieurs champs communs. La plage de valeurs acceptées dépend de si le
+   calendrier utilise le <link linkend="intlcalendar.setlenient">mode
+   tolérant</link>.
+  </para>
+  <para>
+   Pour les champs qui entrent en conflit, les champs définis plus tard ont la priorité.
+  </para>
+  <para>
+   Cette méthode ne peut pas être appelée avec exactement quatre arguments.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>cal</parameter></term>
+    <listitem>
+     &intl.parameter.intl-calendar;
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>field</parameter></term>
+    <listitem>
+     &reference.intl.incfieldparam;
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>value</parameter></term>
+    <listitem>
+     <para>
+      La nouvelle valeur du champ donné.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>year</parameter></term>
+    <listitem>
+     <para>
+      La nouvelle valeur pour <constant>IntlCalendar::FIELD_YEAR</constant>.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>month</parameter></term>
+    <listitem>
+     <para>
+      La nouvelle valeur pour <constant>IntlCalendar::FIELD_MONTH</constant>.
+      La séquence des mois commence à zéro, c'est-à-dire que janvier est
+      représenté par 0, février par 1, …, décembre par 11 et Undecember (si
+      le calendrier le supporte) par 12.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>dayOfMonth</parameter></term>
+    <listitem>
+     <para>
+      La nouvelle valeur pour <constant>IntlCalendar::FIELD_DAY_OF_MONTH</constant>.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>hour</parameter></term>
+    <listitem>
+     <para>
+      La nouvelle valeur pour <constant>IntlCalendar::FIELD_HOUR_OF_DAY</constant>. 
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>minute</parameter></term>
+    <listitem>
+     <para>
+      La nouvelle valeur pour <constant>IntlCalendar::FIELD_MINUTE</constant>.
+      </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>second</parameter></term>
+    <listitem>
+     <para>
+      La nouvelle valeur pour <constant>IntlCalendar::FIELD_SECOND</constant>.  
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &return.true.always;
+  </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      &return.type.true;
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example>
+   <title><function>IntlCalendar::set</function></title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+ini_set('date.timezone', 'Europe/Lisbon');
+ini_set('intl.default_locale', 'pt_PT');
+
+//Les derniers appels ont la priorité
+$cal = new IntlGregorianCalendar(2013, 6 /* July */, 1);
+$cal->set(IntlCalendar::FIELD_YEAR, 2012);
+$cal->set(IntlCalendar::FIELD_EXTENDED_YEAR, 2011);
+var_dump(IntlDateFormatter::formatObject($cal));
+
+
+$cal = new IntlGregorianCalendar(2013, 6 /* July */, 1);
+$cal->set(IntlCalendar::FIELD_YEAR, 2012);
+$cal->set(IntlCalendar::FIELD_EXTENDED_YEAR, 2011);
+//le temps n'a pas été recalculé. Si nous effaçons l'année étendue,
+//l'année définie avant sera utilisée
+$cal->clear(IntlCalendar::FIELD_EXTENDED_YEAR);
+var_dump(IntlDateFormatter::formatObject($cal));
+]]>
+    </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+string(20) "01/07/2011, 00:00:00"
+string(20) "01/07/2012, 00:00:00"
+]]>
+    </screen>
+   </example>
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><methodname>IntlCalendar::get</methodname></member>
+    <member><methodname>IntlCalendar::add</methodname></member>
+    <member><methodname>IntlCalendar::roll</methodname></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/intl/intlcalendar/setdate.xml
+++ b/reference/intl/intlcalendar/setdate.xml
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="utf-8"?>
+<refentry xml:id="intlcalendar.setdate" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>IntlCalendar::setDate</refname>
+  <refpurpose>Définit un champ de date</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="IntlCalendar">
+   <modifier>public</modifier> <type>void</type><methodname>IntlCalendar::setDate</methodname>
+   <methodparam><type>int</type><parameter>year</parameter></methodparam>
+   <methodparam><type>int</type><parameter>month</parameter></methodparam>
+   <methodparam><type>int</type><parameter>dayOfMonth</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Définit un champ de date à la valeur donnée.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>year</parameter></term>
+    <listitem>
+     <para>
+      La nouvelle valeur pour <constant>IntlCalendar::FIELD_YEAR</constant>.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>month</parameter></term>
+    <listitem>
+     <para>
+      La nouvelle valeur pour <constant>IntlCalendar::FIELD_MONTH</constant>.
+      La séquence des mois commence à zéro, c'est-à-dire que janvier est
+      représenté par 0, février par 1, …, décembre par 11 et Undecember (si
+      le calendrier le supporte) par 12.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>dayOfMonth</parameter></term>
+    <listitem>
+     <para>
+      La nouvelle valeur pour <constant>IntlCalendar::FIELD_DAY_OF_MONTH</constant>.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &return.void;
+  </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example>
+   <title>Exemple de <function>IntlCalendar::setDate</function></title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+$intlCal = IntlCalendar::createInstance('UTC');
+
+$intlCal->setDate(2012, 1, 29);
+?>
+]]>
+    </programlisting>
+   </example>
+  </para>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/intl/intlcalendar/setdatetime.xml
+++ b/reference/intl/intlcalendar/setdatetime.xml
@@ -1,0 +1,126 @@
+<?xml version="1.0" encoding="utf-8"?>
+<refentry xml:id="intlcalendar.setdatetime" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>IntlCalendar::setDateTime</refname>
+  <refpurpose>Définit un champ de date et d'heure</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="IntlCalendar">
+   <modifier>public</modifier> <type>void</type><methodname>IntlCalendar::setDateTime</methodname>
+   <methodparam><type>int</type><parameter>year</parameter></methodparam>
+   <methodparam><type>int</type><parameter>month</parameter></methodparam>
+   <methodparam><type>int</type><parameter>dayOfMonth</parameter></methodparam>
+   <methodparam><type>int</type><parameter>hour</parameter></methodparam>
+   <methodparam><type>int</type><parameter>minute</parameter></methodparam>
+   <methodparam choice="opt"><type class="union"><type>int</type><type>null</type></type><parameter>second</parameter><initializer>&null;</initializer></methodparam>
+  </methodsynopsis>
+  <para>
+   Définit un champ de date et d'heure à la valeur donnée.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>year</parameter></term>
+    <listitem>
+     <para>
+      La nouvelle valeur pour <constant>IntlCalendar::FIELD_YEAR</constant>.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>month</parameter></term>
+    <listitem>
+     <para>
+      La nouvelle valeur pour <constant>IntlCalendar::FIELD_MONTH</constant>.
+      La séquence des mois commence à zéro, c'est-à-dire que janvier est
+      représenté par 0, février par 1, …, décembre par 11 et Undecember (si
+      le calendrier le supporte) par 12.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>dayOfMonth</parameter></term>
+    <listitem>
+     <para>
+      La nouvelle valeur pour <constant>IntlCalendar::FIELD_DAY_OF_MONTH</constant>.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>hour</parameter></term>
+    <listitem>
+     <para>
+      La nouvelle valeur pour <constant>IntlCalendar::FIELD_HOUR_OF_DAY</constant>.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>minute</parameter></term>
+    <listitem>
+     <para>
+      The new value for <constant>IntlCalendar::FIELD_MINUTE</constant>.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>second</parameter></term>
+    <listitem>
+     <para>
+      The new value for <constant>IntlCalendar::FIELD_SECOND</constant>.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &return.void;
+  </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example>
+   <title>Exemple de <function>IntlCalendar::setDateTime</function></title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+$intlCal = IntlCalendar::createInstance('UTC');
+
+$intlCal->setDateTime(2012, 1, 29, 23, 58);
+?>
+]]>
+    </programlisting>
+   </example>
+  </para>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/intl/intlcalendar/setlenient.xml
+++ b/reference/intl/intlcalendar/setlenient.xml
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 2ca090342977839edca2f7f4e52305a1b5da6095 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="intlcalendar.setlenient" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>IntlCalendar::setLenient</refname>
+  <refpurpose>Définit si l'interprétation de la date/heure est tolérante</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <para>
+   &style.oop;
+  </para>
+  <methodsynopsis role="IntlCalendar">
+   <modifier>public</modifier> <type>true</type><methodname>IntlCalendar::setLenient</methodname>
+   <methodparam><type>bool</type><parameter>lenient</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   &style.procedural;
+  </para>
+  <methodsynopsis>
+   <type>true</type><methodname>intlcal_set_lenient</methodname>
+   <methodparam><type>IntlCalendar</type><parameter>calendar</parameter></methodparam>
+   <methodparam><type>bool</type><parameter>lenient</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Définit si l'interprétation de la date/heure est tolérante. Dans un tel mode,
+   certaines valeurs hors limites pour certains champs sont acceptées, le
+   comportement étant similaire à celui de <function>IntlCalendar::add</function> (c'est-à-dire, la valeur
+   reboucle, se reportant dans des champs plus significatifs à chaque fois). Si le
+   mode tolérant est désactivé, alors de telles valeurs généreront une erreur.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>calendar</parameter></term>
+    <listitem>
+     &intl.parameter.intl-calendar;
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>lenient</parameter></term>
+    <listitem>
+     <para>
+      Utiliser &true; pour activer le mode tolérant; &false; sinon.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &return.true.always;
+  </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      &return.type.true;
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   Voir un exemple sur <function>IntlCalendar::isLenient</function>.
+  </para>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/intl/intlcalendar/setminimaldaysinfirstweek.xml
+++ b/reference/intl/intlcalendar/setminimaldaysinfirstweek.xml
@@ -1,0 +1,118 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: bad9acb50797346b072f9ff6addf05ee6c385570 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="intlcalendar.setminimaldaysinfirstweek" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>IntlCalendar::setMinimalDaysInFirstWeek</refname>
+  <refpurpose>Définit le nombre minimal de jours que la première semaine d'une année ou d'un mois peut avoir</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <para>
+   &style.oop;
+  </para>
+  <methodsynopsis role="IntlCalendar">
+   <modifier>public</modifier> <type>true</type><methodname>IntlCalendar::setMinimalDaysInFirstWeek</methodname>
+   <methodparam><type>int</type><parameter>days</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   &style.procedural;
+  </para>
+  <methodsynopsis>
+   <type>true</type><methodname>intlcal_set_minimal_days_in_first_week</methodname>
+   <methodparam><type>IntlCalendar</type><parameter>calendar</parameter></methodparam>
+   <methodparam><type>int</type><parameter>days</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Définit le nombre minimal de jours que la première semaine d'une année ou d'un mois peut avoir
+   dans la nouvelle année ou le nouveau mois. Par exemple, dans le calendrier grégorien, si
+   cette valeur est 1, alors la première semaine de l'année inclura nécessairement
+   le 1er janvier, tandis que si cette valeur est 7, alors la semaine avec le 1er janvier
+   sera la première semaine de l'année uniquement si le jour de la semaine pour le 1er janvier
+   correspond au jour de la semaine retourné par
+   <function>IntlCalendar::getFirstDayOfWeek</function>; sinon, ce sera la dernière
+   semaine de l'année précédente.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>calendar</parameter></term>
+    <listitem>
+     &intl.parameter.intl-calendar;
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>days</parameter></term>
+    <listitem>
+     <para>
+      Le nombre de jours minimal à définir.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &return.true.always;
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <para>
+   <classname>ValueError</classname> si <parameter>days</parameter> est hors de portée
+   (moins que <literal>1</literal> ou plus que <literal>7</literal>).
+  </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>8.0.0</entry>
+       <entry>
+        Une <classname>ValueError</classname> est lancée sur une entrée invalide. Précédemment, &false; était retourné.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </para>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/intl/intlcalendar/setrepeatedwalltimeoption.xml
+++ b/reference/intl/intlcalendar/setrepeatedwalltimeoption.xml
@@ -1,0 +1,126 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 2ca090342977839edca2f7f4e52305a1b5da6095 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="intlcalendar.setrepeatedwalltimeoption" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>IntlCalendar::setRepeatedWallTimeOption</refname>
+  <refpurpose>Définit le comportement pour la gestion des heures murales répétées lors des transitions de décalage de fuseau horaire négatif</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <para>
+   &style.oop;
+  </para>
+  <methodsynopsis role="IntlCalendar">
+   <modifier>public</modifier> <type>true</type><methodname>IntlCalendar::setRepeatedWallTimeOption</methodname>
+   <methodparam><type>int</type><parameter>option</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   &style.procedural;
+  </para>
+  <methodsynopsis>
+   <type>true</type><methodname>intlcal_set_repeated_wall_time_option</methodname>
+   <methodparam><type>IntlCalendar</type><parameter>calendar</parameter></methodparam>
+   <methodparam><type>int</type><parameter>option</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Définit la stratégie actuelle pour la gestion des heures murales répétées
+   chaque fois que l'horloge est reculée lors des transitions de fin de l'heure d'été.
+   La valeur par défaut est <constant>IntlCalendar::WALLTIME_LAST</constant> (prendre
+   l'instant post-DST). L'autre valeur possible est
+   <constant>IntlCalendar::WALLTIME_FIRST</constant> (prendre l'instant qui
+   se produit pendant l'heure d'été).
+  </para>
+  <para>
+   Cette fonction nécessite ICU 4.9 ou plus.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>calendar</parameter></term>
+    <listitem>
+     &intl.parameter.intl-calendar;
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>option</parameter></term>
+    <listitem>
+     <para>
+      L'une des constantes <constant>IntlCalendar::WALLTIME_FIRST</constant> ou
+      <constant>IntlCalendar::WALLTIME_LAST</constant>.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &return.true.always;
+  </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      &return.type.true;
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   Voir un exemple sur
+   <function>IntlCalendar::getRepeatedWallTimeOption</function>.
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><methodname>intlCalendar::getRepeatedWallTimeOption</methodname></member>
+    <member><methodname>intlCalendar::setSkippedWallTimeOption</methodname></member>
+    <member><methodname>intlCalendar::getSkippedWallTimeOption</methodname></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/intl/intlcalendar/setskippedwalltimeoption.xml
+++ b/reference/intl/intlcalendar/setskippedwalltimeoption.xml
@@ -1,0 +1,139 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 2ca090342977839edca2f7f4e52305a1b5da6095 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="intlcalendar.setskippedwalltimeoption" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>IntlCalendar::setSkippedWallTimeOption</refname>
+  <refpurpose>Définit le comportement pour la gestion des heures murales sautées lors des transitions de décalage de fuseau horaire positif</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <para>
+   &style.oop;
+  </para>
+  <methodsynopsis role="IntlCalendar">
+   <modifier>public</modifier> <type>true</type><methodname>IntlCalendar::setSkippedWallTimeOption</methodname>
+   <methodparam><type>int</type><parameter>option</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   &style.procedural;
+  </para>
+  <methodsynopsis>
+   <type>true</type><methodname>intlcal_set_skipped_wall_time_option</methodname>
+   <methodparam><type>IntlCalendar</type><parameter>calendar</parameter></methodparam>
+   <methodparam><type>int</type><parameter>option</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Définit la stratégie actuelle pour la gestion des heures murales sautées
+   chaque fois que l'horloge est avancée lors des transitions de début de l'heure d'été.
+   La valeur par défaut est <constant>IntlCalendar::WALLTIME_LAST</constant> (prendre
+   l'instant post-DST). Les autres valeurs possibles sont
+   <constant>IntlCalendar::WALLTIME_FIRST</constant> (prendre l'instant qui
+   se produit pendant l'heure d'été) et
+   <constant>IntlCalendar::WALLTIME_NEXT_VALID</constant> (prendre l'instant
+   lorsque l'heure d'été commence).
+  </para>
+  <para>
+   Cela affecte uniquement l'instant représenté par le calendrier (tel que rapporté par
+   <function>IntlCalendar::getTime</function>), les valeurs des champs ne seront pas
+   réécrites en conséquence.  
+  </para>
+  <para>
+   Le calendrier doit être <link linkend="intlcalendar.setlenient">tolérant</link> pour que cette option ait
+   un effet, sinon tenter de définir un temps inexistant provoquera une
+   erreur.
+  </para>
+  <para>
+   Cette fonction requiert ICU 4.9 ou plus.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>calendar</parameter></term>
+    <listitem>
+     &intl.parameter.intl-calendar;
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>option</parameter></term>
+    <listitem>
+     <para>
+      L'une des constantes <constant>IntlCalendar::WALLTIME_FIRST</constant>,
+      <constant>IntlCalendar::WALLTIME_LAST</constant> ou
+      <constant>IntlCalendar::WALLTIME_NEXT_VALID</constant>.     
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &return.true.always;
+  </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      &return.type.true;
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   Voir un exemple sur
+   <function>IntlCalendar::getSkippedWallTimeOption</function>.
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><methodname>intlCalendar::getSkippedWallTimeOption</methodname></member>
+    <member><methodname>intlCalendar::setRepeatedWallTimeOption</methodname></member>
+    <member><methodname>intlCalendar::getRepeatedWallTimeOption</methodname></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
Here is the translation of missing `IntlCalendar` methods

- `IntlCalendar::fromDateTime()`
- `IntlCalendar::getActualMaximum()`
- `IntlCalendar::getActualMinimum()`
- `IntlCalendar::getAvailableLocales()`
- `IntlCalendar::getDayofweekYype()`
- `IntlCalendar::getErrorCode()`
- `IntlCalendar::getErrorMessage()`
- `IntlCalendar::getFirstDayOfWeek()`
- `IntlCalendar::getGreatestMinimum()`
- `IntlCalendar::getKeywordValuesForLocale()`
- `IntlCalendar::getLeastMaximum()`
- `IntlCalendar::getLocale()`
- `IntlCalendar::getMaximum()`
- `IntlCalendar::getMinimalDaysInFirstweek()`
- `IntlCalendar::getMinimum()`
- `IntlCalendar::getRepeatedWalltimeOption()`
- `IntlCalendar::getSkippedWalltimeOption()`
- `IntlCalendar::getTime()`
- `IntlCalendar::getWeekendTransition()`
- `IntlCalendar::inDaylightTime()`
- `IntlCalendar::isEquivalentTo()`
- `IntlCalendar::isLenient()`
- `IntlCalendar::isset()`
- `IntlCalendar::isWeekend()`
- `IntlCalendar::roll()`
- `IntlCalendar::set()`
- `IntlCalendar::setDate()`
- `IntlCalendar::setDatetime()`
- `IntlCalendar::setLenient()`
- `IntlCalendar::setMinimalDaysInFirstweek()`
- `IntlCalendar::setRepeatedWalltimeOption()`
- `IntlCalendar::setSkippedWalltimeOption()`