### PR TITLE
Sync `curl_set_opt` with en

### DIFF
--- a/reference/curl/constants_curl_setopt.xml
+++ b/reference/curl/constants_curl_setopt.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: b7d6aaa945219da933a0ac2a4b610aa1b09dfcb0 Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: 5af46249c57c3cdee132f275899b0b7750e0cba4 Maintainer: Fan2Shrek Status: ready -->
 <!-- Reviewed: yes -->
  <variablelist role="constant_list">
   <title><function>curl-setopt</function></title>
@@ -17,6 +17,49 @@
      partagent le même stockage et donc une seule d'entre elles peut être
      définie par un gestionnaire.
      Disponible depuis PHP 7.3.0 et cURL 7.53.0
+    </para>
+   </listitem>
+  </varlistentry>
+    <varlistentry xml:id="constant.curlopt-accept-encoding">
+   <term>
+    <constant>CURLOPT_ACCEPT_ENCODING</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Définit un <type>string</type> avec le contenu
+     de l'en-tête <literal>Accept-Encoding:</literal> envoyé dans une requête HTTP.
+     Définir à &null; pour désactiver l'envoi de l'en-tête <literal>Accept-Encoding:</literal>.
+     Par défaut à &null;.
+     Disponible depuis cURL 7.21.6.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-accepttimeout-ms">
+   <term>
+    <constant>CURLOPT_ACCEPTTIMEOUT_MS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Le nombre de maximum de millisecondes à attendre pour qu'un serveur
+     se reconnecte à cURL lorsqu'une connexion FTP active est utilisée.
+     Par défaut à <literal>60000</literal> millisecondes.
+     Disponible depuis cURL 7.24.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-address-scope">
+   <term>
+    <constant>CURLOPT_ADDRESS_SCOPE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     L'identifiant de portée à utiliser lors de la connexion à une adresse IPv6.
+     Cette option accepte n'importe quelle valeur qui peut être convertie en un <type>int</type> valide.
+     Par défaut à <literal>0</literal>.
+     Disponible depuis cURL 7.19.0.
     </para>
    </listitem>
   </varlistentry>
@@ -48,9 +91,23 @@
      Populate the bitmask with the correct set of features to instruct cURL how to handle Alt-Svc for the
      <constant>CURLALTSVC_H1</constant>,
      <constant>CURLALTSVC_H2</constant>,
-     <constant>CURLALTSVC_H3</constant>, et  
+     <constant>CURLALTSVC_H3</constant>, et
      <constant>CURLALTSVC_READONLYFILE</constant>.
      Disponible depuis PHP 8.2.0 et cURL 7.64.1.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-append">
+   <term>
+    <constant>CURLOPT_APPEND</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Mettre cette option à <literal>1</literal> fera que les téléchargements FTP
+     ajoutant au fichier distant au lieu de l'écraser.
+     Par défaut à <literal>0</literal>.
+     Disponible depuis cURL 7.17.0.
     </para>
    </listitem>
   </varlistentry>
@@ -315,6 +372,31 @@
     </para>
    </listitem>
   </varlistentry>
+  <varlistentry xml:id="constant.curlopt-crlfile">
+   <term>
+    <constant>CURLOPT_CRLFILE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Passer un <type>string</type> nommant un fichier avec la concaténation du
+     CRL (Certificate Revocation List) (au format PEM)
+     à utiliser dans la validation du certificat qui se produit pendant l'échange SSL.
+     Lorsque cUrl est compilé pour utiliser GnuTLS,
+     il n'y a aucun moyen d'influencer l'utilisation de CRL passée
+     pour aider dans le processus de vérification.
+     Lorsque cUrl est compilé pour utiliser OpenSSL,
+     <literal>X509_V_FLAG_CRL_CHECK</literal>
+     et <literal>X509_V_FLAG_CRL_CHECK_ALL</literal> sont tous deux définis,
+     exigeant la vérification de la CRL contre tous les éléments de la chaîne de certificats
+     si un fichier CRL est passé.
+     Il est également à noter que <constant>CURLOPT_CRLFILE</constant> implique
+     <constant>CURLSSLOPT_NO_PARTIALCHAIN</constant>
+     à partir de cURL 7.71.0 en raison d'un bogue OpenSSL.
+     Disponible depuis cURL 7.19.0
+    </para>
+   </listitem>
+  </varlistentry>
   <varlistentry xml:id="constant.curlopt-customrequest">
    <term>
     <constant>CURLOPT_CUSTOMREQUEST</constant>
@@ -349,6 +431,26 @@
     <para>
      Le protocole par défaut à utiliser si l'URL manque d'un nom de schéma.
      Disponible depuis PHP 7.0.7 et cURL 7.45.0
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-dirlistonly">
+   <term>
+    <constant>CURLOPT_DIRLISTONLY</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Définit cette option à <literal>1</literal> pour avoir des effets différents
+     basés sur le protocole avec lequel elle est utilisée.
+     Les URLs basées sur FTP et SFTP listeront uniquement les noms de fichiers dans un répertoire.
+     POP3 listera le message ou les messages de courrier électronique sur le serveur POP3.
+     Pour FILE, cette option n'a pas d'effet
+     car les répertoires sont toujours listés dans ce mode.
+     Utiliser cette option avec <constant>CURLOPT_WILDCARDMATCH</constant>
+     empêchera ce dernier d'avoir un quelconque effet.
+     Par défaut à <literal>0</literal>.
+     Disponible depuis cURL 7.17.0.
     </para>
    </listitem>
   </varlistentry>
