### PR TITLE
Translate `Componere\Patch` methods

### DIFF
--- a/reference/componere/componere/patch/apply.xml
+++ b/reference/componere/componere/patch/apply.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 4d298e618cce8d4cca3bc6a296666848080dd510 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="componere-patch.apply" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Componere\Patch::apply</refname>
+  <refpurpose>Applique</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>public</modifier> <type>void</type><methodname>Componere\Patch::apply</methodname>
+   <void />
+  </methodsynopsis>
+  <para>
+   Applique le patch courant
+  </para>
+
+ </refsect1>
+
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/componere/componere/patch/construct.xml
+++ b/reference/componere/componere/patch/construct.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 8477bd29e1e47ddcecf62c56f7f2c636be035192 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="componere-patch.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Componere\Patch::__construct</refname>
+  <refpurpose>Construction de patch</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <constructorsynopsis>
+   <modifier>public</modifier> <methodname>Componere\Patch::__construct</methodname>
+   <methodparam><type>object</type><parameter>instance</parameter></methodparam>
+  </constructorsynopsis>
+  <constructorsynopsis>
+   <modifier>public</modifier> <methodname>Componere\Patch::__construct</methodname>
+   <methodparam><type>object</type><parameter>instance</parameter></methodparam>
+   <methodparam><type>array</type><parameter>interfaces</parameter></methodparam>
+  </constructorsynopsis>
+
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>instance</parameter></term>
+    <listitem>
+     <para>
+      La cible de ce patch
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>interfaces</parameter></term>
+    <listitem>
+     <para>
+      Un tableau insensible à la casse de noms de classes
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="exceptions">
+  <title>Exceptions</title>
+  <warning>
+   <para>
+    Lance une <type>RuntimeException</type> si une classe dans <parameter>interfaces</parameter> ne peut pas être trouvée
+   </para>
+  </warning>
+  <warning>
+   <para>
+    Lance une <type>RuntimeException</type> si une classe dans <parameter>interfaces</parameter> n'est pas une interface
+   </para>
+  </warning>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/componere/componere/patch/derive.xml
+++ b/reference/componere/componere/patch/derive.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 8477bd29e1e47ddcecf62c56f7f2c636be035192 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="componere-patch.derive" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Componere\Patch::derive</refname>
+  <refpurpose>Dérivation de patch</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>public</modifier> <type>Patch</type><methodname>Componere\Patch::derive</methodname>
+   <methodparam><type>object</type><parameter>instance</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Dérive un <type>Patch</type> pour l'<parameter>instance</parameter> donnée
+  </para>
+
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>instance</parameter></term>
+    <listitem>
+     <para>
+      La cible pour le patch dérivé
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Un <type>Patch</type> pour <parameter>instance</parameter> dérivé du <type>Patch</type> courant
+  </para>
+ </refsect1>
+
+ <refsect1 role="exceptions">
+  <title>Exceptions</title>
+  <warning>
+   <para>
+    Lance une <type>InvalidArgumentException</type> si <parameter>instance</parameter> n'est pas compatible
+   </para>
+  </warning>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/componere/componere/patch/getclosure.xml
+++ b/reference/componere/componere/patch/getclosure.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 52bf027d4cb01fee7d4e33095d3c5ecd6f76fff1 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="componere-patch.getclosure" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Componere\Patch::getClosure</refname>
+  <refpurpose>Renvoie une fermeture</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>public</modifier> <type>Closure</type><methodname>Componere\Patch::getClosure</methodname>
+   <methodparam><type>string</type><parameter>name</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Renvoie une fermeture pour la méthode spécifiée par le nom
+  </para>
+
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>name</parameter></term>
+    <listitem>
+     <para>
+      Le nom insensible à la casse de la méthode
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Une fermeture liée au bon contexte et au bon objet
+  </para>
+ </refsect1>
+
+ <refsect1 role="exceptions">
+  <title>Exceptions</title>
+  <warning>
+   <para>
+    Lance une <type>RuntimeException</type> si <parameter>name</parameter> ne peut pas être trouvé
+   </para>
+  </warning>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/componere/componere/patch/getclosures.xml
+++ b/reference/componere/componere/patch/getclosures.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 4d298e618cce8d4cca3bc6a296666848080dd510 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="componere-patch.getclosures" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Componere\Patch::getClosures</refname>
+  <refpurpose>Renvoie des fermetures</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>public</modifier> <type>array</type><methodname>Componere\Patch::getClosures</methodname>
+   <void />
+  </methodsynopsis>
+  <para>
+   Renvoie un tableau de fermetures
+  </para>
+
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+    Renvoie toutes les méthodes sous forme d'un tableau d'objets Fermeture liés au bon contexte et au bon objet
+  </para>
+ </refsect1>
+
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/componere/componere/patch/isapplied.xml
+++ b/reference/componere/componere/patch/isapplied.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 4d298e618cce8d4cca3bc6a296666848080dd510 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="componere-patch.isapplied" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Componere\Patch::isApplied</refname>
+  <refpurpose>Détection d'état</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>public</modifier> <type>bool</type><methodname>Componere\Patch::isApplied</methodname>
+   <void />
+  </methodsynopsis>
+ </refsect1>
+
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/componere/componere/patch/revert.xml
+++ b/reference/componere/componere/patch/revert.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 4d298e618cce8d4cca3bc6a296666848080dd510 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="componere-patch.revert" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Componere\Patch::revert</refname>
+  <refpurpose>Restaure</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>public</modifier> <type>void</type><methodname>Componere\Patch::revert</methodname>
+   <void />
+  </methodsynopsis>
+  <para>
+   Restaure le patch courant
+  </para>
+
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
Here is the translation of missing `Componere\Patch` methods

- `Componere\Patch::apply()`
- `Componere\Patch::__construct()`
- `Componere\Patch::derive()`
- `Componere\Patch::getClosure()`
- `Componere\Patch::getClosures()`
- `Componere\Patch::isApplied()`
- `Componere\Patch::revert()`