### PR TITLE
Change and fix property visibility in lazy-objects example #3

### DIFF
--- a/language/oop5/lazy-objects.xml
+++ b/language/oop5/lazy-objects.xml
@@ -142,9 +142,9 @@ int(1)
 class BlogPost
 {
     public function __construct(
-        private int $id,
-        private string $title,
-        private string $content,
+        public int $id,
+        public string $title,
+        public string $content,
     ) { }
 }
 


### PR DESCRIPTION
When running "Example #3 Initializing Properties Eagerly" result in https://www.php.net/manual/en/language.oop5.lazy-objects.php, an error occurs :
```txt
Fatal error: Uncaught Error: Cannot access private property BlogPost::$id
```

Changing visibility to public on id property for class BlogPost, example #3 resolves this error. All properties for this class example are set to public for preserve visibility homogeneity. 

