### PR TITLE
Translate `MongoDB\Driver\ClientEncryption`

### DIFF
--- a/reference/mongodb/mongodb/driver/clientencryption/addkeyaltname.xml
+++ b/reference/mongodb/mongodb/driver/clientencryption/addkeyaltname.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 9e9578a5c4288bf10c1675da131c79c4e28252a8 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="mongodb-driver-clientencryption.addkeyaltname" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>MongoDB\Driver\ClientEncryption::addKeyAltName</refname>
+  <refpurpose>Ajoute un nom alternatif à un document clé</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>final</modifier> <modifier>public</modifier> <type class="union"><type>object</type><type>null</type></type><methodname>MongoDB\Driver\ClientEncryption::addKeyAltName</methodname>
+   <methodparam><type>MongoDB\BSON\Binary</type><parameter>keyId</parameter></methodparam>
+   <methodparam><type>string</type><parameter>keyAltName</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Ajoute <parameter>keyAltName</parameter> à l'ensemble des noms alternatifs pour le
+   document clé avec l'UUID donné <parameter>keyId</parameter>.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>keyId</parameter></term>
+    <listitem>
+     <para>
+      Une instance <classname>MongoDB\BSON\Binary</classname> avec le sous-type 4
+      (UUID) identifiant le document clé.
+     </para>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry>
+    <term><parameter>keyAltName</parameter></term>
+    <listitem>
+     <para>
+      Nom alternatif à ajouter au document clé.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Renvoie la version précédente du document clé, ou &null; si aucun document
+   correspondant n'a été trouvé.
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simplelist>
+   &mongodb.throws.std;
+   <member>Lance une <classname>MongoDB\Driver\Exception\RuntimeException</classname> sur d'autres erreurs.</member>
+  </simplelist>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>MongoDB\Driver\ClientEncryption::getKeyByAltName</function></member>
+   <member><function>MongoDB\Driver\ClientEncryption::removeKeyAltName</function></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mongodb/mongodb/driver/clientencryption/construct.xml
+++ b/reference/mongodb/mongodb/driver/clientencryption/construct.xml
@@ -1,0 +1,140 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: cc6f9ee922cc02771942f435f66fbd008bf5788d Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes --> 
+<refentry xml:id="mongodb-driver-clientencryption.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>MongoDB\Driver\ClientEncryption::__construct</refname>
+  <refpurpose>Créer un nouvel objet ClientEncryption</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>final</modifier> <modifier>public</modifier> <methodname>MongoDB\Driver\ClientEncryption::__construct</methodname>
+   <methodparam><type>array</type><parameter>options</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Construit un nouvel objet <classname>MongoDB\Driver\ClientEncryption</classname> avec les options spécifiées.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>options</parameter></term>
+    <listitem>
+     <para>
+      <table>
+       <title>options</title>
+       <tgroup cols="3">
+        <thead>
+         <row>
+          <entry>Option</entry>
+          <entry>Type</entry>
+          <entry>Description</entry>
+         </row>
+        </thead>
+        <tbody>
+         <row>
+          <entry>keyVaultClient</entry>
+          <entry><classname>MongoDB\Driver\Manager</classname></entry>
+          <entry>Le gestionnaire utilisé pour router les requêtes de clé de données. Cette option est requise (contrairement à <function>MongoDB\Driver\Manager::createClientEncryption</function>).</entry>
+         </row>
+         &mongodb.option.encryption.keyVaultNamespace;
+         &mongodb.option.encryption.kmsProviders;
+         &mongodb.option.encryption.tlsOptions;
+        </tbody>
+       </tgroup>
+      </table>
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simplelist>
+   &mongodb.throws.argumentparsing;
+   <member>Lance une <classname>MongoDB\Driver\Exception\RuntimeException</classname> si l'extension n'a pas été compilée avec le support libmongocrypt</member>
+  </simplelist>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>PECL mongodb 1.16.0</entry>
+       <entry>
+        <para>
+         Le fournisseur AWS KMS pour le chiffrement côté client accepte désormais
+         une option <literal>"sessionToken"</literal>, qui peut être utilisée pour
+         s'authentifier avec des informations d'identification AWS temporaires.
+        </para>
+        <para>
+         Ajout de <literal>"tlsDisableOCSPEndpointCheck"</literal> à 
+         l'option <literal>"tlsOptions"</literal>.
+        </para>
+        <para>
+         Si un document vide est spécifié pour le fournisseur KMS <literal>"azure"</literal> ou
+         <literal>"gcp"</literal>, le pilote tentera de configurer le fournisseur en utilisant les
+         <link xlink:href="&url.mongodb.specs;/blob/master/source/client-side-encryption/client-side-encryption.rst#automatic-credentials">Les informations d'identification automatiques</link>.
+        </para>
+       </entry>
+      </row>
+      <row>
+       <entry>PECL mongodb 1.15.0</entry>
+       <entry>
+        <para>
+         Si un document vide est spécifié pour le fournisseur KMS <literal>"aws"</literal>,
+         le pilote tentera de configurer le fournisseur en utilisant les
+         <link xlink:href="&url.mongodb.specs;/blob/master/source/client-side-encryption/client-side-encryption.rst#automatic-credentials">Les informations d'identification automatiques</link>.
+        </para>
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>MongoDB\Driver\Manager::createClientEncryption</function></member>
+   <member><link xlink:href="&url.mongodb.docs;core/security-explicit-client-side-encryption/">L'encryption côté client explicite (manuel)</link> dans le manuel MongoDB</member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mongodb/mongodb/driver/clientencryption/createdatakey.xml
+++ b/reference/mongodb/mongodb/driver/clientencryption/createdatakey.xml
@@ -1,0 +1,164 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 2e94692706b2c5e2515eeeb7ce541c1e289f66ca Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="mongodb-driver-clientencryption.createdatakey" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>MongoDB\Driver\ClientEncryption::createDataKey</refname>
+  <refpurpose>Créer un document clé</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>final</modifier> <modifier>public</modifier> <type>MongoDB\BSON\Binary</type><methodname>MongoDB\Driver\ClientEncryption::createDataKey</methodname>
+   <methodparam><type>string</type><parameter>kmsProvider</parameter></methodparam>
+   <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>options</parameter><initializer>&null;</initializer></methodparam>
+  </methodsynopsis>
+  <para>
+   Créer un nouveau document clé et l'insère dans la collection de coffre de clés.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>kmsProvider</parameter></term>
+    <listitem>
+     <para>
+      Le fournisseur KMS (par exemple <literal>"local"</literal>,
+      <literal>"aws"</literal>) qui sera utilisé pour chiffrer le nouveau document clé.
+     </para>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry>
+    <term><parameter>options</parameter></term>
+    <listitem>
+     <para>
+      <table>
+       <title>Options de données de clé</title>
+       <tgroup cols="3">
+        <thead>
+         <row>
+          <entry>Option</entry>
+          <entry>Type</entry>
+          <entry>Description</entry>
+         </row>
+        </thead>
+        <tbody>
+         <row>
+          <entry>masterKey</entry>
+          <entry><type>array</type></entry>
+          <entry>
+           <para>
+            Le document masterKey identifie une clé spécifique à KMS utilisée pour
+            chiffrer le nouveau document clé. Cette option est requise à moins que
+            <parameter>kmsProvider</parameter> soit <literal>"local"</literal>.
+           </para>
+           &mongodb.option.encryption.masterKey-options-by-provider;
+          </entry>
+         </row>
+         <row>
+          <entry>keyAltNames</entry>
+          <entry><type>array</type></entry>
+          <entry>
+           <para>
+            Une liste optionnelle de noms alternatifs de chaîne utilisés pour référencer une clé.
+            Si une clé est créée avec des noms alternatifs, alors le chiffrement peut se référer
+            à la clé par le nom alternatif unique au lieu de par
+            <literal>_id</literal>.
+           </para>
+          </entry>
+         </row>
+         <row>
+          <entry>keyMaterial</entry>
+          <entry><classname>MongoDB\BSON\Binary</classname></entry>
+          <entry>
+           <para>
+            Une valeur optionnelle de 96 octets à utiliser comme matériel de clé
+            pour le document clé en cours de création. Si keyMateria est donné,
+            le matériel de clé personnalisé est utilisé pour chiffrer et déchiffrer
+            les données. Sinon, le matériel de clé pour le nouveau document clé est
+            généré à partir d'un dispositif aléatoire cryptographiquement sécurisé.
+           </para>
+          </entry>
+         </row>
+        </tbody>
+       </tgroup>
+      </table>
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Renvoie un identifiant du nouveau document clé en tant qu'objet
+   <classname>MongoDB\BSON\Binary</classname> avec le sous-type 4 (UUID).
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simplelist>
+   &mongodb.throws.std;
+   <member>Lance une <classname>MongoDB\Driver\Exception\RuntimeException</classname> sur d'autres erreurs.</member>
+  </simplelist>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>PECL mongodb 1.15.0</entry>
+       <entry>
+        Ajout de l'option <literal>"keyMaterial"</literal>.
+       </entry>
+      </row>
+      <row>
+       <entry>PECL mongodb 1.10.0</entry>
+       <entry>
+        Azure et GCP sont désormais pris en charge en tant que fournisseurs KMS pour
+        le chiffrement côté client.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </para>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mongodb/mongodb/driver/clientencryption/decrypt.xml
+++ b/reference/mongodb/mongodb/driver/clientencryption/decrypt.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: b63591939951b1551d47b40650fbfb4693490d16 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes --> 
+<refentry xml:id="mongodb-driver-clientencryption.decrypt" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>MongoDB\Driver\ClientEncryption::decrypt</refname>
+  <refpurpose>Déchiffre une valeur</refpurpose>
+ </refnamediv>
+ 
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>final</modifier> <modifier>public</modifier> <type>mixed</type><methodname>MongoDB\Driver\ClientEncryption::decrypt</methodname>
+   <methodparam><type>MongoDB\BSON\Binary</type><parameter>value</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Déchiffre la valeur.
+  </para>
+ </refsect1>
+ 
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>value</parameter></term>
+    <listitem>
+     <para>
+      Une instance de <classname>MongoDB\BSON\Binary</classname> avec le sous-type 6
+      contenant la valeur chiffrée.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Renvoie la valeur déchiffrée telle qu'elle a été passée à
+   <function>MongoDB\Driver\ClientEncryption::encrypt</function>.
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simplelist>
+   &mongodb.throws.argumentparsing;
+   <member>Lance une <classname>MongoDB\Driver\Exception\EncryptionException</classname> si une erreur se produit lors du déchiffrement de la valeur</member>
+  </simplelist>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>MongoDB\Driver\ClientEncryption::encrypt</function></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mongodb/mongodb/driver/clientencryption/deletekey.xml
+++ b/reference/mongodb/mongodb/driver/clientencryption/deletekey.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 9e9578a5c4288bf10c1675da131c79c4e28252a8 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="mongodb-driver-clientencryption.deletekey" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>MongoDB\Driver\ClientEncryption::deleteKey</refname>
+  <refpurpose>Supprime un document clé</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>final</modifier> <modifier>public</modifier> <type>object</type><methodname>MongoDB\Driver\ClientEncryption::deleteKey</methodname>
+   <methodparam><type>MongoDB\BSON\Binary</type><parameter>keyId</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Enlève le document clé avec l'UUID donné <parameter>keyId</parameter>
+   de la collection de coffre de clés.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>keyId</parameter></term>
+    <listitem>
+     <para>
+      Une instance de <classname>MongoDB\BSON\Binary</classname> avec le sous-type 4
+      (UUID) identifiant le document clé.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Renvoie le résultat de l'opération interne <literal>deleteOne</literal> sur
+   la collection de coffre de clés.
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simplelist>
+   &mongodb.throws.std;
+   <member>Lance une <classname>MongoDB\Driver\Exception\RuntimeException</classname> sur d'autres erreurs.</member>
+  </simplelist>
+ </refsect1>
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mongodb/mongodb/driver/clientencryption/encrypt.xml
+++ b/reference/mongodb/mongodb/driver/clientencryption/encrypt.xml
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 807296daf8be8e09e4a160d7eba832451d1b5e45 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="mongodb-driver-clientencryption.encrypt" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>MongoDB\Driver\ClientEncryption::encrypt</refname>
+  <refpurpose>Chiffre une valeur</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>final</modifier> <modifier>public</modifier> <type>MongoDB\BSON\Binary</type><methodname>MongoDB\Driver\ClientEncryption::encrypt</methodname>
+   <methodparam><type>mixed</type><parameter>value</parameter></methodparam>
+   <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>options</parameter><initializer>&null;</initializer></methodparam>
+  </methodsynopsis>
+  <para>
+   Chiffre la valeur.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>value</parameter></term>
+    <listitem>
+     <para>
+      La valeur à chiffrer. Toute valeur qui peut être insérée dans MongoDB peut
+      être chiffrée en utilisant cette méthode.
+     </para>
+    </listitem>
+   </varlistentry>
+   &mongodb.parameter.encryptOpts;
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Renvoie la valeur chiffrée en tant qu'un objet 
+   <function>MongoDB\Driver\ClientEncryption::decrypt</function> de sous-type 6.
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simplelist>
+   &mongodb.throws.argumentparsing;
+   <member>Lance une <classname>MongoDB\Driver\Exception\EncryptionException</classname> si une erreur se produit lors du chiffrement de la valeur</member>
+  </simplelist>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>PECL mongodb 1.14.0</entry>
+       <entry>
+        Ajout des options <literal>"contentionFactor"</literal> et
+        <literal>"queryType"</literal>.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>MongoDB\Driver\ClientEncryption::decrypt</function></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mongodb/mongodb/driver/clientencryption/encryptexpression.xml
+++ b/reference/mongodb/mongodb/driver/clientencryption/encryptexpression.xml
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: e9214a2619efc5906fab59cd42fb7404c4dc49a5 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="mongodb-driver-clientencryption.encryptexpression" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>MongoDB\Driver\ClientEncryption::encryptExpression</refname>
+  <refpurpose>Chiffre une expression de correspondance ou d'agrégation</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>final</modifier> <modifier>public</modifier> <type>object</type><methodname>MongoDB\Driver\ClientEncryption::encryptExpression</methodname>
+   <methodparam><type class="union"><type>array</type><type>object</type></type><parameter>expr</parameter></methodparam>
+   <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>options</parameter><initializer>&null;</initializer></methodparam>
+  </methodsynopsis>
+  <para>
+   Chiffre une expression de correspondance ou d'agrégation pour interroger un index de plage.
+  </para>
+  <para>Pour interroger avec une charge utile chiffrée par plage, l'option de pilote <classname>MongoDB\Driver\Manager</classname> doit être configurée avec l'option de pilote <literal>"autoEncryption"</literal>. L'option de chiffrement automatique <literal>"bypassQueryAnalysis"</literal> peut être &true;. L'option de chiffrement automatique <literal>"bypassAutoEncryption"</literal> doit être &false;.</para>
+  <note>
+   <para>L'algorithme de plage est expérimental uniquement. Il n'est pas destiné à un usage public.</para>
+   <para>L'extension ne prend pas encore en charge les requêtes de plage pour les types de champ BSON Decimal128.</para>
+  </note>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>expr</parameter></term>
+    <listitem>
+     <para>
+      L'expression de correspondance ou d'agrégation à chiffrer. Les expressions doivent
+      utiliser au moins un des opérateurs <literal>$gt</literal>, <literal>$gte</literal>,
+      <literal>$lt</literal> ou <literal>$lte</literal>. Un opérateur de
+      comparaison unique est utilisé.
+     </para>
+     <para>
+      Un exemple d'expression de correspondance prise en charge (s'applique aux requêtes et à l'étape d'agrégation
+      <literal>$match</literal>) est le suivant :
+     </para>
+     <programlisting role="text">
+<![CDATA[
+[
+    '$and' => [
+        [ '<field>' => [ '$gt'  => '<value1>' ] ],
+        [ '<field>' => [ '$lte' => '<value2>' ] ],
+    ],
+]
+]]>
+     </programlisting>
+     <para>
+      Un exemple d'expression d'agrégation prise en charge est le suivant :
+     </para>
+     <programlisting role="text">
+<![CDATA[
+[
+    '$and' => [
+        [ '$gte' => [ '<fieldPath>', '<value1>' ] ],
+        [ '$lt'  => [ '<fieldPath>', '<value2>' ] ],
+    ],
+]
+]]>
+     </programlisting>
+    </listitem>
+   </varlistentry>
+   &mongodb.parameter.encryptOpts;
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Renvoie l'expression chiffrée en tant qu'objet.
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simplelist>
+   &mongodb.throws.argumentparsing;
+   <member>Lance une <classname>MongoDB\Driver\Exception\EncryptionException</classname> si une erreur se produit lors du chiffrement de l'expression</member>
+  </simplelist>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>MongoDB\Driver\Manager::__construct</function></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mongodb/mongodb/driver/clientencryption/getkey.xml
+++ b/reference/mongodb/mongodb/driver/clientencryption/getkey.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 9e9578a5c4288bf10c1675da131c79c4e28252a8 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="mongodb-driver-clientencryption.getkey" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>MongoDB\Driver\ClientEncryption::getKey</refname>
+  <refpurpose>Renvoie un document clé</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>final</modifier> <modifier>public</modifier> <type class="union"><type>object</type><type>null</type></type><methodname>MongoDB\Driver\ClientEncryption::getKey</methodname>
+   <methodparam><type>MongoDB\BSON\Binary</type><parameter>keyId</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Trouve un document clé unique dans la collection de coffre de clés avec l'UUID donné
+   <parameter>keyId</parameter>.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>keyId</parameter></term>
+    <listitem>
+     <para>
+      Une instance de <classname>MongoDB\BSON\Binary</classname> avec le sous-type 4
+      (UUID) identifiant le document clé.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Renvoie le document clé, ou &null; si aucun document n'a été trouvé.
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simplelist>
+   &mongodb.throws.std;
+   <member>Lance une <classname>MongoDB\Driver\Exception\RuntimeException</classname> sur d'autres erreurs.</member>
+  </simplelist>
+ </refsect1>
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mongodb/mongodb/driver/clientencryption/getkeybyaltname.xml
+++ b/reference/mongodb/mongodb/driver/clientencryption/getkeybyaltname.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 9e9578a5c4288bf10c1675da131c79c4e28252a8 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="mongodb-driver-clientencryption.getkeybyaltname" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>MongoDB\Driver\ClientEncryption::getKeyByAltName</refname>
+  <refpurpose>Renvoie un document clé par un nom alternatif</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>final</modifier> <modifier>public</modifier> <type class="union"><type>object</type><type>null</type></type><methodname>MongoDB\Driver\ClientEncryption::getKeyByAltName</methodname>
+   <methodparam><type>string</type><parameter>keyAltName</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Trouve un document clé unique dans la collection de coffre de clés avec
+   le nom alternatif donné <parameter>keyAltName</parameter>.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>keyAltName</parameter></term>
+    <listitem>
+     <para>
+      Le nom alternatif pour le document clé.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Renvoie le document clé, ou &null; si aucun document n'a été trouvé.
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simplelist>
+   &mongodb.throws.std;
+   <member>Lance une <classname>MongoDB\Driver\Exception\RuntimeException</classname> sur d'autres erreurs.</member>
+  </simplelist>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>MongoDB\Driver\ClientEncryption::addKeyAltName</function></member>
+   <member><function>MongoDB\Driver\ClientEncryption::removeKeyAltName</function></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mongodb/mongodb/driver/clientencryption/getkeys.xml
+++ b/reference/mongodb/mongodb/driver/clientencryption/getkeys.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 9e9578a5c4288bf10c1675da131c79c4e28252a8 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="mongodb-driver-clientencryption.getkeys" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>MongoDB\Driver\ClientEncryption::getKeys</refname>
+  <refpurpose>Renvoie tous les documents clés</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>final</modifier> <modifier>public</modifier> <type>MongoDB\Driver\Cursor</type><methodname>MongoDB\Driver\ClientEncryption::getKeys</methodname>
+   <void />
+  </methodsynopsis>
+  <para>
+   Trouve tous les documents clés dans la collection de coffre de clés.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  &mongodb.returns.cursor;
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simplelist>
+   &mongodb.throws.std;
+   <member>Lance une <classname>MongoDB\Driver\Exception\RuntimeException</classname> sur d'autres erreurs.</member>
+  </simplelist>
+ </refsect1>
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mongodb/mongodb/driver/clientencryption/removekeyaltname.xml
+++ b/reference/mongodb/mongodb/driver/clientencryption/removekeyaltname.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 9e9578a5c4288bf10c1675da131c79c4e28252a8 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="mongodb-driver-clientencryption.removekeyaltname" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>MongoDB\Driver\ClientEncryption::removeKeyAltName</refname>
+  <refpurpose>Enlève un nom alternatif d'un document clé</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>final</modifier> <modifier>public</modifier> <type class="union"><type>object</type><type>null</type></type><methodname>MongoDB\Driver\ClientEncryption::removeKeyAltName</methodname>
+   <methodparam><type>MongoDB\BSON\Binary</type><parameter>keyId</parameter></methodparam>
+   <methodparam><type>string</type><parameter>keyAltName</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Enlève <parameter>keyAltName</parameter> de l'ensemble des noms alternatifs pour
+   le document clé avec l'UUID donné <parameter>keyId</parameter>.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>keyId</parameter></term>
+    <listitem>
+     <para>
+      Une instance de <classname>MongoDB\BSON\Binary</classname> avec le sous-type 4
+      (UUID) identifiant le document clé.
+     </para>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry>
+    <term><parameter>keyAltName</parameter></term>
+    <listitem>
+     <para>
+      Le nom alternatif à enlever du document clé.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Renvoie la version précédente du document clé, ou &null; si aucun document
+   n'a été trouvé.
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simplelist>
+   &mongodb.throws.std;
+   <member>Lance une <classname>MongoDB\Driver\Exception\RuntimeException</classname> sur d'autres erreurs.</member>
+  </simplelist>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>MongoDB\Driver\ClientEncryption::addKeyAltName</function></member>
+   <member><function>MongoDB\Driver\ClientEncryption::getKeyByAltName</function></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mongodb/mongodb/driver/clientencryption/rewrapmanydatakey.xml
+++ b/reference/mongodb/mongodb/driver/clientencryption/rewrapmanydatakey.xml
@@ -1,0 +1,126 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 9e9578a5c4288bf10c1675da131c79c4e28252a8 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="mongodb-driver-clientencryption.rewrapmanydatakey" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>MongoDB\Driver\ClientEncryption::rewrapManyDataKey</refname>
+  <refpurpose>Ré-emballe les clés de données</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>final</modifier> <modifier>public</modifier> <type>object</type><methodname>MongoDB\Driver\ClientEncryption::rewrapManyDataKey</methodname>
+   <methodparam><type class="union"><type>array</type><type>object</type></type><parameter>filter</parameter></methodparam>
+   <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>options</parameter><initializer>&null;</initializer></methodparam>
+  </methodsynopsis>
+  <para>
+   Ré-emballe (c'est-à-dire déchiffre et rechiffre) zéro ou plusieurs clés de données
+   dans la collection de coffre de clés qui correspondent au <parameter>filter</parameter> donné.
+  </para>
+  <para>
+   Si l'option <literal>"provider"</literal> n'est pas spécifiée, les clés de données
+   correspondantes seront ré-emballées avec leur fournisseur KMS actuel. Sinon, les clés de données
+   correspondantes seront rechiffrées selon les options <literal>"provider"</literal> et
+   <literal>"masterKey"</literal> spécifiées.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   &mongodb.parameter.filter;
+   <varlistentry>
+    <term><parameter>options</parameter></term>
+    <listitem>
+     <para>
+      <table>
+       <title>Options de RewrapManyDataKey</title>
+       <tgroup cols="3">
+        <thead>
+         <row>
+          <entry>Option</entry>
+          <entry>Type</entry>
+          <entry>Description</entry>
+         </row>
+        </thead>
+        <tbody>
+         <row>
+          <entry>provider</entry>
+          <entry><type>string</type></entry>
+          <entry>
+           <para>
+            Le fournisseur KMS (par exemple <literal>"local"</literal>,
+            <literal>"aws"</literal>) qui sera utilisé pour rechiffrer les
+            clés de données correspondantes.
+           </para>
+           <para>
+            Si un fournisseur KMS n'est pas spécifié, les clés de données
+            correspondantes seront rechiffrées avec leur fournisseur KMS actuel.
+           </para>
+          </entry>
+         </row>
+         <row>
+          <entry>masterKey</entry>
+          <entry><type>array</type></entry>
+          <entry>
+           <para>
+            La clé masterKey identifie une clé spécifique à un KMS utilisée pour
+            chiffrer la nouvelle clé de données. Cette option ne doit pas être spécifiée sans
+            l'option <literal>"provider"</literal>. Cette option est requise si
+            <literal>"provider"</literal> est spécifié et n'est pas
+            <literal>"local"</literal>.
+           </para>
+           &mongodb.option.encryption.masterKey-options-by-provider;
+          </entry>
+         </row>
+        </tbody>
+       </tgroup>
+      </table>
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Renvoie un objet, qui aura éventuellement une propriété
+   <literal>bulkWriteResult</literal> contenant le résultat de l'opération
+   <literal>bulkWrite</literal> interne sous forme d'un objet. Si aucune clé de données
+   n'a correspondu au filtre ou si l'écriture n'a pas été acquittée, la propriété
+   <literal>bulkWriteResult</literal> sera &null;.
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simplelist>
+   &mongodb.throws.std;
+   <member>Lance une <classname>MongoDB\Driver\Exception\EncryptionException</classname> si une erreur se produit lors du déchiffrement ou du rechiffrement d'une clé de données.</member>
+   <member>Lance une <classname>MongoDB\Driver\Exception\RuntimeException</classname> sur d'autres erreurs.</member>
+  </simplelist>
+ </refsect1>
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
Here is the translation of missing `MongoDB\Driver\ClientEncryption` methods

- `MongoDB\Driver\ClientEncryption::addKeyAltName()`
- `MongoDB\Driver\ClientEncryption::__construct()`
- `MongoDB\Driver\ClientEncryption::createDataKey()`
- `MongoDB\Driver\ClientEncryption::decrypt()`
- `MongoDB\Driver\ClientEncryption::deleteKey()`
- `MongoDB\Driver\ClientEncryption::encrypt()`
- `MongoDB\Driver\ClientEncryption::encrypExpression()`
- `MongoDB\Driver\ClientEncryption::getKey()`
- `MongoDB\Driver\ClientEncryption::getKeyByAltName()`
- `MongoDB\Driver\ClientEncryption::getKeys()`
- `MongoDB\Driver\ClientEncryption::removeKeyAltName()`
- `MongoDB\Driver\ClientEncryption::rewrapManyDataKey()`