### PR TITLE
fix wording translate page pcntl-waitpid

### DIFF
--- a/reference/pcntl/functions/pcntl-waitpid.xml
+++ b/reference/pcntl/functions/pcntl-waitpid.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 61374bbe228e8e9c55a24aba59a1e2bb2a871148 Maintainer: dams Status: ready -->
+<!-- EN-Revision: a747e132c5506a0273c686cbe20e227c980d8ec7 Maintainer: dams Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.pcntl-waitpid" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -49,30 +49,29 @@
           <row>
            <entry><literal>&lt; -1</literal></entry>
            <entry>
-            attend que tous les processus fils dont l'identifiant de groupe
-            est égal à la valeur absolue de <parameter>process_id</parameter> soient
-            terminés.
+            attend un processus fils dont l'identifiant de groupe
+            est égal à la valeur absolue de <parameter>process_id</parameter>.
            </entry>
           </row>
           <row>
            <entry><literal>-1</literal></entry>
            <entry>
-            attend que tous les processus fils soient terminés. Ceci est le
-            même comportement que celui de la fonction <function>pcntl_wait</function>.
+            attend tout processus fils ; cela correspond au
+            même comportement que celui de la fonction <function>pcntl_wait</function> présente.
            </entry>
           </row>
           <row>
            <entry><literal>0</literal></entry>
            <entry>
-            attend que tous les processus fils dont l'identifiant de groupe
-            est égal à celui du processus courant soient terminés.
+            attend un processus fils dont l'identifiant de groupe
+            est égal à celui du processus courant.
            </entry>
           </row>
           <row>
            <entry><literal>&gt; 0</literal></entry>
            <entry>
-            attend que le processus fils dont l'identifiant est
-            égal à <parameter>process_id</parameter> soit terminé.
+            attend le processus fils dont l'identifiant est
+            égal à la valeur de <parameter>process_id</parameter>.
            </entry>
           </row>
          </tbody>


### PR DESCRIPTION
Fix #1950

This pull request includes updates to the `reference/pcntl/functions/pcntl-waitpid.xml` file to improve the clarity and accuracy of the documentation for the `pcntl_waitpid` function. The changes focus on refining the descriptions of the function's behavior based on different `process_id` values.

Documentation improvements:

* Updated the description for `< -1` to specify that it waits for a child process with a group ID equal to the absolute value of `process_id`.
* Clarified the description for `-1` to indicate it waits for any child process, aligning it with the behavior of `pcntl_wait`.
* Refined the description for `0` to state it waits for a child process with a group ID equal to that of the current process.
* Improved the description for `> 0` to specify it waits for the child process with an ID exactly equal to `process_id`.