### PR TITLE
Translate `DOMElement` methods

### DIFF
--- a/reference/dom/domelement/after.xml
+++ b/reference/dom/domelement/after.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: c1349f9574ed77c268c6312a07466f06d59e5078 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="domelement.after" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+ <refnamediv>
+  <refname>DOMElement::after</refname>
+  <refpurpose>Ajoute des noeuds après l'élément</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="DOMElement">
+   <modifier>public</modifier> <type>void</type><methodname>DOMElement::after</methodname>
+   <methodparam rep="repeat"><type class="union"><type>DOMNode</type><type>string</type></type><parameter>nodes</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Ajoute les <parameter>nodes</parameter> passés après l'élément.
+  </para>
+ </refsect1>
+
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domchildnode.after')/db:refsect1[@role='parameters'])" />
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domchildnode.after')/db:refsect1[@role='returnvalues'])" />
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domchildnode.after')/db:refsect1[@role='errors'])" />
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domchildnode.after')/db:refsect1[@role='changelog'])" />
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="domelement.after.example.basic">
+   <title>Exemple de <methodname>DOMElement::after</methodname></title>
+   <para>
+    Ajoute les nœuds après l'élément hello.
+   </para>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$doc = new DOMDocument;
+$doc->loadXML("<hello/>");
+$container = $doc->documentElement;
+
+$container->after("beautiful", $doc->createElement("world"));
+
+echo $doc->saveXML();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+<?xml version="1.0"?>
+<hello/>
+beautiful
+<world/>
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>DOMChildNode::after</methodname></member>
+   <member><methodname>DOMElement::before</methodname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/dom/domelement/append.xml
+++ b/reference/dom/domelement/append.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: c1349f9574ed77c268c6312a07466f06d59e5078 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="domelement.append" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+ <refnamediv>
+  <refname>DOMElement::append</refname>
+  <refpurpose>Ajoute des noeuds après le dernier enfant</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="DOMElement">
+   <modifier>public</modifier> <type>void</type><methodname>DOMElement::append</methodname>
+   <methodparam rep="repeat"><type class="union"><type>DOMNode</type><type>string</type></type><parameter>nodes</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Ajoute un ou plusieurs <parameter>nodes</parameter> à la liste des enfants après le dernier nœud enfant.
+  </para>
+ </refsect1>
+
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domparentnode.append')/db:refsect1[@role='parameters'])" />
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domparentnode.append')/db:refsect1[@role='returnvalues'])" />
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domparentnode.append')/db:refsect1[@role='errors'])" />
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domparentnode.append')/db:refsect1[@role='changelog'])" />
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="domelement.append.example.basic">
+   <title>Exemple de <methodname>DOMElement::append</methodname></title>
+   <para>
+    Ajoute des nœuds dans l'élément conteneur.
+   </para>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$doc = new DOMDocument;
+$doc->loadXML("<container>hello </container>");
+$world = $doc->documentElement;
+
+$world->append("beautiful", $doc->createElement("world"));
+
+echo $doc->saveXML();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+<?xml version="1.0"?>
+<container>hello beautiful<world/></container>
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>DOMParentNode::append</methodname></member>
+   <member><methodname>DOMElement::prepend</methodname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/dom/domelement/before.xml
+++ b/reference/dom/domelement/before.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: c1349f9574ed77c268c6312a07466f06d59e5078 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="domelement.before" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+ <refnamediv>
+  <refname>DOMElement::before</refname>
+  <refpurpose>Ajoute des noeuds avant l'élément</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="DOMElement">
+   <modifier>public</modifier> <type>void</type><methodname>DOMElement::before</methodname>
+   <methodparam rep="repeat"><type class="union"><type>DOMNode</type><type>string</type></type><parameter>nodes</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Ajoute les <parameter>nodes</parameter> passés avant l'élément.
+  </para>
+ </refsect1>
+
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domchildnode.before')/db:refsect1[@role='parameters'])" />
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domchildnode.before')/db:refsect1[@role='returnvalues'])" />
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domchildnode.before')/db:refsect1[@role='errors'])" />
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domchildnode.before')/db:refsect1[@role='changelog'])" />
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="domelement.before.example.basic">
+   <title>Exemple de <methodname>DOMElement::before</methodname></title>
+   <para>
+    Ajoute les nœuds avant l'élément hello.
+   </para>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$doc = new DOMDocument;
+$doc->loadXML("<world/>");
+$world = $doc->documentElement;
+
+$world->before("hello", $doc->createElement("beautiful"));
+
+echo $doc->saveXML();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+hello
+<beautiful/>
+<world/>
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>DOMChildNode::before</methodname></member>
+   <member><methodname>DOMElement::after</methodname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/dom/domelement/getattributenames.xml
+++ b/reference/dom/domelement/getattributenames.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: cdbee08c7312e25ad733047ae65c4628c24aa1b8 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="domelement.getattributenames" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>DOMElement::getAttributeNames</refname>
+  <refpurpose>Renvoie les noms des attributs</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="DOMElement">
+   <modifier>public</modifier> <type>array</type><methodname>DOMElement::getAttributeNames</methodname>
+   <void/>
+  </methodsynopsis>
+  <para>
+   Obtenir les noms des attributs.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Renvoie les noms des attributs.
+  </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Exemple de <methodname>DOMElement::getAttributeNames</methodname></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+
+$dom = new DOMDocument();
+$dom->loadXML('<html xmlns:some="some:ns" some:test="a" test2="b"/>');
+var_dump($dom->documentElement->getAttributeNames());
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+array(3) {
+ [0]=>
+ string(10) "xmlns:some"
+ [1]=>
+ string(9) "some:test"
+ [2]=>
+ string(5) "test2"
+}
+]]>
+   </screen>
+  </example>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/dom/domelement/insertadjacentelement.xml
+++ b/reference/dom/domelement/insertadjacentelement.xml
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: cdbee08c7312e25ad733047ae65c4628c24aa1b8 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="domelement.insertadjacentelement" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>DOMElement::insertAdjacentElement</refname>
+  <refpurpose>Insère un élément adjacent</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="DOMElement">
+   <modifier>public</modifier> <type class="union"><type>DOMElement</type><type>null</type></type><methodname>DOMElement::insertAdjacentElement</methodname>
+   <methodparam><type>string</type><parameter>where</parameter></methodparam>
+   <methodparam><type>DOMElement</type><parameter>element</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Insère un élément à une position relative donnée par <parameter>where</parameter>.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>where</parameter></term>
+     <listitem>
+      <para>
+       <simplelist>
+        <member><literal>beforebegin</literal> - Insère avant l'élément cible.</member>
+        <member><literal>afterbegin</literal> - Insère comme premier enfant de l'élément cible.</member>
+        <member><literal>beforeend</literal> - Insère comme dernier enfant de l'élément cible.</member>
+        <member><literal>afterend</literal> - Insère après l'élément cible.</member>
+       </simplelist>
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>element</parameter></term>
+     <listitem>
+      <para>
+       L'élément à insérer.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Renvoie <classname>DOMElement</classname> ou &null; en cas d'échec.
+  </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Exemple de <methodname>DOMElement::insertAdjacentElement</methodname></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+
+$dom = new DOMDocument();
+$dom->loadXML('<?xml version="1.0"?><container><p>foo</p></container>');
+$container = $dom->documentElement;
+$p = $container->firstElementChild;
+
+$p->insertAdjacentElement('beforebegin', $dom->createElement('A'));
+echo $dom->saveXML();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+<?xml version="1.0"?>
+<container><A/><p>foo</p></container>
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><methodname>DOMElement::insertAdjacentText</methodname></member>
+   </simplelist>
+  </para>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/dom/domelement/insertadjacenttext.xml
+++ b/reference/dom/domelement/insertadjacenttext.xml
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: cdbee08c7312e25ad733047ae65c4628c24aa1b8 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="domelement.insertadjacenttext" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>DOMElement::insertAdjacentText</refname>
+  <refpurpose>Insère un texte adjacent</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="DOMElement">
+   <modifier>public</modifier> <type>void</type><methodname>DOMElement::insertAdjacentText</methodname>
+   <methodparam><type>string</type><parameter>where</parameter></methodparam>
+   <methodparam><type>string</type><parameter>data</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Insère un texte à une position relative donnée par <parameter>where</parameter>.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>where</parameter></term>
+     <listitem>
+      <para>
+       <simplelist>
+        <member><literal>beforebegin</literal> - Insère avant l'élément cible.</member>
+        <member><literal>afterbegin</literal> - Insère comme premier enfant de l'élément cible.</member>
+        <member><literal>beforeend</literal> - Insère comme dernier enfant de l'élément cible.</member>
+        <member><literal>afterend</literal> - Insère après l'élément cible.</member>
+       </simplelist>
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>data</parameter></term>
+     <listitem>
+      <para>
+       La chaîne à insérer.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &return.void;
+  </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Exemple de <methodname>DOMElement::insertAdjacentText</methodname></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+
+$dom = new DOMDocument();
+$dom->loadXML('<?xml version="1.0"?><container><p>H</p></container>');
+
+$container = $dom->documentElement;
+$p = $container->firstElementChild;
+
+$p->insertAdjacentText("afterbegin", "P");
+$p->insertAdjacentText("beforeend", "P");
+
+echo $dom->saveXML();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+<?xml version="1.0"?>
+<container><p>PHP</p></container>
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><methodname>DOMElement::insertAdjacentElement</methodname></member>
+   </simplelist>
+  </para>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/dom/domelement/prepend.xml
+++ b/reference/dom/domelement/prepend.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: c1349f9574ed77c268c6312a07466f06d59e5078 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="domelement.prepend" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+ <refnamediv>
+  <refname>DOMElement::prepend</refname>
+  <refpurpose>Ajoute des noeuds avant le premier enfant</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="DOMElement">
+   <modifier>public</modifier> <type>void</type><methodname>DOMElement::prepend</methodname>
+   <methodparam rep="repeat"><type class="union"><type>DOMNode</type><type>string</type></type><parameter>nodes</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Ajoute un ou plusieurs <parameter>nodes</parameter> à la liste des enfants avant le premier nœud enfant.
+  </para>
+ </refsect1>
+
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domparentnode.prepend')/db:refsect1[@role='parameters'])" />
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domparentnode.prepend')/db:refsect1[@role='returnvalues'])" />
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domparentnode.prepend')/db:refsect1[@role='errors'])" />
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domparentnode.prepend')/db:refsect1[@role='changelog'])" />
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="domelement.prepend.example.basic">
+   <title>Exemple de <methodname>DOMElement::prepend</methodname></title>
+   <para>
+    Ajoute les nœuds avant l'élément conteneur.
+   </para>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$doc = new DOMDocument;
+$doc->loadXML("<container> world</container>");
+$world = $doc->documentElement;
+
+$world->prepend($doc->createElement("hello"), "beautiful");
+
+echo $doc->saveXML();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+<?xml version="1.0"?>
+<container><hello/>beautiful world</container>
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>DOMParentNode::prepend</methodname></member>
+   <member><methodname>DOMElement::append</methodname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/dom/domelement/remove.xml
+++ b/reference/dom/domelement/remove.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 7b1704c9a9d3100e85b47568cb0f06ee2122db08 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="domelement.remove" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+ <refnamediv>
+  <refname>DOMElement::remove</refname>
+  <refpurpose>Enlève l'élément</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="DOMElement">
+   <modifier>public</modifier> <type>void</type><methodname>DOMElement::remove</methodname>
+   <void/>
+  </methodsynopsis>
+  <para>
+   Enlève l'élément.
+  </para>
+ </refsect1>
+
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domchildnode.remove')/db:refsect1[@role='parameters'])" />
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domchildnode.remove')/db:refsect1[@role='returnvalues'])" />
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="domelement.remove.example.basic">
+   <title>Exemple de <methodname>DOMElement::remove</methodname></title>
+   <para>
+    Enlève l'élément.
+   </para>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$doc = new DOMDocument;
+$doc->loadXML("<container><hello/><world/></container>");
+$hello = $doc->documentElement->firstChild;
+
+$hello->remove();
+
+echo $doc->saveXML();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+<?xml version="1.0"?>
+<container><world/></container>
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>DOMElement::after</methodname></member>
+   <member><methodname>DOMElement::before</methodname></member>
+   <member><methodname>DOMElement::replaceWith</methodname></member>
+   <member><methodname>DOMNode::removeChild</methodname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/dom/domelement/replacechildren.xml
+++ b/reference/dom/domelement/replacechildren.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: c1349f9574ed77c268c6312a07466f06d59e5078 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="domelement.replacechildren" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+ <refnamediv>
+  <refname>DOMElement::replaceChildren</refname>
+  <refpurpose>Remplace les enfants dans l'élément</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="DOMElement">
+   <modifier>public</modifier> <type>void</type><methodname>DOMElement::replaceChildren</methodname>
+   <methodparam rep="repeat"><type class="union"><type>DOMNode</type><type>string</type></type><parameter>nodes</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Remplace les enfants dans l'élément par de nouveaux <parameter>nodes</parameter>.
+  </para>
+ </refsect1>
+
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domparentnode.replacechildren')/db:refsect1[@role='parameters'])" />
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domparentnode.replacechildren')/db:refsect1[@role='returnvalues'])" />
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domparentnode.replacechildren')/db:refsect1[@role='errors'])" />
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domparentnode.replacechildren')/db:refsect1[@role='changelog'])" />
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="domelement.replacechildren.example.basic">
+   <title>Exemple de <methodname>DOMElement::replaceChildren</methodname></title>
+   <para>
+    Remplace les enfants par de nouveaux nœuds.
+   </para>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$doc = new DOMDocument;
+$doc->loadXML("<container><hello/></container>");
+$container = $doc->documentElement;
+
+$container->replaceWith("beautiful", $doc->createElement("world"));
+
+echo $doc->saveXML();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+<?xml version="1.0"?>
+beautiful
+<world/>
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>DOMParentNode::replaceChildren</methodname></member>
+   <member><methodname>DOMElement::replaceWith</methodname></member>
+   <member><methodname>DOMElement::after</methodname></member>
+   <member><methodname>DOMElement::before</methodname></member>
+   <member><methodname>DOMElement::remove</methodname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/dom/domelement/replacewith.xml
+++ b/reference/dom/domelement/replacewith.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: c1349f9574ed77c268c6312a07466f06d59e5078 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="domelement.replacewith" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+ <refnamediv>
+  <refname>DOMElement::replaceWith</refname>
+  <refpurpose>Remplace l'élément par de nouveaux nœuds</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="DOMElement">
+   <modifier>public</modifier> <type>void</type><methodname>DOMElement::replaceWith</methodname>
+   <methodparam rep="repeat"><type class="union"><type>DOMNode</type><type>string</type></type><parameter>nodes</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Remaplce l'élément par de nouveaux <parameter>nodes</parameter>.
+  </para>
+ </refsect1>
+
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domchildnode.replacewith')/db:refsect1[@role='parameters'])" />
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domchildnode.replacewith')/db:refsect1[@role='returnvalues'])" />
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domchildnode.replacewith')/db:refsect1[@role='errors'])" />
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domchildnode.replacewith')/db:refsect1[@role='changelog'])" />
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="domelement.replacewith.example.basic">
+   <title>Exemple de <methodname>DOMElement::replaceWith</methodname></title>
+   <para>
+    Remplace l'élément par de nouveaux nœuds.
+   </para>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$doc = new DOMDocument;
+$doc->loadXML("<container><hello/></container>");
+$cdata = $doc->documentElement->firstChild;
+
+$cdata->replaceWith("beautiful", $doc->createElement("world"));
+
+echo $doc->saveXML();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+<?xml version="1.0"?>
+<container>beautiful<world/></container>
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>DOMChildNode::replaceWith</methodname></member>
+   <member><methodname>DOMElement::replaceChildren</methodname></member>
+   <member><methodname>DOMElement::after</methodname></member>
+   <member><methodname>DOMElement::before</methodname></member>
+   <member><methodname>DOMElement::remove</methodname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/dom/domelement/toggleattribute.xml
+++ b/reference/dom/domelement/toggleattribute.xml
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 14170b04f442ee9b915fd5ebc1c2279a4c1b9387 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="domelement.toggleattribute" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>DOMElement::toggleAttribute</refname>
+  <refpurpose>Bascule l'attribut</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="DOMElement">
+   <modifier>public</modifier> <type>bool</type><methodname>DOMElement::toggleAttribute</methodname>
+   <methodparam><type>string</type><parameter>qualifiedName</parameter></methodparam>
+   <methodparam choice="opt"><type class="union"><type>bool</type><type>null</type></type><parameter>force</parameter><initializer>&null;</initializer></methodparam>
+  </methodsynopsis>
+  <para>
+   Bascule l'attribut.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>qualifiedName</parameter></term>
+     <listitem>
+      <para>
+       Le nom qualifié de l'attribut.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>force</parameter></term>
+     <listitem>
+      <para>
+       <simplelist>
+        <member>si &null;, la fonction fait basculer l'attribut.</member>
+        <member>si &true;, la fonction ajoute l'attribut.</member>
+        <member>si &false;, la fonction enlèeve l'attribut.</member>
+       </simplelist>
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Retourne &true; si l'attribut est présent après l'appel, sinon &false;.
+  </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Exemple de <methodname>DOMElement::toggleAttribute</methodname></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+
+$dom = new DOMDocument();
+$dom->loadXML("<?xml version='1.0'?><container selected=\"\"/>");
+
+var_dump($dom->documentElement->toggleAttribute('selected'));
+echo $dom->saveXML() . PHP_EOL;
+
+var_dump($dom->documentElement->toggleAttribute('selected'));
+echo $dom->saveXML();
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+bool(false)
+<?xml version="1.0"?>
+<container/>
+
+bool(true)
+<?xml version="1.0"?>
+<container selected=""/>
+]]>
+   </screen>
+  </example>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
Here is the translation of missing `DOMElement` methods

- `DOMElement::after()`
- `DOMElement::append()`
- `DOMElement::getAttributeNames()`
- `DOMElement::insertAdjancentElement()`
- `DOMElement::insertAdjacentText()`
- `DOMElement::remove()`
- `DOMElement::replaceChildren()`
- `DOMElement::replaceWith()`
- `DOMElement::toggleAttribute()`