@@ -414,6 +516,20 @@
     </para>
    </listitem>
   </varlistentry>
+  <varlistentry xml:id="constant.curlopt-dns-servers">
+   <term>
+    <constant>CURLOPT_DNS_SERVERS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Passer un <type>string</type> avec une liste séparée par des virgules de serveurs DNS à utiliser
+     au lieu du système par défaut
+     (par exemple : <literal>192.168.1.100,192.168.1.101:8080</literal>).
+     Disponible depuis cURL 7.24.0
+    </para>
+   </listitem>
+  </varlistentry>
   <varlistentry xml:id="constant.curlopt-dns-shuffle-addresses">
    <term>
     <constant>CURLOPT_DNS_SHUFFLE_ADDRESSES</constant>
@@ -423,7 +539,7 @@
     <para>
      &true; pour mélanger l'ordre de toutes les adresses retournées afin qu'elles soient utilisées
      dans un ordre aléatoire, lorsqu'un nom est résolu et que plus d'une adresse IP est retournée.
-     Cela peut entraîner l'utilisation d'IPv4 avant IPv6 ou vice versa. 
+     Cela peut entraîner l'utilisation d'IPv4 avant IPv6 ou vice versa.
      Disponible depuis PHP 7.3.0 et cURL 7.60.0
     </para>
    </listitem>
@@ -540,7 +656,7 @@
     <para>
      &true; pour échouer verbalement si le code HTTP retourné
      est supérieur ou égal à 400. Le comportement par défaut est de retourner
-     la page normalement, en ignorant le code. 
+     la page normalement, en ignorant le code.
     </para>
    </listitem>
   </varlistentry>
@@ -552,7 +668,7 @@
    <listitem>
     <para>
      Le fichier dans lequel le transfert doit être écrit. La valeur par défaut
-     est <constant>STDOUT</constant> (la fenêtre du navigateur). 
+     est <constant>STDOUT</constant> (la fenêtre du navigateur).
     </para>
    </listitem>
   </varlistentry>
@@ -564,9 +680,58 @@
    <listitem>
     <para>
      &true; pour tenter de récupérer la date de modification
-     du document distant. Cette valeur peut être récupérée en utilisant l'option 
+     du document distant. Cette valeur peut être récupérée en utilisant l'option
      <constant>CURLINFO_FILETIME</constant> avec
      <function>curl_getinfo</function>.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-fnmatch-function">
+   <term>
+    <constant>CURLOPT_FNMATCH_FUNCTION</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Passer un <type>callable</type> qui sera utilisé pour la correspondance de caractères génériques.
+     La signature de la fonction de rappel doit être :
+     <methodsynopsis>
+      <type>int</type><methodname><replaceable>callback</replaceable></methodname>
+      <methodparam><type>resource</type><parameter>curlHandle</parameter></methodparam>
+      <methodparam><type>string</type><parameter>pattern</parameter></methodparam>
+      <methodparam><type>string</type><parameter>string</parameter></methodparam>
+     </methodsynopsis>
+     <variablelist role="function_parameters">
+      <varlistentry>
+       <term><parameter>curlHandle</parameter></term>
+       <listitem>
+        <simpara>
+         Le gestionnaire cURL.
+        </simpara>
+       </listitem>
+      </varlistentry>
+      <varlistentry>
+       <term><parameter>pattern</parameter></term>
+       <listitem>
+        <simpara>
+         La chaîne de caractères génériques.
+        </simpara>
+       </listitem>
+      </varlistentry>
+      <varlistentry>
+       <term><parameter>string</parameter></term>
+       <listitem>
+        <simpara>
+         Le <type>string</type> sur lequel exécuter la correspondance de caractères génériques.
+        </simpara>
+       </listitem>
+      </varlistentry>
+     </variablelist>
+     La fonction de rappel doit renvoyer
+     <constant>CURL_FNMATCHFUNC_MATCH</constant> si le modèle correspond à la <type>string</type>,
+     <constant>CURL_FNMATCHFUNC_NOMATCH</constant> si ce n'est pas le cas
+     ou <constant>CURL_FNMATCHFUNC_FAIL</constant> si une erreur s'est produite.
+     Disponible depuis cURL 7.21.0.
     </para>
    </listitem>
   </varlistentry>
@@ -628,7 +793,7 @@
    </term>
    <listitem>
     <para>
-     Un alias de 
+     Un alias de
      <constant>CURLOPT_TRANSFERTEXT</constant>. Utilisez plutôt cela.
     </para>
    </listitem>
@@ -675,6 +840,35 @@
     </para>
    </listitem>
   </varlistentry>
+  <varlistentry xml:id="constant.curlopt-ftp-account">
+   <term>
+    <constant>CURLOPT_FTP_ACCOUNT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Passer un <type>string</type> qui sera envoyé comme information de compte sur FTP
+     (utiliser la commande <literal>ACCT</literal>) après que le nom d'utilisateur et le mot de passe aient été fournis
+     au serveur.
+     Définir à &null; pour désactiver l'envoi de l'information de compte.
+     Par défaut à &null;.
+     Disponible depuis cURL 7.13.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-ftp-alternative-to-user">
+   <term>
+    <constant>CURLOPT_FTP_ALTERNATIVE_TO_USER</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Passer un <type>string</type> qui sera utilisé pour essayer de s'authentifier sur FTP
+     si la négociation <literal>USER/PASS</literal> échoue.
+     Disponible depuis cURL 7.15.5.
+    </para>
+   </listitem>
+  </varlistentry>
   <varlistentry xml:id="constant.curlopt-ftp-create-missing-dirs">
    <term>
     <constant>CURLOPT_FTP_CREATE_MISSING_DIRS</constant>
