### PR TITLE
Translate `DomDocument*\` methods

### DIFF
--- a/reference/dom/domdocument/adoptnode.xml
+++ b/reference/dom/domdocument/adoptnode.xml
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 7b1704c9a9d3100e85b47568cb0f06ee2122db08 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="domdocument.adoptnode" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>DOMDocument::adoptNode</refname>
+  <refpurpose>Transfère un nœud d'un autre document</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="DOMDocument">
+   <modifier>public</modifier> <type class="union"><type>DOMNode</type><type>false</type></type><methodname>DOMDocument::adoptNode</methodname>
+   <methodparam><type>DOMNode</type><parameter>node</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Transfère un nœud d'un autre document dans le document courant.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>node</parameter></term>
+     <listitem>
+      <para>
+       Le nœud à transférer.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Le nœud qui a été transféré, ou &false; en cas d'erreur.
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+   &reftitle.errors;
+   <variablelist>
+    <varlistentry>
+     <term><constant>DOM_NOT_SUPPORTED_ERR</constant></term>
+     <listitem>
+      <para>
+       Lancée si le type de nœud n'est pas supporté pour les transferts de document.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="domdocument.adoptnode.example.basic">
+   <title>Exemple de <methodname>DOMDocument::adoptNode</methodname></title>
+   <para>
+    Transfère l'élément hello du premier document dans le second.
+   </para>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$doc1 = new DOMDocument;
+$doc1->loadXML("<container><hello><world/></hello></container>");
+$hello = $doc1->documentElement->firstChild;
+
+$doc2 = new DOMDocument;
+$doc2->loadXML("<root/>");
+$doc2->documentElement->appendChild($doc2->adoptNode($hello));
+
+echo $doc1->saveXML() . PHP_EOL;
+echo $doc2->saveXML();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+<?xml version="1.0"?>
+<container/>
+
+<?xml version="1.0"?>
+<root><hello><world/></hello></root>
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>DOMDocument::importNode</methodname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/dom/domdocument/append.xml
+++ b/reference/dom/domdocument/append.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: c1349f9574ed77c268c6312a07466f06d59e5078 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="domdocument.append" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+ <refnamediv>
+  <refname>DOMDocument::append</refname>
+  <refpurpose>Ajoute des nœuds après le dernier nœud enfant</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="DOMDocument">
+   <modifier>public</modifier> <type>void</type><methodname>DOMDocument::append</methodname>
+   <methodparam rep="repeat"><type class="union"><type>DOMNode</type><type>string</type></type><parameter>nodes</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Ajoute un ou plusieurs <parameter>nodes</parameter> à la liste des enfants après le dernier nœud enfant.
+  </para>
+ </refsect1>
+
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domparentnode.append')/db:refsect1[@role='parameters'])" />
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domparentnode.append')/db:refsect1[@role='returnvalues'])" />
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domparentnode.append')/db:refsect1[@role='errors'])" />
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domparentnode.append')/db:refsect1[@role='changelog'])" />
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="domdocument.append.example.basic">
+   <title>Exemple de <methodname>DOMDocument::append</methodname></title>
+   <para>
+    Ajoute des nœuds après le nœud racine du document.
+   </para>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$doc = new DOMDocument;
+$doc->loadXML("<hello/>");
+
+$doc->append("beautiful", $doc->createElement("world"));
+
+echo $doc->saveXML();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+<hello/>
+beautiful
+<world/>
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>DOMParentNode::append</methodname></member>
+   <member><methodname>DOMDocument::prepend</methodname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/dom/domdocument/prepend.xml
+++ b/reference/dom/domdocument/prepend.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: c1349f9574ed77c268c6312a07466f06d59e5078 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="domdocument.prepend" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+ <refnamediv>
+  <refname>DOMDocument::prepend</refname>
+  <refpurpose>Ajoute des nœuds avant le premier nœud enfant</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="DOMDocument">
+   <modifier>public</modifier> <type>void</type><methodname>DOMDocument::prepend</methodname>
+   <methodparam rep="repeat"><type class="union"><type>DOMNode</type><type>string</type></type><parameter>nodes</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Ajoute un ou plusieurs <parameter>nodes</parameter> à la liste des enfants avant le premier nœud enfant.
+  </para>
+ </refsect1>
+
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domparentnode.prepend')/db:refsect1[@role='parameters'])" />
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domparentnode.prepend')/db:refsect1[@role='returnvalues'])" />
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domparentnode.prepend')/db:refsect1[@role='errors'])" />
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domparentnode.prepend')/db:refsect1[@role='changelog'])" />
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="domdocument.prepend.example.basic">
+   <title>Exemple de <methodname>DOMDocument::prepend</methodname></title>
+   <para>
+    Ajoute des nœuds avant le nœud racine du document.
+   </para>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$doc = new DOMDocument;
+$doc->loadXML("<world/>");
+
+$doc->prepend($doc->createElement("hello"), "beautiful");
+
+echo $doc->saveXML();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+<?xml version="1.0"?>
+<hello/>
+beautiful
+<world/>
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>DOMParentNode::prepend</methodname></member>
+   <member><methodname>DOMDocument::append</methodname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/dom/domdocument/replacechildren.xml
+++ b/reference/dom/domdocument/replacechildren.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: c1349f9574ed77c268c6312a07466f06d59e5078 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="domdocument.replacechildren" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+ <refnamediv>
+  <refname>DOMDocument::replaceChildren</refname>
+  <refpurpose>Remplace les enfants dans le document</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="DOMDocument">
+   <modifier>public</modifier> <type>void</type><methodname>DOMDocument::replaceChildren</methodname>
+   <methodparam rep="repeat"><type class="union"><type>DOMNode</type><type>string</type></type><parameter>nodes</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Remplace les enfants dans le document par de nouveaux <parameter>nodes</parameter>.
+  </para>
+ </refsect1>
+
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domparentnode.replacechildren')/db:refsect1[@role='parameters'])" />
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domparentnode.replacechildren')/db:refsect1[@role='returnvalues'])" />
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domparentnode.replacechildren')/db:refsect1[@role='errors'])" />
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domparentnode.replacechildren')/db:refsect1[@role='changelog'])" />
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="domdocument.replacechildren.example.basic">
+   <title>Exemple de <methodname>DOMDocument::replaceChildren</methodname></title>
+   <para>
+    Remplace les enfants par de nouveaux nœuds.
+   </para>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$doc = new DOMDocument;
+$doc->loadXML("<container><hello/></container>");
+
+$doc->replaceWith("beautiful", $doc->createElement("world"));
+
+echo $doc->saveXML();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+<?xml version="1.0"?>
+beautiful
+<world/>
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>DOMParentNode::replaceChildren</methodname></member>
+   <member><methodname>DOMDocument::append</methodname></member>
+   <member><methodname>DOMDocument::prepend</methodname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/dom/domdocumentfragment/append.xml
+++ b/reference/dom/domdocumentfragment/append.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: c1349f9574ed77c268c6312a07466f06d59e5078 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="domdocumentfragment.append" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+ <refnamediv>
+  <refname>DOMDocumentFragment::append</refname>
+  <refpurpose>Ajoute des nœuds après le dernier nœud enfant</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="DOMDocumentFragment">
+   <modifier>public</modifier> <type>void</type><methodname>DOMDocumentFragment::append</methodname>
+   <methodparam rep="repeat"><type class="union"><type>DOMNode</type><type>string</type></type><parameter>nodes</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Ajoute un ou plusieurs <parameter>nodes</parameter> à la liste des enfants après le dernier nœud enfant.
+  </para>
+ </refsect1>
+
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domparentnode.append')/db:refsect1[@role='parameters'])" />
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domparentnode.append')/db:refsect1[@role='returnvalues'])" />
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domparentnode.append')/db:refsect1[@role='errors'])" />
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domparentnode.append')/db:refsect1[@role='changelog'])" />
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="domdocumentfragment.append.example.basic">
+   <title>Exemple de <methodname>DOMDocumentFragment::append</methodname></title>
+   <para>
+    Ajoute des nœuds dans le fragment.
+   </para>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$doc = new DOMDocument;
+$fragment = $doc->createDocumentFragment();
+$fragment->appendChild($doc->createElement("hello"));
+
+$fragment->append("beautiful", $doc->createElement("world"));
+
+echo $doc->saveXML($fragment);
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+<hello/>beautiful<world/>
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>DOMParentNode::append</methodname></member>
+   <member><methodname>DOMDocumentFragment::prepend</methodname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/dom/domdocumentfragment/prepend.xml
+++ b/reference/dom/domdocumentfragment/prepend.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: c1349f9574ed77c268c6312a07466f06d59e5078 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="domdocumentfragment.prepend" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+ <refnamediv>
+  <refname>DOMDocumentFragment::prepend</refname>
+  <refpurpose>Ajoute des nœuds avant le premier nœud enfant</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="DOMDocumentFragment">
+   <modifier>public</modifier> <type>void</type><methodname>DOMDocumentFragment::prepend</methodname>
+   <methodparam rep="repeat"><type class="union"><type>DOMNode</type><type>string</type></type><parameter>nodes</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Ajoute un ou plusieurs <parameter>nodes</parameter> à la liste des enfants avant le premier nœud enfant.
+  </para>
+ </refsect1>
+
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domparentnode.prepend')/db:refsect1[@role='parameters'])" />
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domparentnode.prepend')/db:refsect1[@role='returnvalues'])" />
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domparentnode.prepend')/db:refsect1[@role='errors'])" />
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domparentnode.prepend')/db:refsect1[@role='changelog'])" />
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="domdocumentfragment.prepend.example.basic">
+   <title>Exemple de <methodname>DOMDocumentFragment::prepend</methodname></title>
+   <para>
+    Ajoute des nœuds avant le fragment racine.
+   </para>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$doc = new DOMDocument;
+$fragment = $doc->createDocumentFragment();
+$fragment->appendChild($doc->createElement("world"));
+
+$fragment->prepend($doc->createElement("hello"), "beautiful");
+
+echo $doc->saveXML($fragment);
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+<hello/>beautiful<world/>
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>DOMParentNode::prepend</methodname></member>
+   <member><methodname>DOMDocumentFragment::append</methodname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/dom/domdocumentfragment/replacechildren.xml
+++ b/reference/dom/domdocumentfragment/replacechildren.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: c1349f9574ed77c268c6312a07466f06d59e5078 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="domdocumentfragment.replacechildren" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+ <refnamediv>
+  <refname>DOMDocumentFragment::replaceChildren</refname>
+  <refpurpose>Remplace les enfants dans le fragment</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="DOMDocumentFragment">
+   <modifier>public</modifier> <type>void</type><methodname>DOMDocumentFragment::replaceChildren</methodname>
+   <methodparam rep="repeat"><type class="union"><type>DOMNode</type><type>string</type></type><parameter>nodes</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Remplace les enfants dans le fragment par de nouveaux <parameter>nodes</parameter>.
+  </para>
+ </refsect1>
+
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domparentnode.replacechildren')/db:refsect1[@role='parameters'])" />
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domparentnode.replacechildren')/db:refsect1[@role='returnvalues'])" />
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domparentnode.replacechildren')/db:refsect1[@role='errors'])" />
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domparentnode.replacechildren')/db:refsect1[@role='changelog'])" />
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="domdocumentfragment.replacechildren.example.basic">
+   <title>Exemple de <methodname>DOMDocumentFragment::replaceChildren</methodname></title>
+   <para>
+    Remaplce les enfants par de nouveaux nœuds.
+   </para>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$doc = new DOMDocument;
+$doc->loadXML("<container><hello/></container>");
+$fragment = $doc->createDocumentFragment();
+$fragment->append("hello");
+
+$fragment->replaceWith("beautiful", $doc->createElement("world"));
+
+echo $doc->saveXML($fragment);
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+beautiful
+<world/>
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>DOMParentNode::replaceChildren</methodname></member>
+   <member><methodname>DOMDocumentFragment::append</methodname></member>
+   <member><methodname>DOMDocumentFragment::prepend</methodname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
Here is the translation of missing `DomDocument*` methods

- `DomDocument::adoptNode()`
- `DomDocument::append()`
- `DomDocument::preprend()`
- `DomDocument::replaceChildren()`

And

- `DOMDocumentFragment::append()`
- `DOMDocumentFragment::prepend()`
- `DOMDocumentFragment::replaceChildren()`