### PR TITLE
Translate `MongoDB\Driver\BulkWrite` methods

### DIFF
--- a/reference/mongodb/mongodb/driver/bulkwrite/construct.xml
+++ b/reference/mongodb/mongodb/driver/bulkwrite/construct.xml
@@ -1,0 +1,233 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 734bafeaf071b78b15d375f9af583befddd8c2a2 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="mongodb-driver-bulkwrite.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>MongoDB\Driver\BulkWrite::__construct</refname>
+  <refpurpose>Créer un nouveau BulkWrite</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>public</modifier> <methodname>MongoDB\Driver\BulkWrite::__construct</methodname>
+   <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>options</parameter><initializer>&null;</initializer></methodparam>
+  </methodsynopsis>
+  <para>
+   Construit un nouveau <classname>MongoDB\Driver\BulkWrite</classname>, qui est un
+   objet mutable auquel une ou plusieurs opérations d'écriture peuvent être ajoutées. Les
+   écritures peuvent ensuite être exécutées avec
+   <methodname>MongoDB\Driver\Manager::executeBulkWrite</methodname>.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>options</parameter> (<type>array</type>)</term>
+    <listitem>
+     <para>
+      <table>
+       <title>options</title>
+       <tgroup cols="4">
+        <thead>
+         <row>
+          <entry>Option</entry>
+          <entry>Type</entry>
+          <entry>Description</entry>
+          <entry>Defaut</entry>
+         </row>
+        </thead>
+        <tbody>
+         <row>
+          <entry>bypassDocumentValidation</entry>
+          <entry><type>bool</type></entry>
+          <entry>
+           <para>
+            Si &true;, permet aux opérations d'insertion et de mise à jour de
+            contourner la validation au niveau du document.
+           </para>
+           <para>
+            Cette option est disponible dans MongoDB 3.2+ et est ignorée pour les
+            anciennes versions du serveur, qui ne prennent pas en charge la validation au niveau du document.
+           </para>
+          </entry>
+          <entry>&false;</entry>
+         </row>
+         <row>
+          <entry>comment</entry>
+          <entry><type>mixed</type></entry>
+          <entry>
+           <para>
+            Un commentaire arbitraire pour aider à tracer l'opération à travers le
+            profil du serveur de base de données, la sortie currentOp et les journaux.
+           </para>
+           <para>
+            Cette option est disponible dans MongoDB 4.4+ et entraînera une
+            exception au moment de l'exécution si elle est spécifiée pour une version de serveur plus ancienne.
+           </para>
+          </entry>
+         </row>
+         &mongodb.option.let;
+         <row>
+          <entry>ordered</entry>
+          <entry><type>bool</type></entry>
+          <entry>
+           Les opérations ordonnées (&true;) sont exécutées séquentiellement sur le serveur MongoDB,
+           tandis que les opérations non ordonnées (&false;) sont envoyées au serveur
+           dans un ordre arbitraire et peuvent être exécutées en parallèle.
+          </entry>
+          <entry>&true;</entry>
+         </row>
+        </tbody>
+       </tgroup>
+      </table>
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simplelist>
+   &mongodb.throws.argumentparsing;
+  </simplelist>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>PECL mongodb 1.14.0</entry>
+       <entry>
+        Ajout des options <literal>"comment"</literal> et <literal>"let"</literal>.
+       </entry>
+      </row>
+      <row>
+       <entry>PECL mongodb 1.1.0</entry>
+       <entry>
+        Ajout de l'option <literal>"bypassDocumentValidation"</literal>.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Exemple de <function>MongoDB\Driver\BulkWrite::__construct</function></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+
+$bulk = new MongoDB\Driver\BulkWrite(['ordered' => true]);
+$bulk->delete([]);
+$bulk->insert(['_id' => 1, 'x' => 1]);
+$bulk->insert(['_id' => 2, 'x' => 2]);
+$bulk->update(
+    ['x' => 2],
+    ['$set' => ['x' => 1]],
+    ['limit' => 1, 'upsert' => false]
+);
+$bulk->delete(['x' => 1], ['limit' => 1]);
+$bulk->update(
+    ['_id' => 3],
+    ['$set' => ['x' => 3]],
+    ['limit' => 1, 'upsert' => true]
+);
+
+$manager = new MongoDB\Driver\Manager('mongodb://localhost:27017');
+$writeConcern = new MongoDB\Driver\WriteConcern(1);
+
+try {
+    $result = $manager->executeBulkWrite('db.collection', $bulk, $writeConcern);
+} catch (MongoDB\Driver\Exception\BulkWriteException $e) {
+    $result = $e->getWriteResult();
+
+    // Vérifie si l'écriture n'a pas pu être effectuée
+    if ($writeConcernError = $result->getWriteConcernError()) {
+        printf("%s (%d): %s\n",
+            $writeConcernError->getMessage(),
+            $writeConcernError->getCode(),
+            var_export($writeConcernError->getInfo(), true)
+        );
+    }
+
+    // Vérifie si certaines opérations d'écriture n'ont pas été effectuées du tout
+    foreach ($result->getWriteErrors() as $writeError) {
+        printf("Operation#%d: %s (%d)\n",
+            $writeError->getIndex(),
+            $writeError->getMessage(),
+            $writeError->getCode()
+        );
+    }
+} catch (MongoDB\Driver\Exception\Exception $e) {
+    printf("Other error: %s\n", $e->getMessage());
+    exit;
+}
+
+printf("Inserted %d document(s)\n", $result->getInsertedCount());
+printf("Updated  %d document(s)\n", $result->getModifiedCount());
+printf("Upserted %d document(s)\n", $result->getUpsertedCount());
+printf("Deleted  %d document(s)\n", $result->getDeletedCount());
+
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+Inserted 2 document(s)
+Updated  1 document(s)
+Upserted 1 document(s)
+Deleted  1 document(s)
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>MongoDB\Driver\Manager::executeBulkWrite</methodname></member>
+   <member><classname>MongoDB\Driver\WriteResult</classname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mongodb/mongodb/driver/bulkwrite/count.xml
+++ b/reference/mongodb/mongodb/driver/bulkwrite/count.xml
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: af5f2f87b3b0bb9ee0f83ccb787a4e7db1eb6bd4 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes --> 
+<refentry xml:id="mongodb-driver-bulkwrite.count" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>MongoDB\Driver\BulkWrite::count</refname>
+  <refpurpose>Compte le nombre d'opérations d'écriture dans le lot</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>public</modifier> <type>int</type><methodname>MongoDB\Driver\BulkWrite::count</methodname>
+   <void />
+  </methodsynopsis>
+  <para>
+   Renvoie le nombre d'opérations d'écriture ajoutées à l'objet
+    <classname>MongoDB\Driver\BulkWrite</classname>.
+  </para>
+
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Renvoie le nombre d'opérations d'écriture ajoutées à l'objet
+   <classname>MongoDB\Driver\BulkWrite</classname>.
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simplelist>
+   &mongodb.throws.argumentparsing;
+  </simplelist>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>PECL mongodb 1.2.0</entry>
+       <entry>
+        Renvoie le nombre d'opérations d'écriture ajoutées à l'objet
+        <classname>MongoDB\Driver\BulkWrite</classname>. Les versions antérieures
+        renvoyaient le nombre d'aller-retours client-serveur nécessaires pour exécuter
+        toutes les opérations d'écriture.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Exemple de <function>MongoDB\Driver\BulkWrite::count</function></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+
+$bulk = new MongoDB\Driver\BulkWrite;
+$bulk->insert(['_id' => 1, 'x' => 1]);
+$bulk->insert(['_id' => 2, 'x' => 2]);
+$bulk->update(['x' => 2], ['$set' => ['x' => 1]]);
+$bulk->delete(['x' => 1]);
+
+var_dump(count($bulk));
+
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+int(4)
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mongodb/mongodb/driver/bulkwrite/delete.xml
+++ b/reference/mongodb/mongodb/driver/bulkwrite/delete.xml
@@ -1,0 +1,171 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 734bafeaf071b78b15d375f9af583befddd8c2a2 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="mongodb-driver-bulkwrite.delete" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>MongoDB\Driver\BulkWrite::delete</refname>
+  <refpurpose>Ajoute une opération de suppression au lot</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>public</modifier> <type>void</type><methodname>MongoDB\Driver\BulkWrite::delete</methodname>
+   <methodparam><type class="union"><type>array</type><type>object</type></type><parameter>filter</parameter></methodparam>
+   <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>deleteOptions</parameter><initializer>&null;</initializer></methodparam>
+  </methodsynopsis>
+  <para>
+   Ajoute une opération de suppression au
+   <classname>MongoDB\Driver\BulkWrite</classname>.
+  </para>
+
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   &mongodb.parameter.filter;
+   <varlistentry>
+    <term><parameter>deleteOptions</parameter></term>
+    <listitem>
+     <para>
+      <table>
+       <title>deleteOptions</title>
+       <tgroup cols="4">
+        <thead>
+         <row>
+          <entry>Option</entry>
+          <entry>Type</entry>
+          <entry>Description</entry>
+          <entry>Defaut</entry>
+         </row>
+        </thead>
+        <tbody>
+         &mongodb.option.collation;
+         <row>
+          <entry>hint</entry>
+          <entry><type class="union"><type>string</type><type>array</type><type>object</type></type></entry>
+          <entry>
+           <para>
+            Spécification d'index. Spécifiez soit le nom de l'index en tant que chaîne
+            soit le modèle de clé d'index. Si spécifié, le système de requête
+            ne considérera que les plans utilisant l'index suggéré.
+           </para>
+           <para>
+            Cette option est disponible dans MongoDB 4.4+ et entraînera une
+            exception au moment de l'exécution si elle est spécifiée pour une version de serveur
+            plus ancienne.
+           </para>
+          </entry>
+         </row>
+         <row>
+          <entry>limit</entry>
+          <entry><type>bool</type></entry>
+          <entry>Supprime tous les documents correspondants (&false;), ou seulement le premier document correspondant (&true;)</entry>
+          <entry>&false;</entry>
+         </row>
+        </tbody>
+       </tgroup>
+      </table>
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &return.void;
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simplelist>
+   &mongodb.throws.argumentparsing;
+  </simplelist>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>PECL mongodb 1.8.0</entry>
+       <entry>
+        Ajout de l'option <literal>"hint"</literal>.
+       </entry>
+      </row>
+      <row>
+       <entry>PECL mongodb 1.2.0</entry>
+       <entry>
+        Ajout de l'option <literal>"collation"</literal>.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Exemple de <function>MongoDB\Driver\BulkWrite::delete</function></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+
+$bulk = new MongoDB\Driver\BulkWrite;
+$bulk->delete(['x' => 1], ['limit' => 1]);
+$bulk->delete(['x' => 2], ['limit' => 0]);
+
+$manager = new MongoDB\Driver\Manager('mongodb://localhost:27017');
+$result = $manager->executeBulkWrite('db.collection', $bulk);
+
+?>
+]]>
+   </programlisting>
+  </example>
+ </refsect1>
+
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>MongoDB\Driver\Manager::executeBulkWrite</methodname></member>
+   <member><classname>MongoDB\Driver\WriteResult</classname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mongodb/mongodb/driver/bulkwrite/insert.xml
+++ b/reference/mongodb/mongodb/driver/bulkwrite/insert.xml
@@ -1,0 +1,152 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 53242ee6628dc1ae6989fe002231fddfd8f005c6 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes --> 
+<refentry xml:id="mongodb-driver-bulkwrite.insert" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>MongoDB\Driver\BulkWrite::insert</refname>
+  <refpurpose>Ajoute une opération d'insertion au lot</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>public</modifier> <type>mixed</type><methodname>MongoDB\Driver\BulkWrite::insert</methodname>
+   <methodparam><type class="union"><type>array</type><type>object</type></type><parameter>document</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Ajoute une opération d'insertion au
+   <classname>MongoDB\Driver\BulkWrite</classname>.
+  </para>
+
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>document</parameter> (<type class="union"><type>array</type><type>object</type></type>)</term>
+    <listitem>
+     <para>
+      Le document à insérer.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Renvoie l'<literal>_id</literal> du document inséré. Si le
+   <parameter>document</parameter> n'avait pas d'<literal>_id</literal>, le
+   <classname>MongoDB\BSON\ObjectId</classname> généré pour l'insertion sera
+   renvoyé.
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simplelist>
+   &mongodb.throws.argumentparsing;
+  </simplelist>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>PECL mongodb 1.3.0</entry>
+       <entry>
+        L'<literal>_id</literal> du document inséré est toujours renvoyé.
+        Auparavant, la méthode ne renvoyait une valeur que si un
+        <classname>MongoDB\BSON\ObjectId</classname> était généré.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Exemple de <function>MongoDB\Driver\BulkWrite::insert</function></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+
+$bulk = new MongoDB\Driver\BulkWrite;
+
+$document1 = ['title' => 'one'];
+$document2 = ['_id' => 'custom ID', 'title' => 'two'];
+$document3 = ['_id' => new MongoDB\BSON\ObjectId, 'title' => 'three'];
+
+$_id1 = $bulk->insert($document1);
+$_id2 = $bulk->insert($document2);
+$_id3 = $bulk->insert($document3);
+
+var_dump($_id1, $_id2, $_id3);
+
+$manager = new MongoDB\Driver\Manager('mongodb://localhost:27017');
+$result = $manager->executeBulkWrite('db.collection', $bulk);
+
+?>
+]]>
+   </programlisting>
+   &example.outputs.similar;
+   <screen>
+<![CDATA[
+object(MongoDB\BSON\ObjectId)#3 (1) {
+  ["oid"]=>
+  string(24) "54d51146bd21b91405401d92"
+}
+NULL
+NULL
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>MongoDB\Driver\Manager::executeBulkWrite</methodname></member>
+   <member><classname>MongoDB\Driver\WriteResult</classname></member>
+   <member><classname>MongoDB\BSON\ObjectId</classname></member>
+   <member><interfacename>MongoDB\BSON\Persistable</interfacename></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mongodb/mongodb/driver/bulkwrite/update.xml
+++ b/reference/mongodb/mongodb/driver/bulkwrite/update.xml
@@ -1,0 +1,243 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 734bafeaf071b78b15d375f9af583befddd8c2a2 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="mongodb-driver-bulkwrite.update" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>MongoDB\Driver\BulkWrite::update</refname>
+  <refpurpose>Ajoute une opération de mise à jour au lot</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>public</modifier> <type>void</type><methodname>MongoDB\Driver\BulkWrite::update</methodname>
+   <methodparam><type class="union"><type>array</type><type>object</type></type><parameter>filter</parameter></methodparam>
+   <methodparam><type class="union"><type>array</type><type>object</type></type><parameter>newObj</parameter></methodparam>
+   <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>updateOptions</parameter><initializer>&null;</initializer></methodparam>
+  </methodsynopsis>
+  <para>
+   Ajoute une opération de mise à jour au
+   <classname>MongoDB\Driver\BulkWrite</classname>.
+  </para>
+
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   &mongodb.parameter.filter;
+   <varlistentry>
+    <term><parameter>newObj</parameter> (<type class="union"><type>array</type><type>object</type></type>)</term>
+    <listitem>
+     <para>
+      Un document contenant des opérateurs de mise à jour (par exemple
+      <literal>$set</literal>), un document de remplacement (c'est-à-dire
+      <emphasis>seulement</emphasis> des expressions <literal>field:valeur</literal>), ou
+      une <link xlink:href="&url.mongodb.docs.command;update/#update-with-an-aggregation-pipeline">pipeline d'agrégation</link>.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>updateOptions</parameter></term>
+    <listitem>
+     <para>
+      <table>
+       <title>updateOptions</title>
+       <tgroup cols="4">
+        <thead>
+         <row>
+          <entry>Option</entry>
+          <entry>Type</entry>
+          <entry>Description</entry>
+          <entry>Defaut</entry>
+         </row>
+        </thead>
+        <tbody>
+         <row>
+          <entry>arrayFilters</entry>
+          <entry><type>array</type></entry>
+          <entry>
+           <para>
+            Un tableau de documents de filtre qui détermine quels éléments de tableau
+            à modifier pour une opération de mise à jour sur un champ de tableau. Voir
+            <link xlink:href="&url.mongodb.docs.command;update/#update-command-arrayfilters">Spécifier des arrayFilters pour les opérations de mise à jour de tableau</link>
+            dans le manuel MongoDB pour plus d'informations.
+           </para>
+           <para>
+            Cette option est disponible dans MongoDB 3.6+ et entraînera une
+            exception au moment de l'exécution si elle est spécifiée pour une version de serveur
+            plus ancienne.
+           </para>
+          </entry>
+         </row>
+         &mongodb.option.collation;
+         <row>
+          <entry>hint</entry>
+          <entry><type class="union"><type>string</type><type>array</type><type>object</type></type></entry>
+          <entry>
+           <para>
+            Spécification d'index. Spécifiez soit le nom de l'index en tant que chaîne
+            soit le modèle de clé d'index. Si spécifié, le système de requête
+            ne considérera que les plans utilisant l'index suggéré.
+           </para>
+           <para>
+            Cette option est disponible dans MongoDB 4.4+ et entraînera une
+            exception au moment de l'exécution si elle est spécifiée pour une version de serveur
+            plus ancienne.
+           </para>
+          </entry>
+         </row>
+         <row>
+          <entry>multi</entry>
+          <entry><type>bool</type></entry>
+          <entry>
+           Met à jour uniquement le premier document correspondant si &false;, ou tout
+           les documents correspondants &true;. Cette option ne peut pas être &true; si
+           <parameter>newObj</parameter> est un document de remplacement.
+          </entry>
+          <entry>&false;</entry>
+         </row>
+         <row>
+          <entry>upsert</entry>
+          <entry><type>bool</type></entry>
+          <entry>
+           Si <parameter>filter</parameter> ne correspond pas à un document existant,
+           insère un <emphasis>unique</emphasis> document. Le document sera
+           crée à partir de <parameter>newObj</parameter> s'il s'agit d'un document de remplacement
+           (c'est-à-dire aucun opérateurs de mise à jour); sinon, les opérateurs dans
+           <parameter>newObj</parameter> seront appliqués à
+           <parameter>filter</parameter> pour créer le nouveau document.
+          </entry>
+          <entry>&false;</entry>
+         </row>
+        </tbody>
+       </tgroup>
+      </table>
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &return.void;
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simplelist>
+   &mongodb.throws.argumentparsing;
+  </simplelist>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>PECL mongodb 1.7.0</entry>
+       <entry>
+        Ajout de l'option <literal>"hint"</literal>.
+       </entry>
+      </row>
+      <row>
+       <entry>PECL mongodb 1.6.0</entry>
+       <entry>
+        Le paramètre <parameter>newObj</parameter> accepte désormais un pipeline
+        d'agrégation. Cette fonctionnalité nécessite MongoDB 4.2+ et entraînera une
+        exception au moment de l'exécution si elle est spécifiée pour une version de serveur
+        plus ancienne.
+       </entry>
+      </row>
+      <row>
+       <entry>PECL mongodb 1.5.0</entry>
+       <entry>
+        Utiliser l'option <literal>"arrayFilters"</literal> entraînera une exception
+        au moment de l'exécution si elle n'est pas prise en charge par le serveur.
+        Auparavant, aucune exception n'était levée et l'option pouvait être ignorée.
+       </entry>
+      </row>
+      <row>
+       <entry>PECL mongodb 1.4.0</entry>
+       <entry>
+        Ajout de l'option <literal>"arrayFilters"</literal>.
+       </entry>
+      </row>
+      <row>
+       <entry>PECL mongodb 1.2.0</entry>
+       <entry>
+        Ajout de l'option <literal>"collation"</literal>.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Exemple de <function>MongoDB\Driver\BulkWrite::update</function></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+
+$bulk = new MongoDB\Driver\BulkWrite;
+$bulk->update(
+    ['x' => 2],
+    ['$set' => ['y' => 3]],
+    ['multi' => false, 'upsert' => false]
+);
+
+$manager = new MongoDB\Driver\Manager('mongodb://localhost:27017');
+$result = $manager->executeBulkWrite('db.collection', $bulk);
+
+?>
+]]>
+   </programlisting>
+  </example>
+ </refsect1>
+
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>MongoDB\Driver\Manager::executeBulkWrite</methodname></member>
+   <member><classname>MongoDB\Driver\WriteResult</classname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
Here is the translation of missing `MongoDB\Driver\BulkWrite` methods

- `MongoDB\Driver\BulkWrite::__construct()`
- `MongoDB\Driver\BulkWrite::count()`
- `MongoDB\Driver\BulkWrite::delete()`
- `MongoDB\Driver\BulkWrite::insert()`
- `MongoDB\Driver\BulkWrite::update()`