### PR TITLE
Translate `MongoDB\Driver\Session`

### DIFF
--- a/reference/mongodb/mongodb/driver/session/aborttransaction.xml
+++ b/reference/mongodb/mongodb/driver/session/aborttransaction.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: f1e951b988e8aafe49b33bdf2f7812740c66c2d2 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="mongodb-driver-session.aborttransaction" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>MongoDB\Driver\Session::abortTransaction</refname>
+  <refpurpose>Annule une transaction</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>final</modifier> <modifier>public</modifier> <type>void</type><methodname>MongoDB\Driver\Session::abortTransaction</methodname>
+   <void />
+  </methodsynopsis>
+  <para>
+   Termine la transaction multi-document et annule toutes les modifications de données
+   effectuées par les opérations dans la transaction. C'est-à-dire que la transaction se termine
+   sans enregistrer aucune des modifications apportées par les opérations dans la transaction.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &return.void;
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simplelist>
+   &mongodb.throws.argumentparsing;
+   <member>Lance une <classname>MongoDB\Driver\Exception\RuntimeException</classname> si la transaction ne peut pas être annulée (par exemple, une transaction n'a pas été démarrée).</member>
+  </simplelist>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>MongoDB\Driver\Manager::startSession</methodname></member>
+   <member><methodname>MongoDB\Driver\Session::commitTransaction</methodname></member>
+   <member><methodname>MongoDB\Driver\Session::startTransaction</methodname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mongodb/mongodb/driver/session/advanceclustertime.xml
+++ b/reference/mongodb/mongodb/driver/session/advanceclustertime.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 53242ee6628dc1ae6989fe002231fddfd8f005c6 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="mongodb-driver-session.advanceclustertime" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>MongoDB\Driver\Session::advanceClusterTime</refname>
+  <refpurpose>Avance le temps du cluster pour cette session</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>final</modifier> <modifier>public</modifier> <type>void</type><methodname>MongoDB\Driver\Session::advanceClusterTime</methodname>
+   <methodparam><type class="union"><type>array</type><type>object</type></type><parameter>clusterTime</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Avance le temps du cluster pour cette session. Si le temps du cluster est inférieur ou égal
+   au temps du cluster actuel de la session, cette fonction ne fait rien.
+  </para>
+  <para>
+   En utilisant cette méthode en conjonction avec
+   <methodname>MongoDB\Driver\Session::advanceOperationTime</methodname> pour copier
+   les temps du cluster et des opérations d'une autre session
+   vous pouvez vous assurer que les opérations dans cette session sont cohérentes
+   avec la dernière opération dans l'autre session.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>clusterTime</parameter></term>
+    <listitem>
+     <para>
+      Le temps du cluster est un document contenant un horodatage logique et une signature de serveur.
+      Typiquement, cette valeur sera obtenue en appelant
+      <methodname>MongoDB\Driver\Session::getClusterTime</methodname> sur un autre
+      objet de session.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &return.void;
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simplelist>
+   &mongodb.throws.argumentparsing;
+  </simplelist>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>MongoDB\Driver\Session::advanceOperationTime</methodname></member>
+   <member><methodname>MongoDB\Driver\Session::getClusterTime</methodname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mongodb/mongodb/driver/session/advanceoperationtime.xml
+++ b/reference/mongodb/mongodb/driver/session/advanceoperationtime.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 0dad2268d5adb19f77270aa2a9515a4bfbca9b22 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="mongodb-driver-session.advanceoperationtime" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>MongoDB\Driver\Session::advanceOperationTime</refname>
+  <refpurpose>Avance le temps d'opération pour cette session</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>final</modifier> <modifier>public</modifier> <type>void</type><methodname>MongoDB\Driver\Session::advanceOperationTime</methodname>
+   <methodparam><type>MongoDB\BSON\TimestampInterface</type><parameter>operationTime</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Avance le temps d'opération pour cette session. Si le temps d'opération est inférieur ou égal
+   au temps d'opération actuel de la session, cette fonction ne fait rien.
+  </para>
+  <para>
+   En utilisant cette méthode en conjonction avec
+   <methodname>MongoDB\Driver\Session::advanceClusterTime</methodname> pour copier
+   les temps d'opération et de cluster d'une autre session
+   vous pouvez vous assurer que les opérations dans cette session sont cohérentes
+   avec la dernière opération dans l'autre session.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>operationTime</parameter></term>
+    <listitem>
+     <para>
+      L'opération est un horodatage logique. Typiquement, cette valeur
+      sera obtenue en appelant
+      <methodname>MongoDB\Driver\Session::getOperationTime</methodname> sur
+      un autre objet de session.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &return.void;
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simplelist>
+   &mongodb.throws.argumentparsing;
+  </simplelist>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>MongoDB\Driver\Session::advanceClusterTime</methodname></member>
+   <member><methodname>MongoDB\Driver\Session::getClusterTime</methodname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mongodb/mongodb/driver/session/committransaction.xml
+++ b/reference/mongodb/mongodb/driver/session/committransaction.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: e9214a2619efc5906fab59cd42fb7404c4dc49a5 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="mongodb-driver-session.committransaction" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>MongoDB\Driver\Session::commitTransaction</refname>
+  <refpurpose>Valide la transaction</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>final</modifier> <modifier>public</modifier> <type>void</type><methodname>MongoDB\Driver\Session::commitTransaction</methodname>
+   <void />
+  </methodsynopsis>
+  <para>
+   Sauvegarde les modifications apportées par les opérations dans la transaction
+   multi-document et termine la transaction. Jusqu'à la validation, aucune des
+   modifications de données apportées par les opérations dans la transaction
+   n'est visible en dehors de la transaction.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &return.void;
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simplelist>
+   &mongodb.throws.argumentparsing;
+   <member>Lance une
+   <classname>MongoDB\Driver\Exception\CommandException</classname> si le
+   serveur ne peut pas valider la transaction (par exemple, en raison de conflits,
+   de problèmes de réseau). Si l'exception contient un élément
+   <literal>"errorLabels"</literal> et que ce tableau contient une valeur
+   <literal>"TransientTransactionError"</literal> ou
+   <literal>"UnKnownTransactionCommitResult"</literal>, il est sûr de re-essayer
+   la <emphasis>totalité</emphasis> de la transaction. Dans les versions plus
+   récentes de l'extension,
+   <methodname>MongoDB\Driver\Exception\RuntimeException::hasErrorLabel</methodname>
+   devrait être utilisé pour tester cette situation à la place.</member>
+   <member>Lance une
+   <classname>MongoDB\Driver\Exception\RuntimeException</classname> si la
+   transaction ne peut pas être validée (par exemple, une transaction n'a pas été
+   démarrée).</member>
+  </simplelist>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>MongoDB\Driver\Manager::startSession</methodname></member>
+   <member><methodname>MongoDB\Driver\Session::abortTransaction</methodname></member>
+   <member><methodname>MongoDB\Driver\Session::startTransaction</methodname></member>
+   <member><methodname>MongoDB\Driver\Exception\RuntimeException::hasErrorLabel</methodname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mongodb/mongodb/driver/session/construct.xml
+++ b/reference/mongodb/mongodb/driver/session/construct.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 0dad2268d5adb19f77270aa2a9515a4bfbca9b22 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="mongodb-driver-session.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>MongoDB\Driver\Session::__construct</refname>
+  <refpurpose>Créer une nouvelle session (inutilisée)</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>final</modifier> <modifier>private</modifier> <methodname>MongoDB\Driver\Session::__construct</methodname>
+   <void />
+  </methodsynopsis>
+  <para>
+   Les objets <classname>MongoDB\Driver\Session</classname> sont retournés par
+   <methodname>MongoDB\Driver\Manager::startSession</methodname> et ne peuvent pas être
+   construits directement.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>MongoDB\Driver\Manager::startSession</function></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mongodb/mongodb/driver/session/endsession.xml
+++ b/reference/mongodb/mongodb/driver/session/endsession.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 69b7314dc644c27289de76afc93684a98428ad05 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="mongodb-driver-session.endsession" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>MongoDB\Driver\Session::endSession</refname>
+  <refpurpose>Termine une session</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>final</modifier> <modifier>public</modifier> <type>void</type><methodname>MongoDB\Driver\Session::endSession</methodname>
+   <void />
+  </methodsynopsis>
+  <para>
+   Cette méthode ferme une session existante. Si une transaction était associée
+   à cette session, la transaction sera annulée. Après avoir appelé cette
+   méthode, les applications ne doivent pas invoquer d'autres méthodes sur la session.
+  </para>
+  <note>
+   <simpara>
+    Les sessions sont également fermées lors du ramassage de miettes. Il ne devrait pas être
+    nécessaire d'appeler cette méthode dans des circonstances normales.
+   </simpara>
+  </note>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &return.void;
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simplelist>
+   &mongodb.throws.argumentparsing;
+  </simplelist>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>MongoDB\Driver\Manager::startSession</methodname></member>
+   <member><methodname>MongoDB\Driver\Session::abortTransaction</methodname></member>
+   <member><methodname>MongoDB\Driver\Session::commitTransaction</methodname></member>
+   <member><methodname>MongoDB\Driver\Session::startTransaction</methodname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mongodb/mongodb/driver/session/getclustertime.xml
+++ b/reference/mongodb/mongodb/driver/session/getclustertime.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 53242ee6628dc1ae6989fe002231fddfd8f005c6 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="mongodb-driver-session.getclustertime" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>MongoDB\Driver\Session::getClusterTime</refname>
+  <refpurpose>Renvoie le temps du cluster pour cette session</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>final</modifier> <modifier>public</modifier> <type class="union"><type>object</type><type>null</type></type><methodname>MongoDB\Driver\Session::getClusterTime</methodname>
+   <void />
+  </methodsynopsis>
+  <para>
+   Renvoie le temps du cluster pour cette session. Si la session n'a pas été utilisée
+   pour une opération et
+   <methodname>MongoDB\Driver\Session::advanceClusterTime</methodname> n'a pas
+   été appelé, le temps du cluster sera &null;.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Renvoie le temps du cluster pour cette session, ou &null; si la session n'a pas
+   de temps du cluster.
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simplelist>
+   &mongodb.throws.argumentparsing;
+  </simplelist>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>MongoDB\Driver\Session::advanceClusterTime</methodname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mongodb/mongodb/driver/session/getlogicalsessionid.xml
+++ b/reference/mongodb/mongodb/driver/session/getlogicalsessionid.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 0dad2268d5adb19f77270aa2a9515a4bfbca9b22 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="mongodb-driver-session.getlogicalsessionid" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>MongoDB\Driver\Session::getLogicalSessionId</refname>
+  <refpurpose>Renvoie l'identifiant de session logique pour cette session</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>final</modifier> <modifier>public</modifier> <type>object</type><methodname>MongoDB\Driver\Session::getLogicalSessionId</methodname>
+   <void />
+  </methodsynopsis>
+  <para>
+   Renvoie l'identifiant de session logique pour cette session, qui peut être utilisé pour
+   identifier les opérations de cette session sur le serveur.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Renvoie l'identifiant de session logique pour cette session.
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simplelist>
+   &mongodb.throws.argumentparsing;
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mongodb/mongodb/driver/session/getoperationtime.xml
+++ b/reference/mongodb/mongodb/driver/session/getoperationtime.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 53242ee6628dc1ae6989fe002231fddfd8f005c6 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="mongodb-driver-session.getoperationtime" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>MongoDB\Driver\Session::getOperationTime</refname>
+  <refpurpose>Renvoie le temps d'opération pour cette session</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>final</modifier> <modifier>public</modifier> <type class="union"><type>MongoDB\BSON\Timestamp</type><type>null</type></type><methodname>MongoDB\Driver\Session::getOperationTime</methodname>
+   <void />
+  </methodsynopsis>
+  <para>
+   Renvoie le temps d'opération pour cette session. Si la session n'a pas été utilisée
+   pour une opération et
+   <methodname>MongoDB\Driver\Session::advanceOperationTime</methodname> n'a pas
+   été appelé, le temps d'opération sera &null;.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Renvoie le temps d'opération pour cette session, ou &null; si la session n'a pas
+   de temps d'opération.
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simplelist>
+   &mongodb.throws.argumentparsing;
+  </simplelist>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>MongoDB\Driver\Session::advanceOperationTime</methodname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mongodb/mongodb/driver/session/getserver.xml
+++ b/reference/mongodb/mongodb/driver/session/getserver.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 53242ee6628dc1ae6989fe002231fddfd8f005c6 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="mongodb-driver-session.getserver" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>MongoDB\Driver\Session::getServer</refname>
+  <refpurpose>Renvoie le serveur auquel cette session est épinglée</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>final</modifier> <modifier>public</modifier> <type class="union"><type>MongoDB\Driver\Server</type><type>null</type></type><methodname>MongoDB\Driver\Session::getServer</methodname>
+   <void />
+  </methodsynopsis>
+  <para>
+   Renvoie le <classname>MongoDB\Driver\Server</classname> auquel cette session
+   est épinglée. Si la session n'est pas épinglée à un serveur, &null;
+   sera renvoyé.
+  </para>
+  <para>
+   La session d'épinglage est principalement utilisée pour les transactions
+   éclatées, car toutes les commandes dans une transaction éclatée doivent
+   être envoyées à la même instance mongos. Cette méthode est destinée à être
+   utilisée par des bibliothèques construites au-dessus de l'extension pour
+   permettre l'utilisation d'un serveur épinglé au lieu d'invoquer la sélection du serveur.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Renvoie le <classname>MongoDB\Driver\Server</classname> auquel cette session
+   est épinglée, ou &null; si la session n'est pas épinglée à un serveur.
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simplelist>
+   &mongodb.throws.argumentparsing;
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mongodb/mongodb/driver/session/gettransactionoptions.xml
+++ b/reference/mongodb/mongodb/driver/session/gettransactionoptions.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 53242ee6628dc1ae6989fe002231fddfd8f005c6 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="mongodb-driver-session.gettransactionoptions" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>MongoDB\Driver\Session::getTransactionOptions</refname>
+  <refpurpose>Renvoie les options pour la transaction en cours</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>final</modifier> <modifier>public</modifier> <type class="union"><type>array</type><type>null</type></type><methodname>MongoDB\Driver\Session::getTransactionOptions</methodname>
+   <void />
+  </methodsynopsis>
+  <para>
+   Renvoie les options pour la transaction en cours.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Renvoie un <type>array</type> contenant les options de transaction actuelles, ou
+   &null; si aucune transaction n'est en cours.
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simplelist>
+   &mongodb.throws.argumentparsing;
+  </simplelist>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>MongoDB\Driver\Session::getTransactionState</methodname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mongodb/mongodb/driver/session/gettransactionstate.xml
+++ b/reference/mongodb/mongodb/driver/session/gettransactionstate.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: a8482dea2af701e5aef299fda555ddc9e1587184 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="mongodb-driver-session.gettransactionstate" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>MongoDB\Driver\Session::getTransactionState</refname>
+  <refpurpose>Renvoie l'état de la transaction actuelle pour cette session</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>final</modifier> <modifier>public</modifier> <type>string</type><methodname>MongoDB\Driver\Session::getTransactionState</methodname>
+   <void />
+  </methodsynopsis>
+  <para>
+   Renvoie l'état de la transaction pour cette session.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Renvoie l'état de la transaction actuelle pour cette session.
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simplelist>
+   &mongodb.throws.argumentparsing;
+  </simplelist>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>MongoDB\Driver\Session::isInTransaction</methodname></member>
+   <member><methodname>MongoDB\Driver\Session::getTransactionOptions</methodname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mongodb/mongodb/driver/session/isdirty.xml
+++ b/reference/mongodb/mongodb/driver/session/isdirty.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: d5127e772887addc6553066a33b31af086cd93b1 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="mongodb-driver-session.isdirty" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>MongoDB\Driver\Session::isDirty</refname>
+  <refpurpose>Renvoie si la session a été marquée comme sale</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>final</modifier> <modifier>public</modifier> <type>bool</type><methodname>MongoDB\Driver\Session::isDirty</methodname>
+   <void />
+  </methodsynopsis>
+  <para>
+   Renvoie si la session a été marquée comme sale (c'est-à-dire qu'elle a été utilisée
+   avec une commande qui a rencontré une erreur réseau).
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Renvoie si la session a été marquée comme sale.
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simplelist>
+   &mongodb.throws.argumentparsing;
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mongodb/mongodb/driver/session/isintransaction.xml
+++ b/reference/mongodb/mongodb/driver/session/isintransaction.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 86e6094e86b84a51d00ab217ac50ce8dde33d82a Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="mongodb-driver-session.isintransaction" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>MongoDB\Driver\Session::isInTransaction</refname>
+  <refpurpose>Renvoie si une transaction multi-document est en cours</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>final</modifier> <modifier>public</modifier> <type>bool</type><methodname>MongoDB\Driver\Session::isInTransaction</methodname>
+   <void />
+  </methodsynopsis>
+  <para>
+   Renvoie si une transaction multi-document est actuellement en cours pour
+   cette session. Une transaction est considérée comme "en cours" si elle a été
+   démarrée mais n'a pas été validée ou annulée.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Renvoie &true; si une transaction est actuellement en cours pour cette session,
+   et &false; sinon.
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simplelist>
+   &mongodb.throws.argumentparsing;
+  </simplelist>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>MongoDB\Driver\Session::getTransactionState</methodname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mongodb/mongodb/driver/session/starttransaction.xml
+++ b/reference/mongodb/mongodb/driver/session/starttransaction.xml
@@ -1,0 +1,145 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 734bafeaf071b78b15d375f9af583befddd8c2a2 Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="mongodb-driver-session.starttransaction" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>MongoDB\Driver\Session::startTransaction</refname>
+  <refpurpose>Commence une transaction</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>final</modifier> <modifier>public</modifier> <type>void</type><methodname>MongoDB\Driver\Session::startTransaction</methodname>
+   <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>options</parameter><initializer>&null;</initializer></methodparam>
+  </methodsynopsis>
+  <para>
+   Commence une transaction multi-document associée à la session. À un moment donné,
+   vous ne pouvez avoir qu'une seule transaction ouverte pour une session. Après avoir
+   commencé une transaction, l'objet de session doit être passé à chaque opération via
+   l'option <literal>"session"</literal> (par exemple
+   <methodname>MongoDB\Driver\Manager::executeBulkWrite</methodname>) pour associer
+   cette opération à la transaction.
+  </para>
+  <para>
+   Les transactions peuvent être confirmées via
+   <methodname>MongoDB\Driver\Session::commitTransaction</methodname>, et
+   annulées avec
+   <methodname>MongoDB\Driver\Session::abortTransaction</methodname>.
+   Les transactions sont également automatiquement annulées lorsque la session est
+   fermée par la collecte des ordures ou en appelant explicitement
+   <methodname>MongoDB\Driver\Session::endSession</methodname>.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>options</parameter></term>
+    <listitem>
+     <para>
+      Les options peuvent être passées en argument à cette méthode. Chaque élément de ce
+      tableau d'options remplace l'option correspondante de l'option
+      <literal>"defaultTransactionOptions"</literal>, si définie lors
+      du démarrage de la session avec
+      <methodname>MongoDB\Driver\Manager::startSession</methodname>.
+     </para>
+     <para>
+      <table>
+       <title>options</title>
+       <tgroup cols="4">
+        <thead>
+         <row>
+          <entry>Option</entry>
+          <entry>Type</entry>
+          <entry>Description</entry>
+         </row>
+        </thead>
+        <tbody>
+         &mongodb.option.maxCommitTimeMS;
+         &mongodb.option.readConcern;
+         &mongodb.option.readPreference;
+         &mongodb.option.writeConcern;
+        </tbody>
+       </tgroup>
+      </table>
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &return.void;
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simplelist>
+   &mongodb.throws.argumentparsing;
+   <member>Lance une <classname>MongoDB\Driver\Exception\CommandException</classname> si la transaction n'a pas pu être démarrée en raison d'un problème côté serveur (par exemple, un verrou n'a pas pu être obtenu).</member>
+   <member>Lance une <classname>MongoDB\Driver\Exception\RuntimeException</classname> si la transaction n'a pas pu être démarrée (par exemple, une transaction était déjà en cours).</member>
+  </simplelist>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>PECL mongodb 1.6.0</entry>
+       <entry>
+        <para>
+         L'option <literal>"maxCommitTimeMS"</literal> a été ajoutée.
+        </para>
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>MongoDB\Driver\Manager::startSession</methodname></member>
+   <member><methodname>MongoDB\Driver\Session::commitTransaction</methodname></member>
+   <member><methodname>MongoDB\Driver\Session::abortTransaction</methodname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
Here is the translation of missing `MongoDB\Driver\Session` methods

- `MongoDB\Driver\Session::abortTransaction()`
- `MongoDB\Driver\Session::advanceClusterTime()`
- `MongoDB\Driver\Session::advanceOperationTime()`
- `MongoDB\Driver\Session::commitTransaction()`
- `MongoDB\Driver\Session::__construct()`
- `MongoDB\Driver\Session::endSession()`
- `MongoDB\Driver\Session::getClusterTime()`
- `MongoDB\Driver\Session::getLogicalSessionId()`
- `MongoDB\Driver\Session::getOperationTime()`
- `MongoDB\Driver\Session::getServer()`
- `MongoDB\Driver\Session::getTransactionOptions()`
- `MongoDB\Driver\Session::getTransactionState()`
- `MongoDB\Driver\Session::isDirty()`
- `MongoDB\Driver\Session::isInTransaction()`
- `MongoDB\Driver\Session::startTransaction()`