### PR TITLE
Translate `Imagick\ImagickKernel`

### DIFF
--- a/reference/imagick/imagickkernel/addkernel.xml
+++ b/reference/imagick/imagickkernel/addkernel.xml
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 1534707f677267513659e57f530ed5f4cf08f924 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="imagickkernel.addkernel" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>ImagickKernel::addKernel</refname>
+  <refpurpose>Attache un autre noyau à une liste de noyaux</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>public</modifier> <type>void</type><methodname>ImagickKernel::addKernel</methodname>
+   <methodparam><type>ImagickKernel</type><parameter>ImagickKernel</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Attache un autre noyau à ce noyau pour leur permettre d'être tous deux appliqués dans une seule fonction de morphologie ou de filtre. Renvoie le nouveau noyau combiné.
+  </para>
+
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>ImagickKernel</parameter></term>
+    <listitem>
+     <para>
+      
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   
+  </para>
+ </refsect1>
+
+
+
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+    <example>
+      <title> <function>ImagickKernel::addKernel</function></title>
+      <programlisting role="php">
+      <![CDATA[
+<?php
+function addKernel($imagePath) {
+    $matrix1 = [
+        [-1, -1, -1],
+        [ 0,  0,  0],
+        [ 1,  1,  1],
+    ];
+
+    $matrix2 = [
+        [-1,  0,  1],
+        [-1,  0,  1],
+        [-1,  0,  1],
+    ];
+
+    $kernel1 = ImagickKernel::fromMatrix($matrix1);
+    $kernel2 = ImagickKernel::fromMatrix($matrix2);
+    $kernel1->addKernel($kernel2);
+
+    $imagick = new \Imagick(realpath($imagePath));
+    $imagick->filter($kernel1);
+    header("Content-Type: image/jpg");
+    echo $imagick->getImageBlob();
+
+}
+
+?>
+]]>
+      </programlisting>
+    </example>
+  </para>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/imagick/imagickkernel/addunitykernel.xml
+++ b/reference/imagick/imagickkernel/addunitykernel.xml
@@ -1,0 +1,154 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 1534707f677267513659e57f530ed5f4cf08f924 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="imagickkernel.addunitykernel" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>ImagickKernel::addUnityKernel</refname>
+  <refpurpose>Ajoute un noyau Unity à la liste des noyaux</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>public</modifier> <type>void</type><methodname>ImagickKernel::addUnityKernel</methodname>
+   <methodparam><type>float</type><parameter>scale</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Ajoute une quantité donnée du noyau de convolution 'Unity' au noyau de convolution pré-échelonné
+   et normalisé donné. Cela a pour effet d'ajouter cette quantité de l'image d'origine
+   dans le noyau de convolution résultant. L'effet résultant est de convertir les noyaux
+   définis en flous doux mélangés, en noyaux non tranchants ou en noyaux de netteté.
+  </para>
+
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   
+  </para>
+ </refsect1>
+
+
+
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+    <example>
+      <title> <function>ImagickKernel::addUnityKernel</function></title>
+      <programlisting role="php">
+      <![CDATA[
+<?php
+
+
+
+    function renderKernelTable($matrix) {
+        $output = "<table class='infoTable'>";
+    
+        foreach ($matrix as $row) {
+            $output .= "<tr>";
+            foreach ($row as $cell) {
+                $output .= "<td style='text-align:left'>";
+                if ($cell === false) {
+                    $output .= "false";
+                }
+                else {
+                    $output .= round($cell, 3);
+                }
+                $output .= "</td>";
+            }
+            $output .= "</tr>";
+        }
+    
+        $output .= "</table>";
+    
+        return $output;
+    }
+
+    $matrix = [
+        [-1, 0, -1],
+        [ 0, 4,  0],
+        [-1, 0, -1],
+    ];
+
+    $kernel = \ImagickKernel::fromMatrix($matrix);
+    $kernel->scale(1, \Imagick::NORMALIZE_KERNEL_VALUE);
+    $output = "Before adding unity kernel: <br/>";
+    $output .= renderKernelTable($kernel->getMatrix());
+    $kernel->addUnityKernel(0.5);
+    $output .= "After adding unity kernel: <br/>";
+    $output .= renderKernelTable($kernel->getMatrix());
+    
+    
+    $kernel->scale(1, \Imagick::NORMALIZE_KERNEL_VALUE);
+    $output .= "After renormalizing kernel: <br/>";
+    $output .= renderKernelTable($kernel->getMatrix());
+
+    echo $output;
+
+?>
+]]>
+      </programlisting>
+    </example>
+
+    <example>
+      <title> <function>ImagickKernel::addUnityKernel</function></title>
+      <programlisting role="php">
+      <![CDATA[
+<?php
+function addUnityKernel($imagePath) {
+
+    $matrix = [
+        [-1, 0, -1],
+        [ 0, 4,  0],
+        [-1, 0, -1],
+    ];
+
+    $kernel = ImagickKernel::fromMatrix($matrix);
+
+    $kernel->scale(4, \Imagick::NORMALIZE_KERNEL_VALUE);
+    $kernel->addUnityKernel(0.5);
+
+
+    $imagick = new \Imagick(realpath($imagePath));
+    $imagick->filter($kernel);
+    header("Content-Type: image/jpg");
+    echo $imagick->getImageBlob();
+
+}
+
+?>
+]]>
+      </programlisting>
+    </example>
+  </para>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/imagick/imagickkernel/frombuiltin.xml
+++ b/reference/imagick/imagickkernel/frombuiltin.xml
@@ -1,0 +1,212 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 1ef9c7a76700b3e72844050d75e6ed1b870f9ca7 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="imagickkernel.frombuiltin" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>ImagickKernel::fromBuiltIn</refname>
+  <refpurpose>Créer un noyau à partir d'un noyau intégré</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>public</modifier> <modifier>static</modifier> <type>ImagickKernel</type><methodname>ImagickKernel::fromBuiltin</methodname>
+   <methodparam><type>int</type><parameter>kernelType</parameter></methodparam>
+   <methodparam><type>string</type><parameter>kernelString</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Créer un noyau à partir d'un noyau intégré. Voir http://www.imagemagick.org/Usage/morphology/#kernel pour des exemples. Actuellement, les symboles de 'rotation' ne sont pas pris en charge. Exemple :
+   $diamondKernel = ImagickKernel::fromBuiltIn(\Imagick::KERNEL_DIAMOND, "2");
+  </para>
+
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>kerneltype</parameter></term>
+    <listitem>
+     <para>
+      Le type de noyau à construire par exemple \Imagick::KERNEL_DIAMOND
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>kernelString</parameter></term>
+    <listitem>
+     <para>
+      Une chaîne qui décrit les paramètres par exemple "4,2.5"
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   
+  </para>
+ </refsect1>
+
+
+
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+    <example>
+      <title> <function>ImagickKernel::fromBuiltin</function></title>
+      <programlisting role="php">
+      <![CDATA[
+<?php
+
+
+function renderKernel(ImagickKernel $imagickKernel) {
+    $matrix = $imagickKernel->getMatrix();
+    
+    $imageMargin = 20;
+    
+    $tileSize = 20;
+    $tileSpace = 4;
+    $shadowSigma = 4;
+    $shadowDropX = 20;
+    $shadowDropY = 0;
+
+    $radius = ($tileSize / 2) * 0.9;
+    
+    $rows = count($matrix);
+    $columns = count($matrix[0]);
+ 
+    $imagickDraw = new \ImagickDraw();
+
+    $imagickDraw->setFillColor('#afafaf');
+    $imagickDraw->setStrokeColor('none');
+    
+    $imagickDraw->translate($imageMargin, $imageMargin);
+    $imagickDraw->push();
+
+    ksort($matrix);
+    
+    foreach ($matrix as $row) {
+        ksort($row);
+        $imagickDraw->push();
+        foreach ($row as $cell) {
+            if ($cell !== false) {
+                $color = intval(255 * $cell);
+                $colorString = sprintf("rgb(%f, %f, %f)", $color, $color, $color);
+                $imagickDraw->setFillColor($colorString);
+                $imagickDraw->rectangle(0, 0, $tileSize, $tileSize);
+            }
+            $imagickDraw->translate(($tileSize + $tileSpace), 0);
+        }
+        $imagickDraw->pop();
+        $imagickDraw->translate(0, ($tileSize + $tileSpace));
+    }
+
+    $imagickDraw->pop();
+
+    $width = ($columns * $tileSize) + (($columns - 1) * $tileSpace);
+    $height = ($rows * $tileSize) + (($rows - 1) * $tileSpace);
+
+    $imagickDraw->push();
+    $imagickDraw->translate($width/2 , $height/2);
+    $imagickDraw->setFillColor('rgba(0, 0, 0, 0)');
+    $imagickDraw->setStrokeColor('white');
+    $imagickDraw->circle(0, 0, $radius - 1, 0);
+    $imagickDraw->setStrokeColor('black');
+    $imagickDraw->circle(0, 0, $radius, 0);
+    $imagickDraw->pop();
+
+    $canvasWidth = $width + (2 * $imageMargin); 
+    $canvasHeight = $height + (2 * $imageMargin);
+
+    $kernel = new \Imagick();
+    $kernel->newPseudoImage(
+        $canvasWidth,
+        $canvasHeight,
+        'canvas:none'
+    );
+
+    $kernel->setImageFormat('png');
+    $kernel->drawImage($imagickDraw);
+ 
+    /* créer une ombre portée sur sa propre couche */
+    $canvas = $kernel->clone();
+    $canvas->setImageBackgroundColor(new \ImagickPixel('rgb(0, 0, 0)'));
+    $canvas->shadowImage(100, $shadowSigma, $shadowDropX, $shadowDropY);
+
+    $canvas->setImagePage($canvasWidth, $canvasHeight, -5, -5);
+    $canvas->cropImage($canvasWidth, $canvasHeight, 0, 0);
+    
+    /* composite original text_layer onto shadow_layer */
+    $canvas->compositeImage($kernel, \Imagick::COMPOSITE_OVER, 0, 0);
+    $canvas->setImageFormat('png');
+
+    return $canvas;
+}
+
+
+function createFromBuiltin($kernelType, $kernelFirstTerm, $kernelSecondTerm, $kernelThirdTerm) {
+    $string = '';
+
+    if ($kernelFirstTerm != false && strlen(trim($kernelFirstTerm)) != 0) {
+        $string .= $kernelFirstTerm;
+
+        if ($kernelSecondTerm != false && strlen(trim($kernelSecondTerm)) != 0) {
+            $string .= ','.$kernelSecondTerm;
+            if ($kernelThirdTerm != false && strlen(trim($kernelThirdTerm)) != 0) {
+                $string .= ','.$kernelThirdTerm;
+            }
+        }
+    }
+
+    $kernel = ImagickKernel::fromBuiltIn(
+        $kernelType,
+        $string
+    );
+
+    return $kernel;
+}
+    
+function fromBuiltin($kernelType, $kernelFirstTerm, $kernelSecondTerm, $kernelThirdTerm) {
+    $diamondKernel = createFromBuiltin($kernelType, $kernelFirstTerm, $kernelSecondTerm, $kernelThirdTerm);
+    $imagick = renderKernel($diamondKernel);
+
+    header("Content-Type: image/png");
+    echo $imagick->getImageBlob();
+}
+
+fromBuiltin(\Imagick::KERNEL_DIAMOND, 2, false, false);
+
+
+?>
+]]>
+      </programlisting>
+    </example>
+  </para>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/imagick/imagickkernel/frommatrix.xml
+++ b/reference/imagick/imagickkernel/frommatrix.xml
@@ -1,0 +1,199 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 1534707f677267513659e57f530ed5f4cf08f924 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="imagickkernel.frommatrix" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>ImagickKernel::fromMatrix</refname>
+  <refpurpose>Créer un noyau à partir d'une matrice 2D de valeurs</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>public</modifier> <modifier>static</modifier> <type>ImagickKernel</type><methodname>ImagickKernel::fromMatrix</methodname>
+   <methodparam><type>array</type><parameter>matrix</parameter></methodparam>
+   <methodparam choice="opt"><type>array</type><parameter>origin</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Créer un noyau à partir d'une matrice 2D de valeurs. Chaque valeur doit être soit un flottant
+   (si l'élément doit être utilisé) ou 'false' si l'élément doit être ignoré. Pour
+   les matrices qui ont des tailles impaires dans les deux dimensions, le pixel d'origine sera par défaut
+   au centre du noyau. Pour toutes les autres tailles de noyau, le pixel d'origine doit être spécifié.
+  </para>
+
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>array</parameter></term>
+    <listitem>
+     <para>
+      Une matrice (c'est-à-dire un tableau 2D) de valeurs qui définissent le noyau. Chaque élément doit être soit une valeur flottante, ou FALSE si cet élément ne doit pas être utilisé par le noyau.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>array</parameter></term>
+    <listitem>
+     <para>
+      Quel élément du noyau doit être utilisé comme pixel d'origine. Par exemple, pour une matrice 3x3 spécifiant l'origine comme [2, 2] spécifierait que l'élément en bas à droite devrait être le pixel d'origine.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   L'objet ImagickKernel généré.
+  </para>
+ </refsect1>
+
+
+
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+    <example>
+      <title> <function>ImagickKernel::fromMatrix</function></title>
+      <programlisting role="php">
+      <![CDATA[
+<?php
+
+function renderKernel(ImagickKernel $imagickKernel) {
+    $matrix = $imagickKernel->getMatrix();
+    
+    $imageMargin = 20;
+    
+    $tileSize = 20;
+    $tileSpace = 4;
+    $shadowSigma = 4;
+    $shadowDropX = 20;
+    $shadowDropY = 0;
+
+    $radius = ($tileSize / 2) * 0.9;
+    
+    $rows = count($matrix);
+    $columns = count($matrix[0]);
+ 
+    $imagickDraw = new \ImagickDraw();
+
+    $imagickDraw->setFillColor('#afafaf');
+    $imagickDraw->setStrokeColor('none');
+    
+    $imagickDraw->translate($imageMargin, $imageMargin);
+    $imagickDraw->push();
+
+    ksort($matrix);
+    
+    foreach ($matrix as $row) {
+        ksort($row);
+        $imagickDraw->push();
+        foreach ($row as $cell) {
+            if ($cell !== false) {
+                $color = intval(255 * $cell);
+                $colorString = sprintf("rgb(%f, %f, %f)", $color, $color, $color);
+                $imagickDraw->setFillColor($colorString);
+                $imagickDraw->rectangle(0, 0, $tileSize, $tileSize);
+            }
+            $imagickDraw->translate(($tileSize + $tileSpace), 0);
+        }
+        $imagickDraw->pop();
+        $imagickDraw->translate(0, ($tileSize + $tileSpace));
+    }
+
+    $imagickDraw->pop();
+
+    $width = ($columns * $tileSize) + (($columns - 1) * $tileSpace);
+    $height = ($rows * $tileSize) + (($rows - 1) * $tileSpace);
+
+    $imagickDraw->push();
+    $imagickDraw->translate($width/2 , $height/2);
+    $imagickDraw->setFillColor('rgba(0, 0, 0, 0)');
+    $imagickDraw->setStrokeColor('white');
+    $imagickDraw->circle(0, 0, $radius - 1, 0);
+    $imagickDraw->setStrokeColor('black');
+    $imagickDraw->circle(0, 0, $radius, 0);
+    $imagickDraw->pop();
+
+    $canvasWidth = $width + (2 * $imageMargin); 
+    $canvasHeight = $height + (2 * $imageMargin);
+
+    $kernel = new \Imagick();
+    $kernel->newPseudoImage(
+        $canvasWidth,
+        $canvasHeight,
+        'canvas:none'
+    );
+
+    $kernel->setImageFormat('png');
+    $kernel->drawImage($imagickDraw);
+ 
+    /* créer une ombre portée sur sa propre couche */
+    $canvas = $kernel->clone();
+    $canvas->setImageBackgroundColor(new \ImagickPixel('rgb(0, 0, 0)'));
+    $canvas->shadowImage(100, $shadowSigma, $shadowDropX, $shadowDropY);
+
+    $canvas->setImagePage($canvasWidth, $canvasHeight, -5, -5);
+    $canvas->cropImage($canvasWidth, $canvasHeight, 0, 0);
+    
+    /* composite original text_layer onto shadow_layer */
+    $canvas->compositeImage($kernel, \Imagick::COMPOSITE_OVER, 0, 0);
+    $canvas->setImageFormat('png');
+
+    return $canvas;
+}
+
+function createFromMatrix() {
+    $matrix = [
+        [0.5, 0, 0.2],
+        [0, 1, 0],
+        [0.9, 0, false],
+    ];
+
+    $kernel = \ImagickKernel::fromMatrix($matrix);
+
+    return $kernel;
+}
+    
+function fromMatrix() {
+    $kernel = createFromMatrix();
+    $imagick = renderKernel($kernel);
+
+    header("Content-Type: image/png");
+    echo $imagick->getImageBlob();
+}
+
+?>
+]]>
+      </programlisting>
+    </example>
+  </para>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/imagick/imagickkernel/getmatrix.xml
+++ b/reference/imagick/imagickkernel/getmatrix.xml
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 1ef9c7a76700b3e72844050d75e6ed1b870f9ca7 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="imagickkernel.getmatrix" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>ImagickKernel::getMatrix</refname>
+  <refpurpose>Renvoie la matrice 2D des valeurs utilisées dans ce noyau</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>public</modifier> <type>array</type><methodname>ImagickKernel::getMatrix</methodname>
+   <void />
+  </methodsynopsis>
+  <para>
+   Renvoie la matrice 2D des valeurs utilisées dans ce noyau. Les éléments sont soit
+   des flottants pour les éléments qui sont utilisés, soit 'false' si l'élément doit être ignoré.
+  </para>
+
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Une matrice (tableau 2D) des valeurs qui représentent le noyau.
+  </para>
+ </refsect1>
+
+
+
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+    <example>
+      <title> <function>ImagickKernel::getMatrix</function></title>
+      <programlisting role="php">
+      <![CDATA[
+<?php
+
+
+function renderKernelTable($matrix) {
+    $output = "<table class='infoTable'>";
+
+    foreach ($matrix as $row) {
+        $output .= "<tr>";
+        foreach ($row as $cell) {
+            $output .= "<td style='text-align:left'>";
+            if ($cell === false) {
+                $output .= "false";
+            }
+            else {
+                $output .= round($cell, 3);
+            }
+            $output .= "</td>";
+        }
+        $output .= "</tr>";
+    }
+
+    $output .= "</table>";
+
+    return $output;
+}
+
+    $output = "The built-in kernel name 'ring' with parameters of '2,3.5':<br/>";
+    $kernel = \ImagickKernel::fromBuiltIn(
+        \Imagick::KERNEL_RING,
+        "2,3.5"
+    );
+    $matrix = $kernel->getMatrix();
+    $output .= renderKernelTable($matrix);
+
+    echo $output;
+
+?>
+]]>
+      </programlisting>
+    </example>
+  </para>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/imagick/imagickkernel/scale.xml
+++ b/reference/imagick/imagickkernel/scale.xml
@@ -1,0 +1,166 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 560a2e6464b7e9ba479ebf7dcc3725819f7eba83 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="imagickkernel.scale" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>ImagickKernel::scale</refname>
+  <refpurpose>Dimensionne une liste de noyaux par la quantité donnée</refpurpose> 
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>public</modifier> <type>void</type><methodname>ImagickKernel::scale</methodname>
+   <methodparam><type>float</type><parameter>scale</parameter></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>normalizeFlag</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Dimensionne la liste de noyaux donnée par la quantité donnée, avec ou sans
+   normalisation de la somme des valeurs du noyau (selon les indicateurs donnés).
+
+   Le comportement exact de cette fonction dépend du type de normalisation utilisé
+   veuillez consulter http://www.imagemagick.org/api/morphology.php#ScaleKernelInfo pour plus de détails.
+  </para>
+
+
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>scale</parameter></term>
+     <listitem>
+      <para>
+
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>normalizeFlag</parameter></term>
+     <listitem>
+      <para>
+       <simplelist>
+        <member>Imagick::NORMALIZE_KERNEL_NONE</member>
+        <member>Imagick::NORMALIZE_KERNEL_VALUE</member>
+        <member>Imagick::NORMALIZE_KERNEL_CORRELATE</member>
+        <member>Imagick::NORMALIZE_KERNEL_PERCENT</member>
+       </simplelist>
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   
+  </para>
+ </refsect1>
+
+
+
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+    <example>
+      <title> <function>ImagickKernel::scale</function></title>
+      <programlisting role="php">
+      <![CDATA[
+<?php
+
+
+    function renderKernelTable($matrix) {
+        $output = "<table class='infoTable'>";
+    
+        foreach ($matrix as $row) {
+            $output .= "<tr>";
+            foreach ($row as $cell) {
+                $output .= "<td style='text-align:left'>";
+                if ($cell === false) {
+                    $output .= "false";
+                }
+                else {
+                    $output .= round($cell, 3);
+                }
+                $output .= "</td>";
+            }
+            $output .= "</tr>";
+        }
+    
+        $output .= "</table>";
+    
+        return $output;
+    }
+
+
+    $output = "";
+    
+    $matrix = [
+        [-1, 0, -1],
+        [ 0, 4,  0],
+        [-1, 0, -1],
+    ];
+
+    $kernel = \ImagickKernel::fromMatrix($matrix);
+    $kernelClone = clone $kernel;
+
+    $output .= "Start kernel<br/>";
+    $output .= renderKernelTable($kernel->getMatrix());
+    
+    
+    $output .= "Scaling with NORMALIZE_KERNEL_VALUE. The  <br/>";
+    $kernel->scale(2, \Imagick::NORMALIZE_KERNEL_VALUE);
+    $output .= renderKernelTable($kernel->getMatrix());
+
+
+    $kernel = clone $kernelClone;
+    $output .= "Scaling by percent<br/>";
+    $kernel->scale(2, \Imagick::NORMALIZE_KERNEL_PERCENT);
+    $output .= renderKernelTable($kernel->getMatrix());
+    
+    $matrix2 = [
+        [-1, -1, 1],
+        [ -1, false,  1],
+        [1, 1, 1],
+    ];
+    
+    $kernel = \ImagickKernel::fromMatrix($matrix2);
+    $output .= "Scaling by correlate<br/>";
+    $kernel->scale(1, \Imagick::NORMALIZE_KERNEL_CORRELATE);
+    $output .= renderKernelTable($kernel->getMatrix());
+
+    return $output; 
+?>
+]]>
+      </programlisting>
+    </example>
+  </para>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/imagick/imagickkernel/separate.xml
+++ b/reference/imagick/imagickkernel/separate.xml
@@ -1,0 +1,127 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 1ef9c7a76700b3e72844050d75e6ed1b870f9ca7 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="imagickkernel.separate" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>ImagickKernel::separate</refname>
+  <refpurpose>Sépare un ensemble de noyaux liés et renvoie un tableau d'ImagickKernels</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>public</modifier> <type>array</type><methodname>ImagickKernel::separate</methodname>
+   <void />
+  </methodsynopsis>
+  <para>
+   Sépare un ensemble de noyaux liés et renvoie un tableau d'ImagickKernels.
+  </para>
+
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   
+  </para>
+ </refsect1>
+
+
+
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+    <example>
+      <title> <function>ImagickKernel::separate</function></title>
+      <programlisting role="php">
+      <![CDATA[
+<?php
+
+
+    
+    function renderKernelTable($matrix) {
+
+        $output = "<table class='infoTable'>";
+        foreach ($matrix as $row) {
+            $output .= "<tr>";
+            foreach ($row as $cell) {
+                $output .= "<td style='text-align:left'>";
+                if ($cell === false) {
+                    $output .= "false";
+                }
+                else {
+                    $output .= round($cell, 3);
+                }
+                $output .= "</td>";
+            }
+            $output .= "</tr>";
+        }
+    
+        $output .= "</table>";
+    
+        return $output;
+    }
+
+
+    $matrix = [
+        [-1, 0, -1],
+        [ 0, 4,  0],
+        [-1, 0, -1],
+    ];
+
+    $kernel = \ImagickKernel::fromMatrix($matrix);
+    $kernel->scale(4, \Imagick::NORMALIZE_KERNEL_VALUE);
+    $diamondKernel = \ImagickKernel::fromBuiltIn(
+        \Imagick::KERNEL_DIAMOND,
+        "2"
+    );
+
+    $kernel->addKernel($diamondKernel);
+    
+    $kernelList = $kernel->separate();
+    
+    $output = '';
+    $count = 0;
+    foreach ($kernelList as $kernel) {
+        $output .= "<br/>Kernel $count<br/>";
+        $output .= renderKernelTable($kernel->getMatrix());
+        $count++;
+    }
+
+    return $output;
+
+?>
+]]>
+      </programlisting>
+    </example>
+  </para>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
Here is the translation of missing `Imagick\ImagickKernel` methods

- `Imagick\ImagickKernel::addKernel()`
- `Imagick\ImagickKernel::addUnityKernel()`
- `Imagick\ImagickKernel::fromBuiltIn()`
- `Imagick\ImagickKernel::fromMatrix()`
- `Imagick\ImagickKernel::getMatrix()`
- `Imagick\ImagickKernel::scale()`
- `Imagick\ImagickKernel::separate()`