@@ -703,6 +897,38 @@
     </para>
    </listitem>
   </varlistentry>
+  <varlistentry xml:id="constant.curlopt-ftp-response-timeout">
+   <term>
+    <constant>CURLOPT_FTP_RESPONSE_TIMEOUT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Le délai en secondes que cURL attendra pour une réponse d'un serveur FTP
+     Cette option remplace <constant>CURLOPT_TIMEOUT</constant>.
+     Cette option accepte n'importe quelle valeur qui peut être convertie en un <type>int</type> valide.
+     Disponible depuis cURL 7.10.8 et dépréciée depuis cURL 7.85.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-ftp-skip-pasv-ip">
+   <term>
+    <constant>CURLOPT_FTP_SKIP_PASV_IP</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Si cette option est définie à <literal>1</literal>,
+     cURL n'utilisera pas l'adresse IP que le serveur suggère
+     dans sa réponse 227 à la commande <literal>PASV</literal> de cURL
+     mais utilisera l'adresse IP qu'il a utilisée pour la connexion.
+     Le numéro de port reçu de la réponse 227 ne sera pas ignoré par cURL.
+     Par défaut à <literal>1</literal> depuis cURL 7.74.0
+     et <literal>0</literal> avant cela.
+     Disponible depuis cURL 7.15.0.
+    </para>
+   </listitem>
+  </varlistentry>
   <varlistentry xml:id="constant.curlopt-ftp-ssl">
    <term>
     <constant>CURLOPT_FTP_SSL</constant>
@@ -711,6 +937,22 @@
    <listitem>
     <para>
 
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-ftp-ssl-ccc">
+   <term>
+    <constant>CURLOPT_FTP_SSL_CCC</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Cette option fait en sorte que cURL utilise CCC (Clear Command Channel)
+     qui arrête la couche SSL/TLS après l'authentification
+     rendant le reste de la communication du canal de contrôle non chiffrée.
+     Utiliser une des constantes <constant>CURLFTPSSL_CCC_<replaceable>*</replaceable></constant>.
+     Par défaut à <constant>CURLFTPSSL_CCC_NONE</constant>.
+     Disponible depuis cURL 7.16.1.
     </para>
    </listitem>
   </varlistentry>
@@ -737,6 +979,38 @@
      &true; pour essayer d'envoyer un commande EPSV pour les transferts FTP
      avant de revenir à PASV. Mettez à &false;
      pour désactiver EPSV.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-ftp-use-pret">
+   <term>
+    <constant>CURLOPT_FTP_USE_PRET</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Définir à <literal>1</literal> pour envoyer une commande <literal>PRET</literal> avant
+     <literal>PASV</literal> (et <literal>EPSV</literal>).
+     N'a aucun effet lors de l'utilisation du mode de transfert FTP actif.
+     Par défaut à <literal>0</literal>.
+     Disponible depuis cURL 7.20.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-gssapi-delegation">
+   <term>
+    <constant>CURLOPT_GSSAPI_DELEGATION</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Définir à <constant>CURLGSSAPI_DELEGATION_FLAG</constant>
+     pour permettre la délégation inconditionnelle des informations d'identification GSSAPI.
+     Définir à <constant>CURLGSSAPI_DELEGATION_POLICY_FLAG</constant>
+     pour déléguer uniquement si le drapeau <literal>OK-AS-DELEGATE</literal> est défini
+     dans le ticket de service.
+     Par défaut à <constant>CURLGSSAPI_DELEGATION_NONE</constant>.
+     Disponible depuis cURL 7.22.0.
     </para>
    </listitem>
   </varlistentry>
@@ -934,6 +1208,22 @@
     </para>
    </listitem>
   </varlistentry>
+  <varlistentry xml:id="constant.curlopt-http-transfer-decoding">
+   <term>
+    <constant>CURLOPT_HTTP_TRANSFER_DECODING</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Si définit à <literal>0</literal>, le décodage de transfert est désactivé.
+     Si définit à <literal>1</literal>, le décodage de transfert est activé.
+     cURL fait le décodage de transfert par morceaux par défaut
+     sauf si cette option est définie à <literal>0</literal>.
+     Par défaut à <literal>1</literal>.
+     Disponible depuis cURL 7.16.2.
+    </para>
+   </listitem>
+  </varlistentry>
   <varlistentry xml:id="constant.curlopt-http-version">
    <term>
     <constant>CURLOPT_HTTP_VERSION</constant>
@@ -949,6 +1239,21 @@
      <constant>CURL_HTTP_VERSION_2</constant> (alias de <constant>CURL_HTTP_VERSION_2_0</constant>),
      <constant>CURL_HTTP_VERSION_2TLS</constant> (essaye HTTP 2 sur TLS (HTTPS) seulement) ou
      <constant>CURL_HTTP_VERSION_2_PRIOR_KNOWLEDGE</constant> (envoie des requêtes HTTP/2 sans TLS sans mise à niveau HTTP/1.1).
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-ignore-content-length">
+   <term>
+    <constant>CURLOPT_IGNORE_CONTENT_LENGTH</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Si définit à <literal>1</literal>,
+     ignore l'en-tête <literal>Content-Length</literal> dans la réponse HTTP
+     et ignore la demande ou la dépendance de celui-ci pour les transferts FTP.
+     Par défaut à <literal>0</literal>.
+     Disponible depuis cURL 7.14.1.
     </para>
    </listitem>
   </varlistentry>
