### PR TITLE
Translate `MongoDB\Driver\TopologyDescription`

### DIFF
--- a/reference/mongodb/mongodb/driver/topologydescription/getservers.xml
+++ b/reference/mongodb/mongodb/driver/topologydescription/getservers.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: bd6e6603b4614c35d9b63c8d157a98569f2358df Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="mongodb-driver-topologydescription.getservers" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>MongoDB\Driver\TopologyDescription::getServers</refname>
+  <refpurpose>Renvoie les serveurs de la topologie</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>final</modifier> <modifier>public</modifier> <type>array</type><methodname>MongoDB\Driver\TopologyDescription::getServers</methodname>
+   <void />
+  </methodsynopsis>
+  <para>
+   Renvoie un tableau d'objets <classname>MongoDB\Driver\ServerDescription</classname>
+   correspondant aux serveurs connus dans la topologie.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Renvoie un tableau d'objets <classname>MongoDB\Driver\ServerDescription</classname>
+   correspondant aux serveurs connus dans la topologie.
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simplelist>
+   &mongodb.throws.argumentparsing;
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mongodb/mongodb/driver/topologydescription/gettype.xml
+++ b/reference/mongodb/mongodb/driver/topologydescription/gettype.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: bd6e6603b4614c35d9b63c8d157a98569f2358df Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="mongodb-driver-topologydescription.gettype" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>MongoDB\Driver\TopologyDescription::getType</refname>
+  <refpurpose>Renvoie une chaîne de caractères dénotant le type de cette topologie</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>final</modifier> <modifier>public</modifier> <type>string</type><methodname>MongoDB\Driver\TopologyDescription::getType</methodname>
+   <void />
+  </methodsynopsis>
+  <para>
+   Renvoie un <type>string</type> dénotant le type de cette topologie. La valeur
+   sera corrélée avec une constante de
+   <classname>MongoDB\Driver\TopologyDescription</classname>.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Renvoie un <type>string</type> dénotant le type de cette topologie.
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simplelist>
+   &mongodb.throws.argumentparsing;
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mongodb/mongodb/driver/topologydescription/hasreadableserver.xml
+++ b/reference/mongodb/mongodb/driver/topologydescription/hasreadableserver.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: bd6e6603b4614c35d9b63c8d157a98569f2358df Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="mongodb-driver-topologydescription.hasreadableserver" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>MongoDB\Driver\TopologyDescription::hasReadableServer</refname>
+  <refpurpose>Renvoie si la topologie a un serveur lisible</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>final</modifier> <modifier>public</modifier> <type>bool</type><methodname>MongoDB\Driver\TopologyDescription::hasReadableServer</methodname>
+   <methodparam choice="opt"><type class="union"><type>MongoDB\Driver\ReadPreference</type><type>null</type></type><parameter>readPreference</parameter><initializer>&null;</initializer></methodparam>
+  </methodsynopsis>
+  <para>
+   Renvoie si la topologie a un serveur lisible ou, si
+   <parameter>readPreference</parameter> est spécifié, un serveur correspondant à
+   la préférence de lecture spécifiée.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Renvoie si la topologie a un serveur lisible ou, si
+   <parameter>readPreference</parameter> est spécifié, un serveur correspondant à
+   la préférence de lecture spécifiée.
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simplelist>
+   &mongodb.throws.argumentparsing;
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mongodb/mongodb/driver/topologydescription/haswritableserver.xml
+++ b/reference/mongodb/mongodb/driver/topologydescription/haswritableserver.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: bd6e6603b4614c35d9b63c8d157a98569f2358df Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="mongodb-driver-topologydescription.haswritableserver" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>MongoDB\Driver\TopologyDescription::hasWritableServer</refname>
+  <refpurpose>Retourne si la topologie dispose d'un serveur en écriture</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>final</modifier> <modifier>public</modifier> <type>bool</type><methodname>MongoDB\Driver\TopologyDescription::hasWritableServer</methodname>
+   <void />
+  </methodsynopsis>
+  <para>
+   Retourne si la topologie dispose d'un serveur en écriture.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Retourne si la topologie dispose d'un serveur en écriture.
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simplelist>
+   &mongodb.throws.argumentparsing;
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
Here is the translation of missing `MongoDB\Driver\TopologyDescription` methods

- `MongoDB\Driver\TopologyDescription::getServers()`
- `MongoDB\Driver\TopologyDescription::getType()`
- `MongoDB\Driver\TopologyDescription::hasReadableServer()`
- `MongoDB\Driver\TopologyDescription::hasWritableServer()`