### PR TITLE
Translate `MongoDB\Driver\ServerApi`

### DIFF
--- a/reference/mongodb/mongodb/driver/serverapi/bsonserialize.xml
+++ b/reference/mongodb/mongodb/driver/serverapi/bsonserialize.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: eaee72c33fe65d1d4648cd8a30bbec0aeb76c960 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="mongodb-driver-serverapi.bsonserialize" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>MongoDB\Driver\ServerApi::bsonSerialize</refname>
+  <refpurpose>Renvoie un objet pour la sérialisation BSON</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>final</modifier> <modifier>public</modifier> <type>stdClass</type><methodname>MongoDB\Driver\ServerApi::bsonSerialize</methodname>
+   <void />
+  </methodsynopsis>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Renvoie un objet pour la sérialisation du ServerApi en BSON.
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simplelist>
+   &mongodb.throws.argumentparsing;
+  </simplelist>
+ </refsect1>
+
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>MongoDB\BSON\Serializable::bsonSerialize</methodname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mongodb/mongodb/driver/serverapi/construct.xml
+++ b/reference/mongodb/mongodb/driver/serverapi/construct.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: a7b808a875840b8850631210ef2190d681b6edfa Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="mongodb-driver-serverapi.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>MongoDB\Driver\ServerApi::__construct</refname>
+  <refpurpose>Créer une nouvelle instance de ServerApi</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>final</modifier> <modifier>public</modifier> <methodname>MongoDB\Driver\ServerApi::__construct</methodname>
+   <methodparam><type>string</type><parameter>version</parameter></methodparam>
+   <methodparam choice="opt"><type class="union"><type>bool</type><type>null</type></type><parameter>strict</parameter><initializer>&null;</initializer></methodparam>
+   <methodparam choice="opt"><type class="union"><type>bool</type><type>null</type></type><parameter>deprecationErrors</parameter><initializer>&null;</initializer></methodparam>
+  </methodsynopsis>
+
+  <para>
+   Créer une nouvelle instance de <classname>MongoDB\Driver\ServerApi</classname> utilisée pour
+   déclarer une version d'API lors de la création d'un
+   <classname>MongoDB\Driver\Manager</classname>.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry xml:id="mongodb-driver-serverapi.construct-version">
+    <term><parameter>version</parameter></term>
+    <listitem>
+     <para>
+      Une version d'API de serveur.
+     </para>
+     <para>
+      Les versions d'API prises en charge sont fournies sous forme de constantes
+      dans <classname>MongoDB\Driver\ServerApi</classname>. La seule version d'API
+      prise en charge est <constant>MongoDB\Driver\ServerApi::V1</constant>.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="mongodb-driver-manager.construct-strict">
+    <term><parameter>strict</parameter></term>
+    <listitem>
+     <para>
+      Si le paramètre <parameter>strict</parameter> est défini sur &true;, le
+      serveur renverra une erreur pour toute commande qui ne fait pas partie de la
+      version d'API spécifiée. Si aucune valeur n'est fournie, la valeur par défaut du serveur
+      (&false;) est utilisée.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="mongodb-driver-manager.construct-deprecationErrors">
+    <term><parameter>deprecationErrors</parameter></term>
+    <listitem>
+     <para>
+      Si le paramètre <parameter>deprecationErrors</parameter> est défini sur &true;,
+      le serveur renverra une erreur lors de l'utilisation d'une commande qui est obsolète dans
+      la version d'API spécifiée. Si aucune valeur n'est fournie, la valeur par défaut du serveur
+      (&false;) est utilisée.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mongodb/mongodb/driver/serverapi/serialize.xml
+++ b/reference/mongodb/mongodb/driver/serverapi/serialize.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: bee33290e8f51645e908e4b18739be6d0c4bfc6b Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="mongodb-driver-serverapi.serialize" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>MongoDB\Driver\ServerApi::serialize</refname>
+  <refpurpose>Sérialise un ServerApi</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>final</modifier> <modifier>public</modifier> <type>string</type><methodname>MongoDB\Driver\ServerApi::serialize</methodname>
+   <void />
+  </methodsynopsis>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Renvoie une chaîne de caractères qui représente la sérialisation de
+   <classname>MongoDB\Driver\ServerApi</classname>.
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simplelist>
+   &mongodb.throws.argumentparsing;
+  </simplelist>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>MongoDB\Driver\ServerApi::unserialize</methodname></member>
+   <member><function>serialize</function></member>
+   <member><link linkend="language.oop5.serialization">Sérialiser des objets</link></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mongodb/mongodb/driver/serverapi/unserialize.xml
+++ b/reference/mongodb/mongodb/driver/serverapi/unserialize.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 7622b01312fbeb531f3efdd62110a7fe508e324e Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="mongodb-driver-serverapi.unserialize" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>MongoDB\Driver\ServerApi::unserialize</refname>
+  <refpurpose>Désérialise un ServerApi</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>final</modifier> <modifier>public</modifier> <type>void</type><methodname>MongoDB\Driver\ServerApi::unserialize</methodname>
+   <methodparam><type>string</type><parameter>data</parameter></methodparam>
+  </methodsynopsis>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>data</parameter></term>
+     <listitem>
+      <para>
+       Le <classname>MongoDB\Driver\ServerApi</classname> sérialisé.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &return.void;
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simplelist>
+   &mongodb.throws.argumentparsing;
+   <member>Lance une <classname>MongoDB\Driver\Exception\UnexpectedValueException</classname> si les propriétés ne peuvent pas être désérialisées (c'est-à-dire si <parameter>serialized</parameter> était mal formé).</member>
+   <member>Lance une <classname>MongoDB\Driver\Exception\InvalidArgumentException</classname> si les propriétés sont invalides (par exemple, des champs manquants ou des valeurs invalides).</member>
+  </simplelist>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>MongoDB\Driver\ServerApi::serialize</methodname></member>
+   <member><function>unserialize</function></member>
+   <member><link linkend="language.oop5.serialization">Sérialiser des objets</link></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
Here is the translation of missing `MongoDB\Driver\ServerApi` methods

- `MongoDB\Driver\ServerApi::bsonSerializ`
- `MongoDB\Driver\ServerApi::__construct()`
- `MongoDB\Driver\ServerApi::serialize`
- `MongoDB\Driver\ServerApi::unserialize`