@@ -1004,6 +1309,24 @@
      <constant>CURL_IPRESOLVE_V6</constant>, par défaut
      <constant>CURL_IPRESOLVE_WHATEVER</constant>.
      Disponible depuis cURL 7.10.8.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-issuercert">
+   <term>
+    <constant>CURLOPT_ISSUERCERT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Si définit à un <type>string</type> nommant un fichier contenant un certificat CA au format PEM,
+     une vérification supplémentaire est effectuée contre le certificat du pair
+     pour vérifier que l'émetteur est bien celui associé
+     avec le certificat fourni par l'option.
+     Pour que le résultat de la vérification soit considéré comme un échec,
+     cette option doit être utilisée en combinaison avec l'option
+     <constant>CURLOPT_SSL_VERIFYPEER</constant>.
+     Disponible depuis cURL 7.19.0.
     </para>
    </listitem>
   </varlistentry>
@@ -1067,6 +1390,59 @@
     </para>
    </listitem>
   </varlistentry>
+  <varlistentry xml:id="constant.curlopt-krblevel">
+   <term>
+    <constant>CURLOPT_KRBLEVEL</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Définit le niveau de sécurité Kerberos pour FTP et active également la prise en charge de Kerberos.
+     Cela doit être défini sur l'une des <type>string</type>s suivantes :
+     <simplelist type="inline">
+      <member><literal>clear</literal></member>
+      <member><literal>safe</literal></member>
+      <member><literal>confidential</literal></member>
+      <member><literal>private</literal></member>
+     </simplelist>
+     .
+     Si l'option <type>string</type> est définie mais ne correspond à aucune de ces valeurs,
+     <literal>private</literal> est utilisé.
+     Définir cette option à &null; désactivera la prise en charge de Kerberos pour FTP.
+     Par défaut à &null;.
+     Disponible depuis cURL 7.16.4.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-localport">
+   <term>
+    <constant>CURLOPT_LOCALPORT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Définit le numéro de port local du socket utilisé pour la connexion.
+     Cette option acccepte n'importe quelle valeur qui peut être convertie en un <type>int</type> valide.
+     Par défaut à <literal>0</literal>.
+     Disponible depuis cURL 7.15.2.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-localportrange">
+   <term>
+    <constant>CURLOPT_LOCALPORTRANGE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Le nombre d'essaie que cURL fait pour trouver un numéro de port local fonctionnel,
+     commençant par celui défini avec <constant>CURLOPT_LOCALPORT</constant>.
+     Cette option accepte n'importe quelle valeur qui peut être convertie en un <type>int</type> valide.
+     Par défaut à <literal>1</literal>.
+     Disponible depuis cURL 7.15.2.
+    </para>
+   </listitem>
+  </varlistentry>
   <varlistentry xml:id="constant.curlopt-login-options">
    <term>
     <constant>CURLOPT_LOGIN_OPTIONS</constant>
@@ -1108,6 +1484,58 @@
     </para>
    </listitem>
   </varlistentry>
+  <varlistentry xml:id="constant.curlopt-mail-auth">
+   <term>
+    <constant>CURLOPT_MAIL_AUTH</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Définit un <type>string</type> avec l'adresse d'authentification (identité)
+     d'un message soumis qui est relayé à un autre serveur.
+     Cette adresse ne doit pas être spécifiée dans une paire de chevrons
+     (<literal>&gt;&lt;</literal>).
+     Si un <type>string</type> vide est utilisé, alors une paire de chevrons est envoyée par cURL
+     comme requis par la RFC 2554.
+     Disponible depuis cURL 7.25.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-mail-from">
+   <term>
+    <constant>CURLOPT_MAIL_FROM</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Définit un <type>string</type> avec l'adresse email de l'expéditeur lors de l'envoi d'un email SMTP.
+     L'adresse email doit être spécifiée avec des chevrons
+     (<literal>&gt;&lt;</literal>) autour d'elle,
+     qui si non spécifiés sont ajoutés automatiquement.
+     Si ce paramètre n'est pas spécifié, une adresse vide est envoyée
+     au serveur SMTP qui pourrait causer le rejet de l'email.
+     Disponible depuis cURL 7.20.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-mail-rcpt">
+   <term>
+    <constant>CURLOPT_MAIL_RCPT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Définit un <type>array</type> de <type>string</type>s
+     avec les destinataires à envoyer au serveur dans une requête de courrier SMTP.
+     Chaque destinataire doit être spécifié dans une paire de chevrons
+     (<literal>&gt;&lt;</literal>).
+     Si un chevron n'est pas utilisé comme premier caractère,
+     cURL suppose qu'une seule adresse email a été fournie
+     et l'encadre dans des chevrons.
+     Disponible depuis cURL 7.20.0.
+    </para>
+   </listitem>
+  </varlistentry>
   <varlistentry xml:id="constant.curlopt-mail-rcpt-alllowfails">
    <term>
     <constant>CURLOPT_MAIL_RCPT_ALLLOWFAILS</constant>
