### PR TITLE
Translate `IntlTimeZone`

### DIFF
--- a/reference/intl/intltimezone/construct.xml
+++ b/reference/intl/intltimezone/construct.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 1976eae0d815797af97a1e16c5cd90ffc2868395 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="intltimezone.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>IntlTimeZone::__construct</refname>
+  <refpurpose>Constructeur privé pour empêcher l'instanciation directe</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <constructorsynopsis role="IntlTimeZone">
+   <modifier>private</modifier> <methodname>IntlTimeZone::__construct</methodname>
+   <void/>
+  </constructorsynopsis>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/intl/intltimezone/createtimezoneidenumeration.xml
+++ b/reference/intl/intltimezone/createtimezoneidenumeration.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 1976eae0d815797af97a1e16c5cd90ffc2868395 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="intltimezone.createtimezoneidenumeration" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>IntlTimeZone::createTimeZoneIDEnumeration</refname>
+  <refname>intltz_create_time_zone_id_enumeration</refname>
+  <refpurpose>Renvoie une énumération sur les identifiants de fuseau horaire système avec les conditions de filtre données</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <para>&style.oop; (method):</para>
+  <methodsynopsis role="IntlTimeZone">
+   <modifier>public</modifier> <modifier>static</modifier> <type class="union"><type>IntlIterator</type><type>false</type></type><methodname>IntlTimeZone::createTimeZoneIDEnumeration</methodname>
+   <methodparam><type>int</type><parameter>type</parameter></methodparam>
+   <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>region</parameter><initializer>&null;</initializer></methodparam>
+   <methodparam choice="opt"><type class="union"><type>int</type><type>null</type></type><parameter>rawOffset</parameter><initializer>&null;</initializer></methodparam>
+  </methodsynopsis>
+  <para>&style.procedural;:</para>
+  <methodsynopsis>
+   <type class="union"><type>IntlIterator</type><type>false</type></type><methodname>intltz_create_time_zone_id_enumeration</methodname>
+   <methodparam><type>int</type><parameter>type</parameter></methodparam>
+   <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>region</parameter><initializer>&null;</initializer></methodparam>
+   <methodparam choice="opt"><type class="union"><type>int</type><type>null</type></type><parameter>rawOffset</parameter><initializer>&null;</initializer></methodparam>
+  </methodsynopsis>
+  <para>
+
+  </para>
+
+  &warn.undocumented.func;
+
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>type</parameter></term>
+    <listitem>
+     <para>
+      
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>region</parameter></term>
+    <listitem>
+     <para>
+      
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>rawOffset</parameter></term>
+    <listitem>
+     <para>
+      
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Renvoie <classname>IntlIterator</classname>&return.falseforfailure;.
+  </para>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/intl/intltimezone/getidforwindowsid.xml
+++ b/reference/intl/intltimezone/getidforwindowsid.xml
@@ -1,0 +1,118 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 1976eae0d815797af97a1e16c5cd90ffc2868395 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="intltimezone.getidforwindowsid" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>IntlTimeZone::getIDForWindowsID</refname>
+  <refname>intltz_get_id_for_windows_id</refname>
+  <refpurpose>Traduit un fuseau horaire Windows en un fuseau horaire système</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <para>&style.oop; (method):</para>
+  <methodsynopsis role="IntlTimeZone">
+   <modifier>public</modifier> <modifier>static</modifier> <type class="union"><type>string</type><type>false</type></type><methodname>IntlTimeZone::getIDForWindowsID</methodname>
+   <methodparam><type>string</type><parameter>timezoneId</parameter></methodparam>
+   <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>region</parameter><initializer>&null;</initializer></methodparam>
+  </methodsynopsis>
+  <para>&style.procedural;:</para>
+  <methodsynopsis>
+   <type class="union"><type>string</type><type>false</type></type><methodname>intltz_get_id_for_windows_id</methodname>
+   <methodparam><type>string</type><parameter>timezoneId</parameter></methodparam>
+   <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>region</parameter><initializer>&null;</initializer></methodparam>
+  </methodsynopsis>
+  <para>
+   Traduit un fuseau horaire Windows (par exemple "Pacific Standard Time") en un fuseau horaire système (par exemple "America/Los_Angeles").
+  </para>
+  <note>
+   <simpara>
+    Cette fonction requiert ICU version ≥ 52.
+   </simpara>
+  </note>
+
+  &warn.undocumented.func;
+
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>timezoneId</parameter></term>
+    <listitem>
+     <para>
+      
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>region</parameter></term>
+    <listitem>
+     <para>
+      
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Renvoie le fuseau horaire système&return.falseforfailure;.
+  </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.0.0</entry>
+      <entry>
+       <parameter>region</parameter> est désormais nullable.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><methodname>IntlTimeZone::getWindowsID</methodname></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/intl/intltimezone/getregion.xml
+++ b/reference/intl/intltimezone/getregion.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 1976eae0d815797af97a1e16c5cd90ffc2868395 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="intltimezone.getregion" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>IntlTimeZone::getRegion</refname>
+  <refname>intltz_get_region</refname>
+  <refpurpose>Renvoie le code de région associé à l'identifiant de fuseau horaire système donné</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <para>&style.oop; (method):</para>
+  <methodsynopsis role="IntlTimeZone">
+   <modifier>public</modifier> <modifier>static</modifier> <type class="union"><type>string</type><type>false</type></type><methodname>IntlTimeZone::getRegion</methodname>
+   <methodparam><type>string</type><parameter>timezoneId</parameter></methodparam>
+  </methodsynopsis>
+  <para>&style.procedural;:</para>
+  <methodsynopsis>
+   <type class="union"><type>string</type><type>false</type></type><methodname>intltz_get_region</methodname>
+   <methodparam><type>string</type><parameter>timezoneId</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+
+  </para>
+
+  &warn.undocumented.func;
+
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>timezoneId</parameter></term>
+    <listitem>
+     <para>
+      
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Return region&return.falseforfailure;.
+  </para>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/intl/intltimezone/getunknown.xml
+++ b/reference/intl/intltimezone/getunknown.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 1976eae0d815797af97a1e16c5cd90ffc2868395 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="intltimezone.getunknown" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>IntlTimeZone::getUnknown</refname>
+  <refname>intltz_get_unknown</refname>
+  <refpurpose>Renvoie le fuseau horaire "inconnu"</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <para>&style.oop; (method):</para>
+  <methodsynopsis role="IntlTimeZone">
+   <modifier>public</modifier> <modifier>static</modifier> <type>IntlTimeZone</type><methodname>IntlTimeZone::getUnknown</methodname>
+   <void/>
+  </methodsynopsis>
+  <para>&style.procedural;:</para>
+  <methodsynopsis>
+   <type>IntlTimeZone</type><methodname>intltz_get_unknown</methodname>
+   <void/>
+  </methodsynopsis>
+  <para>
+
+  </para>
+
+  &warn.undocumented.func;
+
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Renvoie <classname>IntlTimeZone</classname> ou &null; en cas d'échec.
+  </para>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/intl/intltimezone/getwindowsid.xml
+++ b/reference/intl/intltimezone/getwindowsid.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 1976eae0d815797af97a1e16c5cd90ffc2868395 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="intltimezone.getwindowsid" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>IntlTimeZone::getWindowsID</refname>
+  <refname>intltz_get_windows_id</refname>
+  <refpurpose>Traduit un fuseau horaire système en un fuseau horaire Windows</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <para>&style.oop; (method):</para>
+  <methodsynopsis role="IntlTimeZone">
+   <modifier>public</modifier> <modifier>static</modifier> <type class="union"><type>string</type><type>false</type></type><methodname>IntlTimeZone::getWindowsID</methodname>
+   <methodparam><type>string</type><parameter>timezoneId</parameter></methodparam>
+  </methodsynopsis>
+  <para>&style.procedural;:</para>
+  <methodsynopsis>
+   <type class="union"><type>string</type><type>false</type></type><methodname>intltz_get_windows_id</methodname>
+   <methodparam><type>string</type><parameter>timezoneId</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Traduit un fuseau horaire système (par exemple "America/Los_Angeles") en un fuseau horaire Windows (par exemple "Pacific Standard Time").
+  </para>
+  <note>
+   <simpara>
+    Cette fonction requiert ICU version ≥ 52.
+   </simpara>
+  </note>
+
+  &warn.undocumented.func;
+
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>timezoneId</parameter></term>
+    <listitem>
+     <para>
+      
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Renvoie le fuseau horaire Windows&return.falseforfailure;.
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><methodname>IntlTimeZone::getIDForWindowsID</methodname></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
Here is the translation of missing `IntlTimeZone` methods

- `IntlTimeZone::__construct()`
- `IntlTimeZone::createTimeZoneIdEnumeration()`
- `IntlTimeZone::getIdForWindowsId()`
- `IntlTimeZone::getRegion()`
- `IntlTimeZone::getUnknown()`
- `IntlTimeZone::getWindowsId()`