### PR TITLE
Translate `Componere\Abstract\Definition` methods

### DIFF
--- a/reference/componere/componere/abstract/definition/addinterface.xml
+++ b/reference/componere/componere/abstract/definition/addinterface.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 4d298e618cce8d4cca3bc6a296666848080dd510 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="componere-abstract-definition.addinterface" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Componere\Abstract\Definition::addInterface</refname>
+  <refpurpose>Ajoute une interface</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>public</modifier> <type>Definition</type><methodname>Componere\Abstract\Definition::addInterface</methodname>
+   <methodparam><type>string</type><parameter>interface</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+    Ajoute l'interface donnée à la définition courante
+  </para>
+
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>interface</parameter></term>
+    <listitem>
+     <para>
+      Le nom insensible à la casse d'une interface
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   La définition courante
+  </para>
+ </refsect1>
+
+ <refsect1 role="exceptions">
+  <title>Exceptions</title>
+  <warning>
+   <para>
+    Lancera une <type>RuntimeException</type> si la <type>Definition</type> a été enregistrée
+   </para>
+  </warning>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/componere/componere/abstract/definition/addmethod.xml
+++ b/reference/componere/componere/abstract/definition/addmethod.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 52bf027d4cb01fee7d4e33095d3c5ecd6f76fff1 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="componere-abstract-definition.addmethod" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Componere\Abstract\Definition::addMethod</refname>
+  <refpurpose>Ajoute une méthodé</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>public</modifier> <type>Definition</type><methodname>Componere\Abstract\Definition::addMethod</methodname>
+   <methodparam><type>string</type><parameter>name</parameter></methodparam>
+   <methodparam><type>Componere\Method</type><parameter>method</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+    Créer ou remplace une méthode sur la définition courante.
+  </para>
+
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>name</parameter></term>
+    <listitem>
+     <para>
+      Le nom insensible à la casse d'une méthode
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>method</parameter></term>
+    <listitem>
+     <para>
+      Une <type>Componere\Method</type> non précédemment ajoutée à une autre <type>Definition</type>
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   The current Definition
+  </para>
+ </refsect1>
+
+ <refsect1 role="exceptions">
+  <title>Exceptions</title>
+  <warning>
+   <para>
+    Lancera une <type>RuntimeException</type> si la <type>Definition</type> a été enregistrée
+   </para>
+  </warning>
+  <warning>
+   <para>
+    Lancera une <type>RuntimeException</type> si la méthode a été ajoutée à une autre <type>Definition</type>
+   </para>
+  </warning>
+ </refsect1>
+
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/componere/componere/abstract/definition/addtrait.xml
+++ b/reference/componere/componere/abstract/definition/addtrait.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 4d298e618cce8d4cca3bc6a296666848080dd510 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="componere-abstract-definition.addtrait" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Componere\Abstract\Definition::addTrait</refname>
+  <refpurpose>Ajoute un trait</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>public</modifier> <type>Definition</type><methodname>Componere\Abstract\Definition::addTrait</methodname>
+   <methodparam><type>string</type><parameter>trait</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+    Utilise le trait pour la définition courante
+  </para>
+
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>trait</parameter></term>
+    <listitem>
+     <para>
+      Le nom insensible à la casse d'un trait
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   La définition courante 
+  </para>
+ </refsect1>
+
+ <refsect1 role="exceptions">
+  <title>Exceptions</title>
+  <warning>
+   <para>
+    Lancera une <type>RuntimeException</type> si la <type>Definition</type> a été enregistrée
+   </para>
+  </warning>
+ </refsect1>
+
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/componere/componere/abstract/definition/getreflector.xml
+++ b/reference/componere/componere/abstract/definition/getreflector.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 52bf027d4cb01fee7d4e33095d3c5ecd6f76fff1 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="componere-abstract-definition.getreflector" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Componere\Abstract\Definition::getReflector</refname>
+  <refpurpose>Reflection</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>public</modifier> <type>ReflectionClass</type><methodname>Componere\Abstract\Definition::getReflector</methodname>
+   <void />
+  </methodsynopsis>
+  <para>
+   Creer ou retourne une ReflectionClass
+  </para>
+
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Une ReflectionClass pour la definition courante (mise en cache)
+  </para>
+ </refsect1>
+
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
Here is the translation of missing `Componere\Abstract\Definition` methods

- `Componere\Abstract\Definition::addInterface()`
- `Componere\Abstract\Definition::addMethod()`
- `Componere\Abstract\Definition::addTrait()`
- `Componere\Abstract\Definition::getReflector()`