@@ -1142,6 +1570,32 @@
      Le maximum de connexions persistantes autorisées.
      Lorsque la limite est atteinte, la plus ancienne dans le cache est fermée
      pour empêcher l'augmentation du nombre de connexions ouvertes.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-maxfilesize">
+   <term>
+    <constant>CURLOPT_MAXFILESIZE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Définit la taille maximale acceptée (en octets) d'un fichier à télécharger.
+     Si le fichier demandé est trouvé plus grand que cette valeur,
+     le transfert est interrompu
+     et <constant>CURLE_FILESIZE_EXCEEDED</constant> est retourné.
+     Passer <literal>0</literal> désactive cette option,
+     et passer une taille négative retourne une
+     <constant>CURLE_BAD_FUNCTION_ARGUMENT</constant>.
+     Si la taille du fichier n'est pas connue avant le début du téléchargement,
+     cette option n'a pas d'effet.
+     Pour une limite de taille supérieure à <literal>2GB</literal>,
+     <constant>CURLOPT_MAXFILESIZE_LARGE</constant> doit être utilisé.
+     Depuis cURL 8.4.0, cette option arrête également les transferts en cours
+     si ils atteignent ce seuil.
+     Cette option accepte n'importe quelle valeur qui peut être convertie en un <type>int</type> valide.
+     Par défaut à <literal>0</literal>.
+     Disponible depuis cURL 7.10.8.
     </para>
    </listitem>
   </varlistentry>
@@ -1257,6 +1711,53 @@
     </para>
    </listitem>
   </varlistentry>
+  <varlistentry xml:id="constant.curlopt-netrc-file">
+   <term>
+    <constant>CURLOPT_NETRC_FILE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Définit un <type>string</type> contenant le nom complet du fichier <filename>.netrc</filename>.
+     Si cette option est omise et que <constant>CURLOPT_NETRC</constant> est défini,
+     cURL vérifie un fichier <filename>.netrc</filename>
+     dans le répertoire personnel de l'utilisateur actuel.
+     Disponible depuis cURL 7.11.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-new-directory-perms">
+   <term>
+    <constant>CURLOPT_NEW_DIRECTORY_PERMS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Définit la valeur des permissions (<type>int</type>) qui sont définies sur les répertoires nouvellement créés
+     sur le serveur distant. La valeur par défaut est <literal>0755</literal>.
+     Les seuls protocoles qui peuvent utiliser cette option sont
+     <literal>sftp://</literal>, <literal>scp://</literal>
+     et <literal>file://</literal>.
+     Disponible depuis cURL 7.16.4.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-new-file-perms">
+   <term>
+    <constant>CURLOPT_NEW_FILE_PERMS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Définit la valeur des permissions (<type>int</type>) qui sont définies sur les fichiers nouvellement créés
+     sur le serveur distant. La valeur par défaut est <literal>0644</literal>.
+     Les seuls protocoles qui peuvent utiliser cette option sont
+     <literal>sftp://</literal>, <literal>scp://</literal>
+     et <literal>file://</literal>.
+     Disponible depuis cURL 7.16.4.
+    </para>
+   </listitem>
+  </varlistentry>
   <varlistentry xml:id="constant.curlopt-nobody">
    <term>
     <constant>CURLOPT_NOBODY</constant>
@@ -1284,6 +1785,27 @@
        changé que pour des raisons de débogage.
       </para>
      </note>
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-noproxy">
+   <term>
+    <constant>CURLOPT_NOPROXY</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Définit un <type>string</type> consistant en une liste séparée par des virgules de noms d'hôtes
+     qui ne nécessitent pas de proxy pour être atteints.
+     Chaque nom dans cette liste est comparé soit comme un domaine
+     qui contient le nom d'hôte ou le nom d'hôte lui-même.
+     Le seul caractère générique disponibles dans le <type>string</type>
+     est un simple caractère <literal>*</literal> qui correspond à tous les hosts,
+     désactivant effectivement le proxy.
+     Définir cette option à une <type>string</type> vide active le proxy pour tous les noms d'hôtes.
+     Depuis cURL 7.86.0, les adresses IP définies avec cette option
+     peuvent être fournies en utilisant la notation CIDR.
+     Disponible depuis cURL 7.19.4.
     </para>
    </listitem>
   </varlistentry>
@@ -1461,6 +1983,21 @@
     </para>
    </listitem>
   </varlistentry>
+  <varlistentry xml:id="constant.curlopt-prequote">
+   <term>
+    <constant>CURLOPT_PREQUOTE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Définit un tableau de commandes FTP à exécuter sur le serveur avant la requête
+     après que la connexion FTP a été établie.
+     Ces commandes ne sont pas effectués lorsqu'une liste de répertoire est demandée,
+     seulement pour les transfers de fichiers.
+     Disponible depuis cURL 7.9.5.
+    </para>
+   </listitem>
+  </varlistentry>
   <varlistentry xml:id="constant.curlopt-private">
    <term>
     <constant>CURLOPT_PRIVATE</constant>
@@ -1552,7 +2089,7 @@
    </term>
    <listitem>
     <para>
-     Le proxy HTTP pour tunneler les requêtes à travers.  
+     Le proxy HTTP pour tunneler les requêtes à travers.
     </para>
    </listitem>
   </varlistentry>
