### PR TITLE
Translate `MongoDB\Driver\Server`

### DIFF
--- a/reference/mongodb/mongodb/driver/server/executereadcommand.xml
+++ b/reference/mongodb/mongodb/driver/server/executereadcommand.xml
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 80693438668530525ea2a78defbfc9bb218c3b1c Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="mongodb-driver-server.executereadcommand" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>MongoDB\Driver\Server::executeReadCommand</refname>
+  <refpurpose>Exécute une commande de base de données qui lit sur ce serveur</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>final</modifier> <modifier>public</modifier> <type>MongoDB\Driver\Cursor</type><methodname>MongoDB\Driver\Server::executeReadCommand</methodname>
+   <methodparam><type>string</type><parameter>db</parameter></methodparam>
+   <methodparam><type>MongoDB\Driver\Command</type><parameter>command</parameter></methodparam>
+   <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>options</parameter><initializer>&null;</initializer></methodparam>
+  </methodsynopsis>
+  <para>
+   Exécute la commande sur ce serveur, indépendamment de l'option
+   <literal>"readPreference"</literal>.
+  </para>
+  <para>
+   Cette méthode appliquera une logique spécifique aux commandes de lecture (par exemple
+   <link xlink:href="&url.mongodb.docs;reference/command/distinct/">distinct</link>).
+   Les valeurs par défaut pour les options <literal>"readPreference"</literal> et
+   <literal>"readConcern"</literal> seront déduites d'une transaction active (indiquée par
+   l'option <literal>"session"</literal>), suivie de l'
+   <link linkend="mongodb-driver-manager.construct-uri">URI de connexion</link>.
+  </para>
+  &mongodb.note.server.readpreference;
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   &mongodb.parameter.db;
+   &mongodb.parameter.command;
+   <varlistentry>
+    <term><parameter>options</parameter></term>
+    <listitem>
+     <para>
+      <table>
+       <title>options</title>
+       <tgroup cols="3">
+        <thead>
+         <row>
+          <entry>Option</entry>
+          <entry>Type</entry>
+          <entry>Description</entry>
+         </row>
+        </thead>
+        <tbody>
+         &mongodb.option.readConcern;
+         &mongodb.option.readPreference;
+         &mongodb.option.session;
+        </tbody>
+       </tgroup>
+      </table>
+     </para>
+     &mongodb.option.transactionReadWriteConcern;
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  &mongodb.returns.cursor;
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simplelist>
+   &mongodb.throws.session-readwriteconcern;
+   &mongodb.throws.std;
+   <member>Lance une <classname>MongoDB\Driver\Exception\RuntimeException</classname> sur d'autre erreurs (par exemple: commande invalide).</member>
+  </simplelist>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><classname>MongoDB\Driver\Command</classname></member>
+   <member><classname>MongoDB\Driver\Cursor</classname></member>
+   <member><function>MongoDB\Driver\Server::executeCommand</function></member>
+   <member><function>MongoDB\Driver\Server::executeReadWriteCommand</function></member>
+   <member><function>MongoDB\Driver\Server::executeWriteCommand</function></member>
+   <member><function>MongoDB\Driver\Manager::executeReadCommand</function></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mongodb/mongodb/driver/server/executereadwritecommand.xml
+++ b/reference/mongodb/mongodb/driver/server/executereadwritecommand.xml
@@ -1,0 +1,143 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 80693438668530525ea2a78defbfc9bb218c3b1c Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="mongodb-driver-server.executereadwritecommand" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>MongoDB\Driver\Server::executeReadWriteCommand</refname>
+  <refpurpose>Exécute une commande de base de données qui lit et écrit sur ce serveur</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>final</modifier> <modifier>public</modifier> <type>MongoDB\Driver\Cursor</type><methodname>MongoDB\Driver\Server::executeReadWriteCommand</methodname>
+   <methodparam><type>string</type><parameter>db</parameter></methodparam>
+   <methodparam><type>MongoDB\Driver\Command</type><parameter>command</parameter></methodparam>
+   <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>options</parameter><initializer>&null;</initializer></methodparam>
+  </methodsynopsis>
+  <para>
+   Exécute la commande sur ce serveur.
+  </para>
+  <para>
+   Cette méthode appliquera une logique spécifique aux commandes de lecture et d'écriture
+   (par exemple <link xlink:href="&url.mongodb.docs;reference/command/aggregate/">aggregate</link>).
+   Les valeurs par défaut pour les options <literal>"readConcern"</literal> et
+   <literal>"writeConcern"</literal> seront déduites d'une transaction active (indiquée par
+   l'option <literal>"session"</literal>), suivie de l'
+   <link linkend="mongodb-driver-manager.construct-uri">URI de connexion</link>.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   &mongodb.parameter.db;
+   &mongodb.parameter.command;
+   <varlistentry>
+    <term><parameter>options</parameter></term>
+    <listitem>
+     <para>
+      <table>
+       <title>options</title>
+       <tgroup cols="3">
+        <thead>
+         <row>
+          <entry>Option</entry>
+          <entry>Type</entry>
+          <entry>Description</entry>
+         </row>
+        </thead>
+        <tbody>
+         &mongodb.option.readConcern;
+         &mongodb.option.session;
+         &mongodb.option.writeConcern;
+        </tbody>
+       </tgroup>
+      </table>
+     </para>
+     &mongodb.option.transactionReadWriteConcern;
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  &mongodb.returns.cursor;
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simplelist>
+   &mongodb.throws.session-readwriteconcern;
+   &mongodb.throws.session-unacknowledged;
+   &mongodb.throws.std;
+   <member>Lance une <classname>MongoDB\Driver\Exception\RuntimeException</classname> sur d'autre erreurs (par exemple: commande invalide).</member>
+  </simplelist>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>PECL mongodb 1.4.4</entry>
+       <entry>
+        Une <classname>MongoDB\Driver\Exception\InvalidArgumentException</classname>
+        va être lancée si l'option <literal>"session"</literal> est utilisée en
+        combinaison avec un writeConcern non reconnu.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </para>
+ </refsect1>
+
+ <refsect1 role="notes">
+  &reftitle.notes;
+  &mongodb.note.server.write;
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><classname>MongoDB\Driver\Command</classname></member>
+   <member><classname>MongoDB\Driver\Cursor</classname></member>
+   <member><function>MongoDB\Driver\Server::executeCommand</function></member>
+   <member><function>MongoDB\Driver\Server::executeReadCommand</function></member>
+   <member><function>MongoDB\Driver\Server::executeWriteCommand</function></member>
+   <member><function>MongoDB\Driver\Manager::executeReadWriteCommand</function></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mongodb/mongodb/driver/server/executewritecommand.xml
+++ b/reference/mongodb/mongodb/driver/server/executewritecommand.xml
@@ -1,0 +1,152 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 80693438668530525ea2a78defbfc9bb218c3b1c Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="mongodb-driver-server.executewritecommand" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>MongoDB\Driver\Server::executeWriteCommand</refname>
+  <refpurpose>Exécute une commande de base de données qui écrit sur ce serveur</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>final</modifier> <modifier>public</modifier> <type>MongoDB\Driver\Cursor</type><methodname>MongoDB\Driver\Server::executeWriteCommand</methodname>
+   <methodparam><type>string</type><parameter>db</parameter></methodparam>
+   <methodparam><type>MongoDB\Driver\Command</type><parameter>command</parameter></methodparam>
+   <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>options</parameter><initializer>&null;</initializer></methodparam>
+  </methodsynopsis>
+  <para>
+   Exécute la commande sur ce serveur.
+  </para>
+  <para>
+   Cette méthode appliquera une logique spécifique aux commandes qui écrivent (par exemple
+   <link xlink:href="&url.mongodb.docs;reference/command/drop/">drop</link>).
+   La valeur par défaut pour l'option <literal>"writeConcern"</literal> sera déduite d'une transaction active (indiquée par
+   l'option <literal>"session"</literal>), suivie de l'
+   <link linkend="mongodb-driver-manager.construct-uri">URI de connexion</link>.
+  </para>
+  <note>
+   <simpara>
+    Cette méthode n'est pas destinée à être utilisée pour exécuter
+    <link xlink:href="&url.mongodb.docs;reference/command/insert/">insert</link>,
+    <link xlink:href="&url.mongodb.docs;reference/command/update/">update</link>,
+    ou <link xlink:href="&url.mongodb.docs;reference/command/delete/">delete</link>
+    commandes. Les utilisateurs sont encouragés à utiliser
+    <function>MongoDB\Driver\Server::executeBulkWrite</function> pour ces
+    opérations.
+   </simpara>
+  </note>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   &mongodb.parameter.db;
+   &mongodb.parameter.command;
+   <varlistentry>
+    <term><parameter>options</parameter></term>
+    <listitem>
+     <para>
+      <table>
+       <title>options</title>
+       <tgroup cols="3">
+        <thead>
+         <row>
+          <entry>Option</entry>
+          <entry>Type</entry>
+          <entry>Description</entry>
+         </row>
+        </thead>
+        <tbody>
+         &mongodb.option.session;
+         &mongodb.option.writeConcern;
+        </tbody>
+       </tgroup>
+      </table>
+     </para>
+     &mongodb.option.transactionReadWriteConcern;
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  &mongodb.returns.cursor;
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simplelist>
+   &mongodb.throws.session-readwriteconcern;
+   &mongodb.throws.session-unacknowledged;
+   &mongodb.throws.std;
+   <member>Lance une <classname>MongoDB\Driver\Exception\RuntimeException</classname> sur d'autre erreurs (par exemple: commande invalide).</member>
+  </simplelist>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>PECL mongodb 1.4.4</entry>
+       <entry>
+        Une <classname>MongoDB\Driver\Exception\InvalidArgumentException</classname>
+        va être lancée si l'option <literal>"session"</literal> est utilisée en
+        combinaison avec un writeConcern non reconnu.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </para>
+ </refsect1>
+
+ <refsect1 role="notes">
+  &reftitle.notes;
+  &mongodb.note.server.write;
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><classname>MongoDB\Driver\Command</classname></member>
+   <member><classname>MongoDB\Driver\Cursor</classname></member>
+   <member><function>MongoDB\Driver\Server::executeCommand</function></member>
+   <member><function>MongoDB\Driver\Server::executeReadCommand</function></member>
+   <member><function>MongoDB\Driver\Server::executeReadWriteCommand</function></member>
+   <member><function>MongoDB\Driver\Manager::executeWriteCommand</function></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mongodb/mongodb/driver/server/getserverdescription.xml
+++ b/reference/mongodb/mongodb/driver/server/getserverdescription.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: bd6e6603b4614c35d9b63c8d157a98569f2358df Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="mongodb-driver-server.getserverdescription" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>MongoDB\Driver\Server::getServerDescription</refname>
+  <refpurpose>Renvoie une ServerDescription pour ce serveur</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>final</modifier> <modifier>public</modifier> <type>MongoDB\Driver\ServerDescription</type><methodname>MongoDB\Driver\Server::getServerDescription</methodname>
+   <void />
+  </methodsynopsis>
+  <para>
+   Renvoie une <classname>MongoDB\Driver\ServerDescription</classname> pour ce
+   serveur. C'est un objet de valeur immuable qui décrira le serveur au moment
+   où cette méthode est appelée.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Renvoie une <classname>MongoDB\Driver\ServerDescription</classname> pour ce
+   serveur.
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simplelist>
+   &mongodb.throws.argumentparsing;
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mongodb/mongodb/driver/server/gettags.xml
+++ b/reference/mongodb/mongodb/driver/server/gettags.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: e9366ee458b2900c53a503b1ad97664e1d9a8859 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="mongodb-driver-server.gettags" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>MongoDB\Driver\Server::getTags</refname>
+  <refpurpose>Renvoie un tableau de tags décrivant ce serveur dans un ensemble de réplicas</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>final</modifier> <modifier>public</modifier> <type>array</type><methodname>MongoDB\Driver\Server::getTags</methodname>
+   <void />
+  </methodsynopsis>
+  <para>
+   Renvoie un <type>array</type> de
+   <link xlink:href="&url.mongodb.glossary;#term-tag">tags</link> utilisés pour
+   décrire ce serveur dans un ensemble de réplicas. L'array contiendra zéro ou plusieurs
+   paires clé et valeur de type <type>string</type>.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Renvoie un <type>array</type> de tags utilisés pour décrire ce serveur dans un
+   ensemble de réplicas.
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simplelist>
+   &mongodb.throws.argumentparsing;
+  </simplelist>
+ </refsect1>
+
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>MongoDB\Driver\Server::getInfo</function></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mongodb/mongodb/driver/server/isarbiter.xml
+++ b/reference/mongodb/mongodb/driver/server/isarbiter.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 331fbfeac522d4ad00de1e043cc11610d66b88f9 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="mongodb-driver-server.isarbiter" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>MongoDB\Driver\Server::isArbiter</refname>
+  <refpurpose>Vérifie si ce serveur est un membre arbitre d'un ensemble de réplicas</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>final</modifier> <modifier>public</modifier> <type>bool</type><methodname>MongoDB\Driver\Server::isArbiter</methodname>
+   <void />
+  </methodsynopsis>
+  <para>
+   Renvoie si ce serveur est un
+   <link xlink:href="&url.mongodb.glossary;#term-arbiter">membre arbitre</link>
+   d'un ensemble de réplicas.
+  </para>
+
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Renvoie &true; si ce serveur est un membre arbitre d'un ensemble de réplicas, et
+   &false; sinon.
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simplelist>
+   &mongodb.throws.argumentparsing;
+  </simplelist>
+ </refsect1>
+
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>MongoDB\Driver\Server::getInfo</function></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mongodb/mongodb/driver/server/ishidden.xml
+++ b/reference/mongodb/mongodb/driver/server/ishidden.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 331fbfeac522d4ad00de1e043cc11610d66b88f9 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="mongodb-driver-server.ishidden" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>MongoDB\Driver\Server::isHidden</refname>
+  <refpurpose>Renvoie si ce serveur est un membre caché d'un ensemble de réplicas</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>final</modifier> <modifier>public</modifier> <type>bool</type><methodname>MongoDB\Driver\Server::isHidden</methodname>
+   <void />
+  </methodsynopsis>
+  <para>
+   Renvoie si ce serveur est un
+   <link xlink:href="&url.mongodb.glossary;#term-hidden-member">membre caché</link>
+   d'un ensemble de réplicas.
+  </para>
+
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Renvoie &true; si ce serveur est un membre caché d'un ensemble de réplicas, et
+   &false; sinon.
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simplelist>
+   &mongodb.throws.argumentparsing;
+  </simplelist>
+ </refsect1>
+
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>MongoDB\Driver\Server::getInfo</function></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mongodb/mongodb/driver/server/isprimary.xml
+++ b/reference/mongodb/mongodb/driver/server/isprimary.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 331fbfeac522d4ad00de1e043cc11610d66b88f9 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="mongodb-driver-server.isprimary" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>MongoDB\Driver\Server::isPrimary</refname>
+  <refpurpose>Vérifie si ce serveur est un membre principal d'un ensemble de réplicas</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>final</modifier> <modifier>public</modifier> <type>bool</type><methodname>MongoDB\Driver\Server::isPrimary</methodname>
+   <void />
+  </methodsynopsis>
+  <para>
+   Renvoie si ce serveur est un
+   <link xlink:href="&url.mongodb.glossary;#term-primary">membre principal</link>
+   d'un ensemble de réplicas.
+  </para>
+
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Renvoie &true; si ce serveur est un membre principal d'un ensemble de réplicas, et
+   &false; sinon.
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simplelist>
+   &mongodb.throws.argumentparsing;
+  </simplelist>
+ </refsect1>
+
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>MongoDB\Driver\Server::getInfo</function></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mongodb/mongodb/driver/server/issecondary.xml
+++ b/reference/mongodb/mongodb/driver/server/issecondary.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 331fbfeac522d4ad00de1e043cc11610d66b88f9 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="mongodb-driver-server.issecondary" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>MongoDB\Driver\Server::isSecondary</refname>
+  <refpurpose>Vérifie si ce serveur est un membre secondaire d'un ensemble de réplicas</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>final</modifier> <modifier>public</modifier> <type>bool</type><methodname>MongoDB\Driver\Server::isSecondary</methodname>
+   <void />
+  </methodsynopsis>
+  <para>
+   Renvoie is ce serveur est un
+   <link xlink:href="&url.mongodb.glossary;#term-secondary">membre secondaire</link>
+   d'un ensemble de réplicas.
+  </para>
+
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Renvoie &true; si ce serveur est un membre secondaire d'un ensemble de réplicas, et
+   &false; sinon.
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simplelist>
+   &mongodb.throws.argumentparsing;
+  </simplelist>
+ </refsect1>
+
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>MongoDB\Driver\Server::getInfo</function></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
Here is the translation of missing `MongoDB\Driver\Server` methods

- `MongoDB\Driver\Server::executeReadCommand()`
- `MongoDB\Driver\Server::executeReadWriteCommand()`
- `MongoDB\Driver\Server::executeWriteCommand()`
- `MongoDB\Driver\Server::getServerDescription()`
- `MongoDB\Driver\Server::getTags()`
- `MongoDB\Driver\Server::isArbiter()`
- `MongoDB\Driver\Server::isHidden()`
- `MongoDB\Driver\Server::isPrimary()`
- `MongoDB\Driver\Server::isSecondary()`