### PR TITLE
Translate `MongoDB\Driver\Monitoring\CommandSubscriber` methods

### DIFF
--- a/reference/mongodb/mongodb/driver/monitoring/commandsubscriber/commandfailed.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/commandsubscriber/commandfailed.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: e9214a2619efc5906fab59cd42fb7404c4dc49a5 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="mongodb-driver-monitoring-commandsubscriber.commandfailed" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>MongoDB\Driver\Monitoring\CommandSubscriber::commandFailed</refname>
+  <refpurpose>Méthode de notification pour une commande échouée</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>abstract</modifier> <modifier>public</modifier> <type>void</type><methodname>MongoDB\Driver\Monitoring\CommandSubscriber::commandFailed</methodname>
+   <methodparam><type>MongoDB\Driver\Monitoring\CommandFailedEvent</type><parameter>event</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Si l'observateur est enregistré, cette méthode est appelée lorsqu'une commande échoue.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>event</parameter> (<type>MongoDB\Driver\Monitoring\CommandFailedEvent</type>)</term>
+    <listitem>
+     <para>
+      Un objet d'événement encapsulant des informations sur la commande échouée.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &return.void;
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simplelist>
+   &mongodb.throws.argumentparsing;
+  </simplelist>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><classname>MongoDB\Driver\Monitoring\CommandFailedEvent</classname></member>
+   <member><function>MongoDB\Driver\Monitoring\addSubscriber</function></member>
+   <member><function>MongoDB\Driver\Manager::addSubscriber</function></member>
+   <member><xref linkend="mongodb.tutorial.apm" /></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mongodb/mongodb/driver/monitoring/commandsubscriber/commandstarted.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/commandsubscriber/commandstarted.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: e9214a2619efc5906fab59cd42fb7404c4dc49a5 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="mongodb-driver-monitoring-commandsubscriber.commandstarted" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>MongoDB\Driver\Monitoring\CommandSubscriber::commandStarted</refname>
+  <refpurpose>Méthode de notification pour une commande démarrée</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>abstract</modifier> <modifier>public</modifier> <type>void</type><methodname>MongoDB\Driver\Monitoring\CommandSubscriber::commandStarted</methodname>
+   <methodparam><type>MongoDB\Driver\Monitoring\CommandStartedEvent</type><parameter>event</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Si l'observateur est enregistré, cette méthode est appelée lorsqu'une commande est envoyée
+   au serveur.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>event</parameter> (<type>MongoDB\Driver\Monitoring\CommandStartedEvent</type>)</term>
+    <listitem>
+     <para>
+      Un objet d'événement encapsulant des informations sur la commande démarrée.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &return.void;
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simplelist>
+   &mongodb.throws.argumentparsing;
+  </simplelist>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><classname>MongoDB\Driver\Monitoring\CommandStartedEvent</classname></member>
+   <member><function>MongoDB\Driver\Monitoring\addSubscriber</function></member>
+   <member><function>MongoDB\Driver\Manager::addSubscriber</function></member>
+   <member><xref linkend="mongodb.tutorial.apm" /></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mongodb/mongodb/driver/monitoring/commandsubscriber/commandsucceeded.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/commandsubscriber/commandsucceeded.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: e9214a2619efc5906fab59cd42fb7404c4dc49a5 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="mongodb-driver-monitoring-commandsubscriber.commandsucceeded" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>MongoDB\Driver\Monitoring\CommandSubscriber::commandSucceeded</refname>
+  <refpurpose>Méthode de notification pour une commande réussie</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>abstract</modifier> <modifier>public</modifier> <type>void</type><methodname>MongoDB\Driver\Monitoring\CommandSubscriber::commandSucceeded</methodname>
+   <methodparam><type>MongoDB\Driver\Monitoring\CommandSucceededEvent</type><parameter>event</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Si l'observateur est enregistré, cette méthode est appelée lorsqu'une
+   commande réussit.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>event</parameter> (<type>MongoDB\Driver\Monitoring\CommandSucceededEvent</type>)</term>
+    <listitem>
+     <para>
+      Un objet d'événement encapsulant des informations sur la commande réussie.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &return.void;
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simplelist>
+   &mongodb.throws.argumentparsing;
+  </simplelist>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><classname>MongoDB\Driver\Monitoring\CommandSucceededEvent</classname></member>
+   <member><function>MongoDB\Driver\Monitoring\addSubscriber</function></member>
+   <member><function>MongoDB\Driver\Manager::addSubscriber</function></member>
+   <member><xref linkend="mongodb.tutorial.apm" /></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
Here is the translation of missing `MongoDB\Driver\Monitoring\CommandSubscriber` methods

- `MongoDB\Driver\Monitoring\CommandSubscriber::commandFailed()`
- `MongoDB\Driver\Monitoring\CommandSubscriber::commandStarted()`
- `MongoDB\Driver\Monitoring\CommandSubscriber::commandSucceeded()`