### PR TITLE
Translate `COMPersistHelper` methods

### DIFF
--- a/reference/com/compersisthelper/construct.xml
+++ b/reference/com/compersisthelper/construct.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 49ff12041acd30489ef8cb7b1e08ec1ddf4dc6bc Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="compersisthelper.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>COMPersistHelper::__construct</refname>
+  <refpurpose>Construit un objet COMPersistHelper</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <constructorsynopsis role="COMPersistHelper">
+   <modifier>public</modifier> <methodname>COMPersistHelper::__construct</methodname>
+   <methodparam choice="opt"><type class="union"><type>variant</type><type>null</type></type><parameter>variant</parameter><initializer>&null;</initializer></methodparam>
+  </constructorsynopsis>
+  <para>
+   Construit un objet d'aide à la persistance, généralement associé à un
+   <parameter>variant</parameter>.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>variant</parameter></term>
+    <listitem>
+     <simpara>
+      Un objet <acronym>COM</acronym> qui implémente <interfacename>IDispatch</interfacename>.
+      Pour pouvoir appeler avec succès l'une des méthodes de <classname>COMPersistHelper</classname>,
+      l'objet doit implémenter <interfacename>IPersistFile</interfacename>, <interfacename>IPersistStream</interfacename>
+      et/ou <interfacename>IPersistStreamInit</interfacename>.
+     </simpara>
+     <simpara>
+      Passer &null; en tant que <parameter>variant</parameter> n'est utile que si l'objet doit être
+      chargé à partir d'un stream en appelant <methodname>COMPersistHelper::LoadFromStream</methodname>.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <!-- Return values commented out, as constructors generally don't return a
+      value. Uncomment this if you do need a return values section (for
+      example, because there's also a procedural version of the method).
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   
+  </para>
+ </refsect1>
+ -->
+
+
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/com/compersisthelper/getcurfilename.xml
+++ b/reference/com/compersisthelper/getcurfilename.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 49ff12041acd30489ef8cb7b1e08ec1ddf4dc6bc Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="compersisthelper.getcurfilename" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>COMPersistHelper::GetCurFileName</refname>
+  <refpurpose>Renvoie le nom du fichier courant</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="COMPersistHelper">
+   <modifier>public</modifier> <type class="union"><type>string</type><type>false</type></type><methodname>COMPersistHelper::GetCurFileName</methodname>
+   <void/>
+  </methodsynopsis>
+  <para>
+   Renvoie le nom du fichier courrant associé à l'objet.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Renvoie le nom du fichier courrant associé à l'objet.
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <para>
+   Une exception <classname>com_exception</classname> est lancée si l'objet associé n'implémente pas
+   l'interface <acronym>COM</acronym> <interfacename>IPersistFile</interfacename>,
+   ou lorsque l'appel à la méthode <methodname>IPersistFile::GetCurFile</methodname> a échoué.
+  </para>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/com/compersisthelper/getmaxstreamsize.xml
+++ b/reference/com/compersisthelper/getmaxstreamsize.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 49ff12041acd30489ef8cb7b1e08ec1ddf4dc6bc Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="compersisthelper.getmaxstreamsize" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>COMPersistHelper::GetMaxStreamSize</refname>
+  <refpurpose>Renvoie la taille maximum du stream</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="COMPersistHelper">
+   <modifier>public</modifier> <type>int</type><methodname>COMPersistHelper::GetMaxStreamSize</methodname>
+   <void/>
+  </methodsynopsis>
+  <para>
+   Renvoie la taille du stream (en octets) nécessaire pour sauvegarder l'objet.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Renvoie la taille du stream (en octets) nécessaire pour sauvegarder l'objet.
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <para>
+   Une exception <classname>com_exception</classname> est lancée si l'objet associé n'implémente ni
+   l'interface <acronym>COM</acronym> <interfacename>IPersistStream</interfacename>
+   ni <interfacename>IPersistStreamInit</interfacename>, ou lorsque l'appel à la
+   méthode <methodname>IPersistStream::GetSizeMax</methodname> a échoué.
+  </para>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/com/compersisthelper/initnew.xml
+++ b/reference/com/compersisthelper/initnew.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 49ff12041acd30489ef8cb7b1e08ec1ddf4dc6bc Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="compersisthelper.initnew" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>COMPersistHelper::InitNew</refname>
+  <refpurpose>Initialise un objet dans un état par défaut</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="COMPersistHelper">
+   <modifier>public</modifier> <type>bool</type><methodname>COMPersistHelper::InitNew</methodname>
+   <void/>
+  </methodsynopsis>
+  <para>
+   Initialise un objet dans un état par défaut.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &return.success;
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <para>
+   Une exception <classname>com_exception</classname> est lancée si l'objet associé n'implémente pas
+   l'interface <acronym>COM</acronym> <interfacename>IPersistStreamInit</interfacename>,
+   ou lorsque l'appel à la méthode <methodname>IPersistStreamInit::Init</methodname> a échoué.
+  </para>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/com/compersisthelper/loadfromfile.xml
+++ b/reference/com/compersisthelper/loadfromfile.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 49ff12041acd30489ef8cb7b1e08ec1ddf4dc6bc Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="compersisthelper.loadfromfile" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>COMPersistHelper::LoadFromFile</refname>
+  <refpurpose>Charge un objet depuis un fichier</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="COMPersistHelper">
+   <modifier>public</modifier> <type>bool</type><methodname>COMPersistHelper::LoadFromFile</methodname>
+   <methodparam><type>string</type><parameter>filename</parameter></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>0</initializer></methodparam>
+  </methodsynopsis>
+  <para>
+   Ouvre le fichier spécifié et initialise un objet à partir du contenu du fichier.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>filename</parameter></term>
+    <listitem>
+     <simpara>
+      Le nom du fichier à partir duquel charger l'objet.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>flags</parameter></term>
+    <listitem>
+     <simpara>
+      Le mode d'accès à utiliser lors de l'ouverture du fichier. Les valeurs possibles sont
+      extraites de l'<link xlink:href="https://docs.microsoft.com/en-us/windows/win32/stg/stgm-constants">énumération STGM</link>.
+      La méthode peut traiter cette valeur comme une suggestion, ajoutant des permissions plus restrictives
+      si nécessaire. Si <parameter>flags</parameter> est <literal>0</literal>,
+      l'implémentation est censée ouvrir le fichier en utilisant les permissions par défaut.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &return.success;
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <para>
+   Une exception <classname>com_exception</classname> est lancée si l'objet associé n'implémente pas
+   l'interface <acronym>COM</acronym> <interfacename>IPersistFile</interfacename>,
+   ou lorsque l'appel à la méthode <methodname>IPersistFile::Load</methodname> a échoué.
+  </para>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/com/compersisthelper/loadfromstream.xml
+++ b/reference/com/compersisthelper/loadfromstream.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 49ff12041acd30489ef8cb7b1e08ec1ddf4dc6bc Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="compersisthelper.loadfromstream" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>COMPersistHelper::LoadFromStream</refname>
+  <refpurpose>Charge un objet depuis un stream</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="COMPersistHelper">
+   <modifier>public</modifier> <type>bool</type><methodname>COMPersistHelper::LoadFromStream</methodname>
+   <methodparam><type>resource</type><parameter>stream</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Initialise un objet à partir du stream où il a été sauvegardé précédemment.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>stream</parameter></term>
+    <listitem>
+     <simpara>
+      Le stream &resource; à partir duquel charger l'objet.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &return.success;
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <para>
+   Une exception <classname>com_exception</classname> est lancée si l'objet associé n'implémente pas
+   l'interface <acronym>COM</acronym> <interfacename>IPersistStream</interfacename>,
+   ou lorsque l'appel à la méthode <methodname>IPersistStream::Load</methodname> a échoué.
+  </para>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/com/compersisthelper/savetofile.xml
+++ b/reference/com/compersisthelper/savetofile.xml
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 49ff12041acd30489ef8cb7b1e08ec1ddf4dc6bc Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="compersisthelper.savetofile" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>COMPersistHelper::SaveToFile</refname>
+  <refpurpose>Sauvegarde un objet dans un fichier</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="COMPersistHelper">
+   <modifier>public</modifier> <type>bool</type><methodname>COMPersistHelper::SaveToFile</methodname>
+   <methodparam><type class="union"><type>string</type><type>null</type></type><parameter>filename</parameter></methodparam>
+   <methodparam choice="opt"><type>bool</type><parameter>remember</parameter><initializer>&true;</initializer></methodparam>
+  </methodsynopsis>
+  <para>
+   Sauvegarde une copie de l'objet dans le fichier spécifié.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>filename</parameter></term>
+    <listitem>
+     <simpara>
+      Le nom du fichier dans lequel sauvegarder l'objet.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>remember</parameter></term>
+    <listitem>
+     <simpara>
+      Indique si le paramètre <parameter>filename</parameter> doit être utilisé comme fichier de travail
+      courant. Si &true;, <parameter>filename</parameter> devient le fichier courant et l'objet est censé
+      effacer son indicateur de modification après la sauvegarde. Si &false;, cette opération de sauvegarde
+      est une opération "Enregistrer une copie sous ...". Dans ce cas, le fichier courant n'est pas modifié et l'objet
+      n'est pas censé effacer son indicateur de modification.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &return.success;
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <para>
+   Une exception <classname>com_exception</classname> est lancée si l'objet associé n'implémente pas
+   l'interface <acronym>COM</acronym> <interfacename>IPersistFile</interfacename>,
+   ou lorsque l'appel à la méthode <methodname>IPersistFile::Save</methodname> a échoué.
+  </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="compersisthelper.savetofile.example.basic">
+   <title>Usage basique de <methodname>COMPersistHelper::saveToFile</methodname></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$word = new COM('Word.Application');
+$doc = $word->Documents->Add();
+$ph = new COMPersistHelper($doc);
+$ph->SaveToFile('C:\\Users\\cmb\\Documents\\my.docx');
+$word->Quit();
+?>
+]]>
+   </programlisting>
+  </example>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/com/compersisthelper/savetostream.xml
+++ b/reference/com/compersisthelper/savetostream.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 49ff12041acd30489ef8cb7b1e08ec1ddf4dc6bc Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="compersisthelper.savetostream" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>COMPersistHelper::SaveToStream</refname>
+  <refpurpose>Sauvegarde un objet dans un stream</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="COMPersistHelper">
+   <modifier>public</modifier> <type>bool</type><methodname>COMPersistHelper::SaveToStream</methodname>
+   <methodparam><type>resource</type><parameter>stream</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Sauvegarde un objet dans le stream spécifié.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>stream</parameter></term>
+    <listitem>
+     <simpara>
+      Le stream &resource; dans lequel sauvegarder l'objet.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &return.success;
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <para>
+   Une exception <classname>com_exception</classname> est lancée si l'objet associé n'implémente pas
+   l'interface <acronym>COM</acronym> <interfacename>IPersistStream</interfacename>,
+   et/ou l'interface <interfacename>IPersistStreamInit</interfacename>, ou lorsque l'appel
+   à la méthode <methodname>IPersistStream::Save</methodname> a échoué.
+  </para>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
Here is the translation of missing `COMPersistHelper` methods

- `COMPersistHelper::__construct()`
- `COMPersistHelper::getCurFileName()`
- `COMPersistHelper::getMaxSteamSize()`
- `COMPersistHelper::initNew()`
- `COMPersistHelper::loadFromFile()`
- `COMPersistHelper::loadFromStream()`
- `COMPersistHelper::saveToFile()`
- `COMPersistHelper::saveToStream()`