@@ -1567,7 +2104,7 @@
      Utiliser les mêmes masques de bits que décrits dans
      <constant>CURLOPT_HTTPAUTH</constant>. Pour l'authentification du proxy,
      seulement <constant>CURLAUTH_BASIC</constant> et
-     <constant>CURLAUTH_NTLM</constant> sont actuellement supportés. 
+     <constant>CURLAUTH_NTLM</constant> sont actuellement supportés.
      Disponible depuis cURL 7.10.7.
     </para>
    </listitem>
@@ -1581,6 +2118,18 @@
     <para>
      Un tableau d'en-têtes HTTP personnalisés à envoyer au proxy.
      Disponible depuis PHP 7.0.7 et cURL 7.37.0
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-proxypassword">
+   <term>
+    <constant>CURLOPT_PROXYPASSWORD</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Définit un <type>string</type> avec le mot de passe à utiliser pour l'authentification avec le proxy.
+     Disponible depuis cURL 7.19.1.
     </para>
    </listitem>
   </varlistentry>
@@ -1606,9 +2155,21 @@
      Soit <constant>CURLPROXY_HTTP</constant> (défaut),
      <constant>CURLPROXY_SOCKS4</constant>,
      <constant>CURLPROXY_SOCKS5</constant>,
-     <constant>CURLPROXY_SOCKS4A</constant> ou 
+     <constant>CURLPROXY_SOCKS4A</constant> ou
      <constant>CURLPROXY_SOCKS5_HOSTNAME</constant>.
      Disponible depuis cURL 7.10.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-proxyusername">
+   <term>
+    <constant>CURLOPT_PROXYUSERNAME</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Définit un <type>string</type> avec le nom d'utilisateur à utiliser pour l'authentification avec le proxy.
+     Disponible depuis cURL 7.19.1.
     </para>
    </listitem>
   </varlistentry>
@@ -2001,6 +2562,24 @@
     </para>
    </listitem>
   </varlistentry>
+  <varlistentry xml:id="constant.curlopt-proxy-transfer-mode">
+   <term>
+    <constant>CURLOPT_PROXY_TRANSFER_MODE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Définit à <literal>1</literal> pour définir le mode de transfert (binaire ou ASCII)
+     pour les transfers FTP effectués via un proxy HTTP, en ajoutant
+     <literal>type=a</literal> ou <literal>type=i</literal> à l'URL.
+     Sans ce paramètre ou s'il est défini à <literal>0</literal>,
+     <constant>CURLOPT_TRANSFERTEXT</constant> n'a aucun effet
+     lors de l'utilisation de FTP via un proxy.
+     Par défaut à <literal>0</literal>.
+     Disponible depuis cURL 7.18.0.
+    </para>
+   </listitem>
+  </varlistentry>
   <varlistentry xml:id="constant.curlopt-put">
    <term>
     <constant>CURLOPT_PUT</constant>
@@ -2059,6 +2638,19 @@
      <literal>"X-Y"</literal> où X ou Y sont optionnels. Les transferts HTTP
      supportent également plusieurs intervalles, séparés par des virgules au format
      <literal>"X-Y,N-M"</literal>.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-readdata">
+   <term>
+    <constant>CURLOPT_READDATA</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Définit un pointeur de fichier <type>resource</type> qui sera utilisé par la fonction de lecture de fichier
+     définie avec <constant>CURLOPT_READFUNCTION</constant>.
+     Disponible depuis cURL 7.9.7.
     </para>
    </listitem>
   </varlistentry>
@@ -2173,6 +2765,97 @@
     </para>
    </listitem>
   </varlistentry>
+  <varlistentry xml:id="constant.curlopt-rtsp-client-cseq">
+   <term>
+    <constant>CURLOPT_RTSP_CLIENT_CSEQ</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Définit un <type>int</type> avec le numéro CSEQ à émettre pour la prochaine requête RTSP.
+     Utilise si l'application reprend une connexion précédemment interrompue.
+     Le CSEQ s'incrémente à partir de ce nouveau numéro par la suite.
+     Par défaut à <literal>0</literal>.
+     Disponible depuis cURL 7.20.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-rtsp-request">
+   <term>
+    <constant>CURLOPT_RTSP_REQUEST</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Définit le type de requête RTSP à effectuer.
+     Doit être une des constantes <constant>CURL_RTSPREQ_<replaceable>*</replaceable></constant>.
+     Disponible depuis cURL 7.20.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-rtsp-server-cseq">
+   <term>
+    <constant>CURLOPT_RTSP_SERVER_CSEQ</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Définit un <type>int</type> avec le numéro CSEQ à attendre
+     pour la prochaine requête RTSP du serveur.
+     Cette fonctionnalité (écoute des requêtes du serveur) n'est pas implémentée.
+     Par défaut à <literal>0</literal>.
+     Disponible depuis cURL 7.20.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-rtsp-session-id">
+   <term>
+    <constant>CURLOPT_RTSP_SESSION_ID</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Définit un <type>string</type> avec la valeur de l'identifiant de la session RTSP courante pour la poignée.
+     Une fois que cette valeur est définie sur une valeur non-&null;,
+     cURL renvoie <constant>CURLE_RTSP_SESSION_ERROR</constant>
+     si l'identifiant reçu du serveur ne correspond pas.
+     Si défini sur &null;, cURL définit automatiquement l'identifiant
+     la première fois que le serveur le définit dans une réponse.
+     Par défaut à &null;
+     Disponible depuis cURL 7.20.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-rtsp-stream-uri">
+   <term>
+    <constant>CURLOPT_RTSP_STREAM_URI</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Définit un <type>string</type> avec l'URI du flux sur lequel opérer.
+     S'il n'est pas définit, cURL définit par défaut l'opération sur les options de serveur génériques
+     en passant <literal>*</literal> à la place de l'URI du flux RTSP.
+     Lors du travail avec RTSP, <literal>CURLOPT_RTSP_STREAM_URI</literal>
+     indique quelle URL envoyer au serveur dans l'en-tête de requête
+     tandis que <literal>CURLOPT_URL</literal> indique
+     où établir la connexion.
+     Disponible depuis cURL 7.20.0.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-rtsp-transport">
+   <term>
+    <constant>CURLOPT_RTSP_TRANSPORT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Définit l'en-tête <literal>Transport:</literal> pour cette session RTSP.
+     Disponible depuis cURL 7.20.0.
+    </para>
+   </listitem>
+  </varlistentry>
   <varlistentry xml:id="constant.curlopt-safe-upload">
    <term>
     <constant>CURLOPT_SAFE_UPLOAD</constant>
