### PR TITLE
Translate missing `ReflectionClass` methods

### DIFF
--- a/reference/reflection/reflectionclass/getlazyinitializer.xml
+++ b/reference/reflection/reflectionclass/getlazyinitializer.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: c0fa5077c8862405942d8aac7360c5169558b59b Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="reflectionclass.getlazyinitializer" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>ReflectionClass::getLazyInitializer</refname>
+  <refpurpose>Renvoie l'initialiseur paresseux</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="ReflectionClass">
+   <modifier>public</modifier> <type class="union"><type>callable</type><type>null</type></type><methodname>ReflectionClass::getLazyInitializer</methodname>
+   <methodparam><type>object</type><parameter>object</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Renvoie l'initialiseur paresseux ou l'usine attachée à
+   <parameter>object</parameter>.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>object</parameter></term>
+    <listitem>
+     <simpara>
+      L'objet à partir duquel obtenir l'initialiseur.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Renvoie l'initialiseur si l'objet est un objet paresseux non initialisé,
+   &null; sinon.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><link linkend="language.oop5.lazy-objects">Objet paresseux</link></member>
+   <member><methodname>ReflectionClass::newLazyGhost</methodname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/reflection/reflectionclass/initializelazyobject.xml
+++ b/reference/reflection/reflectionclass/initializelazyobject.xml
@@ -1,0 +1,130 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: c0fa5077c8862405942d8aac7360c5169558b59b Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="reflectionclass.initializelazyobject" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>ReflectionClass::initializeLazyObject</refname>
+  <refpurpose>Force l'initialisation d'un objet paresseux</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="ReflectionClass">
+   <modifier>public</modifier> <type>object</type><methodname>ReflectionClass::initializeLazyObject</methodname>
+   <methodparam><type>object</type><parameter>object</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Force l'initialisation de l'<parameter>object</parameter> spécifié. Cette
+   méthode n'a aucun effet si l'objet n'est pas paresseux ou a déjà été
+   initialisé. Sinon, l'initialisation se déroule comme décrit dans la
+   <link linkend="language.oop5.lazy-objects.initialization-sequence">Séquence
+   d'initialisation</link>.
+  </simpara>
+
+  <note>
+   <simpara>
+    Dans la plupart des cas, appeler cette méthode est inutile, car les objets
+    paresseux s'initialisent automatiquement lorsqu'ils sont observés ou
+    modifiés.
+   </simpara>
+  </note>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>object</parameter></term>
+    <listitem>
+     <simpara>
+      L'objet à initialiser.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Si <parameter>object</parameter> est un proxy paresseux, renvoie son instance
+   réelle. Sinon, renvoie <parameter>object</parameter> lui-même.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Utilisation basique</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+class Example
+{
+    public function __construct(public int $prop) {
+    }
+}
+
+$reflector = new ReflectionClass(Example::class);
+
+$object = $reflector->newLazyGhost(function ($object) {
+    echo "Initializer called\n";
+    $object->__construct(1);
+});
+
+var_dump($object);
+
+$reflector->initializeLazyObject($object);
+
+var_dump($object);
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+lazy ghost object(Example)#3 (0) {
+  ["prop"]=>
+  uninitialized(int)
+}
+Initializer called
+object(Example)#3 (1) {
+  ["prop"]=>
+  int(1)
+}
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><link linkend="language.oop5.lazy-objects">Objet paresseux</link></member>
+   <member><methodname>ReflectionClass::newLazyGhost</methodname></member>
+   <member><methodname>ReflectionClass::markLazyObjectAsInitialized</methodname></member>
+   <member><methodname>ReflectionClass::isUninitializedLazyObject</methodname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/reflection/reflectionclass/isuninitializedlazyobject.xml
+++ b/reference/reflection/reflectionclass/isuninitializedlazyobject.xml
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: c0fa5077c8862405942d8aac7360c5169558b59b Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="reflectionclass.isuninitializedlazyobject" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>ReflectionClass::isUninitializedLazyObject</refname>
+  <refpurpose>Vérifie si un objet est paresseux et non initialisé</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="ReflectionClass">
+   <modifier>public</modifier> <type>bool</type><methodname>ReflectionClass::isUninitializedLazyObject</methodname>
+   <methodparam><type>object</type><parameter>object</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Vérifie si un objet est paresseux et non initialisé.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>object</parameter></term>
+    <listitem>
+     <simpara>
+      L'objet à vérifier.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Renvoie &true; si <parameter>object</parameter> est un objet paresseux et non initialisé
+   et sinon &false;.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Utilisation basique</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+class Example
+{
+    public function __construct(public int $prop) {
+    }
+}
+
+$reflector = new ReflectionClass(Example::class);
+
+$object = $reflector->newLazyGhost(function ($object) {
+    echo "Initializer called\n";
+    $object->__construct(1);
+});
+
+var_dump($reflector->isUninitializedLazyObject($object));
+
+var_dump($object->prop);
+
+var_dump($reflector->isUninitializedLazyObject($object));
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+bool(true)
+Initializer called
+int(1)
+bool(false)
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+    <member><link linkend="language.oop5.lazy-objects">Objet paresseux</link></member>
+   <member><methodname>ReflectionClass::newLazyGhost</methodname></member>
+   <member><methodname>ReflectionClass::markLazyObjectAsInitialized</methodname></member>
+   <member><methodname>ReflectionClass::initializeLazyObject</methodname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/reflection/reflectionclass/marklazyobjectasinitialized.xml
+++ b/reference/reflection/reflectionclass/marklazyobjectasinitialized.xml
@@ -1,0 +1,197 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: c0fa5077c8862405942d8aac7360c5169558b59b Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="reflectionclass.marklazyobjectasinitialized" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>ReflectionClass::markLazyObjectAsInitialized</refname>
+  <refpurpose>Marque un objet paresseux comme initialisé sans appeler l'initialiseur ou l'usine</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="ReflectionClass">
+   <modifier>public</modifier> <type>object</type><methodname>ReflectionClass::markLazyObjectAsInitialized</methodname>
+   <methodparam><type>object</type><parameter>object</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Marque un objet paresseux comme initialisé sans appeler l'initialiseur ou
+   l'usine. Cela n'a aucun effet si <parameter>object</parameter> n'est pas
+   paresseux ou est déjà initialisé.
+  </simpara>
+  <simpara>
+   L'effect de l'appel de cette méthode est le même que décrit pour les objets fantômes
+   (peu importe la stratégie de paresse de <parameter>object</parameter>) dans
+   <link linkend="language.oop5.lazy-objects.initialization-sequence">séquence
+   d'initialisation</link>, sauf que l'initialiseur n'est pas appelé.
+   Après cela, l'objet est indiscernable d'un objet qui n'était jamais paresseux et
+   a été créé avec
+   <methodname>ReflectionClass::newInstanceWithoutConstructor</methodname>,
+   excepté pour la valeur des propriétés qui ont déjà été initialisées avec
+   <methodname>ReflectionProperty::setRawValueWithoutLazyInitialization</methodname>
+   ou <methodname>ReflectionProperty::skipLazyInitialization</methodname>.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>object</parameter></term>
+    <listitem>
+     <simpara>
+      L'objet à marquer comme initialisé.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Renvoie <parameter>object</parameter>.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Marquer un objet paresseux non initialisé comme initialisé</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+class Example
+{
+    public string $prop1;
+    public string $prop2;
+    public string $prop3 = 'default value';
+}
+
+$reflector = new ReflectionClass(Example::class);
+
+$object = $reflector->newLazyGhost(function ($object) {
+    echo "Initializer called\n";
+    $object->prop1 = 'initialized';
+});
+
+$reflector->getProperty('prop1')
+          ->setRawValueWithoutLazyInitialization($object, 'prop1 value');
+
+var_dump($object);
+
+$reflector->markLazyObjectAsInitialized($object);
+
+var_dump($object);
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+lazy ghost object(Example)#3 (1) {
+  ["prop1"]=>
+  string(11) "prop1 value"
+  ["prop2"]=>
+  uninitialized(string)
+  ["prop3"]=>
+  uninitialized(string)
+}
+object(Example)#3 (2) {
+  ["prop1"]=>
+  string(11) "prop1 value"
+  ["prop2"]=>
+  uninitialized(string)
+  ["prop3"]=>
+  string(13) "default value"
+}
+]]>
+   </screen>
+  </example>
+  <example>
+   <title>Marquer un objet paresseux initialisé comme initialisé</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+class Example
+{
+    public string $prop1;
+    public string $prop2;
+    public string $prop3 = 'default value';
+}
+
+$reflector = new ReflectionClass(Example::class);
+
+$object = $reflector->newLazyGhost(function ($object) {
+    echo "Initializer called\n";
+    $object->prop1 = 'initialized';
+});
+
+$reflector->getProperty('prop1')
+          ->setRawValueWithoutLazyInitialization($object, 'prop1 value');
+
+var_dump($object->prop3);
+var_dump($object);
+
+$reflector->markLazyObjectAsInitialized($object);
+
+var_dump($object);
+?>
+]]>
+    </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+Initializer called
+string(13) "default value"
+object(Example)#3 (2) {
+  ["prop1"]=>
+  string(11) "initialized"
+  ["prop2"]=>
+  uninitialized(string)
+  ["prop3"]=>
+  string(13) "default value"
+}
+object(Example)#3 (2) {
+  ["prop1"]=>
+  string(11) "initialized"
+  ["prop2"]=>
+  uninitialized(string)
+  ["prop3"]=>
+  string(13) "default value"
+}
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><link linkend="language.oop5.lazy-objects">Objet paresseux</link></member>
+   <member><methodname>ReflectionClass::newLazyGhost</methodname></member>
+   <member><methodname>ReflectionClass::initializeLazyObject</methodname></member>
+   <member><methodname>ReflectionClass::isUninitializedLazyObject</methodname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/reflection/reflectionclass/newlazyghost.xml
+++ b/reference/reflection/reflectionclass/newlazyghost.xml
@@ -1,0 +1,187 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: c0fa5077c8862405942d8aac7360c5169558b59b Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="reflectionclass.newlazyghost" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>ReflectionClass::newLazyGhost</refname>
+  <refpurpose>Créer une nouvelle instance fantôme paresseuse</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="ReflectionClass">
+   <modifier>public</modifier> <type>object</type> <methodname>ReflectionClass::newLazyGhost</methodname>
+   <methodparam><type>callable</type><parameter>initializer</parameter></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>options</parameter><initializer>0</initializer></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Créer une nouvelle instance fantôme paresseuse de la classe, en attachant
+   l'<parameter>initializer</parameter> à celle-ci. Le constructeur n'est pas
+   appelé, et les propriétés ne sont pas définies à leur valeur par défaut.
+   Cependant, l'objet sera automatiquement initialisé en invoquant
+   l'<parameter>initializer</parameter> la première fois que son état est observé
+   ou modifié. Voir
+   <link linkend="language.oop5.lazy-objects.initialization-triggers">déclencheurs
+   d'initialisation</link> et <link linkend="language.oop5.lazy-objects.initialization-sequence">
+   séquence d'initialisation</link>.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>initializer</parameter></term>
+    <listitem>
+     <simpara>
+      L'initialiseur est une fonction de rappel avec la signature suivante:
+     </simpara>
+     <para>
+      <methodsynopsis>
+       <type>void</type><methodname><replaceable>initializer</replaceable></methodname>
+       <methodparam><type>object</type><parameter>object</parameter></methodparam>
+      </methodsynopsis>
+      <variablelist>
+       <varlistentry>
+        <term><parameter>object</parameter></term>
+        <listitem>
+         <simpara>
+          L'<parameter>object</parameter> en cours d'initialisation. À ce stade,
+          l'objet n'est plus marqué comme paresseux, et y accéder ne déclenche
+          plus l'initialisation.
+         </simpara>
+        </listitem>
+       </varlistentry>
+      </variablelist>
+     </para>
+     <simpara>
+      La fonction <parameter>initializer</parameter> doit renvoyer &null; ou ne
+      rien renvoyer.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="reflectionclass.newlazyghost.parameters.options">
+    <term><parameter>options</parameter></term>
+    <listitem>
+     <para>
+      <parameter>options</parameter> peut être une combinaison des drapeaux
+      suivants:
+      <variablelist>
+       <varlistentry>
+        <term>
+         <constant>ReflectionClass::SKIP_INITIALIZATION_ON_SERIALIZE</constant>
+        </term>
+        <listitem>
+         <simpara>
+          Par défaut, la sérialisation d'un objet paresseux déclenche son
+          initialisation. Définir ce drapeau empêche l'initialisation, permettant
+          aux objets paresseux d'être sérialisés sans être initialisés.
+         </simpara>
+        </listitem>
+       </varlistentry>
+      </variablelist>
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Renvoyer une instance fantôme paresseuse. Si l'objet n'a pas de propriétés,
+   ou si toutes ses propriétés sont statiques ou virtuelles, une instance normale
+   (non paresseuse) est renvoyée. Voir aussi
+   <link linkend="language.oop5.lazy-objects.lifecycle">Cycle de vie des objets
+   paresseux</link>.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simpara>
+   Une <classname>ReflectionException</classname> si la classe est interne ou
+   étends une classe interne, sauf <classname>stdClass</classname>.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Utilisation basique</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+
+class Example {
+    public function __construct(public int $prop) {
+        echo __METHOD__, "\n";
+    }
+}
+
+$reflector = new ReflectionClass(Example::class);
+$object = $reflector->newLazyGhost(function (Example $object) {
+     $object->__construct(1);
+});
+
+var_dump($object);
+var_dump($object instanceof Example);
+
+// Déclenche l'initialisation, et récupère la propriété après cela
+var_dump($object->prop);
+
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+lazy ghost object(Example)#3 (0) {
+  ["prop"]=>
+  uninitialized(int)
+}
+bool(true)
+Example::__construct
+int(1)
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><link linkend="language.oop5.lazy-objects">Objet paresseux</link></member>
+   <member><methodname>ReflectionClass::newLazyProxy</methodname></member>
+   <member><methodname>ReflectionClass::newInstanceWithoutConstructor</methodname></member>
+   <member><methodname>ReflectionClass::resetAsLazyGhost</methodname></member>
+   <member><methodname>ReflectionClass::markLazyObjectAsInitialized</methodname></member>
+   <member><methodname>ReflectionClass::initializeLazyObject</methodname></member>
+   <member><methodname>ReflectionClass::isUninitializedLazyObject</methodname></member>
+   <member><methodname>ReflectionProperty::setRawValueWithoutLazyInitialization</methodname></member>
+   <member><methodname>ReflectionProperty::skipLazyInitialization</methodname></member>
+   <member><methodname>ReflectionProperty::isLazy</methodname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/reflection/reflectionclass/newlazyproxy.xml
+++ b/reference/reflection/reflectionclass/newlazyproxy.xml
@@ -1,0 +1,179 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: c0fa5077c8862405942d8aac7360c5169558b59b Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="reflectionclass.newlazyproxy" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+ <refnamediv>
+  <refname>ReflectionClass::newLazyProxy</refname>
+  <refpurpose>Créer une nouvelle instance proxy paresseuse</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="ReflectionClass">
+   <modifier>public</modifier> <type>object</type><methodname>ReflectionClass::newLazyProxy</methodname>
+   <methodparam><type>callable</type><parameter>factory</parameter></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>options</parameter><initializer>0</initializer></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Créer une nouvelle instance proxy paresseuse de la classe, en attachant la
+   <parameter>factory</parameter> à celle-ci. Le constructeur n'est pas
+   appelé, et les propriétés ne sont pas définies à leur valeur par défaut. Lorsqu'une
+   tentative est faite d'observer ou de modifier l'état du proxy pour la première
+   fois, la fonction d'usine est appelée pour fournir une instance réelle, qui
+   est ensuite attachée au proxy. Après cela, toutes les interactions ultérieures
+   avec le proxy sont transmises à l'instance réelle. Voir
+   <link linkend="language.oop5.lazy-objects.initialization-triggers">déclencheurs
+   d'initialisation</link> et <link linkend="language.oop5.lazy-objects.initialization-sequence">
+   séquence d'initialisation</link>.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>factory</parameter></term>
+    <listitem>
+     <simpara>
+      L'usine est une fonction de rappel avec la signature suivante:
+     </simpara>
+     <para>
+      <methodsynopsis>
+       <type>object</type><methodname><replaceable>factory</replaceable></methodname>
+       <methodparam><type>object</type><parameter>object</parameter></methodparam>
+      </methodsynopsis>
+      <variablelist>
+       <varlistentry>
+        <term><parameter>object</parameter></term>
+        <listitem>
+         <simpara>
+          L'<parameter>object</parameter> en cours d'initialisation. À ce point,
+          l'objet n'est plus marqué comme paresseux, et y accéder ne déclenche
+          plus l'initialisation.
+         </simpara>
+        </listitem>
+       </varlistentry>
+      </variablelist>
+     </para>
+     <simpara>
+      La fonction d'usine doit renvoyer un objet, appelé <emphasis>instance réelle</emphasis>,
+      qui est ensuite attaché au proxy. Cette instance réelle ne doit pas être paresseuse
+      et ne doit pas être le proxy lui-même. Si l'instance réelle n'a pas la même classe
+      que le proxy, la classe du proxy doit être une sous-classe de la classe de l'instance
+      réelle, sans propriétés supplémentaires, et ne doit pas remplacer les méthodes
+      <methodname>__destruct</methodname> ou <methodname>__clone</methodname>.
+      methods.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('reflectionclass.newlazyghost.parameters.options')/*)">
+     <xi:fallback/>
+    </xi:include>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Renvoie une instance proxy paresseuse. Si l'objet n'a pas de propriétés, ou si
+   toutes ses propriétés sont statiques ou virtuelles, une instance normale (non paresseuse)
+   est renvoyée. Voir aussi
+   <link linkend="language.oop5.lazy-objects.lifecycle">Cycle de vie des objets
+   paresseux</link>.
+  </simpara>
+ </refsect1>
+
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('reflectionclass.newlazyghost')/db:refsect1[@role='errors'])">
+  <xi:fallback/>
+ </xi:include>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Utilisation basique</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+class Example {
+    public function __construct(public int $prop) {
+        echo __METHOD__, "\n";
+    }
+}
+
+$reflector = new ReflectionClass(Example::class);
+$object = $reflector->newLazyProxy(function (Example $object) {
+     $realInstance = new Example(1);
+     return $realInstance;
+});
+
+var_dump($object);
+var_dump($object instanceof Example);
+
+// Déclenche l'initialisation, et transmet la récupération de la propriété à l'instance réelle  
+var_dump($object->prop);
+
+var_dump($object);
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+lazy proxy object(Example)#3 (0) {
+  ["prop"]=>
+  uninitialized(int)
+}
+bool(true)
+Example::__construct
+int(1)
+lazy proxy object(Example)#3 (1) {
+  ["instance"]=>
+  object(Example)#4 (1) {
+    ["prop"]=>
+    int(1)
+  }
+}
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><link linkend="language.oop5.lazy-objects">Objet paresseux</link></member>
+   <member><methodname>ReflectionClass::newLazyGhost</methodname></member>
+   <member><methodname>ReflectionClass::newInstanceWithoutConstructor</methodname></member>
+   <member><methodname>ReflectionClass::resetAsLazyProxy</methodname></member>
+   <member><methodname>ReflectionClass::markLazyObjectAsInitialized</methodname></member>
+   <member><methodname>ReflectionClass::initializeLazyObject</methodname></member>
+   <member><methodname>ReflectionClass::isUninitializedLazyObject</methodname></member>
+   <member><methodname>ReflectionProperty::setRawValueWithoutLazyInitialization</methodname></member>
+   <member><methodname>ReflectionProperty::skipLazyInitialization</methodname></member>
+   <member><methodname>ReflectionProperty::isLazy</methodname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/reflection/reflectionclass/resetaslazyghost.xml
+++ b/reference/reflection/reflectionclass/resetaslazyghost.xml
@@ -1,0 +1,170 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: c0fa5077c8862405942d8aac7360c5169558b59b Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="reflectionclass.resetaslazyghost" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>ReflectionClass::resetAsLazyGhost</refname>
+  <refpurpose>Réinitialise un objet et le marque comme paresseux</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="ReflectionClass">
+   <modifier>public</modifier> <type>void</type><methodname>ReflectionClass::resetAsLazyGhost</methodname>
+   <methodparam><type>object</type><parameter>object</parameter></methodparam>
+   <methodparam><type>callable</type><parameter>initializer</parameter></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>options</parameter><initializer>0</initializer></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Réinitialise un <parameter>objet</parameter> existant et le marque comme paresseux.
+  </simpara>
+  <simpara>
+   Le destructeur de l'objet est appelé (s'il existe) sauf si le drapeau
+   <constant>ReflectionClass::SKIP_DESTRUCTOR</constant> est spécifié. Dans le cas
+   particulier où l'objet est un proxy initialisé, l'instance réelle est détachée
+   du proxy. Si l'instance réelle n'est plus référencée ailleurs, son destructeur
+   est appelé indépendamment du
+   drapeau <constant>SKIP_DESTRUCTOR</constant>.
+  </simpara>
+  <simpara>
+   Les propriétés dynamiques sont supprimées, et la valeur des propriétés
+   déclarées sur la classe est jetée comme si <function>unset</function> était
+   appelée, et marquée comme paresseuse. Cela implique que si l'objet est une
+   instance d'une sous-classe avec des propriétés supplémentaires, ces propriétés
+   ne sont pas modifiées et ne sont pas marquées comme paresseuses.
+   Les <link linkend="language.oop5.properties.readonly-properties">propriétés
+   en lecture seule</link> ne sont pas modifiées et ne sont pas marquées comme
+   paresseuses si elles sont <literal>final</literal> ou si la classe elle-même
+   est <literal>final</literal>.
+  </simpara>
+  <simpara>
+   Si aucune propriété n'est marquée comme paresseuse, l'objet n'est pas marqué comme paresseux. Voir
+   aussi
+   <link linkend="language.oop5.lazy-objects.lifecycle">Cycle de vie des objets
+   paresseux</link>.
+  </simpara>
+  <simpara>
+   Sinon, après l'appel de cette méthode, le comportement de l'objet est le même
+   qu'un objet créé par
+   <methodname>ReflectionClass::newLazyGhost</methodname> (sauf pour
+   les propriétés de sous-classe et les propriétés en lecture seule, comme décrit ci-dessus).
+  </simpara>
+  <simpara>
+   L'objet n'est pas remplacé par un autre, et son identité reste inchangée. Les
+   fonctionnalités telles que <function>spl_object_id</function>,
+   <function>spl_object_hash</function>,
+   <classname>SplObjectStorage</classname>, <classname>WeakMap</classname>,
+   <classname>WeakReference</classname>, ou
+   <link linkend="language.oop5.object-comparison">l'opérateur d'identité
+   (<literal>===</literal>)</link> ne sont pas affectées.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>object</parameter></term>
+    <listitem>
+     <simpara>
+      Un objet non paresseux, ou un objet paresseux initialisé.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>initializer</parameter></term>
+    <listitem>
+     <simpara>
+      Une fonction de rappel avec la même signature et le même but que dans
+      <methodname>ReflectionClass::newLazyGhost</methodname>.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="reflectionclass.resetaslazyghost.parameters.options">
+    <term><parameter>options</parameter></term>
+    <listitem>
+     <para>
+      <parameter>options</parameter> peut être une combinaison des drapeaux
+      suivants :
+      <variablelist>
+       <varlistentry>
+        <term>
+         <constant>ReflectionClass::SKIP_INITIALIZATION_ON_SERIALIZE</constant>
+        </term>
+        <listitem>
+         <simpara>
+          Par défaut, la sérialisation d'un objet paresseux déclenche son
+          initialisation. Définir ce drapeau empêche l'initialisation, permettant
+          aux objets paresseux d'être sérialisés sans être initialisés.
+         </simpara>
+        </listitem>
+       </varlistentry>
+       <varlistentry>
+        <term>
+         <constant>ReflectionClass::SKIP_DESTRUCTOR</constant>
+        </term>
+        <listitem>
+         <simpara>
+          Par défaut, le destructeur de l'objet est appelé (s'il existe) avant de
+          le marquer comme paresseux. Ce drapeau désactive ce comportement,
+          permettant aux objets d'être réinitialisés comme paresseux sans appeler
+          le destructeur.
+         </simpara>
+        </listitem>
+       </varlistentry>
+      </variablelist>
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   &return.void;
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simpara>
+   Une <classname>ReflectionException</classname> si l'objet est paresseux et non
+   initialisé.
+  </simpara>
+  <simpara>
+   Une <classname>Error</classname> si l'objet est en cours d'initialisation, ou si
+   les propriétés de l'objet sont itérées avec
+   <link linkend="control-structures.foreach"><literal>foreach</literal></link>.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>ReflectionClass::newLazyGhost</methodname></member>
+   <member><methodname>ReflectionClass::resetAsLazyProxy</methodname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/reflection/reflectionclass/resetaslazyproxy.xml
+++ b/reference/reflection/reflectionclass/resetaslazyproxy.xml
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: c0fa5077c8862405942d8aac7360c5169558b59b Maintainer: Fan2Shrek Status: ready -->
+<!-- Reviewed: yes -->
+<refentry xml:id="reflectionclass.resetaslazyproxy" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+ <refnamediv>
+  <refname>ReflectionClass::resetAsLazyProxy</refname>
+  <refpurpose>Réinitialise un objet et le marque comme paresseux</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="ReflectionClass">
+   <modifier>public</modifier> <type>void</type><methodname>ReflectionClass::resetAsLazyProxy</methodname>
+   <methodparam><type>object</type><parameter>object</parameter></methodparam>
+   <methodparam><type>callable</type><parameter>factory</parameter></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>options</parameter><initializer>0</initializer></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Le comportement de cette méthode est le même que
+   <methodname>ReflectionClass::resetAsLazyGhost</methodname> sauf qu'elle utilise
+   la stratégie de proxy.
+  </simpara>
+  <simpara>
+   L'<parameter>object</parameter> lui-même devient le proxy. De manière similaire
+   à <methodname>ReflectionClass::resetAsLazyGhost</methodname>, l'objet n'est pas
+   remplacé par un autre, et son identité ne change pas, même après
+   l'initialisation. Le proxy et l'instance réelle sont des objets distincts, avec
+   des identités distinctes.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>object</parameter></term>
+    <listitem>
+     <simpara>
+      Un objet non-paresseux, ou un objet paresseux initialisé.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>factory</parameter></term>
+    <listitem>
+     <simpara>
+      Une fonction de rappel avec la même signature et le même but que dans
+      <methodname>ReflectionClass::newLazyProxy</methodname>.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('reflectionclass.resetaslazyghost.parameters.options')/*)">
+     <xi:fallback/>
+    </xi:include>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   &return.void;
+  </simpara>
+ </refsect1>
+
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('reflectionclass.resetaslazyghost')/db:refsect1[@role='errors'])">
+  <xi:fallback/>
+ </xi:include>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>ReflectionClass::newLazyProxy</methodname></member>
+   <member><methodname>ReflectionClass::resetAsLazyGhost</methodname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
Here is the translation of new `ReflectionClass` methods

- `ReflectionClass::getLazyInitializer()`
- `ReflectionClass::initializeLazyObject()`
- `ReflectionClass::isUninitializedLazyObject()`
- `ReflectionClass::markLazyObjectAsInitialized()` 
- `ReflectionClass::newLazyGhost()`
- `ReflectionClass::newLazyProxy()`
- `ReflectionClass::resetAsLazyGhost()`
- `ReflectionClass::resetAsLazyProxy()`