### PR TITLE
Translate `MongoDB\Driver\Manager`

### DIFF
--- a/reference/mongodb/mongodb/driver/manager/addsubscriber.xml
+++ b/reference/mongodb/mongodb/driver/manager/addsubscriber.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: b817c8855866acbb37c260cbc62235b8d2d88ea1 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes --> 
+<refentry xml:id="mongodb-driver-manager.addsubscriber" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>MongoDB\Driver\Manager::addSubscriber</refname>
+  <refpurpose>Enregistre un observateur d'événements de surveillance avec ce manager</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>final</modifier> <modifier>public</modifier> <type>void</type><methodname>MongoDB\Driver\Manager::addSubscriber</methodname>
+   <methodparam><type>MongoDB\Driver\Monitoring\Subscriber</type><parameter>subscriber</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Enregistre un observateur d'événements de surveillance avec ce Manager. L'observateur
+   sera notifié de tous les événements pour ce Manager.
+  </para>
+  <note>
+   <simpara>
+    Si <parameter>subscriber</parameter> est déjà enregistré avec ce manager, cette
+    fonction ne fait rien. Si <parameter>subscriber</parameter> est également
+    enregistré globalement, il ne sera notifié qu'une seule fois de chaque événement
+    pour ce manager.
+   </simpara>
+  </note>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>subscriber</parameter> (<type>MongoDB\Driver\Monitoring\Subscriber</type>)</term>
+    <listitem>
+     <para>
+      Un observateur d'événements de surveillance à enregistrer avec ce Manager.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &return.void;
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simplelist>
+   &mongodb.throws.argumentparsing;
+   <member>
+    Lance une
+    <classname>MongoDB\Driver\Exception\InvalidArgumentException</classname> si
+    <parameter>subscriber</parameter> est un
+    <classname>MongoDB\Driver\Monitoring\LogSubscriber</classname>, car les
+    observateurs ne peuvent être enregistrés que globalement.
+   </member>
+  </simplelist>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>MongoDB\Driver\Manager::removeSubscriber</function></member>
+   <member><interfacename>MongoDB\Driver\Monitoring\Subscriber</interfacename></member>
+   <member><interfacename>MongoDB\Driver\Monitoring\CommandSubscriber</interfacename></member>
+   <member><function>MongoDB\Driver\Monitoring\addSubscriber</function></member>
+   <member><xref linkend="mongodb.tutorial.apm" /></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mongodb/mongodb/driver/manager/construct.xml
+++ b/reference/mongodb/mongodb/driver/manager/construct.xml
@@ -1,0 +1,1409 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: e9214a2619efc5906fab59cd42fb7404c4dc49a5 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="mongodb-driver-manager.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>MongoDB\Driver\Manager::__construct</refname>
+  <refpurpose>Crée un nouveau Manager MongoDB</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>final</modifier> <modifier>public</modifier> <methodname>MongoDB\Driver\Manager::__construct</methodname>
+   <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>uri</parameter><initializer>&null;</initializer></methodparam>
+   <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>uriOptions</parameter><initializer>&null;</initializer></methodparam>
+   <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>driverOptions</parameter><initializer>&null;</initializer></methodparam>
+  </methodsynopsis>
+  <para>
+   Construit un nouvel objet <classname>MongoDB\Driver\Manager</classname> avec les options spécifiées.
+  </para>
+  <note>
+   <simpara>
+    Avec la <link xlink:href="&url.mongodb.sdam;#single-threaded-client-construction">Spécification de découverte et de surveillance du serveur</link>,
+    ce constructeur n'effectue pas d'E/S. Les connexions seront initialisées à la demande,
+    lors de l'exécution de la première opération.
+   </simpara>
+  </note>
+  <note>
+   <simpara>
+    Lorsque des options d'URI SSL ou TLS sont spécifiées via la chaîne de connexion ou le
+    paramètre <parameter>uriOptions</parameter>, l'extension activera implicitement TLS pour ses connexions.
+    Pour éviter cela, désactivez explicitement l'option
+    <literal>tls</literal> ou ne spécifiez aucune option TLS.
+   </simpara>
+  </note>
+  &mongodb.note.forking;
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry xml:id="mongodb-driver-manager.construct-uri">
+    <term><parameter>uri</parameter></term>
+    <listitem>
+     <para>
+      Une URI de connexion <link xlink:href="&url.mongodb.docs;reference/connection-string/">mongodb://</link>:
+      <programlisting role="txt">
+<![CDATA[
+mongodb://[username:password@]host1[:port1][,host2[:port2],...[,hostN[:portN]]][/[defaultAuthDb][?options]]
+]]>
+      </programlisting>
+     </para>
+     <para>
+      Pour les détails sur les options d'URI prises en charge, voir
+      <link xlink:href="&url.mongodb.docs;reference/connection-string/#connections-connection-options">Options de chaîne de connexion</link>
+      dans le manuel MongoDB.
+      <link xlink:href="&url.mongodb.docs;reference/connection-string/#connection-pool-options">Options de pool de connexions</link>
+      ne sont pas prises en charge, car l'extension n'implémente pas de pools de connexions.
+     </para>
+     <para>
+      L'<parameter>uri</parameter> est une URL, donc tous les caractères spéciaux dans
+      ses composants doivent être encodés en URL selon la
+      <link xlink:href="&url.rfc;3986">RFC 3986</link>. Cela est particulièrement
+      pertinent pour le nom d'utilisateur et le mot de passe, qui peuvent souvent inclure des caractères spéciaux tels que
+      <literal>@</literal>, <literal>:</literal> ou <literal>%</literal>.
+      Lors de la connexion via un socket de domaine Unix, le chemin du socket
+      peut contenir des caractères spéciaux tels que des barres obliques et doit être encodé.
+      La fonction <function>rawurlencode</function> peut être utilisée pour encoder
+      les parties constitutives de l'URI.
+     </para>
+     <para>
+      Le composant <literal>defaultAuthDb</literal> peut être utilisé pour spécifier la
+      base de données associée aux informations d'identification de l'utilisateur; cependant, l'option d'URI
+      <literal>authSource</literal> aura la priorité si elle est spécifiée.
+      Si ni <literal>defaultAuthDb</literal> ni <literal>authSource</literal> ne sont spécifiés, la base de données
+      <literal>admin</literal> sera utilisée par défaut. Le composant <literal>defaultAuthDb</literal>
+      n'a aucun effet en l'absence d'informations d'identification utilisateur.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="mongodb-driver-manager.construct-urioptions">
+    <term><parameter>uriOptions</parameter></term>
+    <listitem>
+     <para>
+      Options supplémentaires
+      <link xlink:href="&url.mongodb.docs;reference/connection-string/#connections-connection-options">de chaîne de connexion</link>,
+      qui écraseront toute option portant le même nom dans le paramètre
+      <parameter>uri</parameter>.
+     </para>
+     <para>
+      <table>
+       <title>uriOptions</title>
+       <tgroup cols="3">
+        <thead>
+         <row>
+          <entry>Option</entry>
+          <entry>Type</entry>
+          <entry>Description</entry>
+         </row>
+        </thead>
+        <tbody>
+         <row>
+          <entry>appname</entry>
+          <entry><type>string</type></entry>
+          <entry>
+           <para>
+            MongoDB 3.4+ a la capacité d'annoter les connexions avec des métadonnées
+            fournies par le client connecté. Ces métadonnées sont incluses dans les
+            journaux du serveur lors de l'établissement d'une connexion et également enregistrées dans
+            les journaux de requêtes lentes lorsque le profilage de la base de données est activé.
+           </para>
+           <para>
+            Cette option peut être utilisée pour spécifier un nom d'application, qui sera
+            inclus dans les métadonnées. La valeur ne peut pas dépasser 128 caractères
+            de longueur.
+           </para>
+          </entry>
+         </row>
+         <row>
+          <entry>authMechanism</entry>
+          <entry><type>string</type></entry>
+          <entry>
+           <para>
+            Le mécanisme d'authentification que MongoDB utilisera pour authentifier
+            la connexion. Pour plus de détails et une liste des valeurs prises en charge, voir
+            <link xlink:href="&url.mongodb.docs;reference/connection-string/#urioption.authMechanism">Options d'authentification</link>
+            dans le manuel MongoDB.
+           </para>
+          </entry>
+         </row>
+         <row>
+          <entry>authMechanismProperties</entry>
+          <entry><type>array</type></entry>
+          <entry>
+           <para>
+            Les propriétés spécifiques au mécanisme d'authentification sélectionné. Pour plus
+            de détails et une liste des propriétés prises en charge, voir la
+            <link xlink:href="&url.mongodb.specs;/blob/master/source/auth/auth.rst#auth-related-options">Spécification d'authentification du pilote</link>.
+           </para>
+           <note>
+            <simpara>
+             Lorsque non spécifiée dans la chaîne d'URI, cette option est exprimée comme
+             un tableau de paires clé/valeur. Les clés et valeurs de ce tableau
+             doivent être des chaînes.
+            </simpara>
+           </note>
+          </entry>
+         </row>
+         <row>
+          <entry>authSource</entry>
+          <entry><type>string</type></entry>
+          <entry>
+           <para>
+            Le nom de la base de données associée aux informations d'identification de l'utilisateur. Par défaut
+            au composant de la base de données de l'URI de connexion, ou à la base de données
+            <literal>admin</literal> si les deux sont non spécifiés.
+           </para>
+           <para>
+            Pour les mécanismes d'authentification qui ne prennent pas en charge la notion de base de données
+            (e.g. GSSAPI), cela devrait être
+            <literal>"$external"</literal>.
+           </para>
+          </entry>
+         </row>
+         <row>
+          <entry>canonicalizeHostname</entry>
+          <entry><type>bool</type></entry>
+          <entry>
+           <para>
+            Si &true;, le pilote résoudra le nom d'hôte réel pour l'adresse IP du serveur
+            avant de s'authentifier via SASL. Certaines couches GSSAPI sous-jacentes le font déjà,
+            mais la fonctionnalité peut être désactivée dans leur configuration (e.g.
+            <literal>krb.conf</literal>).
+            Par défaut à &false;.
+           </para>
+           <para>
+            Cette option est un alias obsolète pour la propriété
+            <literal>"CANONICALIZE_HOST_NAME"</literal> de l'option d'URI
+            <literal>"authMechanismProperties"</literal>.
+           </para>
+          </entry>
+         </row>
+         <row>
+          <entry>compressors</entry>
+          <entry><type>string</type></entry>
+          <entry>
+           <para>
+            Un liste priorisée et délimitée par des virgules de compresseurs que le client
+            souhaite utiliser. Les messages ne sont compressés que si le client et le serveur
+            partagent des compresseurs en commun, et le compresseur utilisé dans chaque
+            direction dépendra de la configuration individuelle du serveur
+            ou du pilote. Voir la
+            <link xlink:href="&url.mongodb.specs;/blob/master/source/compression/OP_COMPRESSED.rst#compressors">Spécification de compression de pilote</link>
+            pour plus d'informations.
+           </para>
+          </entry>
+         </row>
+         <row xml:id="mongodb-driver-manager.construct-urioptions.connecttimeoutms">
+          <entry>connectTimeoutMS</entry>
+          <entry><type>int</type></entry>
+          <entry>
+           <para>
+            Le temps en millisecondes pour tenter une connexion avant d'expirer.
+            Par défaut à 10 000 millisecondes.
+           </para>
+          </entry>
+         </row>
+         <row>
+          <entry>directConnection</entry>
+          <entry><type>bool</type></entry>
+          <entry>
+           <para>
+            Cette option peut être utilisée pour contrôler le comportement de découverte de l'ensemble de réplicas
+            lorsqu'un seul hôte est fourni dans la chaîne de connexion.
+            Par défaut, fournir un seul membre dans la chaîne de connexion
+            établira une connexion directe ou découvrira des membres supplémentaires
+            selon que l'option d'URI <literal>"replicaSet"</literal> est omise ou présente,
+            respectivement. Spécifiez &false; pour forcer la découverte à se produire
+            (si <literal>"replicaSet"</literal> est omis)
+            ou spécifiez &true; pour forcer une connexion directe (si
+            <literal>"replicaSet"</literal> est présent).
+           </para>
+          </entry>
+         </row>
+         <row>
+          <entry>gssapiServiceName</entry>
+          <entry><type>string</type></entry>
+          <entry>
+           <para>
+            Définit le nom du service Kerberos lors de la connexion à des instances MongoDB sécurisées par Kerberos.
+            Cette valeur doit correspondre au nom du service défini sur les instances MongoDB (i.e.
+            <link xlink:href="&url.mongodb.docs;reference/parameters/#param.saslServiceName">saslServiceName</link>
+            paramètre du serveur). Par défaut à <literal>"mongodb"</literal>.
+           </para>
+           <para>
+            Cette option est décpréciée et devrait être remplacée par
+            la propriété <literal>"SERVICE_NAME"</literal> de l'option d'URI
+            <literal>"authMechanismProperties"</literal>.
+           </para>
+          </entry>
+         </row>
+         <row>
+          <entry>heartbeatFrequencyMS</entry>
+          <entry><type>int</type></entry>
+          <entry>
+           <para>
+            Spécifie l'intervalle en millisecondes entre les vérifications de la topologie MongoDB,
+            compté de la fin de la vérification précédente jusqu'au début de la suivante.
+            Par défaut à 60 000 millisecondes.
+           </para>
+           <para>
+            Pour la
+            <link xlink:href="&url.mongodb.sdam;#heartbeatfrequencyms">Spécification de découverte et de surveillance du serveur</link>,
+            cette valeur ne peut pas être inférieure à 500 millisecondes.
+           </para>
+          </entry>
+         </row>
+         <row>
+          <entry>journal</entry>
+          <entry><type>bool</type></entry>
+          <entry>
+           <para>
+            Correspond à l'option <parameter>journal</parameter> du write concern par défaut.
+            Si &true;, les écritures nécessiteront un accusé de réception de MongoDB indiquant que l'opération a été
+            écrite dans le journal. Pour plus de détails, voir
+            <classname>MongoDB\Driver\WriteConcern</classname>.
+           </para>
+          </entry>
+         </row>
+         <row>
+          <entry>loadBalanced</entry>
+          <entry><type>bool</type></entry>
+          <entry>
+           <para>
+            Spécife si le pilote se connecte à un cluster MongoDB via
+            un équilibreur de charge. Si &true;, le pilote ne peut se connecter qu'à
+            un seul hôte (spécifié par la chaîne de connexion ou la recherche SRV),
+            l'option d'URI <literal>"directConnection"</literal> ne peut
+            pas être &true;, et l'option d'URI <literal>"replicaSet"</literal>
+            doit être omise. Par défaut à &false;.
+           </para>
+          </entry>
+         </row>
+         <row>
+          <entry>localThresholdMS</entry>
+          <entry><type>int</type></entry>
+          <entry>
+           <para>
+            La taille en millisecondes de la fenêtre de latence pour la sélection parmi
+            plusieurs instances MongoDB appropriées lors de la résolution d'une préférence de lecture.
+            Par défaut à 15 millisecondes.
+           </para>
+          </entry>
+         </row>
+         <row>
+          <entry>maxStalenessSeconds</entry>
+          <entry><type>int</type></entry>
+          <entry>
+           <para>
+            Correspond à l'option <literal>maxStalenessSeconds</literal> de la préférence de lecture.
+            Spécifie, en secondes, la durée de validité maximale d'une instance secondaire avant que le client ne cesse de l'utiliser pour les
+            opérations de lecture. Par défaut, il n'y a pas de durée de validité maximale et
+            les clients ne tiendront pas compte du délai d'une instance secondaire lors du choix de la direction d'une opération de lecture. Pour plus de détails, voir
+            <classname>MongoDB\Driver\ReadPreference</classname>.
+           </para>
+           <para>
+            Si spécifié, la durée de validité maximale doit être un entier signé de 32 bits
+            supérieur ou égal à
+            <constant>MongoDB\Driver\ReadPreference::SMALLEST_MAX_STALENESS_SECONDS</constant>
+            (par exemple 90 secondes).
+           </para>
+          </entry>
+         </row>
+         <row>
+          <entry>password</entry>
+          <entry><type>string</type></entry>
+          <entry>
+           Le mot de passe de l'utilisateur en cours d'authentification. Cette option est utile
+           si le mot de passe contient des caractères spéciaux, qui devraient autrement
+           être encodés en URL pour l'URI de connexion.
+          </entry>
+         </row>
+         <row>
+          <entry>readConcernLevel</entry>
+          <entry><type>string</type></entry>
+          <entry>
+           Correspond à l'option <parameter>level</parameter> de la préférence de lecture.
+           Spécifie le niveau d'isolation de lecture. Pour plus de détails, voir
+           <classname>MongoDB\Driver\ReadConcern</classname>.
+          </entry>
+         </row>
+         <row>
+          <entry>readPreference</entry>
+          <entry><type>string</type></entry>
+          <entry>
+           <para>
+            Correspond à l'option <parameter>mode</parameter> de la préférence de lecture.
+            Par défaut à <literal>"primary"</literal>. Pour plus de détails, voir
+            <classname>MongoDB\Driver\ReadPreference</classname>.
+           </para>
+          </entry>
+         </row>
+         <row>
+          <entry>readPreferenceTags</entry>
+          <entry><type>array</type></entry>
+          <entry>
+           <para>
+            Correspond à l'option <parameter>tagSets</parameter> de la préférence de lecture.
+            Les ensembles de balises permettent de cibler les opérations de lecture sur des
+            membres spécifiques d'un ensemble de réplicas.Pour plus de détails,
+            voir <classname>MongoDB\Driver\ReadPreference</classname>.
+           </para>
+           <note>
+            <simpara>
+             Lorsque non spécifiée dans la chaîne d'URI, cette option est exprimée comme
+             un tableau conforme au format attendu par
+             <function>MongoDB\Driver\ReadPreference::__construct</function>.
+            </simpara>
+           </note>
+          </entry>
+         </row>
+         <row>
+          <entry>replicaSet</entry>
+          <entry><type>string</type></entry>
+          <entry>
+           <para>
+            Spécifie le nom de l'ensemble de réplicas.
+           </para>
+          </entry>
+         </row>
+         <row>
+          <entry>retryReads</entry>
+          <entry><type>bool</type></entry>
+          <entry>
+           <para>
+            Spécife si le pilote doit automatiquement réessayer
+            certaines opérations de lecture qui échouent en raison d'erreurs réseau transitoires
+            ou d'élections d'ensemble de réplicas. Cette fonctionnalité nécessite MongoDB 3.6+.
+            Par défaut à &true;.
+           </para>
+           <para>
+            Voir la
+            <link xlink:href="&url.mongodb.specs;/blob/master/source/retryable-reads/retryable-reads.rst">Spécification de lecture réessayable</link>
+            pour plus d'informations.
+           </para>
+          </entry>
+         </row>
+         <row>
+          <entry>retryWrites</entry>
+          <entry><type>bool</type></entry>
+          <entry>
+           <para>
+            Spécife si le pilote doit automatiquement réessayer
+            certaines opérations d'écriture qui échouent en raison d'erreurs réseau transitoires
+            ou d'élections d'ensemble de réplicas. Cette fonctionnalité nécessite MongoDB 3.6+.
+            Par défaut à &true;.
+           </para>
+           <para>
+            Voir
+            <link xlink:href="&url.mongodb.docs;core/retryable-writes/">Écritures réessayables</link>
+            dans le manuel MongoDB pour plus d'informations.
+           </para>
+          </entry>
+         </row>
+         <row>
+          <entry>safe</entry>
+          <entry><type>bool</type></entry>
+          <entry>
+           <para>
+            Si &true;, spécifie <literal>1</literal> pour le paramètre <parameter>w</parameter>
+            du write concern par défaut. Si &false;, <literal>0</literal>
+            est spécifié. Pour plus de détails, voir
+            <classname>MongoDB\Driver\WriteConcern</classname>.
+           </para>
+           <para>
+            Cette option est obsolète et ne devrait pas être utilisée.
+           </para>
+          </entry>
+         </row>
+         <row xml:id="mongodb-driver-manager.construct-urioptions.serverselectiontimeoutms">
+          <entry>serverSelectionTimeoutMS</entry>
+          <entry><type>int</type></entry>
+          <entry>
+           <para>
+            Spécifie combien de temps en millisecondes bloquer pour la sélection du serveur
+            avant de lancer une exception. Par défaut à 30 000 millisecondes.
+           </para>
+          </entry>
+         </row>
+         <row>
+          <entry>serverSelectionTryOnce</entry>
+          <entry><type>bool</type></entry>
+          <entry>
+           <para>
+            Lorsque &true;, indique au pilote de scanner le déploiement MongoDB
+            exactement une fois après un échec de sélection du serveur, puis de sélectionner
+            un serveur ou de lancer une exception. Lorsque &false;, le pilote bloque et
+            recherche un serveur jusqu'à la valeur de
+            <literal>"serverSelectionTimeoutMS"</literal>. Par défaut à
+            &true;.
+           </para>
+          </entry>
+         </row>
+         <row>
+          <entry>socketCheckIntervalMS</entry>
+          <entry><type>int</type></entry>
+          <entry>
+           <para>
+            Si un socket n'a pas été utilisé récemment, le pilote doit le vérifier via
+            une commande <literal>hello</literal> avant de l'utiliser pour toute
+            opération. Par défaut à 5 000 millisecondes.
+           </para>
+          </entry>
+         </row>
+         <row>
+          <entry>socketTimeoutMS</entry>
+          <entry><type>int</type></entry>
+          <entry>
+           <para>
+            Le temps en millisecondes pour tenter un envoi ou une réception sur un socket
+            avant d'expirer. Par défaut à 300 000 millisecondes (i.e. cinq
+            minutes).
+           </para>
+          </entry>
+         </row>
+         <row>
+          <entry>srvMaxHosts</entry>
+          <entry><type>int</type></entry>
+          <entry>
+           <para>
+            Le nombre maximum de résultats SRV à sélectionner aléatoirement lors de la
+            première population de la liste de semences ou, lors du sondage SRV, l'ajout de nouveaux hôtes à
+            la topologie. Par défaut à <literal>0</literal> (i.e. pas de maximum).
+           </para>
+          </entry>
+         </row>
+         <row>
+          <entry>srvServiceName</entry>
+          <entry><type>string</type></entry>
+          <entry>
+           <para>
+            Le nom de service à utiliser pour la recherche SRV dans la liste de semences initiale
+            et le sondage SRV. Par défaut à <literal>"mongodb"</literal>.
+           </para>
+          </entry>
+         </row>
+         <row>
+          <entry>ssl</entry>
+          <entry><type>bool</type></entry>
+          <entry>
+           <para>
+            Initialise la connexion avec TLS/SSL si &true;. Par défaut à
+            &false;.
+           </para>
+           <para>
+            Cette option est un alias obsolète pour l'option d'URI
+            <literal>"tls"</literal>.
+           </para>
+          </entry>
+         </row>
+         <row>
+          <entry>tls</entry>
+          <entry><type>bool</type></entry>
+          <entry>
+           <para>
+            Initialise la connexion avec TLS/SSL si &true;. Par défaut à
+            &false;.
+           </para>
+          </entry>
+         </row>
+         <row>
+          <entry>tlsAllowInvalidCertificates</entry>
+          <entry><type>bool</type></entry>
+          <entry>
+           <para>
+            Spécifie si le pilote doit générer une erreur lorsque le certificat
+            TLS du serveur est invalide. Par défaut à &false;.
+           </para>
+           <warning>
+            <simpara>
+             Désactiver la validation du certificat créant une vulnérabilité.
+            </simpara>
+           </warning>
+          </entry>
+         </row>
+         <row>
+          <entry>tlsAllowInvalidHostnames</entry>
+          <entry><type>bool</type></entry>
+          <entry>
+           <para>
+            Spécifie si le pilote doit générer une erreur lorsqu'il y a un
+            désaccord entre le nom d'hôte du serveur et le nom d'hôte spécifié par
+            le certificat TLS. Par défaut à &false;.
+           </para>
+           <warning>
+            <simpara>
+             Désactive la validation du certificat créant une vulnérabilité. Autoriser
+             les noms d'hôte invalides peut exposer le pilote à une
+             <link xlink:href="&url.mongodb.wiki.mitm;">attaque de l'homme du milieu</link>.
+            </simpara>
+           </warning>
+          </entry>
+         </row>
+         <row>
+          <entry>tlsCAFile</entry>
+          <entry><type>string</type></entry>
+          <entry>
+           <para>
+            Le chemin du fichier contenant un seul certificat ou un ensemble de certificats
+            d'autorités à considérer comme fiables lors de l'établissement d'une connexion TLS.
+            Le magasin de certificats système sera utilisé par défaut.
+           </para>
+          </entry>
+         </row>
+         <row>
+          <entry>tlsCertificateKeyFile</entry>
+          <entry><type>string</type></entry>
+          <entry>
+           <para>
+            Le chemin du fichier de certificat client ou du fichier de clé privée client;
+            dans le cas où les deux sont nécessaires, les fichiers doivent être
+            concaténés.
+           </para>
+          </entry>
+         </row>
+         <row>
+          <entry>tlsCertificateKeyFilePassword</entry>
+          <entry><type>string</type></entry>
+          <entry>
+           <para>
+            Le mot de passe pour décrypter la clé privée client (i.e.
+            l'option d'URI <literal>"tlsCertificateKeyFile"</literal>) à utiliser
+            pour les connexions TLS.
+           </para>
+          </entry>
+         </row>
+         <row>
+          <entry>tlsDisableCertificateRevocationCheck</entry>
+          <entry><type>bool</type></entry>
+          <entry>
+           <para>
+            Si &true;, le pilote n'essaiera pas de vérifier l'état de révocation du certificat
+            (e.g. OCSP, CRL). Par défaut à &false;.
+           </para>
+          </entry>
+         </row>
+         <row>
+          <entry>tlsDisableOCSPEndpointCheck</entry>
+          <entry><type>bool</type></entry>
+          <entry>
+           <para>
+            Si &true;, le pilote n'essaiera pas de contacter un point de terminaison de répondeur OCSP
+            si nécessaire (i.e. une réponse OCSP n'est pas agrafée). Par défaut à &false;.
+           </para>
+          </entry>
+         </row>
+         <row>
+          <entry>tlsInsecure</entry>
+          <entry><type>bool</type></entry>
+          <entry>
+           <para>
+            Détend les contraintes TLS autant que possible. Spécifier &true; pour
+            que cette option ait le même effet que de spécifier &true; pour les
+            options d'URI <literal>"tlsAllowInvalidCertificates"</literal> et
+            <literal>"tlsAllowInvalidHostnames"</literal>. Par défaut à &false;.
+           </para>
+           <warning>
+            <simpara>
+             Désactive la validation du certificat créant une vulnérabilité. Autoriser
+             les noms d'hôte invalides peut exposer le pilote à une
+             <link xlink:href="&url.mongodb.wiki.mitm;">attaque de l'homme du milieu</link>.
+            </simpara>
+           </warning>
+          </entry>
+         </row>
+         <row>
+          <entry>username</entry>
+          <entry><type>string</type></entry>
+          <entry>
+           Le nom d'utilisateur de l'utilisateur en cours d'authentification. Cette option est utile
+           si le nom d'utilisateur contient des caractères spéciaux, qui devraient autrement
+           être encodés en URL pour l'URI de connexion.
+          </entry>
+         </row>
+         <row>
+          <entry>w</entry>
+          <entry><type class="union"><type>int</type><type>string</type></type></entry>
+          <entry>
+           <para>
+            Correspond à l'option <parameter>w</parameter> du write concern par défaut.
+            Pour plus de détails, voir
+            <classname>MongoDB\Driver\WriteConcern</classname>.
+           </para>
+          </entry>
+         </row>
+         <row>
+          <entry>wTimeoutMS</entry>
+          <entry><type class="union"><type>int</type><type>string</type></type></entry>
+          <entry>
+           <para>
+            Correspond à l'option <parameter>wtimeout</parameter> du write concern
+            par défaut. Spécifie une limite de temps,
+            en millisecondes, pour le write concern. Pour plus de détails, voir
+            <classname>MongoDB\Driver\WriteConcern</classname>.
+           </para>
+           <para>
+            Si spécifié, <literal>wTimeoutMS</literal> doit être un entier signé de 32 bits
+            supérieur ou égal à zéro.
+           </para>
+          </entry>
+         </row>
+         <row>
+          <entry>zlibCompressionLevel</entry>
+          <entry><type>int</type></entry>
+          <entry>
+           <para>
+            Spécife le niveau de compression à utiliser pour le compresseur zlib. Cette
+            option n'a aucun effet si <literal>zlib</literal> n'est pas inclus dans
+            l'option d'URI <literal>"compressors"</literal>. Voir la
+            <link xlink:href="&url.mongodb.specs;/blob/master/source/compression/OP_COMPRESSED.rst#zlibcompressionlevel">Spécification de compression de pilote</link>
+            pour plus d'informations.
+           </para>
+          </entry>
+         </row>
+        </tbody>
+       </tgroup>
+      </table>
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="mongodb-driver-manager.construct-driveroptions">
+    <term><parameter>driverOptions</parameter></term>
+    <listitem>
+     <para>
+      <table>
+       <title>driverOptions</title>
+       <tgroup cols="3">
+        <thead>
+         <row>
+          <entry>Option</entry>
+          <entry>Type</entry>
+          <entry>Description</entry>
+         </row>
+        </thead>
+        <tbody>
+         <row>
+          <entry>allow_invalid_hostname</entry>
+          <entry><type>bool</type></entry>
+          <entry>
+           <para>
+            Désactive la validation du nom d'hôte si &true;. Par défaut à &false;.
+           </para>
+           <para>
+            Autorise les noms d'hôte invalides exposant le pilote à une
+             <link xlink:href="&url.mongodb.wiki.mitm;">attaque de l'homme du milieu</link>.
+           </para>
+           <para>
+            Cette option est un alias obsolète pour l'option d'URI
+            <literal>"tlsAllowInvalidHostnames"</literal>.
+           </para>
+          </entry>
+         </row>
+         <row>
+          <entry>autoEncryption</entry>
+          <entry><type>array</type></entry>
+          <entry>
+           <para>
+            Apporte des options pour activer le chiffrement côté client au niveau
+            des champs.
+           </para>
+           <note>
+            <para>
+             Le chiffrement automatique est une fonctionnalité d'entreprise
+             qui ne s'applique qu'aux opérations sur une collection. Le chiffrement automatique n'est pas
+             pris en charge pour les opérations sur une base de données ou une vue, et les opérations qui ne
+             sont pas contournées entraîneront une erreur (voir
+             <link xlink:href="https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/client-side-encryption.rst#libmongocrypt-auto-encryption-allow-list">libmongocrypt: Le liste d'autorisation de chiffrement automatique</link>). Pour contourner le chiffrement automatique
+             pour toutes les opérations, définissez <literal>bypassAutoEncryption</literal> à
+             &true;.
+            </para>
+            <para>
+             Le chiffrement automatique nécessite que l'utilisateur authentifié ait le
+             privilège d'action
+             <link xlink:href="&url.mongodb.docs;reference/command/listCollections/#required-access">listCollections</link>.
+            </para>
+            <para>
+             Le chiffrement explicite et automatique est une fonctionnalité de la communauté.
+             Le pilote peut toujours décrypter automatiquement lorsque
+             <literal>bypassAutoEncryption</literal> est &true;.
+            </para>
+           </note>
+           <para>
+            Les options suivantes sont prises en charge:
+
+            <table>
+             <title>Options pour le chiffrement automatique</title>
+             <tgroup cols="3">
+              <thead>
+               <row>
+                <entry>Option</entry>
+                <entry>Type</entry>
+                <entry>Description</entry>
+               </row>
+              </thead>
+              <tbody>
+               &mongodb.option.encryption.keyVaultClient;
+               &mongodb.option.encryption.keyVaultNamespace;
+               &mongodb.option.encryption.kmsProviders;
+               &mongodb.option.encryption.tlsOptions;
+               <row>
+                <entry>schemaMap</entry>
+                <entry><type class="union"><type>array</type><type>object</type></type></entry>
+                <entry>
+                 <para>
+                  Mappe les espaces de noms de collection à un schéma JSON local. Ceci est
+                  utilisé pour configurer le chiffrement automatique. Voir
+                  <link xlink:href="&url.mongodb.docs;reference/security-client-side-automatic-json-schema/">Règles de chiffrement automatique</link>
+                  dans le manuel MongoDB pour plus d'informations. Il est une erreur de
+                  spécifier une collection à la fois dans <literal>schemaMap</literal> et
+                  <literal>encryptedFieldsMap</literal>.
+                 </para>
+                 <note>
+                  <simpara>
+                   Fournir un <literal>schemaMap</literal> fournit plus
+                   de sécurité que de se fier aux schémas JSON obtenus du
+                   serveur. Cela protège contre un serveur malveillant annonçant un faux
+                   schéma JSON, qui pourrait tromper le client en envoyant
+                   des données non chiffrées qui devraient être chiffrées.
+                  </simpara>
+                 </note>
+                 <note>
+                  <simpara>
+                   Les schémas fournis dans le <literal>schemaMap</literal> s'appliquent uniquement
+                   à la configuration du chiffrement automatique pour le chiffrement côté client.
+                   D'autres règles de validation dans le schéma JSON ne seront
+                   pas appliquées par le pilote et entraîneront une erreur.
+                  </simpara>
+                 </note>
+                </entry>
+               </row>
+               <row>
+                <entry>bypassAutoEncryption</entry>
+                <entry><type>bool</type></entry>
+                <entry>
+                 Si &true;, <literal>mongocryptd</literal> ne sera pas lancé
+                 automatiquement. Ceci est utilisé pour désactiver le chiffrement automatique.
+                 Par défaut à &false;.
+                </entry>
+               </row>
+               <row>
+                <entry>bypassQueryAnalysis</entry>
+                <entry><type>bool</type></entry>
+                <entry>
+                 <para>
+                  Si &true;, l'analyse automatique des commandes sortantes sera désactivée et
+                  <literal>mongocryptd</literal> ne sera pas lancé automatiquement. Cela permet
+                  le cas d'utilisation du chiffrement explicite pour interroger des champs indexés sans nécessiter
+                  la bibliothèque <literal>crypt_shared</literal> sous licence entreprise ou
+                  le processus <literal>mongocryptd</literal>. Par défaut à &false;.
+                 </para>
+                </entry>
+               </row>
+               <row>
+                <entry>encryptedFieldsMap</entry>
+                <entry><type class="union"><type>array</type><type>object</type></type></entry>
+                <entry>
+                 <para>
+                  Mappe les espaces de noms de collection à un document
+                  <literal>encryptedFields</literal>. Ceci est utilisé pour
+                  configurer le chiffrement interrogeable. Voir
+                  <link xlink:href="&url.mongodb.docs;core/queryable-encryption/fundamentals/encrypt-and-query/">Chiffrement de champ et interrogeabilité</link>
+                  dans le manuel MongoDB pour plus d'informations. Il est une erreur de
+                  spécifier une collection à la fois dans
+                  <literal>encryptedFieldsMap</literal> et
+                  <literal>schemaMap</literal>.
+                 </para>
+                 <note>
+                  <simpara>
+                   Fournir un <literal>encryptedFieldsMap</literal> fournit plus
+                   de sécurité que de se fier aux
+                   <literal>encryptedFields</literal> obtenus du serveur.
+                   Cela protège contre un serveur malveillant annonçant un faux
+                   <literal>encryptedFields</literal>.
+                  </simpara>
+                 </note>
+                </entry>
+               </row>
+               <row>
+                <entry>extraOptions</entry>
+                <entry><type>array</type></entry>
+                <entry>
+                 <para>
+                  Le <literal>extraOptions</literal> se rapportent au
+                  processus <literal>mongocryptd</literal>. Les options suivantes
+                  sont prises en charge:
+                 </para>
+                 <simplelist>
+                  <member><literal>mongocryptdURI</literal> (<type>string</type>): URI pour se connecter à un processus <literal>mongocryptd</literal> existant. Par défaut à <literal>"mongodb://localhost:27020"</literal>.</member>
+                  <member><literal>mongocryptdBypassSpawn</literal> (<type>bool</type>): Si &true;, empêche le pilote de lancer <literal>mongocryptd</literal>. Par défaut à &false;.</member>
+                  <member><literal>mongocryptdSpawnPath</literal> (<type>string</type>): Chemin absolu pour rechercher le binaire <literal>mongocryptd</literal>. Par défaut à une chaîne vide et consulte les chemins système.</member>
+                  <member><literal>mongocryptdSpawnArgs</literal> (<type>array</type>): Tableau d'arguments de chaîne à passer à <literal>mongocryptd</literal> lors du lancement. Par défaut à <literal>["--idleShutdownTimeoutSecs=60"]</literal>.</member>
+                  <member><literal>cryptSharedLibPath</literal> (<type>string</type>): Chemin absolu vers la bibliothèque partagée <literal>crypt_shared</literal>. Par défaut à une chaîne vide et consulte les chemins système.</member>
+                  <member><literal>cryptSharedLibRequired</literal> (<type>bool</type>): Si &true;, exige que le pilote charge <literal>crypt_shared</literal>. Par défaut à &false;.</member>
+                 </simplelist>
+                 <para>
+                  Voir la <link xlink:href="&url.mongodb.specs;/blob/master/source/client-side-encryption/client-side-encryption.rst#extraoptions">Spécification de chiffrement côté client</link> pour plus d'informations.
+                 </para>
+                </entry>
+               </row>
+              </tbody>
+             </tgroup>
+            </table>
+           </para>
+
+           <note>
+            <simpara>
+             Le chiffrement automatique est une fonctionnalité d'entreprise qui
+             ne s'applique qu'aux opérations sur une collection. Le chiffrement automatique n'est pas
+             pris en charge pour les opérations sur une base de données ou une vue, et les opérations qui
+             ne sont pas contournées entraîneront une erreur. Pour contourner le chiffrement automatique
+             pour toutes les opérations, définissez <literal>bypassAutoEncryption=true</literal>
+             dans <literal>autoEncryption</literal>. Pour plus d'informations sur les opérations autorisées,
+             voir la <link xlink:href="&url.mongodb.specs;/blob/master/source/client-side-encryption/client-side-encryption.rst#libmongocrypt-auto-encryption-whitelist">Spécification de chiffrement côté client</link>.
+            </simpara>
+           </note>
+          </entry>
+         </row>
+         <row>
+          <entry>ca_dir</entry>
+          <entry><type>string</type></entry>
+          <entry>
+           <para>
+            Le chemin du répertoire de certificats correctement hachés. Le magasin de certificats système
+            sera utilisé par défaut.
+           </para>
+          </entry>
+         </row>
+         <row>
+          <entry>ca_file</entry>
+          <entry><type>string</type></entry>
+          <entry>
+           <para>
+            Le chemin du fichier avec un seul certificat ou un ensemble de certificats
+            d'autorités à considérer comme fiables lors de l'établissement d'une connexion TLS.
+            Le magasin de certificats système sera utilisé par défaut.
+           </para>
+           <para>
+            Cette option est un alias obsolète pour l'option d'URI
+            <literal>"tlsCAFile"</literal>.
+           </para>
+          </entry>
+         </row>
+         <row>
+          <entry>context</entry>
+          <entry><type>resource</type></entry>
+          <entry>
+           <para>
+            Les <link linkend="context.ssl">options de contexte SSL</link> à utiliser comme
+            solutions de secours si une option de pilote ou son équivalent URI, le cas échéant,
+            n'est pas spécifié. Notez que l'extension ne consulte pas
+            le contexte de flux par défaut (i.e.
+            <function>stream_context_get_default</function>). Les options
+            de contexte suivantes sont prises en charge:
+           </para>
+
+           <table>
+            <title>Options de contexte SSL de secours</title>
+            <tgroup cols="2">
+             <thead>
+              <row>
+               <entry>Option de Driver</entry>
+               <entry>Option de Contexte (solution de secours)</entry>
+              </row>
+             </thead>
+             <tbody>
+              <row>
+               <entry>ca_dir</entry>
+               <entry>capath</entry>
+              </row>
+              <row>
+               <entry>ca_file</entry>
+               <entry>cafile</entry>
+              </row>
+              <row>
+               <entry>pem_file</entry>
+               <entry>local_cert</entry>
+              </row>
+              <row>
+               <entry>pem_pwd</entry>
+               <entry>passphrase</entry>
+              </row>
+              <row>
+               <entry>weak_cert_validation</entry>
+               <entry>allow_self_signed</entry>
+              </row>
+             </tbody>
+            </tgroup>
+           </table>
+           <para>
+            Cette option est prise en charge pour des raisons de compatibilité ascendante, mais
+            devrait être considérée comme obsolète.
+           </para>
+          </entry>
+         </row>
+         <row>
+          <entry>crl_file</entry>
+          <entry><type>string</type></entry>
+          <entry>Le chemin du fichier de liste de révocation de certificat.</entry>
+         </row>
+         <row>
+          <entry>disableClientPersistence</entry>
+          <entry><type>bool</type></entry>
+          <entry>
+           <para>
+            Si &true;, ce Manager utilisera un nouveau client libmongoc, qui ne sera
+            pas persisté ou partagé avec d'autres objets Manager. Lorsque cet
+            objet Manager est libéré, son client sera détruit et toutes
+            les connexions seront fermées. Par défaut à &false;.
+           </para>
+           <note>
+            <simpara>
+             Désactive la persistance du client n'est généralement pas recommandé.
+            </simpara>
+           </note>
+          </entry>
+         </row>
+         <row>
+          <entry>driver</entry>
+          <entry><type>array</type></entry>
+          <entry>
+           <para>
+            Autorise un niveau supérieur de bibliothèque à ajouter ses propres métadonnées
+            à la poignée de main du serveur. Par défaut, l'extension soumet son propre nom,
+            version et plateforme (i.e. version PHP) dans la poignée de main. Les chaînes
+            peuvent être spécifiées pour les clés <literal>"name"</literal>,
+            <literal>"version"</literal> et <literal>"platform"</literal> de ce tableau, et seront
+            ajoutées au champ respectif(s)
+            de la poignée de main du serveur.
+           </para>
+           <note>
+            <simpara>
+             Les informations de poignée de main sont limitées à 512 octets. L'extension
+             tronquera les données de poignée de main pour s'adapter à cette chaîne de 512 octets. Les
+             bibliothèques de niveau supérieur sont encouragées à conserver leurs propres métadonnées concises.
+            </simpara>
+           </note>
+          </entry>
+         </row>
+         <row>
+          <entry>pem_file</entry>
+          <entry><type>string</type></entry>
+          <entry>
+           <para>
+            Le chemin du fichier contenant un certificat <acronym>PEM</acronym> à utiliser pour l'authentification du client.
+           </para>
+           <para>
+            Cette option est un alias obsolète pour l'option d'URI
+            <literal>"tlsCertificateKeyFile"</literal>.
+           </para>
+          </entry>
+         </row>
+         <row>
+          <entry>pem_pwd</entry>
+          <entry><type>string</type></entry>
+          <entry>
+           <para>
+            La phrase de passe pour le certificat <acronym>PEM</acronym> encodé (si applicable).
+           </para>
+           <para>
+            Cette option est un alias obsolète pour l'option d'URI
+            <literal>"tlsCertificateKeyFilePassword"</literal>.
+           </para>
+          </entry>
+         </row>
+         <row>
+          <entry>serverApi</entry>
+          <entry><classname>MongoDB\Driver\ServerApi</classname></entry>
+          <entry>
+           <para>
+            Cette option est utilisée pour déclarer une version d'API serveur pour le Manager.
+            Si omis, aucune version d'API n'est déclarée.
+           </para>
+          </entry>
+         </row>
+         <row>
+          <entry>weak_cert_validation</entry>
+          <entry><type>bool</type></entry>
+          <entry>
+           <para>
+            Désactive la validation du certificat si &true;. Par défaut à &false;.
+           </para>
+           <para>
+            Cette option est un alias obsolète pour l'option d'URI
+            <literal>"tlsAllowInvalidCertificates"</literal>.
+           </para>
+          </entry>
+         </row>
+        </tbody>
+       </tgroup>
+      </table>
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simplelist>
+   &mongodb.throws.argumentparsing;
+   <member>Lance une exception <classname>MongoDB\Driver\Exception\InvalidArgumentException</classname> si un paramètre est de type incorrect</member>
+  </simplelist>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>PECL mongodb 1.16.0</entry>
+       <entry>
+        <para>
+         Le fournisseur AWS KMS pour le chiffrement côté client accepte désormais une
+         option <literal>"sessionToken"</literal>, qui peut être utilisée pour
+         s'authentifier avec des informations d'identification AWS temporaires.
+        </para>
+        <para>
+         Ajout de <literal>"tlsDisableOCSPEndpointCheck"</literal> au
+         champ <literal>"tlsOptions"</literal> de l'option de pilote
+         <literal>"autoEncryption"</literal>.
+        </para>
+        <para>
+         Si un document vide est spécifié pour le fournisseur KMS <literal>"azure"</literal> ou
+         <literal>"gcp"</literal>, le pilote tentera de configurer le fournisseur en utilisant
+         <link xlink:href="&url.mongodb.specs;/blob/master/source/client-side-encryption/client-side-encryption.rst#automatic-credentials">les informations d'identification automatiques</link>.
+         If an empty document is specified for the <literal>"azure"</literal> or
+        </para>
+       </entry>
+      </row>
+      <row>
+       <entry>PECL mongodb 1.15.0</entry>
+       <entry>
+        <para>
+         Si un document vide est spécifié pour le fournisseur KMS <literal>"aws"</literal>, le pilote
+         tentera de configurer le fournisseur en utilisant
+         <link xlink:href="&url.mongodb.specs;/blob/master/source/client-side-encryption/client-side-encryption.rst#automatic-credentials">les informations d'identification automatiques</link>.
+        </para>
+       </entry>
+      </row>
+      <row>
+       <entry>PECL mongodb 1.14.0</entry>
+       <entry>
+        <para>
+         Ajout des options de chiffrement côté client <literal>"bypassQueryAnalysis"</literal> et
+         <literal>"encryptedFieldsMap"</literal>.
+         Des options supplémentaires concernant <literal>crypt_shared</literal> sont
+         désormais prises en charge dans l'option de chiffrement côté client
+         <literal>"extraOptions"</literal>.
+        </para>
+       </entry>
+      </row>
+      <row>
+       <entry>PECL mongodb 1.13.0</entry>
+       <entry>
+        <para>
+         Ajout des options d'URI <literal>"srvMaxHosts"</literal> et
+         <literal>"srvServiceName"</literal>.
+        </para>
+       </entry>
+      </row>
+      <row>
+       <entry>PECL mongodb 1.12.0</entry>
+       <entry>
+        <para>
+         KMIP est désormais pris en charge en tant que fournisseur KMS pour le chiffrement côté client et
+         peut être configuré dans le champ <literal>"kmsProviders"</literal> de l'option de pilote
+         <literal>"autoEncryption"</literal>. De plus, les options TLS
+         pour les fournisseurs KMS peuvent désormais être configurées dans le
+         champ <literal>"tlsOptions"</literal> de l'option de pilote
+         <literal>"autoEncryption"</literal>.
+        </para>
+       </entry>
+      </row>
+      <row>
+       <entry>PECL mongodb 1.11.0</entry>
+       <entry>
+        <para>
+         Ajout de l'option d'URI <literal>"loadBalanced"</literal>.
+        </para>
+       </entry>
+      </row>
+      <row>
+       <entry>PECL mongodb 1.10.0</entry>
+       <entry>
+        <para>
+         Ajout de l'option de pilote <literal>"disableClientPersistence"</literal>.
+        </para>
+        <para>
+         Azure et GCP sont désormais pris en charge en tant que fournisseurs KMS pour
+         le chiffrement côté client et peuvent être configurés dans le champ
+         <literal>"kmsProviders"</literal> de l'option de pilote
+         <literal>"autoEncryption"</literal>. Les chaînes encodées en base64 sont désormais acceptées
+         en tant qu'alternative à <classname>MongoDB\BSON\Binary</classname> pour les options dans
+         <literal>"kmsProviders"</literal>.
+        </para>
+       </entry>
+      </row>
+      <row>
+       <entry>PECL mongodb 1.8.0</entry>
+       <entry>
+        <para>
+         Ajout des options d'URI <literal>"directConnection"</literal>,
+         <literal>"tlsDisableCertificateRevocationCheck"</literal> et
+         <literal>"tlsDisableOCSPEndpointCheck"</literal>.
+        </para>
+        <para>
+         Ajout de l'option de pilote <literal>"driver"</literal>.
+        </para>
+       </entry>
+      </row>
+      <row>
+       <entry>PECL mongodb 1.7.0</entry>
+       <entry>
+        <para>
+         Ajout de l'option de pilote <literal>"autoEncryption"</literal>.
+        </para>
+        <para>
+         Spécifier n'importe quelle option SSL ou TLS via le paramètre
+         <parameter>driverOptions</parameter> activera désormais implicitement TLS, comme
+         c'est le cas pour les options d'URI correspondantes.
+        </para>
+       </entry>
+      </row>
+      <row>
+       <entry>PECL mongodb 1.6.0</entry>
+       <entry>
+        <para>
+         Ajout des options d'URI <literal>"retryReads"</literal>, <literal>"tls"</literal>,
+         <literal>"tlsAllowInvalidCertificates"</literal>,
+         <literal>"tlsAllowInvalidHostnames"</literal>,
+         <literal>"tlsCAFile"</literal>,
+         <literal>"tlsCertificateKeyFile"</literal>,
+         <literal>"tlsCertificateKeyFilePassword"</literal>, et
+         <literal>"tlsInsecure"</literal>.
+        </para>
+        <para>
+         L'option d'URI <literal>"retryWrites"</literal> est désormais à &true; par défaut.
+        </para>
+        <para>
+         Spécifier une option d'URI SSL ou TLS via la chaîne de connexion ou
+         le paramètre <parameter>uriOptions</parameter> activera désormais
+         implicitement TLS à moins que <literal>ssl</literal> ou <literal>tls</literal> ne soit &false;.
+         TLS n'est <emphasis>pas</emphasis> implicitement activé pour les options dans
+         le paramètre <parameter>driverOptions</parameter>, ce qui est inchangé
+         par rapport aux versions précédentes.
+        </para>
+       </entry>
+      </row>
+      <row>
+       <entry>PECL mongodb 1.5.0</entry>
+       <entry>
+        <para>
+         <literal>"wtimeoutMS"</literal> est désormais toujours validé et appliqué au
+         write concern. Auparavant, l'option était ignorée si
+         <literal>"w"</literal> était &lt;= 1, car le délai s'applique uniquement à
+         la réplication.
+        </para>
+       </entry>
+      </row>
+      <row>
+       <entry>PECL mongodb 1.4.0</entry>
+       <entry>
+        <para>
+         Ajout des options d'URI <literal>"compressors"</literal>,
+         <literal>"retryWrites"</literal>, er
+         <literal>"zlibCompressionLevel"</literal>.
+        </para>
+       </entry>
+      </row>
+      <row>
+       <entry>PECL mongodb 1.3.0</entry>
+       <entry>
+        <para>
+         L'argument <parameter>uriOptions</parameter> accepte désormais
+         les options <literal>"authMechanism"</literal> et
+         <literal>"authMechanismProperties"</literal>. Auparavant, ces
+         options n'étaient prises en charge que dans l'argument
+         <parameter>uri</parameter>.
+        </para>
+       </entry>
+      </row>
+      <row>
+       <entry>PECL mongodb 1.2.0</entry>
+       <entry>
+        <para>
+         L'argument <parameter>uri</parameter> est désormais facultatif et
+         par défaut à <literal>"mongodb://</literal>. Le port par défaut reste
+         <literal>27017</literal>.
+        </para>
+        <para>
+         Ajout de l'option d'URI <literal>"appname"</literal>.
+        </para>
+        <para>
+         Ajout des options de pilote <literal>"allow_invalid_hostname"</literal>,
+         <literal>"ca_file"</literal>, <literal>"ca_dir"</literal>,
+         <literal>"clr_file"</literal>, <literal>"pem_file"</literal>,
+         <literal>"pem_pwd"</literal>, et
+         <literal>"weak_cert_validation"</literal>.
+        </para>
+        <para>
+         L'API des flux PHP n'est plus utilisée pour la communication par socket. L'option
+         <literal>"connectTimeoutMS"</literal> de l'URI est désormais par défaut à 10
+         secondes au lieu de
+         <link linkend="ini.default-socket-timeout">default_socket_timeout</link>
+         dans les versions précédentes. De plus, l'extension ne prend plus en charge
+         toutes les <link linkend="context.ssl">options de contexte SSL</link> via
+         l'option de pilote <literal>"context"</literal>.
+        </para>
+       </entry>
+      </row>
+      <row>
+       <entry>PECL mongodb 1.1.0</entry>
+       <entry>
+        <para>
+         L'argument <parameter>uri</parameter> est désormais facultatif et par défaut à
+         <literal>"mongodb://localhost:27017/"</literal>.
+        </para>
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Exemples basiques <function>MongoDB\Driver\Manager::__construct</function></title>
+   <para>Connexion à un nœud MongoDB autonome:</para>
+   <programlisting role="php">
+<![CDATA[
+<?php
+
+$manager = new MongoDB\Driver\Manager("mongodb://example.com:27017");
+
+?>
+]]>
+   </programlisting>
+   <para>
+    Connecxion à un nœud MongoDB autonome via un socket de domaine Unix. Le chemin du
+    socket peut inclure des caractères spéciaux tels que des barres obliques et doit être encodé
+    avec <function>rawurlencode</function>.
+   </para>
+   <programlisting role="php">
+<![CDATA[
+<?php
+
+$manager = new MongoDB\Driver\Manager("mongodb://" . rawurlencode("/tmp/mongodb-27017.sock"));
+
+?>
+]]>
+   </programlisting>
+   <para>Connexion à un ensemble de réplicas:</para>
+   <programlisting role="php">
+<![CDATA[
+<?php
+
+$manager = new MongoDB\Driver\Manager("mongodb://rs1.example.com,rs2.example.com/?replicaSet=myReplicaSet");
+
+?>
+]]>
+   </programlisting>
+   <para>Connexion à un cluster fragmenté (c'est-à-dire un ou plusieurs instances mongos):</para>
+   <programlisting role="php">
+<![CDATA[
+<?php
+
+$manager = new MongoDB\Driver\Manager("mongodb://mongos1.example.com,mongos2.example.com/");
+
+?>
+]]>
+   </programlisting>
+   <para>Connexion à MongoDB avec des informations d'authentification pour un utilisateur et une base de données particuliers:</para>
+   <programlisting role="php">
+<![CDATA[
+<?php
+
+$manager = new MongoDB\Driver\Manager("mongodb://myusername:mypassword@example.com/?authSource=databaseName");
+
+?>
+]]>
+   </programlisting>
+
+   <para>
+    Connexion à MongoDB avec des informations d'authentification pour un utilisateur
+    et une base de données particuliers, où le nom d'utilisateur ou le mot de passe inclut
+    des caractères spéciaux (par exemple <literal>@</literal>, <literal>:</literal>,
+    <literal>%</literal>). Dans l'exemple suivant, la chaîne de mot de passe
+    <literal>myp@ss:w%rd</literal> a été manuellement échappée; cependant,
+    <function>rawurlencode</function> peut également être utilisé pour échapper
+    les composants d'URI qui peuvent contenir des caractères spéciaux.
+   </para>
+   <programlisting role="php">
+<![CDATA[
+<?php
+
+$manager = new MongoDB\Driver\Manager("mongodb://myusername:myp%40ss%3Aw%25rd@example.com/?authSource=databaseName");
+
+?>
+]]>
+   </programlisting>
+
+   <para>Connexion à MongoDB avec l'authentification X509:</para>
+   <programlisting role="php">
+<![CDATA[
+<?php
+
+$manager = new MongoDB\Driver\Manager(
+    "mongodb://example.com/?ssl=true&authMechanism=MONGODB-X509",
+    [],
+    [
+        "pem_file" => "/path/to/client.pem",
+    ]
+);
+?>
+]]>
+   </programlisting>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><link linkend="mongodb.connection-handling">Gestion de la connexion et de la persistance</link></member>
+   <member><link xlink:href="&url.mongodb.docs;reference/connection-string/">Format de chaîne de connexion MongoDB</link></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mongodb/mongodb/driver/manager/createclientencryption.xml
+++ b/reference/mongodb/mongodb/driver/manager/createclientencryption.xml
@@ -1,0 +1,166 @@
+<?xml version="1.0" encoding="utf-8"?> <!-- EN-Revision: cc6f9ee922cc02771942f435f66fbd008bf5788d Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="mongodb-driver-manager.createclientencryption" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>MongoDB\Driver\Manager::createClientEncryption</refname>
+  <refpurpose>Créer un nouvel objet ClientEncryption</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>final</modifier> <modifier>public</modifier> <type>MongoDB\Driver\ClientEncryption</type><methodname>MongoDB\Driver\Manager::createClientEncryption</methodname>
+   <methodparam><type>array</type><parameter>options</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Construit un nouvel objet <classname>MongoDB\Driver\ClientEncryption</classname> avec les options spécifiées.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>options</parameter></term>
+    <listitem>
+     <para>
+      <table>
+       <title>options</title>
+       <tgroup cols="3">
+        <thead>
+         <row>
+          <entry>Option</entry>
+          <entry>Type</entry>
+          <entry>Description</entry>
+         </row>
+        </thead>
+        <tbody>
+         &mongodb.option.encryption.keyVaultClient;
+         &mongodb.option.encryption.keyVaultNamespace;
+         &mongodb.option.encryption.kmsProviders;
+         &mongodb.option.encryption.tlsOptions;
+        </tbody>
+       </tgroup>
+      </table>
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Renvoie une nouvelle instance de <classname>MongoDB\Driver\ClientEncryption</classname>.
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simplelist>
+   &mongodb.throws.argumentparsing;
+   <member>Lance une exception <classname>MongoDB\Driver\Exception\RuntimeException</classname> si l'extension a été compilée sans le support de libmongocrypt</member>
+  </simplelist>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>PECL mongodb 1.16.0</entry>
+       <entry>
+        <para>
+         Le fournisseur AWS KMS pour le chiffrement côté client accepte
+         désormais une option <literal>"sessionToken"</literal>, qui peut être utilisée
+         pour s'authentifier avec des informations d'identification AWS temporaires.
+        </para>
+        <para>
+         Ajout de <literal>"tlsDisableOCSPEndpointCheck"</literal> à l'option
+         <literal>"tlsOptions"</literal>.
+        </para>
+        <para>
+         Si un document vide est spécifié pour le fournisseur KMS <literal>"azure"</literal> ou
+         <literal>"gcp"</literal>, le pilote tentera de
+         configurer le fournisseur en utilisant
+         <link xlink:href="&url.mongodb.specs;/blob/master/source/client-side-encryption/client-side-encryption.rst#automatic-credentials">Les informations d'identification automatiques</link>.
+        </para>
+       </entry>
+      </row>
+      <row>
+       <entry>PECL mongodb 1.15.0</entry>
+       <entry>
+        <para>
+         Si un document vide est spécifié pour le fournisseur KMS <literal>"aws"</literal>,
+         le pilote tentera de configurer le fournisseur en utilisant
+         <link xlink:href="&url.mongodb.specs;/blob/master/source/client-side-encryption/client-side-encryption.rst#automatic-credentials">Les informations d'identification automatiques</link>.
+        </para>
+       </entry>
+      </row>
+      <row>
+       <entry>PECL mongodb 1.12.0</entry>
+       <entry>
+        <para>
+         KMIP est désormais pris en charge en tant que fournisseur KMS pour le chiffrement
+         côté client et peut être configuré dans l'option <literal>"kmsProviders"</literal>.
+        </para>
+        <para>
+         Ajout de l'option <literal>"tlsOptions"</literal>.
+        </para>
+       </entry>
+      </row>
+      <row>
+       <entry>PECL mongodb 1.10.0</entry>
+       <entry>
+        Azure et GCP sont désormais pris en charge en tant que fournisseurs KMS pour le chiffrement
+        côté client et peuvent être configurés dans l'option
+        <literal>"kmsProviders"</literal>.
+        Les chaînes encodées en base64 sont désormais acceptées en tant qu'alternative à
+        <classname>MongoDB\BSON\Binary</classname>
+        pour les options dans <literal>"kmsProviders"</literal>.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>MongoDB\Driver\ClientEncryption::__construct</function></member>
+   <member><link xlink:href="&url.mongodb.docs;core/security-explicit-client-side-encryption/">Chiffrement côté client explicite (manuel)</link> dans le manuel MongoDB</member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mongodb/mongodb/driver/manager/executebulkwrite.xml
+++ b/reference/mongodb/mongodb/driver/manager/executebulkwrite.xml
@@ -1,0 +1,225 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 80693438668530525ea2a78defbfc9bb218c3b1c Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="mongodb-driver-manager.executebulkwrite" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>MongoDB\Driver\Manager::executeBulkWrite</refname>
+  <refpurpose>Exécute une ou plusieurs opérations d'écriture</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>final</modifier> <modifier>public</modifier> <type>MongoDB\Driver\WriteResult</type><methodname>MongoDB\Driver\Manager::executeBulkWrite</methodname>
+   <methodparam><type>string</type><parameter>namespace</parameter></methodparam>
+   <methodparam><type>MongoDB\Driver\BulkWrite</type><parameter>bulk</parameter></methodparam>
+   <methodparam choice="opt"><type class="union"><type>array</type><type>MongoDB\Driver\WriteConcern</type><type>null</type></type><parameter>options</parameter><initializer>&null;</initializer></methodparam>
+  </methodsynopsis>
+  <para>
+   Exécute une ou plusieurs opérations d'écriture sur le serveur primaire.
+  </para>
+  <para>
+   Un <classname>MongoDB\Driver\BulkWrite</classname> peut être construit avec
+   une ou plusieurs opérations d'écriture de types variés (par exemple, mises à
+   jour, suppressions et insertions). Le pilote tentera d'envoyer les
+   opérations du même type au serveur en aussi peu de requêtes que possible
+   pour optimiser les allers-retours.
+  </para>
+  <para>
+   La valeur par défaut de l'option <literal>"writeConcern"</literal> sera
+   déduite à partir d'une transaction active (indiquée par l'option
+   <literal>"session"</literal>), suivie de l'
+   <link linkend="mongodb-driver-manager.construct-uri">URI de connexion</link>.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   &mongodb.parameter.namespace;
+   &mongodb.parameter.bulkwrite;
+   <varlistentry>
+    <term><parameter>options</parameter></term>
+    <listitem>
+     <para>
+      <table>
+       <title>options</title>
+       <tgroup cols="3">
+        <thead>
+         <row>
+          <entry>Option</entry>
+          <entry>Type</entry>
+          <entry>Description</entry>
+         </row>
+        </thead>
+        <tbody>
+         &mongodb.option.session;
+         &mongodb.option.writeConcern;
+        </tbody>
+       </tgroup>
+      </table>
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  &mongodb.returns.writeresult;
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simplelist>
+   <member>Lance une <classname>MongoDB\Driver\Exception\InvalidArgumentException</classname> si <parameter>bulk</parameter> ne contient aucune opérations d'écriture.</member>
+   <member>Lance une <classname>MongoDB\Driver\Exception\InvalidArgumentException</classname> si <parameter>bulk</parameter> a déjà été éxécuté. Les objets <classname>MongoDB\Driver\BulkWrite</classname> ne peuvent pas être exécutés plusieurs fois.</member>
+   &mongodb.throws.session-unacknowledged;
+   &mongodb.throws.std;
+   &mongodb.throws.bulkwriteexception;
+   <member>Lance une <classname>MongoDB\Driver\Exception\RuntimeException</classname> sur d'autre erreurs.</member>
+  </simplelist>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>PECL mongodb 1.4.4</entry>
+       <entry>
+        Une <classname>MongoDB\Driver\Exception\InvalidArgumentException</classname>
+        sera lancée si l'option <literal>"session"</literal> est utilisée en
+        combinaison avec un <literal>"writeConcern"</literal> non-acknowledged.
+       </entry>
+      </row>
+      <row>
+       <entry>PECL mongodb 1.4.0</entry>
+       <entry>
+        Le troisième paramètre est maintenant un tableau d'<parameter>options</parameter>.
+        Pour des raisons de compatibilité ascendante, ce paramètre acceptera
+        toujours un objet <classname>MongoDB\Driver\WriteConcern</classname>.
+       </entry>
+      </row>
+      <row>
+       <entry>PECL mongodb 1.3.0</entry>
+       <entry>
+        Une <classname>MongoDB\Driver\Exception\InvalidArgumentException</classname>
+        est maintenant lancée si <parameter>bulk</parameter> ne contient aucune
+        opération d'écriture. Précédemment, une
+        <classname>MongoDB\Driver\Exception\BulkWriteException</classname> était
+        lancée.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Exemple de <function>MongoDB\Driver\Manager::executeBulkWrite</function></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+
+$bulk = new MongoDB\Driver\BulkWrite();
+
+$bulk->insert(['_id' => 1, 'x' => 1]);
+$bulk->insert(['_id' => 2, 'x' => 2]);
+
+$bulk->update(['x' => 2], ['$set' => ['x' => 1]], ['multi' => false, 'upsert' => false]);
+$bulk->update(['x' => 3], ['$set' => ['x' => 3]], ['multi' => false, 'upsert' => true]);
+$bulk->update(['_id' => 3], ['$set' => ['x' => 3]], ['multi' => false, 'upsert' => true]);
+
+$bulk->insert(['_id' => 4, 'x' => 2]);
+
+$bulk->delete(['x' => 1], ['limit' => 1]);
+
+$manager = new MongoDB\Driver\Manager('mongodb://localhost:27017');
+$writeConcern = new MongoDB\Driver\WriteConcern(MongoDB\Driver\WriteConcern::MAJORITY, 100);
+$result = $manager->executeBulkWrite('db.collection', $bulk, $writeConcern);
+
+printf("Inserted %d document(s)\n", $result->getInsertedCount());
+printf("Matched  %d document(s)\n", $result->getMatchedCount());
+printf("Updated  %d document(s)\n", $result->getModifiedCount());
+printf("Upserted %d document(s)\n", $result->getUpsertedCount());
+printf("Deleted  %d document(s)\n", $result->getDeletedCount());
+
+foreach ($result->getUpsertedIds() as $index => $id) {
+    printf('upsertedId[%d]: ', $index);
+    var_dump($id);
+}
+
+/* Si le WriteConcern n'a pas pu être satisfait */
+if ($writeConcernError = $result->getWriteConcernError()) {
+    printf("%s (%d): %s\n", $writeConcernError->getMessage(), $writeConcernError->getCode(), var_export($writeConcernError->getInfo(), true));
+}
+
+/* Si une écriture n'a pas pu se faire du tout */
+foreach ($result->getWriteErrors() as $writeError) {
+    printf("Operation#%d: %s (%d)\n", $writeError->getIndex(), $writeError->getMessage(), $writeError->getCode());
+}
+?>
+]]>
+   </programlisting>
+   &example.outputs.similar;
+   <screen>
+<![CDATA[
+Inserted 3 document(s)
+Matched  1 document(s)
+Updated  1 document(s)
+Upserted 2 document(s)
+Deleted  1 document(s)
+upsertedId[3]: object(MongoDB\BSON\ObjectId)#5 (1) {
+  ["oid"]=>
+  string(24) "54d3adc3ce7a792f4d703756"
+}
+upsertedId[4]: int(3)
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><classname>MongoDB\Driver\BulkWrite</classname></member>
+   <member><classname>MongoDB\Driver\WriteResult</classname></member>
+   <member><classname>MongoDB\Driver\WriteConcern</classname></member>
+   <member><function>MongoDB\Driver\Server::executeBulkWrite</function></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mongodb/mongodb/driver/manager/executecommand.xml
+++ b/reference/mongodb/mongodb/driver/manager/executecommand.xml
@@ -1,0 +1,302 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 80693438668530525ea2a78defbfc9bb218c3b1c Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="mongodb-driver-manager.executecommand" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>MongoDB\Driver\Manager::executeCommand</refname>
+  <refpurpose>Exécute une commande de base de données</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>final</modifier> <modifier>public</modifier> <type>MongoDB\Driver\Cursor</type><methodname>MongoDB\Driver\Manager::executeCommand</methodname>
+   <methodparam><type>string</type><parameter>db</parameter></methodparam>
+   <methodparam><type>MongoDB\Driver\Command</type><parameter>command</parameter></methodparam>
+   <methodparam choice="opt"><type class="union"><type>array</type><type>MongoDB\Driver\ReadPreference</type><type>null</type></type><parameter>options</parameter><initializer>&null;</initializer></methodparam>
+  </methodsynopsis>
+  <para>
+   Sélectionne un serveur en fonction de l'option <literal>"readPreference"</literal>
+   et exécute la commande sur ce serveur.
+  </para>
+  <para>
+   Cette méthode n'applique aucune logique spéciale à la commande. Les valeurs
+   par défaut des options <literal>"readPreference"</literal>,
+   <literal>"readConcern"</literal> et <literal>"writeConcern"</literal> seront
+   déduites à partir d'une transaction active (indiquée par l'option
+   <literal>"session"</literal>). S'il n'y a pas de transaction active, une
+   préférence de lecture primaire sera utilisée pour la sélection du serveur.
+  </para>
+  <para>
+   Les valeurs par défaut ne seront <emphasis>pas</emphasis> déduites à partir de
+   l'<link linkend="mongodb-driver-manager.construct-uri">URI de connexion</link>.
+   Il est donc recommandé aux utilisateurs d'utiliser des méthodes de commande
+   de lecture et/ou d'écriture spécifiques si possible.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   &mongodb.parameter.db;
+   &mongodb.parameter.command;
+   <varlistentry>
+    <term><parameter>options</parameter></term>
+    <listitem>
+     <para>
+      <table>
+       <title>options</title>
+       <tgroup cols="3">
+        <thead>
+         <row>
+          <entry>Option</entry>
+          <entry>Type</entry>
+          <entry>Description</entry>
+         </row>
+        </thead>
+        <tbody>
+         &mongodb.option.readConcern;
+         &mongodb.option.readPreference;
+         &mongodb.option.session;
+         &mongodb.option.writeConcern;
+        </tbody>
+       </tgroup>
+      </table>
+     </para>
+     &mongodb.option.transactionReadWriteConcern;
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  &mongodb.returns.cursor;
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simplelist>
+   &mongodb.throws.session-readwriteconcern;
+   &mongodb.throws.session-unacknowledged;
+   &mongodb.throws.std;
+   <member>Lance une <classname>MongoDB\Driver\Exception\RuntimeException</classname> sur d'autre erreurs (par exemple: commande invalide, délivrance d'une commande d'écriture à un secondaire).</member>
+  </simplelist>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>PECL mongodb 1.4.4</entry>
+       <entry>
+        Une <classname>MongoDB\Driver\Exception\InvalidArgumentException</classname>
+        sera lancée si l'option <literal>"session"</literal> est utilisée en
+        combinaison avec une préférence d'écriture non reconnue.
+       </entry>
+      </row>
+      <row>
+       <entry>PECL mongodb 1.4.0</entry>
+       <entry>
+        Ce troisième paramètre est maintenant un tableau d'<parameter>options</parameter>.
+        Pour des raisons de compatibilité ascendante, ce paramètre acceptera
+        toujours un objet <classname>MongoDB\Driver\ReadPreference</classname>.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title><function>MongoDB\Driver\Manager::executeCommand</function> avec une commande retournant un seul document de résultat</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+
+$manager = new MongoDB\Driver\Manager('mongodb://localhost:27017');
+$command = new MongoDB\Driver\Command(['ping' => 1]);
+
+try {
+    $cursor = $manager->executeCommand('admin', $command);
+} catch(MongoDB\Driver\Exception $e) {
+    echo $e->getMessage(), "\n";
+    exit;
+}
+
+/* La commande ping retourne un seul document de résultat, nous devons donc
+ * accéder au premier résultat dans le curseur. */
+$response = $cursor->toArray()[0];
+
+var_dump($response);
+
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+array(1) {
+  ["ok"]=>
+  float(1)
+}
+]]>
+   </screen>
+  </example>
+  <example>
+   <title><function>MongoDB\Driver\Manager::executeCommand</function> avec une commande retournant un curseur</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+
+$manager = new MongoDB\Driver\Manager("mongodb://localhost:27017");
+
+$bulk = new MongoDB\Driver\BulkWrite;
+$bulk->insert(['x' => 1, 'y' => 'foo']);
+$bulk->insert(['x' => 2, 'y' => 'bar']);
+$bulk->insert(['x' => 3, 'y' => 'bar']);
+$manager->executeBulkWrite('db.collection', $bulk);
+
+$command = new MongoDB\Driver\Command([
+    'aggregate' => 'collection',
+    'pipeline' => [
+        ['$group' => ['_id' => '$y', 'sum' => ['$sum' => '$x']]],
+    ],
+    'cursor' => new stdClass,
+]);
+$cursor = $manager->executeCommand('db', $command);
+
+/* La commande d'agrégation peut éventuellement retourner ses résultats dans
+ * un curseur au lieu d'un seul document de résultat. Dans ce cas, nous pouvons
+ * itérer directement sur le curseur pour accéder à ces résultats. */
+foreach ($cursor as $document) {
+    var_dump($document);
+}
+
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+object(stdClass)#6 (2) {
+  ["_id"]=>
+  string(3) "bar"
+  ["sum"]=>
+  int(10)
+}
+object(stdClass)#7 (2) {
+  ["_id"]=>
+  string(3) "foo"
+  ["sum"]=>
+  int(2)
+}
+]]>
+   </screen>
+  </example>
+
+  <example>
+   <title>Limiter le temps d'exécution d'une commande</title>
+   <para>
+    Le temps d'exécution d'une commande peut être limité en spécifiant une
+    valeur pour <literal>"maxTimeMS"</literal> dans le document
+    <classname>MongoDB\Driver\Command</classname>. Notez que cette limite de
+    temps est appliquée côté serveur et ne prend pas en compte la latence du
+    réseau. Voir
+    <link xlink:href="&url.mongodb.docs.maxtimems;">Terminer les opérations en cours
+    </link> dans le manuel MongoDB pour plus d'informations.
+   </para>
+   <programlisting role="php">
+<![CDATA[
+<?php
+
+$manager = new MongoDB\Driver\Manager('mongodb://localhost:27017');
+
+$command = new MongoDB\Driver\Command([
+    'count' => 'collection',
+    'query' => ['x' => ['$gt' => 1]],
+    'maxTimeMS' => 1000,
+]);
+
+$cursor = $manager->executeCommand('db', $command);
+
+var_dump($cursor->toArray()[0]);
+
+?>
+]]>
+   </programlisting>
+   <para>
+    Si la commande ne parvient pas à se terminer après une seconde d'exécution
+    sur le serveur, une
+    <classname>MongoDB\Driver\Exception\ExecutionTimeoutException</classname>
+    sera lancée.
+   </para>
+  </example>
+ </refsect1>
+
+ <refsect1 role="notes">
+  &reftitle.notes;
+  <note>
+   <simpara>
+    Si un deuxième <parameter>readPreference</parameter> est utilisé, il est de
+    la responsabilité de l'appelant de s'assurer que la
+    <parameter>commande</parameter> peut être exécutée sur un secondaire. Aucune
+    validation n'est effectuée par le pilote.
+   </simpara>
+  </note>
+  <note>
+   <simpara>
+    Cette méthode n'utilise pas par défaut la préférence de lecture de
+    <link linkend="mongodb-driver-manager.construct-uri">l'URI de connexion
+    MongoDB</link>. Les applications qui en ont besoin devraient envisager
+    d'utiliser <function>MongoDB\Driver\Manager::executeReadCommand</function>.
+   </simpara>
+  </note>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><classname>MongoDB\Driver\Command</classname></member>
+   <member><classname>MongoDB\Driver\Cursor</classname></member>
+   <member><function>MongoDB\Driver\Manager::executeReadCommand</function></member>
+   <member><function>MongoDB\Driver\Manager::executeReadWriteCommand</function></member>
+   <member><function>MongoDB\Driver\Manager::executeWriteCommand</function></member>
+   <member><function>MongoDB\Driver\Server::executeCommand</function></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mongodb/mongodb/driver/manager/executequery.xml
+++ b/reference/mongodb/mongodb/driver/manager/executequery.xml
@@ -1,0 +1,218 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 80693438668530525ea2a78defbfc9bb218c3b1c Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="mongodb-driver-manager.executequery" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>MongoDB\Driver\Manager::executeQuery</refname>
+  <refpurpose>Exécute une requête de base de données</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>final</modifier> <modifier>public</modifier> <type>MongoDB\Driver\Cursor</type><methodname>MongoDB\Driver\Manager::executeQuery</methodname>
+   <methodparam><type>string</type><parameter>namespace</parameter></methodparam>
+   <methodparam><type>MongoDB\Driver\Query</type><parameter>query</parameter></methodparam>
+   <methodparam choice="opt"><type class="union"><type>array</type><type>MongoDB\Driver\ReadPreference</type><type>null</type></type><parameter>options</parameter><initializer>&null;</initializer></methodparam>
+  </methodsynopsis>
+  <para>
+   Selectionne un serveur en fonction de l'option <literal>"readPreference"</literal>
+   et exécute la requête sur ce serveur.
+  </para>
+  <para>
+   Les valeurs par défaut de l'option <literal>"readPreference"</literal> et de
+   l'option <literal>"readConcern"</literal> de la requête seront déduites à
+   partir d'une transaction active (indiquée par l'option <literal>"session"</literal>),
+   suivie de l'<link linkend="mongodb-driver-manager.construct-uri">URI de connexion</link>.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   &mongodb.parameter.namespace;
+   &mongodb.parameter.query;
+   <varlistentry>
+    <term><parameter>options</parameter></term>
+    <listitem>
+     <para>
+      <table>
+       <title>options</title>
+       <tgroup cols="3">
+        <thead>
+         <row>
+          <entry>Option</entry>
+          <entry>Type</entry>
+          <entry>Description</entry>
+         </row>
+        </thead>
+        <tbody>
+         &mongodb.option.readPreference;
+         &mongodb.option.session;
+        </tbody>
+       </tgroup>
+      </table>
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  &mongodb.returns.cursor;
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simplelist>
+   &mongodb.throws.std;
+   <member>Lance une <classname>MongoDB\Driver\Exception\RuntimeException</classname> sur d'autre erreur (par exemple: opérateurs de requête invalides).</member>
+  </simplelist>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>PECL mongodb 1.4.0</entry>
+       <entry>
+        Le troisième paramètre est maintenant un tableau <parameter>options</parameter>.
+        Pour des raisons de compatibilité ascendante, ce paramètre acceptera toujours un
+        objet <classname>MongoDB\Driver\ReadPreference</classname>.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Exemple de <function>MongoDB\Driver\Manager::executeQuery</function></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+
+$manager = new MongoDB\Driver\Manager("mongodb://localhost:27017");
+
+$bulk = new MongoDB\Driver\BulkWrite;
+$bulk->insert(['x' => 1]);
+$bulk->insert(['x' => 2]);
+$bulk->insert(['x' => 3]);
+$manager->executeBulkWrite('db.collection', $bulk);
+
+$filter = ['x' => ['$gt' => 1]];
+$options = [
+    'projection' => ['_id' => 0],
+    'sort' => ['x' => -1],
+];
+
+$query = new MongoDB\Driver\Query($filter, $options);
+$cursor = $manager->executeQuery('db.collection', $query);
+
+foreach ($cursor as $document) {
+    var_dump($document);
+}
+
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+object(stdClass)#6 (1) {
+  ["x"]=>
+  int(3)
+}
+object(stdClass)#7 (1) {
+  ["x"]=>
+  int(2)
+}
+]]>
+   </screen>
+  </example>
+
+  <example>
+   <title>Limiter le temps d'exécution d'une requête</title>
+   <para>
+    L'option <literal>"maxTimeMS"</literal> de la classe
+    <classname>MongoDB\Driver\Query</classname> peut être utilisée pour limiter
+    le temps d'exécution d'une requête. Notez que cette limite de temps est
+    appliquée côté serveur et ne prend pas en compte la latence réseau. Voir
+    <link xlink:href="&url.mongodb.docs.maxtimems;">Terminer les opérations en cours
+    </link> dans le manuel MongoDB pour plus d'informations.
+   </para>
+   <programlisting role="php">
+<![CDATA[
+<?php
+
+$manager = new MongoDB\Driver\Manager('mongodb://localhost:27017');
+
+$filter = ['x' => ['$gt' => 1]];
+$options = [
+    'maxTimeMS' => 1000,
+];
+
+$query = new MongoDB\Driver\Query($filter, $options);
+$cursor = $manager->executeQuery('db.collection', $query);
+
+foreach ($cursor as $document) {
+    var_dump($document);
+}
+
+?>
+]]>
+   </programlisting>
+   <para>
+    Si la requête ne parvient pas à se terminer après une seconde d'exécution
+    sur le serveur, une
+    <classname>MongoDB\Driver\Exception\ExecutionTimeoutException</classname>
+    sera lancée.
+   </para>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><classname>MongoDB\Driver\Cursor</classname></member>
+   <member><classname>MongoDB\Driver\Query</classname></member>
+   <member><classname>MongoDB\Driver\ReadPreference</classname></member>
+   <member><function>MongoDB\Driver\Server::executeQuery</function></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mongodb/mongodb/driver/manager/executereadcommand.xml
+++ b/reference/mongodb/mongodb/driver/manager/executereadcommand.xml
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 80693438668530525ea2a78defbfc9bb218c3b1c Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="mongodb-driver-manager.executereadcommand" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>MongoDB\Driver\Manager::executeReadCommand</refname>
+  <refpurpose>Exécute une commande de base de données qui lit</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>final</modifier> <modifier>public</modifier> <type>MongoDB\Driver\Cursor</type><methodname>MongoDB\Driver\Manager::executeReadCommand</methodname>
+   <methodparam><type>string</type><parameter>db</parameter></methodparam>
+   <methodparam><type>MongoDB\Driver\Command</type><parameter>command</parameter></methodparam>
+   <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>options</parameter><initializer>&null;</initializer></methodparam>
+  </methodsynopsis>
+  <para>
+   Selectionne un serveur en fonction de l'option <literal>"readPreference"</literal>
+   et exécute la commande sur ce serveur.
+  </para>
+  <para>
+   Cette méthode appliquera une logique spécifique aux commandes qui lisent (par exemple
+   <link xlink:href="&url.mongodb.docs;reference/command/distinct/">distinct</link>).
+   Les valeurs par défaut des options <literal>"readPreference"</literal> et
+   <literal>"readConcern"</literal> seront déduites à partir d'une transaction active
+   (indiquée par l'option <literal>"session"</literal>), suivie de l'
+   <link linkend="mongodb-driver-manager.construct-uri">URI de connexion</link>.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   &mongodb.parameter.db;
+   &mongodb.parameter.command;
+   <varlistentry>
+    <term><parameter>options</parameter></term>
+    <listitem>
+     <para>
+      <table>
+       <title>options</title>
+       <tgroup cols="3">
+        <thead>
+         <row>
+          <entry>Option</entry>
+          <entry>Type</entry>
+          <entry>Description</entry>
+         </row>
+        </thead>
+        <tbody>
+         &mongodb.option.readConcern;
+         &mongodb.option.readPreference;
+         &mongodb.option.session;
+        </tbody>
+       </tgroup>
+      </table>
+     </para>
+     &mongodb.option.transactionReadWriteConcern;
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  &mongodb.returns.cursor;
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simplelist>
+   &mongodb.throws.session-readwriteconcern;
+   &mongodb.throws.std;
+   <member>Lance une <classname>MongoDB\Driver\Exception\RuntimeException</classname> sur d'autre erreurs (par exemple: commande invalide).</member>
+  </simplelist>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><classname>MongoDB\Driver\Command</classname></member>
+   <member><classname>MongoDB\Driver\Cursor</classname></member>
+   <member><function>MongoDB\Driver\Manager::executeCommand</function></member>
+   <member><function>MongoDB\Driver\Manager::executeReadWriteCommand</function></member>
+   <member><function>MongoDB\Driver\Manager::executeWriteCommand</function></member>
+   <member><function>MongoDB\Driver\Server::executeReadCommand</function></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mongodb/mongodb/driver/manager/executereadwritecommand.xml
+++ b/reference/mongodb/mongodb/driver/manager/executereadwritecommand.xml
@@ -1,0 +1,138 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: c90167b57a4b5a81acc18f9f952022e062b08104 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="mongodb-driver-manager.executereadwritecommand" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>MongoDB\Driver\Manager::executeReadWriteCommand</refname>
+  <refpurpose>Exécute une commande de base de données qui lit et écrit</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>final</modifier> <modifier>public</modifier> <type>MongoDB\Driver\Cursor</type><methodname>MongoDB\Driver\Manager::executeReadWriteCommand</methodname>
+   <methodparam><type>string</type><parameter>db</parameter></methodparam>
+   <methodparam><type>MongoDB\Driver\Command</type><parameter>command</parameter></methodparam>
+   <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>options</parameter><initializer>&null;</initializer></methodparam>
+  </methodsynopsis>
+  <para>
+   Exécute une commande sur le serveur primaire.
+  </para>
+  <para>
+   Cette méthode appliquera une logique spécifique aux commandes qui lisent et écrivent
+   (par exemple <link xlink:href="&url.mongodb.docs;reference/command/aggregate/">aggregate</link>).
+   Les valeurs par défaut des options <literal>"readConcern"</literal> et
+   <literal>"writeConcern"</literal> seront déduites à à partir d'une transaction active
+   (indiquée par l'option <literal>"session"</literal>), suivie de l'
+   <link linkend="mongodb-driver-manager.construct-uri">URI de connexion</link>.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   &mongodb.parameter.db;
+   &mongodb.parameter.command;
+   <varlistentry>
+    <term><parameter>options</parameter></term>
+    <listitem>
+     <para>
+      <table>
+       <title>options</title>
+       <tgroup cols="3">
+        <thead>
+         <row>
+          <entry>Option</entry>
+          <entry>Type</entry>
+          <entry>Description</entry>
+         </row>
+        </thead>
+        <tbody>
+         &mongodb.option.readConcern;
+         &mongodb.option.session;
+         &mongodb.option.writeConcern;
+        </tbody>
+       </tgroup>
+      </table>
+     </para>
+     &mongodb.option.transactionReadWriteConcern;
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  &mongodb.returns.cursor;
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simplelist>
+   &mongodb.throws.session-readwriteconcern;
+   &mongodb.throws.session-unacknowledged;
+   &mongodb.throws.std;
+   <member>Lance une <classname>MongoDB\Driver\Exception\RuntimeException</classname> sur d'autre erreurs (par exemple: commande invalide).</member>
+  </simplelist>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>PECL mongodb 1.4.4</entry>
+       <entry>
+        Une <classname>MongoDB\Driver\Exception\InvalidArgumentException</classname>
+        sera lancée si l'option <literal>"session"</literal> est utilisée en
+        combinaison avec un critère de lecture ou d'écriture non reconnu.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><classname>MongoDB\Driver\Command</classname></member>
+   <member><classname>MongoDB\Driver\Cursor</classname></member>
+   <member><function>MongoDB\Driver\Manager::executeCommand</function></member>
+   <member><function>MongoDB\Driver\Manager::executeReadCommand</function></member>
+   <member><function>MongoDB\Driver\Manager::executeWriteCommand</function></member>
+   <member><function>MongoDB\Driver\Server::executeReadWriteCommand</function></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mongodb/mongodb/driver/manager/executewritecommand.xml
+++ b/reference/mongodb/mongodb/driver/manager/executewritecommand.xml
@@ -1,0 +1,147 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 80693438668530525ea2a78defbfc9bb218c3b1c Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="mongodb-driver-manager.executewritecommand" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>MongoDB\Driver\Manager::executeWriteCommand</refname>
+  <refpurpose>Exécute une commande de base de données qui écrit</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>final</modifier> <modifier>public</modifier> <type>MongoDB\Driver\Cursor</type><methodname>MongoDB\Driver\Manager::executeWriteCommand</methodname>
+   <methodparam><type>string</type><parameter>db</parameter></methodparam>
+   <methodparam><type>MongoDB\Driver\Command</type><parameter>command</parameter></methodparam>
+   <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>options</parameter><initializer>&null;</initializer></methodparam>
+  </methodsynopsis>
+  <para>
+   Exécute la commande sur le serveur primaire.
+  </para>
+  <para>
+   Cette méthode appliquera une logique spécifique aux commandes qui écrivent (par exemple
+   <link xlink:href="&url.mongodb.docs;reference/command/drop/">drop</link>).
+   Les valeurs par défaut de l'option <literal>"writeConcern"</literal> seront déduites à
+   partir d'une transaction active (indiquée par l'option <literal>"session"</literal>), suivie de
+   l'<link linkend="mongodb-driver-manager.construct-uri">URI de connexion</link>.
+  </para>
+  <note>
+   <simpara>
+    Cette méthode n'est pas destinée à être utilisée pour exécuter
+    <link xlink:href="&url.mongodb.docs;reference/command/insert/">insert</link>,
+    <link xlink:href="&url.mongodb.docs;reference/command/update/">update</link>,
+    ou <link xlink:href="&url.mongodb.docs;reference/command/delete/">delete</link>.
+    Il est recommandé aux utilisateurs d'utiliser
+    <function>MongoDB\Driver\Manager::executeBulkWrite</function> pour ces
+    opérations.
+   </simpara>
+  </note>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   &mongodb.parameter.db;
+   &mongodb.parameter.command;
+   <varlistentry>
+    <term><parameter>options</parameter></term>
+    <listitem>
+     <para>
+      <table>
+       <title>options</title>
+       <tgroup cols="3">
+        <thead>
+         <row>
+          <entry>Option</entry>
+          <entry>Type</entry>
+          <entry>Description</entry>
+         </row>
+        </thead>
+        <tbody>
+         &mongodb.option.session;
+         &mongodb.option.writeConcern;
+        </tbody>
+       </tgroup>
+      </table>
+     </para>
+     &mongodb.option.transactionReadWriteConcern;
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  &mongodb.returns.cursor;
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simplelist>
+   &mongodb.throws.session-readwriteconcern;
+   &mongodb.throws.session-unacknowledged;
+   &mongodb.throws.std;
+   <member>Lance une <classname>MongoDB\Driver\Exception\RuntimeException</classname> sur d'autre erreurs (par exemple: commande invalide).</member>
+  </simplelist>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>PECL mongodb 1.4.4</entry>
+       <entry>
+        Une <classname>MongoDB\Driver\Exception\InvalidArgumentException</classname>
+        sera lancée si l'option <literal>"session"</literal> est utilisée en
+        combinaison avec un <literal>"writeConcern"</literal> non reconnu.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><classname>MongoDB\Driver\Command</classname></member>
+   <member><classname>MongoDB\Driver\Cursor</classname></member>
+   <member><function>MongoDB\Driver\Manager::executeCommand</function></member>
+   <member><function>MongoDB\Driver\Manager::executeReadCommand</function></member>
+   <member><function>MongoDB\Driver\Manager::executeReadWriteCommand</function></member>
+   <member><function>MongoDB\Driver\Server::executeWriteCommand</function></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mongodb/mongodb/driver/manager/getencryptedfieldsmap.xml
+++ b/reference/mongodb/mongodb/driver/manager/getencryptedfieldsmap.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 6c44e7b831d1ee04c932847b83a19cecfd51c98e Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes --> 
+<refentry xml:id="mongodb-driver-manager.getencryptedfieldsmap" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>MongoDB\Driver\Manager::getEncryptedFieldsMap</refname>
+  <refpurpose>Renvoie l'option de chiffrement automatique encryptedFieldsMap pour le Manager</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>final</modifier> <modifier>public</modifier> <type class="union"><type>array</type><type>object</type><type>null</type></type><methodname>MongoDB\Driver\Manager::getEncryptedFieldsMap</methodname>
+   <void />
+  </methodsynopsis>
+  <para>
+   Renvoie l'option de chiffrement automatique <literal>encryptedFieldsMap</literal>
+   pour le Manager, si spécifiée.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   L'option de chiffrement automatique <literal>encryptedFieldsMap</literal> pour le
+   Manager, ou &null; si elle n'a pas été spécifiée.
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simplelist>
+   &mongodb.throws.argumentparsing;
+  </simplelist>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>MongoDB\Driver\Manager::__construct</function></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mongodb/mongodb/driver/manager/getreadconcern.xml
+++ b/reference/mongodb/mongodb/driver/manager/getreadconcern.xml
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: e9366ee458b2900c53a503b1ad97664e1d9a8859 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes --> 
+<refentry xml:id="mongodb-driver-manager.getreadconcern" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>MongoDB\Driver\Manager::getReadConcern</refname>
+  <refpurpose>Renvoie le ReadConcern pour le Manager</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>final</modifier> <modifier>public</modifier> <type>MongoDB\Driver\ReadConcern</type><methodname>MongoDB\Driver\Manager::getReadConcern</methodname>
+   <void />
+  </methodsynopsis>
+  <para>
+   Renvoie le <classname>MongoDB\Driver\ReadConcern</classname> pour le
+   Manager, qui est dérivé de ses options URI. C'est le ReadConcern par défaut
+   pour les requêtes et commandes exécutées sur le Manager.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Le <classname>MongoDB\Driver\ReadConcern</classname> pour le Manager.
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simplelist>
+   &mongodb.throws.argumentparsing;
+  </simplelist>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Exemple <function>MongoDB\Driver\Manager::getReadConcern</function></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+
+$manager = new MongoDB\Driver\Manager('mongodb://localhost:27017');
+var_dump($manager->getReadConcern());
+
+$manager = new MongoDB\Driver\Manager('mongodb://localhost:27017/?readConcernLevel=local');
+var_dump($manager->getReadConcern());
+
+?>
+]]>
+   </programlisting>
+   &example.outputs.similar;
+   <screen>
+<![CDATA[
+object(MongoDB\Driver\ReadConcern)#2 (0) {
+}
+object(MongoDB\Driver\ReadConcern)#1 (1) {
+  ["level"]=>
+  string(5) "local"
+}
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><classname>MongoDB\Driver\ReadConcern</classname></member>
+   <member><function>MongoDB\Driver\Manager::__construct</function></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mongodb/mongodb/driver/manager/getreadpreference.xml
+++ b/reference/mongodb/mongodb/driver/manager/getreadpreference.xml
@@ -1,0 +1,122 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: e9366ee458b2900c53a503b1ad97664e1d9a8859 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes --> 
+<refentry xml:id="mongodb-driver-manager.getreadpreference" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>MongoDB\Driver\Manager::getReadPreference</refname>
+  <refpurpose>Renvoie le ReadPreference pour le Manager</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>final</modifier> <modifier>public</modifier> <type>MongoDB\Driver\ReadPreference</type><methodname>MongoDB\Driver\Manager::getReadPreference</methodname>
+   <void />
+  </methodsynopsis>
+  <para>
+   Renvoie le <classname>MongoDB\Driver\ReadPreference</classname> pour le
+   Manager, qui est dérivé de ses options URI. C'est le ReadPreference par défaut
+   pour les requêtes et commandes exécutées sur le Manager.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Le <classname>MongoDB\Driver\ReadPreference</classname> pour le Manager.
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simplelist>
+   &mongodb.throws.argumentparsing;
+  </simplelist>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Exemple de <function>MongoDB\Driver\Manager::getReadPreference</function></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+
+$manager = new MongoDB\Driver\Manager('mongodb://localhost:27017');
+var_dump($manager->getReadPreference());
+
+$manager = new MongoDB\Driver\Manager('mongodb://localhost:27017/?readPreference=secondaryPreferred&readPreferenceTags=dc:ny,rack:1&readPreferenceTags=dc:ny&readPreferenceTags=');
+var_dump($manager->getReadPreference());
+
+?>
+]]>
+   </programlisting>
+   &example.outputs.similar;
+   <screen>
+<![CDATA[
+object(MongoDB\Driver\ReadPreference)#2 (1) {
+  ["mode"]=>
+  string(7) "primary"
+}
+object(MongoDB\Driver\ReadPreference)#1 (2) {
+  ["mode"]=>
+  string(18) "secondaryPreferred"
+  ["tags"]=>
+  array(3) {
+    [0]=>
+    object(stdClass)#3 (2) {
+      ["dc"]=>
+      string(2) "ny"
+      ["rack"]=>
+      string(1) "1"
+    }
+    [1]=>
+    object(stdClass)#4 (1) {
+      ["dc"]=>
+      string(2) "ny"
+    }
+    [2]=>
+    object(stdClass)#5 (0) {
+    }
+  }
+}
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><classname>MongoDB\Driver\ReadPreference</classname></member>
+   <member><function>MongoDB\Driver\Manager::__construct</function></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mongodb/mongodb/driver/manager/getwriteconcern.xml
+++ b/reference/mongodb/mongodb/driver/manager/getwriteconcern.xml
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: e9366ee458b2900c53a503b1ad97664e1d9a8859 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes --> 
+<refentry xml:id="mongodb-driver-manager.getwriteconcern" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>MongoDB\Driver\Manager::getWriteConcern</refname>
+  <refpurpose>Renvoie le WriteConcern pour le Manager</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>final</modifier> <modifier>public</modifier> <type>MongoDB\Driver\WriteConcern</type><methodname>MongoDB\Driver\Manager::getWriteConcern</methodname>
+   <void />
+  </methodsynopsis>
+  <para>
+   Renvoie le <classname>MongoDB\Driver\WriteConcern</classname> pour le
+   Manager, qui est dérivé de ses options URI. C'est le WriteConcern par défaut
+   pour les écritures et commandes exécutées sur le Manager.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Le <classname>MongoDB\Driver\WriteConcern</classname> pour le Manager.
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simplelist>
+   &mongodb.throws.argumentparsing;
+  </simplelist>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Exemple de <function>MongoDB\Driver\Manager::getWriteConcern</function></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+
+$manager = new MongoDB\Driver\Manager('mongodb://localhost:27017');
+var_dump($manager->getWriteConcern());
+
+$manager = new MongoDB\Driver\Manager('mongodb://localhost:27017/?w=majority&wtimeoutMS=2000');
+var_dump($manager->getWriteConcern());
+
+?>
+]]>
+   </programlisting>
+   &example.outputs.similar;
+   <screen>
+<![CDATA[
+object(MongoDB\Driver\WriteConcern)#2 (0) {
+}
+object(MongoDB\Driver\WriteConcern)#1 (2) {
+  ["w"]=>
+  string(8) "majority"
+  ["wtimeout"]=>
+  int(2000)
+}
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><classname>MongoDB\Driver\WriteConcern</classname></member>
+   <member><function>MongoDB\Driver\Manager::__construct</function></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mongodb/mongodb/driver/manager/removesubscriber.xml
+++ b/reference/mongodb/mongodb/driver/manager/removesubscriber.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 40dbbc56e321e36deee0f82df820c91fa79087cb Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes --> 
+<refentry xml:id="mongodb-driver-manager.removesubscriber" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>MongoDB\Driver\Manager::removeSubscriber</refname>
+  <refpurpose>Enlève un observateur d'événements de surveillance de ce Manager</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>final</modifier> <modifier>public</modifier> <type>void</type><methodname>MongoDB\Driver\Manager::removeSubscriber</methodname>
+   <methodparam><type>MongoDB\Driver\Monitoring\Subscriber</type><parameter>subscriber</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Enlève un observateur d'événements de surveillance de ce Manager.
+  </para>
+  <note>
+   <simpara>
+    Si <parameter>subscriber</parameter> n'est pas déjà enregistré avec ce
+    Manager, cette fonction ne fait rien.
+   </simpara>
+  </note>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>subscriber</parameter> (<type>MongoDB\Driver\Monitoring\Subscriber</type>)</term>
+    <listitem>
+     <para>
+      Un observateur d'événements de surveillance à enlever de ce Manager.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &return.void;
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simplelist>
+   &mongodb.throws.argumentparsing;
+  </simplelist>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>MongoDB\Driver\Manager::addSubscriber</function></member>
+   <member><interfacename>MongoDB\Driver\Monitoring\Subscriber</interfacename></member>
+   <member><interfacename>MongoDB\Driver\Monitoring\CommandSubscriber</interfacename></member>
+   <member><function>MongoDB\Driver\Monitoring\removeSubscriber</function></member>
+   <member><xref linkend="mongodb.tutorial.apm" /></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mongodb/mongodb/driver/manager/selectserver.xml
+++ b/reference/mongodb/mongodb/driver/manager/selectserver.xml
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 929fb17986921c8aadadb7c7bd877ee6f7a7126e Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="mongodb-driver-manager.selectserver" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>MongoDB\Driver\Manager::selectServer</refname>
+  <refpurpose>Sélectionne un serveur correspondant à une préférence de lecture</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>final</modifier> <modifier>public</modifier> <type>MongoDB\Driver\Server</type><methodname>MongoDB\Driver\Manager::selectServer</methodname>
+   <methodparam choice="opt"><type class="union"><type>MongoDB\Driver\ReadPreference</type><type>null</type></type><parameter>readPreference</parameter><initializer>&null;</initializer></methodparam>
+  </methodsynopsis>
+  <para>
+   Sélectionne un <classname>MongoDB\Driver\Server</classname> correspondant à
+   <parameter>readPreference</parameter>. Si <parameter>readPreference</parameter>
+   est &null; ou omis, le serveur primaire sera sélectionné par défaut. Cela peut
+   être utilisé pour pré-sélectionner un serveur afin d'effectuer une vérification
+   de version avant d'exécuter une opération.
+  </para>
+  <note>
+   <simpara>
+    Contrairement à <function>MongoDB\Driver\Manager::getServers</function>, cette
+    méthode initialisera les connexions de base de données et effectuera la
+    découverte de serveurs si nécessaire. Voir la
+    <link xlink:href="&url.mongodb.serverselection;#single-threaded-server-selection">Spécification de sélection de serveur</link>
+    pour plus d'informations.
+   </simpara>
+  </note>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>readPreference</parameter> (<classname>MongoDB\Driver\ReadPreference</classname>)</term>
+    <listitem>
+     <para>
+      Les préférences de lecture à utiliser pour sélectionner un serveur. Si
+      &null; ou omis, le serveur primaire sera sélectionné par défaut.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Renvoie un <classname>MongoDB\Driver\Server</classname> correspondant à la
+   préférence de lecture.
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simplelist>
+   &mongodb.throws.std;
+   <member>Lance une <classname>MongoDB\Driver\Exception\RuntimeException</classname> si un serveur correspondant à la préférence de lecture n'a pas pu être trouvé.</member>
+  </simplelist>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>PECL mongodb 1.11.0</entry>
+       <entry>
+        Le <parameter>readPreference</parameter> est maintenant optionnel. Si &null; ou
+        omis, le serveur primaire sera sélectionné par défaut.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><classname>MongoDB\Driver\Server</classname></member>
+   <member><function>MongoDB\Driver\Manager::getServers</function></member>
+   <member><link xlink:href="&url.mongodb.serverselection;">Spécification de sélection de serveur</link></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mongodb/mongodb/driver/manager/startsession.xml
+++ b/reference/mongodb/mongodb/driver/manager/startsession.xml
@@ -1,0 +1,224 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 734bafeaf071b78b15d375f9af583befddd8c2a2 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="mongodb-driver-manager.startsession" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>MongoDB\Driver\Manager::startSession</refname>
+  <refpurpose>Démarre une nouvelle session client pour être utilisée avec ce client</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>final</modifier> <modifier>public</modifier> <type>MongoDB\Driver\Session</type><methodname>MongoDB\Driver\Manager::startSession</methodname>
+   <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>options</parameter><initializer>&null;</initializer></methodparam>
+  </methodsynopsis>
+  <para>
+   Créer une <classname>MongoDB\Driver\Session</classname> pour les options données.
+   La session peut ensuite être spécifiée lors de l'exécution de commandes, de requêtes
+   et d'opérations d'écriture.
+  </para>
+  <note>
+   <simpara>
+    Une <classname>MongoDB\Driver\Session</classname> ne peut être utilisée qu'avec le
+    <classname>MongoDB\Driver\Manager</classname> à partir duquel elle a été créée.
+   </simpara>
+  </note>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>options</parameter></term>
+    <listitem>
+     <para>
+      <table>
+       <title>options</title>
+       <tgroup cols="4">
+        <thead>
+         <row>
+          <entry>Option</entry>
+          <entry>Type</entry>
+          <entry>Description</entry>
+          <entry>Default</entry>
+         </row>
+        </thead>
+        <tbody>
+         <row>
+          <entry>causalConsistency</entry>
+          <entry><type>bool</type></entry>
+          <entry>
+           <para>
+            Configure la cohérence causale dans une session. Si &true;, chaque opération
+            dans la session sera ordonnée de manière causale après l'opération de lecture
+            ou d'écriture précédente. Définissez à &false; pour désactiver la cohérence causale.
+           </para>
+           <para>
+            Voir
+            <link xlink:href="&url.mongodb.docs;core/read-isolation-consistency-recency/#causal-consistency">Consistance causale</link>
+            dans le manuel MongoDB pour plus d'informations.
+           </para>
+          </entry>
+          <entry>&true;</entry>
+         </row>
+         <row>
+          <entry>defaultTransactionOptions</entry>
+          <entry><type>array</type></entry>
+          <entry>
+           <para>
+            Les options par défaut à appliquer aux transactions nouvellement créées. Ces
+            options sont utilisées sauf si elles sont remplacées lorsqu'une transaction est
+            démarrée avec une valeur différente pour chaque option.
+           </para>
+           <para>
+            <table>
+             <title>options</title>
+             <tgroup cols="3">
+              <thead>
+               <row>
+                <entry>Option</entry>
+                <entry>Type</entry>
+                <entry>Description</entry>
+               </row>
+              </thead>
+              <tbody>
+               &mongodb.option.maxCommitTimeMS;
+               &mongodb.option.readConcern;
+               &mongodb.option.readPreference;
+               &mongodb.option.writeConcern;
+              </tbody>
+             </tgroup>
+            </table>
+           </para>
+           <para>
+            Cette option est disponible dans MongoDB 4.0+.
+           </para>
+          </entry>
+          <entry><literal>[]</literal></entry>
+         </row>
+         <row>
+          <entry>snapshot</entry>
+          <entry><type>bool</type></entry>
+          <entry>
+           <para>
+            Configure les lectures instantanées dans une session. Si &true;, un horodatage sera
+            obtenu à partir de la première opération de lecture prise en charge dans la session
+            (c'est-à-dire <literal>find</literal>, <literal>aggregate</literal>, ou
+            <literal>distinct</literal> non fragmenté). Les opérations de lecture ultérieures
+            dans la session utiliseront ensuite un niveau de cohérence de lecture <literal>"snapshot"</literal>
+            pour lire des données majoritairement engagées à partir de cet horodatage. Définissez
+            à &false; pour désactiver les lectures instantanées.
+           </para>
+           <para>
+            Les lectures instantanées nécessitent MongoDB 5.0+ et ne peuvent pas être utilisées
+            avec la cohérence causale, les transactions ou les opérations d'écriture. Si
+            <literal>"snapshot"</literal> est &true;,
+            <literal>"causalConsistency"</literal> sera par défaut à &false;.
+           </para>
+           <para>
+            Voir
+            <link xlink:href="&url.mongodb.docs;reference/read-concern-snapshot/#read-concern-and-atclustertime">Read Concern "instantanés"</link>
+            dans le manuel MongoDB pour plus d'informations.
+           </para>
+          </entry>
+          <entry>&false;</entry>
+         </row>
+        </tbody>
+       </tgroup>
+      </table>
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Renvoie une <classname>MongoDB\Driver\Session</classname>.
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simplelist>
+   &mongodb.throws.argumentparsing;
+   <member>Lance une <classname>MongoDB\Driver\Exception\InvalidArgumentException</classname> si les options <literal>"causalConsistency"</literal> et <literal>"snapshot"</literal> sont toutes les deux &true;.</member>
+   <member>Lance une <classname>MongoDB\Driver\Exception\RuntimeException</classname> si la session ne peut pas être créée (par exemple, libmongoc ne prend pas en charge le chiffrement).</member>
+  </simplelist>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>PECL mongodb 1.11.0</entry>
+       <entry>
+        <para>
+         L'option <literal>"snapshot"</literal> a été ajoutée.
+        </para>
+       </entry>
+      </row>
+      <row>
+       <entry>PECL mongodb 1.6.0</entry>
+       <entry>
+        <para>
+         L'option <literal>"maxCommitTimeMS"</literal> a été ajoutée à
+         <literal>"defaultTransactionOptions"</literal>.
+        </para>
+       </entry>
+      </row>
+      <row>
+       <entry>PECL mongodb 1.5.0</entry>
+       <entry>
+        <para>
+         L'option <literal>"defaultTransactionOptions"</literal> a été ajoutée.
+        </para>
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><classname>MongoDB\Driver\Session</classname></member>
+   <member><link xlink:href="&url.mongodb.docs;core/read-isolation-consistency-recency/#causal-consistency">Consistance causale</link> dans le manuel MongoDB</member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
Here is the translation of missing `MongoDB\Driver\Manager` methods

- `MongoDB\Driver\Manager::addSubcriber()`
- `MongoDB\Driver\Manager::__construct()`
- `MongoDB\Driver\Manager::createClientEncryption()`
- `MongoDB\Driver\Manager::executeBulkWrite()`
- `MongoDB\Driver\Manager::executeCommand()`
- `MongoDB\Driver\Manager::executeQuery()`
- `MongoDB\Driver\Manager::executeReadCommand()`
- `MongoDB\Driver\Manager::executeReadWriteCommand()`
- `MongoDB\Driver\Manager::executeWriteCommand()`
- `MongoDB\Driver\Manager::getEncryptedFieldsMap()`
- `MongoDB\Driver\Manager::getReadConcern()`
- `MongoDB\Driver\Manager::getReadPreference()`
- `MongoDB\Driver\Manager::getWriteConcern()`
- `MongoDB\Driver\Manager::removeSubscriber()`
- `MongoDB\Driver\Manager::selectServer()`
- `MongoDB\Driver\Manager::startSession()`