### PR TITLE
Translate `Zookeeper\Zookeeper`

### DIFF
--- a/reference/zookeeper/zookeeper/addauth.xml
+++ b/reference/zookeeper/zookeeper/addauth.xml
@@ -1,0 +1,142 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 09965ec0c7ced02607bfcca1525ffe856122e7bb Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="zookeeper.addauth" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Zookeeper::addAuth</refname>
+  <refpurpose>Spécifie les informations d'authentification de l'application</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="oop">
+   <modifier>public</modifier>
+   <type>bool</type><methodname>Zookeeper::addAuth</methodname>
+   <methodparam><type>string</type><parameter>scheme</parameter></methodparam>
+   <methodparam><type>string</type><parameter>cert</parameter></methodparam>
+   <methodparam choice="opt"><type>callable</type><parameter>completion_cb</parameter><initializer>&null;</initializer></methodparam>
+  </methodsynopsis>
+  <para>
+   L'application appelle cette fonction pour spécifier ses informations d'authentification. Le serveur utilisera le fournisseur de sécurité spécifié par le paramètre scheme pour authentifier la connexion du client. Si la demande d'authentification a échoué :
+    - la connexion du serveur est abandonnée.
+    - l'observateur est appelé avec la valeur ZOO_AUTH_FAILED_STATE comme paramètre d'état.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>scheme</parameter></term>
+    <listitem>
+     <para>
+      L'id du schéma d'authentification. Pris en charge nativement : "digest" authentification basée sur le mot de passe
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>cert</parameter></term>
+    <listitem>
+     <para>
+      Les informations d'authentification de l'application. La valeur réelle dépend du schéma.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>completion_cb</parameter></term>
+    <listitem>
+     <para>
+      La routine à invoquer lorsque la demande est terminée. L'un des codes de résultat suivants peut être passé à la fonction de rappel de fin :
+        - ZOK l'opération s'est terminée avec succès
+        - ZAUTHFAILED l'authentification a échoué
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &return.success;
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <para>
+   Cette méthode émet une erreur PHP/avertissement lorsque le nombre de paramètres ou les types sont incorrects ou lorsque l'opération échoue.
+  </para>
+  <caution>
+    <para>
+      Depuis la version 0.3.0, cette méthode émet <classname>ZookeeperException</classname> et ses dérivés.
+    </para>
+  </caution>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="zookeeper.addauth.example.basic">
+   <title>Exemple de <methodname>Zookeeper::addAuth</methodname></title>
+   <para>
+     Ajoute l'authentification avant de demander la valeur du nœud.
+   </para>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$zookeeper = new Zookeeper('locahost:2181');
+$path = '/path/to/node';
+$value = 'nodevalue';
+$zookeeper->set($path, $value);
+
+$zookeeper->addAuth('digest', 'user0:passwd0');
+$r = $zookeeper->get($path);
+if ($r)
+  echo $r;
+else
+  echo 'ERR';
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+nodevalue
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Zookeeper::create</methodname></member>
+   <member><methodname>Zookeeper::setAcl</methodname></member>
+   <member><methodname>Zookeeper::getAcl</methodname></member>
+   <member><link linkend="zookeeper.constants.states">Etat de ZooKeeper</link></member>
+   <member><classname>ZookeeperException</classname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/zookeeper/zookeeper/close.xml
+++ b/reference/zookeeper/zookeeper/close.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 299d1daf07b166ec08d7f395e2d1a145a59751d9 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="zookeeper.close" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Zookeeper::close</refname>
+  <refpurpose>Ferme la connexion au serveur ZooKeeper et libère les ressources associées</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="oop">
+   <modifier>public</modifier>
+   <type>void</type><methodname>Zookeeper::close</methodname>
+   <void />
+  </methodsynopsis>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &return.void;
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <para>
+   Cette méthode émet <classname>ZookeeperException</classname> et ses dérivés lors de la fermeture d'une instance non initialisée.
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Zookeeper::__construct</methodname></member>
+   <member><methodname>Zookeeper::connect</methodname></member>
+   <member><classname>ZookeeperException</classname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/zookeeper/zookeeper/connect.xml
+++ b/reference/zookeeper/zookeeper/connect.xml
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 299d1daf07b166ec08d7f395e2d1a145a59751d9 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="zookeeper.connect" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Zookeeper::connect</refname>
+  <refpurpose>Créer une connexion pour communiquer avec Zookeeper</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="oop">
+   <modifier>public</modifier>
+   <type>void</type><methodname>Zookeeper::connect</methodname>
+   <methodparam><type>string</type><parameter>host</parameter></methodparam>
+   <methodparam choice="opt"><type>callable</type><parameter>watcher_cb</parameter><initializer>&null;</initializer></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>recv_timeout</parameter><initializer>10000</initializer></methodparam>
+  </methodsynopsis>
+
+  <para>
+   Cette méthode crée une nouvelle connexion et une session zookeeper qui correspond à cette connexion. L'établissement de session est asynchrone, ce qui signifie que la session ne doit pas être considérée comme établie jusqu'à ce qu'un événement d'état ZOO_CONNECTED_STATE soit reçu.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>host</parameter></term>
+    <listitem>
+     <para>
+      Séparés par des virgules, chaque paire hôte:port correspondant à un serveur zk. Par exemple, "127.0.0.1:3000,127.0.0.1:3001,127.0.0.1:3002"
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>watcher_cb</parameter></term>
+    <listitem>
+     <para>
+      La fonction de rappel globale d'observation. Lorsque des notifications sont déclenchées, cette fonction sera invoquée.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>recv_timeout</parameter></term>
+    <listitem>
+     <para>
+      Le délai d'attente pour cette session, uniquement valide si la connexion est actuellement connectée (c'est-à-dire que le dernier état de l'observateur est ZOO_CONNECTED_STATE).
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &return.void;
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <para>
+   Cette méthode émet une erreur/warning PHP lorsque le nombre de paramètres ou les types sont incorrects ou que l'instance n'a pas pu être initialisée.
+  </para>
+  <caution>
+    <para>
+      Depuis la version 0.3.0, cette méthode émet <classname>ZookeeperException</classname> et ses dérivés.
+    </para>
+  </caution>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Zookeeper::__construct</methodname></member>
+   <member><classname>ZookeeperException</classname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/zookeeper/zookeeper/construct.xml
+++ b/reference/zookeeper/zookeeper/construct.xml
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: c44e9cb68b9b65771f9c45db2c07a06c63d71359 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="zookeeper.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Zookeeper::__construct</refname>
+  <refpurpose>Créer une connexion pour communiquer avec Zookeeper</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <constructorsynopsis role="oop">
+   <modifier>public</modifier>
+   <methodname>Zookeeper::__construct</methodname>
+   <methodparam choice="opt"><type>string</type><parameter>host</parameter><initializer>''</initializer></methodparam>
+   <methodparam choice="opt"><type>callable</type><parameter>watcher_cb</parameter><initializer>&null;</initializer></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>recv_timeout</parameter><initializer>10000</initializer></methodparam>
+  </constructorsynopsis>
+  <para>
+   Cette méthode crée une nouvelle connexion et une session zookeeper qui correspond à cette poignée. L'établissement de session est asynchrone, ce qui signifie que la session ne doit pas être considérée comme établie jusqu'à ce qu'un événement d'état ZOO_CONNECTED_STATE soit reçu.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>host</parameter></term>
+    <listitem>
+     <para>
+      Séparés par des virgules, chaque paire hôte:port correspondant à un serveur zk. Par exemple, "127.0.0.1:3000,127.0.0.1:3001,127.0.0.1:3002"
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>watcher_cb</parameter></term>
+    <listitem>
+     <para>
+      La fonction de rappel globale d'observation. Lorsque des notifications sont déclenchées, cette fonction sera invoquée.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>recv_timeout</parameter></term>
+    <listitem>
+     <para>
+      Le délai d'attente pour cette session, uniquement valide si la connexion est actuellement connectée (c'est-à-dire que le dernier état de l'observateur est ZOO_CONNECTED_STATE).
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <para>
+   Cette méthode émet une erreur/warning PHP lorsque le nombre de paramètres ou les types sont incorrects ou que l'instance n'a pas pu être initialisée.
+  </para>
+  <caution>
+    <para>
+      Depuis la version 0.3.0, cette méthode émet <classname>ZookeeperException</classname> et ses dérivés.
+    </para>
+  </caution>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Zookeeper::connect</methodname></member>
+   <member><classname>ZookeeperException</classname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/zookeeper/zookeeper/create.xml
+++ b/reference/zookeeper/zookeeper/create.xml
@@ -1,0 +1,149 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 09965ec0c7ced02607bfcca1525ffe856122e7bb Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="zookeeper.create" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Zookeeper::create</refname>
+  <refpurpose>Créer un nœud de manière synchrone</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="oop">
+   <modifier>public</modifier>
+   <type>string</type><methodname>Zookeeper::create</methodname>
+   <methodparam><type>string</type><parameter>path</parameter></methodparam>
+   <methodparam><type>string</type><parameter>value</parameter></methodparam>
+   <methodparam><type>array</type><parameter>acls</parameter></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>&null;</initializer></methodparam>
+  </methodsynopsis>
+  <para>
+   Cette méthode crée un nœud dans ZooKeeper. Un nœud ne peut être créé que s'il n'existe pas déjà. Les drapeaux de création affectent la création des nœuds. Si le drapeau ZOO_EPHEMERAL est défini, le nœud sera automatiquement supprimé si la session client disparaît. Si le drapeau ZOO_SEQUENCE est défini, un numéro de séquence unique et croissant est ajouté au nom du chemin.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>path</parameter></term>
+    <listitem>
+     <para>
+      Le nom du nœud. Exprimé sous la forme d'un nom de fichier avec des barres obliques séparant les ancêtres du nœud.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>value</parameter></term>
+    <listitem>
+     <para>
+      Les données à stocker dans le nœud.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>acls</parameter></term>
+    <listitem>
+     <para>
+      Les ACL initiaux du nœud. L'ACL ne doit pas être nul ou vide.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>flags</parameter></term>
+    <listitem>
+     <para>
+      Ce paramètre peut être défini sur 0 pour une création normale ou un OU des drapeaux de création.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Renvoie le chemin du nouveau nœud (cela peut être différent du chemin fourni en raison du drapeau ZOO_SEQUENCE) en cas de succès, et false en cas d'échec.
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <para>
+   Cette méthode émet une erreur/warning PHP lorsque le nombre de paramètres ou les types sont incorrects ou que la création du nœud a échoué.
+  </para>
+  <caution>
+    <para>
+      Depuis la version 0.3.0, cette méthode émet <classname>ZookeeperException</classname> et ses dérivés.
+    </para>
+  </caution>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="zookeeper.create.example.basic">
+   <title><methodname>Zookeeper::create</methodname> example</title>
+   <para>
+     Créer un nouveau nœud.
+   </para>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$zookeeper = new Zookeeper('locahost:2181');
+$aclArray = array(
+  array(
+    'perms'  => Zookeeper::PERM_ALL,
+    'scheme' => 'world',
+    'id'     => 'anyone',
+  )
+);
+$path = '/path/to/newnode';
+$realPath = $zookeeper->create($path, null, $aclArray);
+if ($realPath)
+  echo $realPath;
+else
+  echo 'ERR';
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+/path/to/newnode
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Zookeeper::delete</methodname></member>
+   <member><methodname>Zookeeper::getChildren</methodname></member>
+   <member><link linkend="zookeeper.constants.perms">Permissions de ZooKeeper</link></member>
+   <member><classname>ZookeeperException</classname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/zookeeper/zookeeper/delete.xml
+++ b/reference/zookeeper/zookeeper/delete.xml
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: dd07341fae2c414adc1f700be0890ff32e8daab4 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="zookeeper.delete" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Zookeeper::delete</refname>
+  <refpurpose>Enlève un nœud de manière synchrone</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="oop">
+   <modifier>public</modifier>
+   <type>bool</type><methodname>Zookeeper::delete</methodname>
+   <methodparam><type>string</type><parameter>path</parameter></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>version</parameter><initializer>-1</initializer></methodparam>
+  </methodsynopsis>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>path</parameter></term>
+    <listitem>
+     <para>
+      Le nom du nœud. Exprimé sous la forme d'un nom de fichier avec des barres obliques séparant les ancêtres du nœud.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>version</parameter></term>
+    <listitem>
+     <para>
+      La version attendue du nœud. La fonction échouera si la version actuelle du nœud ne correspond pas à la version attendue. Si -1 est utilisé, la vérification de version n'aura pas lieu.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &return.success;
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <para>
+   Cette méthode émet une erreur/warning PHP lorsque le nombre de paramètres ou les types sont incorrects ou que la suppression du nœud a échoué.
+  </para>
+  <caution>
+    <para>
+      Depuis la version 0.3.0, cette méthode émet <classname>ZookeeperException</classname> et ses dérivés.
+    </para>
+  </caution>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="zookeeper.delete.example.basic">
+   <title>Exemple de <methodname>Zookeeper::delete</methodname></title>
+   <para>
+     Supprime un nœud existant.
+   </para>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$zookeeper = new Zookeeper('locahost:2181');
+$path = '/path/to/node';
+$r = $zookeeper->delete($path);
+if ($r)
+  echo 'SUCCESS';
+else
+  echo 'ERR';
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+SUCCESS
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Zookeeper::create</methodname></member>
+   <member><methodname>Zookeeper::getChildren</methodname></member>
+   <member><classname>ZookeeperException</classname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/zookeeper/zookeeper/exists.xml
+++ b/reference/zookeeper/zookeeper/exists.xml
@@ -1,0 +1,119 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: a20b7f936b03d76e8a3ddcadbfa1699f3e2bd1b6 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="zookeeper.exists" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Zookeeper::exists</refname>
+  <refpurpose>Vérifie l'existence d'un nœud de manière synchrone</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="oop">
+   <modifier>public</modifier>
+   <type>array</type><methodname>Zookeeper::exists</methodname>
+   <methodparam><type>string</type><parameter>path</parameter></methodparam>
+   <methodparam choice="opt"><type>callable</type><parameter>watcher_cb</parameter><initializer>&null;</initializer></methodparam>
+  </methodsynopsis>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>path</parameter></term>
+    <listitem>
+     <para>
+      Le nom du nœud. Exprimé sous la forme d'un nom de fichier avec des barres obliques séparant les ancêtres du nœud.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>watcher_cb</parameter></term>
+    <listitem>
+     <para>
+      Si différent de zéro, un observateur sera défini sur le serveur pour notifier le client si le nœud change. L'observateur sera défini même si le nœud n'existe pas.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Renvoie la valeur de stat pour le chemin si le nœud donné existe, sinon false.
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <para>
+   Cette méthode émet une erreur/warning PHP lorsque le nombre de paramètres ou les types sont incorrects ou que la vérification de l'existence du nœud a échoué.
+  </para>
+  <caution>
+    <para>
+      Depuis la version 0.3.0, cette méthode émet <classname>ZookeeperException</classname> et ses dérivés.
+    </para>
+  </caution>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="zookeeper.exists.example.basic">
+   <title>Exemple de <methodname>Zookeeper::exists</methodname></title>
+   <para>
+     Vérifie l'existence d'un nœud.
+   </para>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$zookeeper = new Zookeeper('locahost:2181');
+$path = '/path/to/node';
+$r = $zookeeper->exists($path);
+if ($r)
+  echo 'EXISTS';
+else
+  echo 'N/A or ERR';
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+EXISTS
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Zookeeper::get</methodname></member>
+   <member><classname>ZookeeperException</classname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/zookeeper/zookeeper/get.xml
+++ b/reference/zookeeper/zookeeper/get.xml
@@ -1,0 +1,187 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: bde4b64a45645d6f83f0f056f5d8517f44157006 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="zookeeper.get" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Zookeeper::get</refname>
+  <refpurpose>Renvoie les données associées à un nœud de manière synchrone</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="oop">
+   <modifier>public</modifier>
+   <type>string</type><methodname>Zookeeper::get</methodname>
+   <methodparam><type>string</type><parameter>path</parameter></methodparam>
+   <methodparam choice="opt"><type>callable</type><parameter>watcher_cb</parameter><initializer>&null;</initializer></methodparam>
+   <methodparam choice="opt"><type>array</type><parameter role="reference">stat</parameter><initializer>&null;</initializer></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>max_size</parameter><initializer>0</initializer></methodparam>
+  </methodsynopsis>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>path</parameter></term>
+    <listitem>
+     <para>
+      Le nom du nœud. Exprimé sous la forme d'un nom de fichier avec des barres obliques séparant les ancêtres du nœud.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>watcher_cb</parameter></term>
+    <listitem>
+     <para>
+      Si différent de zéro, un observateur sera défini sur le serveur pour notifier le client si le nœud change.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>stat</parameter></term>
+    <listitem>
+     <para>
+      Si différent de NULL, contiendra la valeur de stat pour le chemin lors du retour.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>max_size</parameter></term>
+    <listitem>
+     <para>
+      La taille maximale des données. Si 0 est utilisé, cette méthode renverra l'ensemble des données.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Renvoie les données en cas de succès, et false en cas d'échec.
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <para>
+   Cette méthode émet une erreur/warning PHP lorsque le nombre de paramètres ou les types sont incorrects ou que la récupération des données a échoué.
+  </para>
+  <caution>
+    <para>
+      Depuis la version 0.3.0, cette méthode émet <classname>ZookeeperException</classname> et ses dérivés.
+    </para>
+  </caution>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="zookeeper.get.example.basic">
+   <title>Exemple de <methodname>Zookeeper::get</methodname></title>
+   <para>
+     Récupère la valeur du nœud.
+   </para>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$zookeeper = new Zookeeper('locahost:2181');
+$path = '/path/to/node';
+$value = 'nodevalue';
+$zookeeper->set($path, $value);
+
+$r = $zookeeper->get($path);
+if ($r)
+  echo $r;
+else
+  echo 'ERR';
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+nodevalue
+]]>
+   </screen>
+  </example>
+
+  <example xml:id="zookeeper.get.example.stat">
+   <title>Exemple de stats de <methodname>Zookeeper::get</methodname></title>
+   <para>
+     Renvoie les informations de stats du nœud.
+   </para>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$zookeeper = new Zookeeper('localhost:2181');
+$path = '/path/to/node';
+$stat = [];
+$zookeeper->get($path, null, $stat);
+var_dump($stat);
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+array(11) {
+  ["czxid"]=>
+  float(0)
+  ["mzxid"]=>
+  float(0)
+  ["ctime"]=>
+  float(0)
+  ["mtime"]=>
+  float(0)
+  ["version"]=>
+  int(0)
+  ["cversion"]=>
+  int(-2)
+  ["aversion"]=>
+  int(0)
+  ["ephemeralOwner"]=>
+  float(0)
+  ["dataLength"]=>
+  int(0)
+  ["numChildren"]=>
+  int(2)
+  ["pzxid"]=>
+  float(0)
+}
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Zookeeper::set</methodname></member>
+   <member><classname>ZookeeperException</classname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/zookeeper/zookeeper/getacl.xml
+++ b/reference/zookeeper/zookeeper/getacl.xml
@@ -1,0 +1,131 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 09965ec0c7ced02607bfcca1525ffe856122e7bb Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="zookeeper.getacl" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Zookeeper::getAcl</refname>
+  <refpurpose>Renvoie les ACL associées à un nœud de manière synchrone</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="oop">
+   <modifier>public</modifier>
+   <type>array</type><methodname>Zookeeper::getAcl</methodname>
+   <methodparam><type>string</type><parameter>path</parameter></methodparam>
+  </methodsynopsis>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>path</parameter></term>
+    <listitem>
+     <para>
+      Le nom du nœud. Exprimé sous la forme d'un nom de fichier avec des barres obliques séparant les ancêtres du nœud.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Renvoie un tableau d'ACL en cas de succès et false en cas d'échec.
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <para>
+   Cette méthode émet une erreur/warning PHP lorsque le nombre de paramètres ou les types sont incorrects ou que la récupération des ACL du nœud a échoué.
+  </para>
+  <caution>
+    <para>
+      Depuis la version 0.3.0, cette méthode émet <classname>ZookeeperException</classname> et ses dérivés.
+    </para>
+  </caution>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="zookeeper.getacl.example.basic">
+   <title>Exemple de <methodname>Zookeeper::getAcl</methodname></title>
+   <para>
+     Renvoie les ACL d'un nœud.
+   </para>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$zookeeper = new Zookeeper('locahost:2181');
+$aclArray = array(
+  array(
+    'perms'  => Zookeeper::PERM_ALL,
+    'scheme' => 'world',
+    'id'     => 'anyone',
+  )
+);
+$path = '/path/to/newnode';
+$zookeeper->setAcl($path, $aclArray);
+
+$r = $zookeeper->getAcl($path);
+if ($r)
+  var_dump($r);
+else
+  echo 'ERR';
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+array(1) {
+  [0]=>
+  array(3) {
+    ["perms"]=>
+    int(31)
+    ["scheme"]=>
+    string(5) "world"
+    ["id"]=>
+    string(6) "anyone"
+  }
+}
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Zookeeper::create</methodname></member>
+   <member><methodname>Zookeeper::setAcl</methodname></member>
+   <member><link linkend="zookeeper.constants.perms">Permissions de ZooKeeper</link></member>
+   <member><classname>ZookeeperException</classname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/zookeeper/zookeeper/getchildren.xml
+++ b/reference/zookeeper/zookeeper/getchildren.xml
@@ -1,0 +1,127 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 16f729a56f0dabc39c93b27315f36d6838f00027 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="zookeeper.getchildren" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Zookeeper::getChildren</refname>
+  <refpurpose>Liste les enfants d'un nœud de manière synchrone</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="oop">
+   <modifier>public</modifier>
+   <type>array</type><methodname>Zookeeper::getChildren</methodname>
+   <methodparam><type>string</type><parameter>path</parameter></methodparam>
+   <methodparam choice="opt"><type>callable</type><parameter>watcher_cb</parameter><initializer>&null;</initializer></methodparam>
+  </methodsynopsis>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>path</parameter></term>
+    <listitem>
+     <para>
+      Le nom du nœud. Exprimé sous la forme d'un nom de fichier avec des barres obliques séparant les ancêtres du nœud.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>watcher_cb</parameter></term>
+    <listitem>
+     <para>
+      Si différent de zéro, un observateur sera défini sur le serveur pour notifier le client si le nœud change.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Renvoie un tableau avec les chemins des enfants en cas de succès, et false en cas d'échec.
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <para>
+   Cette méthode émet une erreur/warning PHP lorsque le nombre de paramètres ou les types sont incorrects ou que la liste des enfants d'un nœud a échoué.
+  </para>
+  <caution>
+    <para>
+      Depuis la version 0.3.0, cette méthode émet <classname>ZookeeperException</classname> et ses dérivés.
+    </para>
+  </caution>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="zookeeper.getchildren.example.basic">
+   <title>Exemple de <methodname>Zookeeper::getChildren</methodname></title>
+   <para>
+     Liste les enfants d'un nœud.
+   </para>
+   <programlisting role="php">
+<![CDATA[
+<?php
+
+$zookeeper = new Zookeeper('locahost:2181');
+$path = '/zookeeper';
+$r = $zookeeper->getchildren($path);
+
+if ($r) {
+    var_dump($r);
+} else {
+    echo 'ERR';
+}
+
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+array(1) {
+  [0]=>
+  string(6) "config"
+}
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Zookeeper::create</methodname></member>
+   <member><methodname>Zookeeper::delete</methodname></member>
+   <member><classname>ZookeeperException</classname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/zookeeper/zookeeper/getclientid.xml
+++ b/reference/zookeeper/zookeeper/getclientid.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 09965ec0c7ced02607bfcca1525ffe856122e7bb Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="zookeeper.getclientid" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Zookeeper::getClientId</refname>
+  <refpurpose>Renvoie l'identifiant de session client, uniquement valide si la connexion est actuellement établie (c'est-à-dire si le dernier état de l'observateur est ZOO_CONNECTED_STATE)</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="oop">
+   <modifier>public</modifier>
+   <type>int</type><methodname>Zookeeper::getClientId</methodname>
+   <void />
+  </methodsynopsis>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Renvoie l'identifiant de session client en cas de succès, et false en cas d'échec.
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <para>
+   Cette méthode émet une erreur/warning PHP lorsque le client n'a pas pu obtenir l'identifiant de session.
+  </para>
+  <caution>
+    <para>
+      Depuis la version 0.3.0, cette méthode émet <classname>ZookeeperException</classname> et ses dérivés.
+    </para>
+  </caution>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Zookeeper::__construct</methodname></member>
+   <member><methodname>Zookeeper::connect</methodname></member>
+   <member><methodname>Zookeeper::getState</methodname></member>
+   <member><link linkend="zookeeper.constants.states">Etats de ZooKeeper</link></member>
+   <member><classname>ZookeeperException</classname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/zookeeper/zookeeper/getconfig.xml
+++ b/reference/zookeeper/zookeeper/getconfig.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 47e2bde2fa408e9b46db226bd551b5fba98b7674 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="zookeeper.getconfig" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Zookeeper::getConfig</refname>
+  <refpurpose>Renvoie l'instance de ZookeeperConfig</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="oop">
+   <modifier>public</modifier>
+   <type>ZookeeperConfig</type><methodname>Zookeeper::getConfig</methodname>
+   <void />
+  </methodsynopsis>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Renvoie l'instance de <classname>ZookeeperConfig</classname>.
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><classname>ZookeeperConfig</classname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/zookeeper/zookeeper/getrecvtimeout.xml
+++ b/reference/zookeeper/zookeeper/getrecvtimeout.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 299d1daf07b166ec08d7f395e2d1a145a59751d9 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="zookeeper.getrecvtimeout" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Zookeeper::getRecvTimeout</refname>
+  <refpurpose>Renvoie le délai d'attente pour cette session, uniquement valide si la connexion est actuellement établie (c'est-à-dire si le dernier état de l'observateur est ZOO_CONNECTED_STATE). Cette valeur peut changer après une reconnexion au serveur</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="oop">
+   <modifier>public</modifier>
+   <type>int</type><methodname>Zookeeper::getRecvTimeout</methodname>
+   <void />
+  </methodsynopsis>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Renvoie le délai d'attente pour cette session en cas de succès, et false en cas d'échec.
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <para>
+   Cette méthode émet une erreur/warning PHP lorsque l'opération échoue.
+  </para>
+  <caution>
+    <para>
+      Depuis la version 0.3.0, cette méthode émet <classname>ZookeeperException</classname> et ses dérivés.
+    </para>
+  </caution>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Zookeeper::__construct</methodname></member>
+   <member><methodname>Zookeeper::connect</methodname></member>
+   <member><classname>ZookeeperException</classname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/zookeeper/zookeeper/getstate.xml
+++ b/reference/zookeeper/zookeeper/getstate.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 09965ec0c7ced02607bfcca1525ffe856122e7bb Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="zookeeper.getstate" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Zookeeper::getState</refname>
+  <refpurpose>Renvoie l'état de la connexion zookeeper</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="oop">
+   <modifier>public</modifier>
+   <type>int</type><methodname>Zookeeper::getState</methodname>
+   <void />
+  </methodsynopsis>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Renvoie l'état de la connexion zookeeper en cas de succès, et false en cas d'échec.
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <para>
+   Cette méthode émet une erreur/warning PHP lorsque l'état de la connexion zookeeper n'a pas pu être obtenu. 
+  </para>
+  <caution>
+    <para>
+      Depuis la version 0.3.0, cette méthode émet <classname>ZookeeperException</classname> et ses dérivés.
+    </para>
+  </caution>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Zookeeper::__construct</methodname></member>
+   <member><methodname>Zookeeper::connect</methodname></member>
+   <member><methodname>Zookeeper::getClientId</methodname></member>
+   <member><link linkend="zookeeper.constants.states">Etat de ZooKeeper</link></member>
+   <member><classname>ZookeeperException</classname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/zookeeper/zookeeper/isrecoverable.xml
+++ b/reference/zookeeper/zookeeper/isrecoverable.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 09965ec0c7ced02607bfcca1525ffe856122e7bb Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="zookeeper.isrecoverable" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Zookeeper::isRecoverable</refname>
+  <refpurpose>Vérifie si l'état de connexion zookeeper actuel peut être récupéré</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="oop">
+   <modifier>public</modifier>
+   <type>bool</type><methodname>Zookeeper::isRecoverable</methodname>
+   <void />
+  </methodsynopsis>
+  <para>
+   L'application doit fermer le gestionnaire et essayer de se reconnecter.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Renvoie true/faux en cas de succès, et faux en cas d'échec.
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <para>
+   Cette méthode émet une erreur/warning PHP lorsque l'opération échoue.
+  </para>
+  <caution>
+    <para>
+      Depuis la version 0.3.0, cette méthode émet <classname>ZookeeperException</classname> et ses dérivés.
+    </para>
+  </caution>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Zookeeper::__construct</methodname></member>
+   <member><methodname>Zookeeper::connect</methodname></member>
+   <member><methodname>Zookeeper::getClientId</methodname></member>
+   <member><link linkend="zookeeper.constants.states">Etat de ZooKeeper</link></member>
+   <member><classname>ZookeeperException</classname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/zookeeper/zookeeper/set.xml
+++ b/reference/zookeeper/zookeeper/set.xml
@@ -1,0 +1,139 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: b8758b0605e80c4e3610137b7502a6abeea5c69b Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="zookeeper.set" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Zookeeper::set</refname>
+  <refpurpose>Définit les données associées à un nœud</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="oop">
+   <modifier>public</modifier>
+   <type>bool</type><methodname>Zookeeper::set</methodname>
+   <methodparam><type>string</type><parameter>path</parameter></methodparam>
+   <methodparam><type>string</type><parameter>value</parameter></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>version</parameter><initializer>-1</initializer></methodparam>
+   <methodparam choice="opt"><type>array</type><parameter role="reference">stat</parameter><initializer>&null;</initializer></methodparam>
+  </methodsynopsis>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>path</parameter></term>
+    <listitem>
+     <para>
+      Le nom du nœud. Exprimé sous la forme d'un nom de fichier avec des barres obliques séparant les ancêtres du nœud.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>value</parameter></term>
+    <listitem>
+     <para>
+      Les données à stocker dans le nœud.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>version</parameter></term>
+    <listitem>
+     <para>
+      La version attendue du nœud. La fonction échouera si la version actuelle du nœud ne correspond pas à la version attendue. Si -1 est utilisé, la vérification de version ne sera pas effectuée.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>stat</parameter></term>
+    <listitem>
+     <para>
+      Si différent de NULL, contiendra la valeur de stat pour le chemin lors du retour.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &return.success;
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <para>
+   Cette méthode émet une erreur/warning PHP lorsque le nombre de paramètres ou les types sont incorrects ou que la sauvegarde de la valeur dans le nœud a échoué.
+  </para>
+  <caution>
+    <para>
+      Depuis la version 0.3.0, cette méthode émet <classname>ZookeeperException</classname> et ses dérivés.
+    </para>
+  </caution>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="zookeeper.set.example.basic">
+   <title>Exemple de <methodname>Zookeeper::set</methodname></title>
+   <para>
+     Sauvegarde une valeur dans un nœud.
+   </para>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$zookeeper = new Zookeeper('locahost:2181');
+$path = '/path/to/node';
+$value = 'nodevalue';
+$r = $zookeeper->set($path, $value);
+if ($r)
+  echo 'SUCCESS';
+else
+  echo 'ERR';
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+SUCCESS
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Zookeeper::create</methodname></member>
+   <member><methodname>Zookeeper::get</methodname></member>
+   <member><classname>ZookeeperException</classname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/zookeeper/zookeeper/setacl.xml
+++ b/reference/zookeeper/zookeeper/setacl.xml
@@ -1,0 +1,149 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 09965ec0c7ced02607bfcca1525ffe856122e7bb Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="zookeeper.setacl" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Zookeeper::setAcl</refname>
+  <refpurpose>Définit l'ACL associé à un nœud de manière synchrone</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="oop">
+   <modifier>public</modifier>
+   <type>bool</type><methodname>Zookeeper::setAcl</methodname>
+   <methodparam><type>string</type><parameter>path</parameter></methodparam>
+   <methodparam><type>int</type><parameter>version</parameter></methodparam>
+   <methodparam><type>array</type><parameter>acl</parameter></methodparam>
+  </methodsynopsis>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>path</parameter></term>
+    <listitem>
+     <para>
+      Le nom du nœud. Exprimé sous la forme d'un nom de fichier avec des barres obliques séparant les ancêtres du nœud.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>version</parameter></term>
+    <listitem>
+     <para>
+      Le numéro de version attendu du chemin.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>acl</parameter></term>
+    <listitem>
+     <para>
+      L'ACL à définir sur le chemin.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &return.success;
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <para>
+   Cette méthode émet une erreur/warning PHP lorsque le nombre de paramètres ou les types sont incorrects ou que l'ACL n'a pas pu être définie pour un nœud.
+  </para>
+  <caution>
+    <para>
+      Depuis la version 0.3.0, cette méthode émet <classname>ZookeeperException</classname> et ses dérivés.
+    </para>
+  </caution>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="zookeeper.setacl.example.basic">
+   <title>Exemple de <methodname>Zookeeper::setAcl</methodname></title>
+   <para>
+     Définit l'ACL pour un nœud.
+   </para>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$zookeeper = new Zookeeper('locahost:2181');
+$aclArray = array(
+  array(
+    'perms'  => Zookeeper::PERM_ALL,
+    'scheme' => 'world',
+    'id'     => 'anyone',
+  )
+);
+$path = '/path/to/newnode';
+$zookeeper->setAcl($path, $aclArray);
+
+$r = $zookeeper->getAcl($path);
+if ($r)
+  var_dump($r);
+else
+  echo 'ERR';
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+array(1) {
+  [0]=>
+  array(3) {
+    ["perms"]=>
+    int(31)
+    ["scheme"]=>
+    string(5) "world"
+    ["id"]=>
+    string(6) "anyone"
+  }
+}
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Zookeeper::create</methodname></member>
+   <member><methodname>Zookeeper::getAcl</methodname></member>
+   <member><link linkend="zookeeper.constants.perms">Permissions de ZooKeeper</link></member>
+   <member><classname>ZookeeperException</classname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/zookeeper/zookeeper/setdebuglevel.xml
+++ b/reference/zookeeper/zookeeper/setdebuglevel.xml
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 09965ec0c7ced02607bfcca1525ffe856122e7bb Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="zookeeper.setdebuglevel" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Zookeeper::setDebugLevel</refname>
+  <refpurpose>Définit le niveau de débogage pour la librairie</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="oop">
+   <modifier>public</modifier>
+   <modifier>static</modifier>
+   <type>bool</type><methodname>Zookeeper::setDebugLevel</methodname>
+   <methodparam><type>int</type><parameter>logLevel</parameter></methodparam>
+  </methodsynopsis>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>logLevel</parameter></term>
+    <listitem>
+     <para>
+      Constantes de niveau de débogage ZooKeeper.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &return.success;
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <para>
+   Cette méthode émet une erreur/warning PHP lorsque le nombre de paramètres ou les types sont incorrects ou échouent à définir le niveau de débogage.
+  </para>
+  <caution>
+    <para>
+      Depuis la version 0.3.0, cette méthode émet <classname>ZookeeperException</classname> et ses dérivés.
+    </para>
+  </caution>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="zookeeper.setdebuglevel.example.basic">
+   <title>Exemple de <methodname>Zookeeper::setDebugLevel</methodname></title>
+   <para>
+     Définit le niveau de débogage.
+   </para>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$r = Zookeeper::setDebugLevel(Zookeeper::LOG_LEVEL_WARN);
+if ($r)
+  echo 'SUCCESS';
+else
+  echo 'ERR';
+?>
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+SUCCESS
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><link linkend="zookeeper.constants.log-levels">Niveau de journalisation ZooKeeper</link></member>
+   <member><classname>ZookeeperException</classname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/zookeeper/zookeeper/setdeterministicconnorder.xml
+++ b/reference/zookeeper/zookeeper/setdeterministicconnorder.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 63cfa87a784c175a5360f18be7c4cb5550cc1d66 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="zookeeper.setdeterministicconnorder" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Zookeeper::setDeterministicConnOrder</refname>
+  <refpurpose>Active/désactive la randomisation de l'ordre des points de terminaison du quorum</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="oop">
+   <modifier>public</modifier>
+   <modifier>static</modifier>
+   <type>bool</type><methodname>Zookeeper::setDeterministicConnOrder</methodname>
+   <methodparam><type>bool</type><parameter>yesOrNo</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Si passé à une valeur vraie, fera en sorte que le client se connecte aux pairs du quorum dans l'ordre tel que spécifié dans l'appel à zookeeper_init(). Une valeur fausse fait en sorte que zookeeper_init() permutte les points de terminaison des pairs du quorum, ce qui est bon pour une distribution plus uniforme des connexions client parmi les pairs du quorum.
+   Le client C ZooKeeper utilise false par défaut.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>yesOrNo</parameter></term>
+    <listitem>
+     <para>
+      Active/désactive la randomisation de l'ordre des points de terminaison du quorum.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &return.success;
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <para>
+   Cette méthode émet une erreur/warning PHP lorsque le nombre de paramètres ou les types sont incorrects ou l'opération échoue.
+  </para>
+  <caution>
+    <para>
+      Depuis la version 0.3.0, cette méthode émet <classname>ZookeeperException</classname> et ses dérivés.
+    </para>
+  </caution>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Zookeeper::__construct</methodname></member>
+   <member><methodname>Zookeeper::connect</methodname></member>
+   <member><classname>ZookeeperException</classname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/zookeeper/zookeeper/setlogstream.xml
+++ b/reference/zookeeper/zookeeper/setlogstream.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: dd07341fae2c414adc1f700be0890ff32e8daab4 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="zookeeper.setlogstream" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Zookeeper::setLogStream</refname>
+  <refpurpose>Définit le flux à utiliser par la librairie pour le journal</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="oop">
+   <modifier>public</modifier>
+   <type>bool</type><methodname>Zookeeper::setLogStream</methodname>
+   <methodparam><type>resource</type><parameter>stream</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   La librairie zookeeper utilise stderr comme flux de journalisation par défaut. L'application doit s'assurer que le flux est inscriptible. Passer NULL réinitialise le flux à sa valeur par défaut (stderr).
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>stream</parameter></term>
+    <listitem>
+     <para>
+      Le flux à utiliser par la librairie pour le journal.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &return.success;
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <para>
+   Cette méthode émet une erreur/warning PHP lorsque le nombre de paramètres ou les types sont incorrects ou l'opération échoue.
+  </para>
+  <caution>
+    <para>
+      Depuis la version 0.3.0, cette méthode émet <classname>ZookeeperException</classname> et ses dérivés.
+    </para>
+  </caution>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Zookeeper::setDebugLevel</methodname></member>
+   <member><classname>ZookeeperException</classname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/zookeeper/zookeeper/setwatcher.xml
+++ b/reference/zookeeper/zookeeper/setwatcher.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: dd07341fae2c414adc1f700be0890ff32e8daab4 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="zookeeper.setwatcher" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Zookeeper::setWatcher</refname>
+  <refpurpose>Définit une fonction d'observation</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="oop">
+   <modifier>public</modifier>
+   <type>bool</type><methodname>Zookeeper::setWatcher</methodname>
+   <methodparam><type>callable</type><parameter>watcher_cb</parameter></methodparam>
+  </methodsynopsis>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>watcher_cb</parameter></term>
+    <listitem>
+     <para>
+      Un observateur qui sera appelé chaque fois que le nœud change.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &return.success;
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <para>
+   Cette méthode émet une erreur/warning PHP lorsque le nombre de paramètres ou les types sont incorrects ou impossible de changer l'observateur.
+  </para>
+  <caution>
+    <para>
+      Depuis la version 0.3.0, cette méthode émet <classname>ZookeeperException</classname> et ses dérivés.
+    </para>
+  </caution>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Zookeeper::exists</methodname></member>
+   <member><methodname>Zookeeper::get</methodname></member>
+   <member><classname>ZookeeperException</classname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
Here is the translation of missing `Zookeeper\Zookeepe` methods

- `Zookeeper\ZooKeeper::addauth()`
- `Zookeeper\ZooKeeper::close()`
- `Zookeeper\ZooKeeper::connect()`
- `Zookeeper\ZooKeeper::construct()`
- `Zookeeper\ZooKeeper::create()`
- `Zookeeper\ZooKeeper::delete()`
- `Zookeeper\ZooKeeper::exists()`
- `Zookeeper\ZooKeeper::get()`
- `Zookeeper\ZooKeeper::getAcl()`
- `Zookeeper\ZooKeeper::getChildren()`
- `Zookeeper\ZooKeeper::getClientid()`
- `Zookeeper\ZooKeeper::getConfig()`
- `Zookeeper\ZooKeeper::getRecvtimeout()`
- `Zookeeper\ZooKeeper::getState()`
- `Zookeeper\ZooKeeper::isRecoverable()`
- `Zookeeper\ZooKeeper::set()`
- `Zookeeper\ZooKeeper::setAcl()`
- `Zookeeper\ZooKeeper::setDebugLevel()`
- `Zookeeper\ZooKeeper::setDeterministicConnorder()`
- `Zookeeper\ZooKeeper::setLogStream()`
- `Zookeeper\ZooKeeper::setWatcher()`