### PR TITLE
Translate `LuaSandboxFunctions` methods

### DIFF
--- a/reference/luasandbox/luasandboxfunction/call.xml
+++ b/reference/luasandbox/luasandboxfunction/call.xml
@@ -1,0 +1,160 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: cdc9d28d334bbc08386fecf8aade66080004a9dd Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="luasandboxfunction.call" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>LuaSandboxFunction::call</refname>
+  <refpurpose>Appelle une fonction Lua</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>public</modifier> <type class="union"><type>array</type><type>bool</type></type><methodname>LuaSandboxFunction::call</methodname>
+   <methodparam rep="repeat"><type>string</type><parameter>args</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Appelle une fonction Lua.
+  </para>
+  <para>
+   Les erreurs considérées comme étant de la faute du code PHP entraîneront
+   le retour de la fonction avec la valeur &false; et l'émission de <constant>E_WARNING</constant>,
+   par exemple, un type <type>resource</type> utilisé comme argument. Les erreurs Lua
+   entraîneront le lancement d'une exception <classname>LuaSandboxRuntimeError</classname>.
+  </para>
+  <para>
+   Les types PHP et Lua sont convertis comme suit :
+  </para>
+  <para>
+   <itemizedlist>
+    <listitem>
+     <para>Les &null; de PHP est Lua <literal>nil</literal>, et vice versa.</para>
+    </listitem>
+    <listitem>
+     <para>
+      Les <type>int</type>s de PHP et <type>float</type>s sont convertis en nombres Lua.
+      L'infini et <constant>NAN</constant> sont supportés.
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      Les nombres Lua sans partie fractionnaire entre environ <literal>-2**53</literal>
+      et <literal>2**53</literal> sont convertis en <type>int</type>s PHP, les autres
+      sont convertis en <type>float</type>s PHP.
+     </para>
+    </listitem>
+    <listitem>
+     <para>Les <type>bool</type>s de PHP sont des booléens Lua, et vice versa.</para>
+    </listitem>
+    <listitem>
+     <para>Les <type>string</type>s de PHP sont des chaînes Lua, et vice versa.</para>
+    </listitem>
+    <listitem>
+     <para>
+      Les fonctions Lua sont des objets PHP <classname>LuaSandboxFunction</classname>, et vice versa.
+      Les <type>callable</type>s PHP généraux ne sont pas supportés.
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      Les <type>array</type>s de PHP sont convertis en tables Lua, et vice versa.
+     </para>
+     <para>
+      <itemizedlist>
+       <listitem>
+        <para>
+         Il est à noter que Lua indexe typiquement les tableaux à partir de 1, tandis que PHP
+         indexe les tableaux à partir de 0. Aucun ajustement n'est fait pour ces conventions
+         différentes.
+        </para>
+       </listitem>
+       <listitem>
+        <para>Les tableaux auto-référentiels ne sont pas supportés dans les deux sens.</para>
+       </listitem>
+       <listitem>
+        <para>Les références PHP sont déréférencées.</para>
+       </listitem>
+       <listitem>
+        <para>
+         Les <literal>__pairs</literal> et <literal>__ipairs</literal> de Lua sont traités.
+         <literal>__index</literal> est ignoré.
+        </para>
+       </listitem>
+       <listitem>
+        <para>
+         Lors de la conversion de PHP en Lua, les clés entières entre
+         <literal>-2**53</literal> et <literal>2**53</literal> sont représentées
+         comme des nombres Lua. Toutes les autres clés sont représentées comme des chaînes Lua.
+        </para>
+       </listitem>
+       <listitem>
+        <para>
+         Lors de la conversion de Lua en PHP, les clés autres que les chaînes et
+         les nombres entraîneront une erreur, tout comme les collisions lors de la conversion
+         de nombres en chaînes ou vice versa (puisque PHP considère des choses comme
+         <literal>$a[0]</literal> et <literal>$a["0"]</literal> comme étant équivalentes).
+        </para>
+       </listitem>
+      </itemizedlist>
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      Tous les autres types ne sont pas supportés et entraîneront une erreur/exception,
+      y compris les <type>object</type>s PHP généraux et les types userdata et thread Lua.
+     </para>
+    </listitem>
+   </itemizedlist>
+  </para>
+  <para>
+   Les fonctions Lua retournent intrinsèquement une liste de résultats. Donc, sur succès,
+   cette méthode retourne un <type>array</type> contenant toutes les valeurs retournées par Lua,
+   avec des clés <type>int</type> commençant à zéro. Lua peut ne retourner aucun résultat, auquel
+   cas un tableau vide est retourné.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>args</parameter></term>
+    <listitem>
+     <para>
+      Les arguments passés à la fonction.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Renvoie un <type>array</type> des valeurs retournées par la fonction, qui peut être vide,
+   &return.falseforfailure;.
+  </para>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/luasandbox/luasandboxfunction/construct.xml
+++ b/reference/luasandbox/luasandboxfunction/construct.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 990521c9ca64fe7d83016a613b850177d3a90776 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="luasandboxfunction.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>LuaSandboxFunction::__construct</refname>
+  <refpurpose>Inutilisé</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <constructorsynopsis>
+   <modifier>final</modifier> <modifier>private</modifier> <methodname>LuaSandboxFunction::__construct</methodname>
+   <void />
+  </constructorsynopsis>
+  <para>
+   Les <classname>LuaSandboxFunction</classname> sont obtenus en tant que valeur de retour de Lua,
+   en tant que paramètre passé à un rappel depuis Lua, ou en utilisant
+   <methodname>LuaSandbox::wrapPhpFunction</methodname>,
+   <methodname>LuaSandbox::loadString</methodname>, ou
+   <methodname>LuaSandbox::loadBinary</methodname>. Ils ne peuvent pas être construits directement.
+  </para>
+
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/luasandbox/luasandboxfunction/dump.xml
+++ b/reference/luasandbox/luasandboxfunction/dump.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 990521c9ca64fe7d83016a613b850177d3a90776 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="luasandboxfunction.dump" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>LuaSandboxFunction::dump</refname>
+  <refpurpose>Affiche la fonction sous forme de blob binaire</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>public</modifier> <type>string</type><methodname>LuaSandboxFunction::dump</methodname>
+   <void />
+  </methodsynopsis>
+  <para>
+   Affiche la fonction sous forme de blob binaire.
+  </para>
+
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Renvoie une chaîne qui peut être passée à <methodname>LuaSandbox::loadBinary</methodname>.
+  </para>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
Here is the translation of missing `LuaSandboxFunctions` methods

- `LuaSandboxFunctions::call()`
- `LuaSandboxFunctions::__construct()`
- `LuaSandboxFunctions::dump()`