@@ -2262,6 +2945,34 @@
     </para>
    </listitem>
   </varlistentry>
+  <varlistentry xml:id="constant.curlopt-socks5-gssapi-nec">
+   <term>
+    <constant>CURLOPT_SOCKS5_GSSAPI_NEC</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Définir à <literal>1</literal> pour activer et à <literal>0</literal> pour désactiver
+     l'échange non protégé de la négociation du mode de protection
+     dans le cadre de la négociation GSSAPI.
+     Disponible depuis cURL 7.19.4.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-socks5-gssapi-service">
+   <term>
+    <constant>CURLOPT_SOCKS5_GSSAPI_SERVICE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Définit un <type>string</type> contenant le nom du service SOCKSS.
+     Par défaut à <literal>rcmd</literal>.
+     Disponible depuis cURL 7.19.4 et déprécié depuis cURL 7.49.0.
+     Utiliser <constant>CURLOPT_PROXY_SERVICE_NAME</constant> à la place.
+    </para>
+   </listitem>
+  </varlistentry>
   <varlistentry xml:id="constant.curlopt-ssh-auth-types">
    <term>
     <constant>CURLOPT_SSH_AUTH_TYPES</constant>
@@ -2273,7 +2984,7 @@
      <constant>CURLSSH_AUTH_PUBLICKEY</constant>,
      <constant>CURLSSH_AUTH_PASSWORD</constant>,
      <constant>CURLSSH_AUTH_HOST</constant>,
-     <constant>CURLSSH_AUTH_KEYBOARD</constant>. Définissez-le sur 
+     <constant>CURLSSH_AUTH_KEYBOARD</constant>. Définissez-le sur
      <constant>CURLSSH_AUTH_ANY</constant> pour laisser libcurl en choisir un.
      Disponible depuis cURL 7.16.1.
     </para>
@@ -2328,6 +3039,19 @@
      Le hachage SHA256 encodé en base64 de la clé publique de l'hôte distant.
      Le transfert échouera si le hachage donné ne correspond pas au hachage fourni par l'hôte distant.
      Disponible depuis PHP 8.2.0 et cURL 7.80.0
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-ssh-knownhosts">
+   <term>
+    <constant>CURLOPT_SSH_KNOWNHOSTS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Définit le nom du fichier <filename>known_host</filename> à utiliser
+     qui devrait utiliser le format de fichier OpenSSH pris en charge par libssh2.
+     Disponible depuis cURL 7.19.6.
     </para>
    </listitem>
   </varlistentry>
@@ -2627,6 +3351,20 @@
     </para>
    </listitem>
   </varlistentry>
+  <varlistentry xml:id="constant.curlopt-ssl-sessionid-cache">
+   <term>
+    <constant>CURLOPT_SSL_SESSIONID_CACHE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Définir à <literal>0</literal> pour désactiver et à <literal>1</literal> pour activer
+     le cache de session SSL.
+     Par défaut, tous les transferts sont effectués en utilisant le cache activé.
+     Disponible depuis cURL 7.16.0.
+    </para>
+   </listitem>
+  </varlistentry>
   <varlistentry xml:id="constant.curlopt-ssl-verifyhost">
    <term>
     <constant>CURLOPT_SSL_VERIFYHOST</constant>
@@ -2728,7 +3466,7 @@
    </term>
    <listitem>
     <para>
-     Si défini à <literal>1</literal>, des sondes de maintien de la connexion TCP seront envoyées. Le déliat et 
+     Si défini à <literal>1</literal>, des sondes de maintien de la connexion TCP seront envoyées. Le déliat et
      la fréquence de ces sondes peuvent être contrôlés par les options <constant>CURLOPT_TCP_KEEPIDLE</constant>
      et <constant>CURLOPT_TCP_KEEPINTVL</constant>, à condition que le système d'exploitation
      les supporte. Si défini à <literal>0</literal> (par défaut), les sondes de maintien de la connexion sont désactivées.
@@ -2776,6 +3514,39 @@
      &true; pour désactiver l'algorithme de Nagle TCP, qui tente de minimiser
      le nombre de petits paquets sur le réseau.
      Disponible depuis cURL 7.11.2.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-telnetoptions">
