### PR TITLE
Add missing hash revision on `xpass/constants`

### DIFF
--- a/reference/xpass/constants.xml
+++ b/reference/xpass/constants.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision:  Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: 505ee6ad7881f1d6999752a20008eb9134e0fdd8 Maintainer: Fan2Shrek Status: ready -->
 <!-- Reviewed: yes -->
 <appendix xml:id="xpass.constants" xmlns="http://docbook.org/ns/docbook">
  &reftitle.constants;


### PR DESCRIPTION
See #1984
(https://doc.php.net/revcheck.php?p=misstags&lang=fr)