### PR TITLE
Translate `Componere\Definition` methods

### DIFF
--- a/reference/componere/componere/definition/addconstant.xml
+++ b/reference/componere/componere/definition/addconstant.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 52bf027d4cb01fee7d4e33095d3c5ecd6f76fff1 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="componere-definition.addconstant" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Componere\Definition::addConstant</refname>
+  <refpurpose>Ajoute une constante</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>public</modifier> <type>Definition</type><methodname>Componere\Definition::addConstant</methodname>
+   <methodparam><type>string</type><parameter>name</parameter></methodparam>
+   <methodparam><type>Componere\Value</type><parameter>value</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Déclare une constante de classe sur la définition actuelle
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>name</parameter></term>
+    <listitem>
+     <para>
+      Le nom sensible à la casse de la constante
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>value</parameter></term>
+    <listitem>
+     <para>
+      La valeur de la constante, ne doit pas être indéfinie ou statique
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   La définition actuelle
+  </para>
+ </refsect1>
+
+ <refsect1 role="exceptions">
+  <title>Exceptions</title>
+  <warning>
+   <para>
+    Lance une <type>RuntimeException</type> si la <type>Definition</type> a été enregistrée
+   </para>
+  </warning>
+  <warning>
+   <para>
+    Lance une <type>RuntimeException</type> si <parameter>name</parameter> est déjà déclaré comme une constante
+   </para>
+  </warning>
+  <warning>
+   <para>
+    Lance une <type>RuntimeException</type> si <parameter>value</parameter> est statique
+   </para>
+  </warning>
+  <warning>
+   <para>
+    Lance une <type>RuntimeException</type> si <parameter>value</parameter> est indéfinie
+   </para>
+  </warning>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/componere/componere/definition/addproperty.xml
+++ b/reference/componere/componere/definition/addproperty.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 52bf027d4cb01fee7d4e33095d3c5ecd6f76fff1 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="componere-definition.addproperty" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Componere\Definition::addProperty</refname>
+  <refpurpose>Ajoute une propriété</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>public</modifier> <type>Definition</type><methodname>Componere\Definition::addProperty</methodname>
+   <methodparam><type>string</type><parameter>name</parameter></methodparam>
+   <methodparam><type>Componere\Value</type><parameter>value</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Déclare une propriété de classe sur la définition actuelle
+  </para>
+
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>name</parameter></term>
+    <listitem>
+     <para>
+      Le nom sensible à la casse de la propriété
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>value</parameter></term>
+    <listitem>
+     <para>
+      La valeur par défaut de la propriété.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   La définition actuelle
+  </para>
+ </refsect1>
+
+ <refsect1 role="exceptions">
+  <title>Exceptions</title>
+  <warning>
+   <para>
+    Lance une <type>RuntimeException</type> si la <type>Definition</type> a été enregistrée
+   </para>
+  </warning>
+  <warning>
+   <para>
+    Lance une <type>RuntimeException</type> si <parameter>name</parameter> est déjà déclaré comme propriété 
+   </para>
+  </warning>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/componere/componere/definition/construct.xml
+++ b/reference/componere/componere/definition/construct.xml
@@ -1,0 +1,118 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 4d298e618cce8d4cca3bc6a296666848080dd510 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="componere-definition.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Componere\Definition::__construct</refname>
+  <refpurpose>Constructeurs de Definition</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <constructorsynopsis>
+   <modifier>public</modifier> <methodname>Componere\Definition::__construct</methodname>
+   <methodparam><type>string</type><parameter>name</parameter></methodparam>
+  </constructorsynopsis>
+
+  <constructorsynopsis>
+   <modifier>public</modifier> <methodname>Componere\Definition::__construct</methodname>
+   <methodparam><type>string</type><parameter>name</parameter></methodparam>
+   <methodparam><type>string</type><parameter>parent</parameter></methodparam>
+  </constructorsynopsis>
+
+  <constructorsynopsis>
+   <modifier>public</modifier> <methodname>Componere\Definition::__construct</methodname>
+   <methodparam><type>string</type><parameter>name</parameter></methodparam>
+   <methodparam><type>array</type><parameter>interfaces</parameter></methodparam>
+  </constructorsynopsis>
+
+  <constructorsynopsis>
+   <modifier>public</modifier> <methodname>Componere\Definition::__construct</methodname>
+   <methodparam><type>string</type><parameter>name</parameter></methodparam>
+   <methodparam><type>string</type><parameter>parent</parameter></methodparam>
+   <methodparam><type>array</type><parameter>interfaces</parameter></methodparam>
+  </constructorsynopsis>
+
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>name</parameter></term>
+    <listitem>
+     <para>
+      Un nom de classe insensible à la casse
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>parent</parameter></term>
+    <listitem>
+     <para>
+      Un nom de classe insensible à la casse
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>interfaces</parameter></term>
+    <listitem>
+     <para>
+      Un tableau de noms de classes insensibles à la casse
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+  <refsect1 role="exceptions">
+  <title>Exceptions</title>
+  <warning>
+   <para>
+    Lance une <type>InvalidArgumentException</type> si une tentative est fait pour remplacer une classe interne 
+   </para>
+  </warning>
+  <warning>
+   <para>
+    Lance une <type>InvalidArgumentException</type> si une tentative est fait pour remplacer une interface
+   </para>
+  </warning>
+  <warning>
+   <para>
+    Lance une <type>InvalidArgumentException</type> si une tentative est fait pour remplacer un trait
+   </para>
+  </warning>
+  <warning>
+   <para>
+    Lance une <type>InvalidArgumentException</type> si une des classes dans <parameter>interfaces</parameter> ne peut être trouvée
+   </para>
+  </warning>
+  <warning>
+   <para>
+    Lance une <type>InvalidArgumentException</type> si une des classes dans <parameter>interfaces</parameter> n'est pas une interface
+   </para>
+  </warning>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/componere/componere/definition/getclosure.xml
+++ b/reference/componere/componere/definition/getclosure.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 52bf027d4cb01fee7d4e33095d3c5ecd6f76fff1 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="componere-definition.getclosure" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Componere\Definition::getClosure</refname>
+  <refpurpose>Renvoie la fermeture</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>public</modifier> <type>Closure</type><methodname>Componere\Definition::getClosure</methodname>
+   <methodparam><type>string</type><parameter>name</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Renvoie une fermeture pour la méthode spécifiée par le nom
+  </para>
+
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>name</parameter></term>
+    <listitem>
+     <para>
+      Le nom insensible à la casse de la méthode
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Une fermeture liée à la portée correcte
+  </para>
+ </refsect1>
+
+ <refsect1 role="exceptions">
+  <title>Exceptions</title>
+  <warning>
+   <para>
+    Lance une <type>RuntimeException</type> si la <type>Definition</type> a été enregistrée
+   </para>
+  </warning>
+  <warning>
+   <para>
+    Lance une <type>RuntimeException</type> si <parameter>name</parameter> n'a pas pu être trouvé
+   </para>
+  </warning>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/componere/componere/definition/getclosures.xml
+++ b/reference/componere/componere/definition/getclosures.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 4d298e618cce8d4cca3bc6a296666848080dd510 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="componere-definition.getclosures" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Componere\Definition::getClosures</refname>
+  <refpurpose>Renvoie des fermetures</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>public</modifier> <type>array</type><methodname>Componere\Definition::getClosures</methodname>
+   <void />
+  </methodsynopsis>
+  <para>
+   Renvoie un tableau de fermetures
+  </para>
+
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Renvoie toutes les méthodes sous forme d'un tableau d'objets Fermetures liés à la portée correcte
+  </para>
+ </refsect1>
+
+ <refsect1 role="exceptions">
+  <title>Exceptions</title>
+  <warning>
+   <para>
+    Lance une <type>RuntimeException</type> si la <type>Definition</type> a été enregistrée
+   </para>
+  </warning>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/componere/componere/definition/isregistered.xml
+++ b/reference/componere/componere/definition/isregistered.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 4d298e618cce8d4cca3bc6a296666848080dd510 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="componere-definition.isregistered" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Componere\Definition::isRegistered</refname>
+  <refpurpose>Détection d'état</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>public</modifier> <type>bool</type><methodname>Componere\Definition::isRegistered</methodname>
+   <void />
+  </methodsynopsis>
+  <para>
+   Détecte l'état d'enregistrement de cette Définition
+  </para>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Renvoie true si cette Définition est enregistrée
+  </para>
+ </refsect1>
+
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/componere/componere/definition/register.xml
+++ b/reference/componere/componere/definition/register.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 4d298e618cce8d4cca3bc6a296666848080dd510 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="componere-definition.register" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Componere\Definition::register</refname>
+  <refpurpose>Inscription</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>public</modifier> <type>void</type><methodname>Componere\Definition::register</methodname>
+   <void />
+  </methodsynopsis>
+  <para>
+   Inscrit la définition actuelle
+  </para>
+
+ </refsect1>
+
+ <refsect1 role="exceptions">
+  <title>Exceptions</title>
+  <warning>
+   <para>
+    Lance une <type>RuntimeException</type> si la <type>Definition</type> a été enregistrée
+   </para>
+  </warning>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
Here is the translation of missing `Componere\Definition` methods

- `Componere\Definition::addConstant()`
- `Componere\Definition::addProperty()`
- `Componere\Definition::__construct()`
- `Componere\Definition::getClosure()`
- `Componere\Definition::getClosures()`
- `Componere\Definition::isRegistered()`
- `Componere\Definition::register()`