### PR TITLE
Translate `Dom\*node*` methods

### DIFF
--- a/reference/dom/domnamednodemap/getiterator.xml
+++ b/reference/dom/domnamednodemap/getiterator.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 7b1704c9a9d3100e85b47568cb0f06ee2122db08 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="domnamednodemap.getiterator" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+ <refnamediv>
+  <refname>DOMNamedNodeMap::getIterator</refname>
+  <refpurpose>Récupère un itérateur externe</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="DOMNamedNodeMap">
+   <modifier>public</modifier> <type>Iterator</type><methodname>DOMNamedNodeMap::getIterator</methodname>
+   <void/>
+  </methodsynopsis>
+  <para>
+   Renvoie un itérateur externe pour la collection de nœuds nommés.
+  </para>
+ </refsect1>
+
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('iteratoraggregate.getiterator')/db:refsect1[@role='parameters'])" />
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('iteratoraggregate.getiterator')/db:refsect1[@role='returnvalues'])" />
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('iteratoraggregate.getiterator')/db:refsect1[@role='errors'])" />
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>IteratorAggregate::getIterator</methodname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/dom/domnode/contains.xml
+++ b/reference/dom/domnode/contains.xml
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: cdbee08c7312e25ad733047ae65c4628c24aa1b8 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="domnode.contains" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>DOMNode::contains</refname>
+  <refpurpose>Vérifie si un nœud contient un autre nœud</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="DOMNode">
+   <modifier>public</modifier> <type>bool</type><methodname>DOMNode::contains</methodname>
+   <methodparam><type class="union"><type>DOMNode</type><type>DOMNameSpaceNode</type><type>null</type></type><parameter>other</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Vérifie si le nœud contient l'autre nœud <parameter>other</parameter>.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>other</parameter></term>
+     <listitem>
+      <para>
+       Le nœud à vérifier.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Renvoie &true; si le nœud contient le nœud <parameter>other</parameter>, sinon &false;.
+  </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Exemple de <methodname>DOMNode::contains</methodname></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+
+$dom = new DOMDocument();
+$dom->loadXML(<<<XML
+<!DOCTYPE HTML>
+<html>
+   <body>
+       <main>
+           <p>Hello, world!</p>
+       </main>
+   </body>
+</html>
+XML);
+
+$xpath = new DOMXPath($dom);
+$main = $xpath->query("//main")[0];
+
+var_dump($dom->documentElement->contains($main));
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+bool(true)
+]]>
+   </screen>
+  </example>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/dom/domnode/getrootnode.xml
+++ b/reference/dom/domnode/getrootnode.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: d715365c098db000eaf7dcd987ee6093f6e83091 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="domnode.getrootnode" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>DOMNode::getRootNode</refname>
+  <refpurpose>Renvoie le nœud racine</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="DOMNode">
+   <modifier>public</modifier> <type>DOMNode</type><methodname>DOMNode::getRootNode</methodname>
+   <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>options</parameter><initializer>&null;</initializer></methodparam>
+  </methodsynopsis>
+  <para>
+   Renvoie le nœud racine.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>options</parameter></term>
+     <listitem>
+      <para>
+       Ce paramètre n'a pas encore d'effet.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Renvoie le nœud racine.
+  </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Exemple de <methodname>DOMNode::getRootNode</methodname></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+
+$dom = new DOMDocument();
+$dom->loadXML('<?xml version="1.0"?><html><body/></html>');
+
+var_dump($dom->documentElement->firstElementChild->getRootNode() === $dom);
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+bool(true)
+]]>
+   </screen>
+  </example>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/dom/domnode/isequalnode.xml
+++ b/reference/dom/domnode/isequalnode.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: cdbee08c7312e25ad733047ae65c4628c24aa1b8 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="domnode.isequalnode" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>DOMNode::isEqualNode</refname>
+  <refpurpose>Vérifie que les deux nœuds sont égaux</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="DOMNode">
+   <modifier>public</modifier> <type>bool</type><methodname>DOMNode::isEqualNode</methodname>
+   <methodparam><type class="union"><type>DOMNode</type><type>null</type></type><parameter>otherNode</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Vérifie que les deux nœuds sont égaux.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>otherNode</parameter></term>
+     <listitem>
+      <para>
+       Le nœud.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Renvoie &true; si les deux nœuds sont égaux, sinon &false;.
+  </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Exemple de <methodname>DOMNode::isEqualNode</methodname></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+
+$dom1 = (new DOMDocument())->createElement('h1', 'Hello World!');
+$dom2 = (new DOMDocument())->createElement('h1', 'Hello World!');
+
+var_dump($dom1->isEqualNode($dom2));
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+bool(true)
+]]>
+   </screen>
+  </example>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/dom/domnodelist/getiterator.xml
+++ b/reference/dom/domnodelist/getiterator.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 7b1704c9a9d3100e85b47568cb0f06ee2122db08 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="domnodelist.getiterator" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+ <refnamediv>
+  <refname>DOMNodeList::getIterator</refname>
+  <refpurpose>Retourne un itérateur externe</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="DOMNodeList">
+   <modifier>public</modifier> <type>Iterator</type><methodname>DOMNodeList::getIterator</methodname>
+   <void/>
+  </methodsynopsis>
+  <para>
+   Retourne un itérateur externe pour la liste de nœuds.
+  </para>
+ </refsect1>
+
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('iteratoraggregate.getiterator')/db:refsect1[@role='parameters'])" />
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('iteratoraggregate.getiterator')/db:refsect1[@role='returnvalues'])" />
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('iteratoraggregate.getiterator')/db:refsect1[@role='errors'])" />
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>IteratorAggregate::getIterator</methodname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/dom/domparentnode/replacechildren.xml
+++ b/reference/dom/domparentnode/replacechildren.xml
@@ -1,0 +1,122 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: c1349f9574ed77c268c6312a07466f06d59e5078 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="domparentnode.replacechildren" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>DOMParentNode::replaceChildren</refname>
+  <refpurpose>Remplace les enfants dans un nœud</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="DOMParentNode">
+   <modifier>public</modifier> <type>void</type><methodname>DOMParentNode::replaceChildren</methodname>
+   <methodparam rep="repeat"><type class="union"><type>DOMNode</type><type>string</type></type><parameter>nodes</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Remplace les enfants dans un nœud. 
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>nodes</parameter></term>
+     <listitem>
+      <para>
+       Les nœuds remplaçant les enfants.
+       Les chaînes de caractères sont automatiquement converties en nœuds texte.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &return.void;
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <variablelist>
+   &dom.errors.hierarchy.self;
+   &dom.errors.wrong_document;
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.3.0</entry>
+      <entry>
+       Appeler cette méthode sur un nœud sans document propriétaire fonctionne désormais.
+       &dom.changelog.previous_hierarchy_exception;
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Exemple de <methodname>DOMParentNode::replaceChildren</methodname></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+
+$dom = new DOMDocument();
+$dom->loadHTML('<!DOCTYPE HTML><html><p>hi</p> test <p>hi2</p></html>');
+
+$dom->documentElement->replaceChildren('foo', $dom->createElement('p'), 'bar');
+echo $dom->saveXML();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+<?xml version="1.0" standalone="yes"?>
+<!DOCTYPE HTML>
+<html>foo<p/>bar</html>
+]]>
+   </screen>
+  </example>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
Translation of

- `DOMNamedNodeMap::getIterator()`

- `DOMNode::contains()`
- `DOMNode::getRootNode()`
- `DOMNode::isEqualNode()`

- `DOMNodeList::getIterator()`

- `DOMParentNode::replaceChildren()`