+   <term>
+    <constant>CURLOPT_TELNETOPTIONS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Définit un <type>array</type> de <type>string</type>s à passer aux négociations telnet.
+     Ces variables doivent être au format <literal>&gt;option=valeur&lt;</literal>.
+     cURL supporte les options <literal>TTYPE</literal>,
+     <literal>XDISPLOC</literal> et <literal>NEW_ENV</literal>.
+     Disponible depuis cURL 7.7.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-tftp-blksize">
+   <term>
+    <constant>CURLOPT_TFTP_BLKSIZE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Définit la taille de bloc à utiliser pour la transmission de données TFTP.
+     La plage valide est de <literal>8</literal> à <literal>65464</literal> octets.
+     Par défaut, <literal>512</literal> octets sont utilisés si cette option n'est pas spécifiée.
+     La taille du bloc spécifiée n'est utilisée que si elle est prise en charge par le serveur distant.
+     SI le serveur ne renvoie pas d'accusé de réception d'option
+     ou renvoie un accusé de réception d'option sans taille de bloc,
+     la valeur par défaut de <literal>512</literal> octets est utilisée.
+     Disponible depuis cURL 7.19.4.
     </para>
    </listitem>
   </varlistentry>
@@ -2884,6 +3655,68 @@
     </para>
    </listitem>
   </varlistentry>
+  <varlistentry xml:id="constant.curlopt-tlsauth-password">
+   <term>
+    <constant>CURLOPT_TLSAUTH_PASSWORD</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Définit un mot de passe à utiliser pour l'authentification spécifiée
+     avec l'option <constant>CURLOPT_TLSAUTH_TYPE</constant>. Requiert que
+     l'option <constant>CURLOPT_TLSAUTH_USERNAME</constant> soit également définie.
+     Cette fonctionnalité repose sur TLS SRP qui ne fonctionne pas avec TLS 1.3.
+     Disponible depuis cURL 7.21.4.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-tlsauth-type">
+   <term>
+    <constant>CURLOPT_TLSAUTH_TYPE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Définit une <type>string</type> avec la méthode d'authentification TLS.
+     La méthode supportée est <literal>SRP</literal>
+     (authentification TLS Secure Remote Password).
+     Disponible à partir de cURL 7.21.4.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-tlsauth-username">
+   <term>
+    <constant>CURLOPT_TLSAUTH_USERNAME</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Définit un <type>string</type> avec le nom d'utilisateur à utiliser pour la méthode d'authentification TLS
+     spécifié avec l'option <constant>CURLOPT_TLSAUTH_TYPE</constant>.
+     Requiert que l'option <constant>CURLOPT_TLSAUTH_PASSWORD</constant>
+     soit également définie.
+     Cette fonctionnalité repose sur TLS SRP qui ne fonctionne pas avec TLS 1.3.
+     Disponible depuis cURL 7.21.4.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-transfer-encoding">
+   <term>
+    <constant>CURLOPT_TRANSFER_ENCODING</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Définit à <literal>1</literal> pour activer et à <literal>0</literal> pour désactiver
+     la demande de <literal>Transfer Encoding</literal> compressé dans la requête
+     HTTP sortante. Si le serveur répond avec un
+     <literal>Transfer Encoding</literal> compressé,
+     cURL va automatiquement le décompresser à la réception.
+     Par défaut à <literal>0</literal>.
+     Disponible à partir de cURL 7.21.6.
+    </para>
+   </listitem>
+  </varlistentry>
   <varlistentry xml:id="constant.curlopt-transfertext">
    <term>
     <constant>CURLOPT_TRANSFERTEXT</constant>
@@ -2978,6 +3811,26 @@
     </para>
    </listitem>
   </varlistentry>
+  <varlistentry xml:id="constant.curlopt-use-ssl">
+   <term>
+    <constant>CURLOPT_USE_SSL</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Définit le niveau de SSL/TLS souhaité pour le transfert
+     lors de l'utilisation de FTP, SMTP, POP3, IMAP, etc.
+     Ce sont tous des protocoles qui commencent en texte clair
+     et sont "améliorés" en SSL en utilisant la commande STARTTLS.
+     Définit à l'un des suivants :
+     <constant>CURLUSESSL_NONE</constant>,
+     <constant>CURLUSESSL_TRY</constant>,
+     <constant>CURLUSESSL_CONTROL</constant> ou
+     <constant>CURLUSESSL_ALL</constant>.
+     Disponible depuis cURL 7.17.0.
+    </para>
+   </listitem>
+  </varlistentry>
   <varlistentry xml:id="constant.curlopt-useragent">
    <term>
     <constant>CURLOPT_USERAGENT</constant>
@@ -3025,6 +3878,23 @@
      &true; pour afficher des informations détaillées sur la connexion.
      Écrit la sortie sur <constant>STDERR</constant>, ou le fichier spécifié en utilisant
      <constant>CURLOPT_STDERR</constant>.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-wildcardmatch">
+   <term>
+    <constant>CURLOPT_WILDCARDMATCH</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Définir à <literal>1</literal> pour transférer plusieurs fichiers
+     selon un modèle de nom de fichier.
+     Le patterne peut être spécifié en tant que partie de l'option
+     <constant>CURLOPT_URL</constant>,
+     en utilisant un modèle fnmatch-like (Shell Pattern Matching)
+     dans la dernière partie de l'URL (nom de fichier).
+     Disponible depuis cURL 7.21.0.
     </para>
    </listitem>
   </varlistentry>


### PR DESCRIPTION
Sync `curl_set_opt` with en
Remove some useless spaces