### PR TITLE
fix wording grammar folder security and language

### DIFF
--- a/language/attributes.xml
+++ b/language/attributes.xml
@@ -9,7 +9,7 @@
 
    <para>
     Les attributs permettent d'ajouter des informations de métadonnées structurées et lisibles par la machine
-    sur les déclarations dans le code: les classes, les méthodes, les fonctions, les paramètres, les propriétés
+    sur les déclarations dans le code : les classes, les méthodes, les fonctions, les paramètres, les propriétés
     et les constantes de classe peuvent être la cible d'un attribut. Les métadonnées
     définies par les attributs peuvent ensuite être inspectées au moment de l'exécution à l'aide de
     l'<link linkend="book.reflection">API de Réflexion</link>.
@@ -22,7 +22,7 @@
     comparables aux interfaces et à leurs implémentations. Mais là où les interfaces et les implémentations
     portent sur le code, les attributs concernent l'annotation d'informations supplémentaires et la configuration.
     Les interfaces peuvent être implémentées par des classes, mais les attributs peuvent également être déclarés sur
-    sur les méthodes, les fonctions, les paramètres, les propriétés et les constantes de classe.
+    les méthodes, les fonctions, les paramètres, les propriétés et les constantes de classe.
     Ils sont donc plus flexibles que les interfaces.
    </para>
 

--- a/language/basic-syntax.xml
+++ b/language/basic-syntax.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 6b09bb638aa64d1fad5f4a630a8da9a2692ce733 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: f4f96ef8b2a95283c92ea2183fe1dedf06f3ad22 Maintainer: yannick Status: ready -->
 <!-- Reviewed: no -->
 <!-- CREDITS: DavidA -->
 
@@ -60,7 +60,7 @@
    la balise de fermeture à la fin du fichier. Ceci permet d'éviter d'oublier
    un espace ou une nouvelle ligne après la balise de fermeture de PHP, ce qui
    causerait des effets non voulus car PHP commencera à afficher la sortie,
-   ce qui n'est souvent pas le cas désiré.   
+   ce qui n'est souvent pas le cas désiré.
    <informalexample>
     <programlisting role="php">
 <![CDATA[
@@ -99,9 +99,9 @@ echo "Dernière instruction";
    rencontre (mis à part la nouvelle ligne qui est immédiatement suivie : voir
    l'<link linkend="language.basic-syntax.instruction-separation">instruction
    de séparation</link>) jusqu'à ce qu'il rencontre une autre balise ouvrante
-   même si PHP se trouve au milieu d'une instruction conditionnelle, au quel cas,
+   même si PHP se trouve au milieu d'une instruction conditionnelle, auquel cas,
    l'interpréteur va déterminer la condition à prendre en compte avant de prendre
-   une décision sur ce qui doit être afficher.
+   une décision sur ce qui doit être affiché.
    Voir le prochain exemple.
   </para>
   <para>

--- a/language/constants.xml
+++ b/language/constants.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 9418ae19ae6ab1d3f1536db986830362b207b1d6 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: f4f96ef8b2a95283c92ea2183fe1dedf06f3ad22 Maintainer: yannick Status: ready -->
 <!-- Reviewed: no -->
 <!-- CREDITS: DAnnebicque -->
 <chapter xml:id="language.constants" xmlns="http://docbook.org/ns/docbook">
@@ -119,7 +119,7 @@ define("__FOO__", "something");
    <simpara>
     Les constantes et les variables globales utilisent deux espaces de
     noms différents. Ce qui implique que &true; et
-    <varname>$TRUE</varname> sont généralement différents (en tous cas, ils
+    <varname>$TRUE</varname> sont généralement différents (en tout cas, ils
     peuvent avoir des valeurs différentes).
    </simpara>
   </note>

--- a/language/context.xml
+++ b/language/context.xml
@@ -8,7 +8,7 @@
 
  <partintro>
   <para>
-   PHP offre divers options et paramètres de contexte, qui peuvent être utilisés
+   PHP offre diverses options et paramètres de contexte, qui peuvent être utilisés
    avec tous les systèmes de fichiers et gestionnaires de flux. Le contexte
    est créé avec la fonction <function>stream_context_create</function>.
    Les options sont définies avec la fonction

--- a/language/control-structures.xml
+++ b/language/control-structures.xml
@@ -22,7 +22,7 @@
   <sect2 role="seealso">
    &reftitle.seealso;
    <para>
-    Les éléments suivant sont considérés comme des structures de contrôles
+    Les éléments suivants sont considérés comme des structures de contrôles
     même s'ils sont référencés dans les fonctions dans la documentation.
    </para>
    <para>

--- a/language/enumerations.xml
+++ b/language/enumerations.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 06e4d8f936c5b102e60b59c02a048601e9beaf82 Maintainer: pierrick Status: ready -->
+<!-- EN-Revision: f4f96ef8b2a95283c92ea2183fe1dedf06f3ad22 Maintainer: pierrick Status: ready -->
 <!-- Reviewed: no -->
  <chapter xml:id="language.enumerations" xmlns="http://docbook.org/ns/docbook">
   <title>Les énumérations</title>
@@ -118,7 +118,7 @@ $a instanceof Suit;  // true
 
    <para>
     Ce type de cas, sans données connexes, est appelé "cas pur" ou "Pure Case". Une enum qui ne contient
-    que des cas purs s'appelle une Enum pure ou "Pure Enum".
+    que des cas purs s'appellent une Enum pure ou "Pure Enum".
    </para>
 
    <para>
@@ -185,10 +185,10 @@ enum Suit: string
    Une Enum avec valeur de base peut être avec des valeurs de types <literal>int</literal> ou <literal>string</literal>,
    et une énumération donnée ne supporte qu'un seul type à la fois (c'est-à-dire pas d'union de <literal>int|string</literal>).
    Si une énumération est marquée comme ayant un équivalent scalaire, tous les cas doivent avoir un équivalent scalaire
-   unique défini explicitement.  Il n'y a pas d'équivalents scalaires auto-générés
-   (par exemple, des entiers séquentiels).  Les cas avec valeur de base doivent être uniques ; deux cas enum avec valeur de base
-   ne peuvent pas avoir le même équivalent scalaire.  Cependant, une constante peut faire référence à un
-   cas, créant ainsi un alias.  Voir <link linkend="language.enumerations.constants">Constantes d'énumération</link>.
+   unique défini explicitement. Il n'y a pas d'équivalents scalaires auto-générés
+   (par exemple, des entiers séquentiels). Les cas avec valeur de base doivent être uniques ; deux cas enum avec valeur de base
+   ne peuvent pas avoir le même équivalent scalaire. Cependant, une constante peut faire référence à un
+   cas, créant ainsi un alias. Voir <link linkend="language.enumerations.constants">Constantes d'énumération</link>.
   </para>
 
   <para>
@@ -215,7 +215,7 @@ print Suit::Clubs->value;
 
   <para>
    Afin d'enforcer la propriété <literal>value</literal> en lecture seule, une variable ne peut pas
-   être assignée en tant que référence à cette propriété.  En d'autres termes, l'opération suivante entraîne une erreur:
+   être assignée en tant que référence à cette propriété. En d'autres termes, l'opération suivante entraîne une erreur:
   </para>
 
   <programlisting role="php">
@@ -237,13 +237,13 @@ $ref = &$suit->value;
   <simplelist>
    <member>
     <literal>from(int|string): self</literal> prend un scalaire et renvoie le cas d'Enum
-    correspondant.  S'il n'en trouve pas, il lèvera une <classname>ValueError</classname>.  Ceci est principalement
+    correspondant. S'il n'en trouve pas, il lèvera une <classname>ValueError</classname>. Ceci est principalement
     utile dans les cas où le scalaire en entrée est fiable et où une valeur d'enum manquante devrait être
     considérée comme une erreur qui arrête l'application.
    </member>
    <member>
     <literal>tryFrom(int|string): ?self</literal> prend un scalaire et renvoie le
-    cas d'Enum correspondant.  S'il n'en trouve pas, il retournera <literal>null</literal>.
+    cas d'Enum correspondant. S'il n'en trouve pas, il retournera <literal>null</literal>.
     Ceci est principalement utile dans les cas où le scalaire en entrée n'est pas fiable et que l'appelant souhaite
     implémenter sa propre gestion d'erreur ou sa logique de valeur par défaut.
    </member>
@@ -251,11 +251,11 @@ $ref = &$suit->value;
 
   <para>
    Les méthodes <literal>from()</literal> et <literal>tryFrom()</literal> suivent les règles
-   standard de typage faible/fort.  En mode de typage faible, il est possible de passer un entier ou une chaîne de caractères.
-   et le système forcera la valeur en conséquence.  Le passage d'un flottant fonctionnera également et sera
-   coercitif.  En mode de typage strict, passer un entier à <literal>from()</literal> sur une enum avec valeur de base
+   standard de typage faible/fort. En mode de typage faible, il est possible de passer un entier ou une chaîne de caractères
+   et le système forcera la valeur en conséquence. Le passage d'un flottant fonctionnera également et sera
+   coercitif. En mode de typage strict, passer un entier à <literal>from()</literal> sur une enum avec valeur de base
    par une chaîne de caractères (ou vice versa) entraînera une erreur de type (<classname>TypeError</classname>),
-   tout comme un float dans toutes les circonstances.  Tous les autres types de paramètres provoqueront une TypeError
+   tout comme un float dans toutes les circonstances. Tous les autres types de paramètres provoqueront une TypeError
    dans les deux modes.
   </para>
 
@@ -334,7 +334,7 @@ print Suit::Diamonds->shape(); // prints "Rectangle"
 
   <para>
    Dans cet exemple, les quatre instances de <literal>Suit</literal> ont deux méthodes,
-   <literal>color()</literal> et <literal>shape()</literal>.  En ce qui concerne le code d'appel
+   <literal>color()</literal> et <literal>shape()</literal>. En ce qui concerne le code d'appel
    et les vérifications de type, elles se comportent exactement comme n'importe quelle autre instance d'objet.
   </para>
 
@@ -444,8 +444,8 @@ final class Suit implements UnitEnum, Colorful
   <title>Méthodes statiques d'Enumération</title>
 
   <para>
-   Les énumérations peuvent également avoir des méthodes statiques.  L'utilisation de méthodes statiques sur une énumération elle-même
-   est principalement pour les constructeurs alternatifs.  Par exemple :
+   Les énumérations peuvent également avoir des méthodes statiques. L'utilisation de méthodes statiques sur une énumération elle-même
+   est principalement pour les constructeurs alternatifs. Par exemple :
   </para>
 
   <programlisting role="php">
@@ -510,7 +510,7 @@ enum Size
 
   <para>Les énumérations peuvent s'appuyer sur des traits, qui se comportent de la même manière que les classes.
    La précondition est que les traits utilisés dans une énumération ne doivent pas contenir de propriétés.
-   Ils ne peuvent inclure que des méthodes, des méthodes statiques et des constantes.  Un trait contenant des propriétés
+   Ils ne peuvent inclure que des méthodes, des méthodes statiques et des constantes. Un trait contenant des propriétés
    entraînera une erreur fatale.
   </para>
 
@@ -557,7 +557,7 @@ enum Suit implements Colorful
 
   <para>
    Les cas étant représentés comme des aonstantes dans l'énumération elle-même, ils peuvent être utilisés comme des valeurs statiques
-   dans la plupart des expressions constantes: valeurs par défaut des propriétés, valeurs par défaut des variables statiques,
+   dans la plupart des expressions constantes : valeurs par défaut des propriétés, valeurs par défaut des variables statiques,
    valeurs par défaut des paramètres, valeurs constantes globales et de classe. Elles ne peuvent pas être utilisées dans d'autres valeurs de cas de l'enum, mais les
    constantes normales peuvent faire référence à un cas d'énumération.
   </para>
@@ -646,8 +646,8 @@ $foo = new Foo();
    <member>Les Enums peuvent implémenter un nombre quelconque d'interfaces.</member>
    <member>
     Les enums et les cas peuvent avoir des <link linkend="language.attributes">attributs</link>
-    qui leur sont attachés.  Le filtre <constant>TARGET_CLASS</constant> 
-    inclut les Enums elles-mêmes.  Le filtre cible <constant>TARGET_CLASS_CONST</constant> 
+    qui leur sont attachés. Le filtre <constant>TARGET_CLASS</constant> 
+    inclut les Enums elles-mêmes. Le filtre cible <constant>TARGET_CLASS_CONST</constant> 
     inclut les cas d'Enum.
    </member>
    <member>
@@ -659,14 +659,14 @@ $foo = new Foo();
 
   <para>
    La constante magique <literal>::class</literal> sur un type Enum évalue le nom du type,
-   y compris l'espace de noms, exactement comme pour un objet.  La constante magique <literal>::class</literal>
+   y compris l'espace de noms, exactement comme pour un objet. La constante magique <literal>::class</literal>
    sur une instance d'un cas Case évalue également le type Enum, puisqu'il s'agit d'une instance
    de ce type.
   </para>
 
   <para>
    En outre, les cas d'énumération ne peuvent pas être instanciés directement avec <literal>new</literal>, ni avec
-   <methodname>ReflectionClass::newInstanceWithoutConstructor</methodname> de la réflexion.  Ces deux méthodes entraîneront une erreur.
+   <methodname>ReflectionClass::newInstanceWithoutConstructor</methodname> de la réflexion. Ces deux méthodes entraîneront une erreur.
   </para>
 
   <programlisting role="php">
@@ -709,9 +709,9 @@ Suit::cases();
   <title>Sérialisation</title>
 
   <para>
-   Les énumérations sont sérialisées différemment des objets.  En particulier, elles ont un nouveau code de sérialisation,
-   <literal>"E"</literal>, qui spécifie le nom du cas de l'énumération.  La routine de désérialisation est alors
-   en mesure d'utiliser ce code pour définir une variable à la valeur singleton existante.  Cela garantit que :
+   Les énumérations sont sérialisées différemment des objets. En particulier, elles ont un nouveau code de sérialisation,
+   <literal>"E"</literal>, qui spécifie le nom du cas de l'énumération. La routine de désérialisation est alors
+   en mesure d'utiliser ce code pour définir une variable à la valeur singleton existante. Cela garantit que :
   </para>
 
   <programlisting role="php">
@@ -731,9 +731,9 @@ print serialize(Suit::Hearts);
    un avertissement sera émis et un &false; sera retourné.</para>
 
   <para>
-   Si une Enum pure est sérialisée en JSON, une erreur sera générée.  Si une Enum avec valeur de base
+   Si une Enum pure est sérialisée en JSON, une erreur sera générée. Si une Enum avec valeur de base
    est sérialisée en JSON, elle sera représentée par sa valeur scalaire uniquement, dans le
-   type approprié.  Le comportement des deux peut être surchargé en implémentant la méthode
+   type approprié. Le comportement des deux peut être surchargé en implémentant la méthode
    <classname>JsonSerializable</classname>.
   </para>
 
@@ -896,7 +896,7 @@ function query($fields, $filter, SortOrder $order = SortOrder::Asc)
     <para>
      La fonction <literal>query()</literal> peut maintenant être exécutée en sachant que
      <literal>$order</literal> est garanti d'être soit <literal>SortOrder::Asc</literal>
-     ou <literal>SortOrder::Desc</literal>.  Toute autre valeur aurait entraîné une
+     ou <literal>SortOrder::Desc</literal>. Toute autre valeur aurait entraîné une
      <classname>TypeError</classname>, donc aucune autre vérification d'erreur ou test n'est nécessaire.
     </para>
    </example>
@@ -935,7 +935,7 @@ enum UserStatus: string
     <para>
      Dans cet exemple, le statut d'un utilisateur peut être l'un de, et exclusivement, <literal>UserStatus::Pending</literal>,
      <literal>UserStatus::Active</literal>, <literal>UserStatus::Suspended</literal>, ou
-     <literal>UserStatus::CanceledByUser</literal>.  Une fonction peut typer un paramètre par rapport à
+     <literal>UserStatus::CanceledByUser</literal>. Une fonction peut typer un paramètre par rapport à
      <literal>UserStatus</literal> et n'accepter que ces quatre valeurs, un point c'est tout.
     </para>
 

--- a/language/exceptions.xml
+++ b/language/exceptions.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 7a75b854c8c52226d38397e7e8177e339fdb273f Maintainer: yannick Status: ready -->
+<!-- EN-Revision: f4f96ef8b2a95283c92ea2183fe1dedf06f3ad22 Maintainer: yannick Status: ready -->
 <!-- Reviewed: no -->
 
 <chapter xml:id="language.exceptions">

--- a/language/expressions.xml
+++ b/language/expressions.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4decb44c7141a97e348a1235bbb20d930d2baac0 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: f4f96ef8b2a95283c92ea2183fe1dedf06f3ad22 Maintainer: yannick Status: ready -->
 <!-- Reviewed: no -->
 <chapter xml:id="language.expressions" xmlns="http://docbook.org/ns/docbook">
  <title>Les expressions</title>

--- a/language/functions.xml
+++ b/language/functions.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: ae8e5c871b1a71ea77f5b97f7929d76d4ca724ab Maintainer: yannick Status: ready -->
+<!-- EN-Revision: f4f96ef8b2a95283c92ea2183fe1dedf06f3ad22 Maintainer: yannick Status: ready -->
 <!-- Reviewed: no -->
 <chapter xml:id="language.functions" xmlns="http://docbook.org/ns/docbook">
  <title>Les fonctions</title>

--- a/language/namespaces.xml
+++ b/language/namespaces.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 874f7c1266d4e4f2e1e6c79b5fb48b590caa1197 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: f4f96ef8b2a95283c92ea2183fe1dedf06f3ad22 Maintainer: yannick Status: ready -->
 <!-- Reviewed: no -->
 <!-- CREDITS: DAnnebicque -->
 <chapter xml:id="language.namespaces" xmlns="http://docbook.org/ns/docbook"
@@ -336,9 +336,9 @@ echo MonProjet\Connexion::start();
      <simpara>
       Un nom sans qualificatif, ou une classe sans préfixe, telle que 
       <literal>$a = new foo();</literal> ou
-      <literal>foo::methodestatique();</literal>.  Si l'espace de noms courant
-      est <literal>espacedenomscourant</literal>, ceci se résout en 
-      <literal>espacedenomscourant\foo</literal>.  Si l'espace de noms est 
+      <literal>foo::methodestatique();</literal>. Si l'espace de noms courant
+      est <literal>espacedenomscourant</literal>, ceci se résout en
+      <literal>espacedenomscourant\foo</literal>. Si l'espace de noms est
       global, soit encore l'espace de noms sans nom, cela devient <literal>foo</literal>.
      </simpara>
      <simpara>
@@ -742,7 +742,7 @@ $obj = new \Another\untruc; // instantie un objet de la classe Another\untruc
     externe d'un fichier (le contexte global) ou alors dans les déclarations d'espace
     de noms. Ceci car l'importation est effectuée à la compilation et non durant
     l'éxecution, donc on ne peut empiler les contextes. L'exemple qui suit montre des
-    utilisation incorrectes du mot-clé <literal>use</literal>:
+    utilisations incorrectes du mot-clé <literal>use</literal>:
    </para>
    <para>
     <example>

--- a/language/references.xml
+++ b/language/references.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: d58ee8eaaa7f716c51f66f5f1058ab3c42376d98 Maintainer: jpauli Status: ready -->
+<!-- EN-Revision: f4f96ef8b2a95283c92ea2183fe1dedf06f3ad22 Maintainer: jpauli Status: ready -->
 <!-- Reviewed: no -->
 <!-- CREDITS: DAnnebicque -->
 
@@ -14,7 +14,7 @@
    pointeurs en C : vous ne pouvez pas effectuer d'opération arithmétique de pointeurs 
    sur celles-ci, ce ne sont pas des adresses mémoires, etc.
    Vous pouvez consulter
-   <xref linkend="language.references.arent" /> pour plus d'informations.    
+   <xref linkend="language.references.arent" /> pour plus d'informations.
    En fait, les références sont des alias dans la
    <link linkend="features.gc.refcounting-basics">table des symboles</link>.
    Notez qu'en PHP, le nom d'une variable et son contenu sont deux

--- a/language/variables.xml
+++ b/language/variables.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 7d804723a85d3a8039ba3d0d2c8c414e85f5ede1 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: f4f96ef8b2a95283c92ea2183fe1dedf06f3ad22 Maintainer: yannick Status: ready -->
 <!-- Reviewed: yes -->
 
 <chapter xml:id="language.variables" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -28,7 +28,7 @@
    <simpara>
     PHP ne prend pas en charge les noms de variables Unicode, cependant, certains
     encodages de caractères (comme UTF-8) encodent les caractères de manière
-    à ce que tous les octets d'un caractère multi-octet soient dans la plage
+    que tous les octets d'un caractère multi-octet soient dans la plage
     autorisée, ce qui en fait ainsi un nom de variable valide.
    </simpara>
   </note>

--- a/security/database.xml
+++ b/security/database.xml
@@ -16,7 +16,7 @@
   de bases de données, envoyer une requête valide, lire le résultat et
   refermer la connexion. De nos jours, le langage le plus courant pour ce
   type de communication est le langage SQL 
-  (<literal>Structured Query Language</literal>). Voyez
+  (<literal>Structured Query Language</literal>). Voir
   comment un pirate peut
   <link linkend="security.database.sql-injection">s'introduire dans une
    requête SQL</link>.

--- a/security/errors.xml
+++ b/security/errors.xml
@@ -7,7 +7,7 @@
  <title>Rapport d'erreurs</title>
  <para>
   En termes de sécurité, il y a deux conséquences au rapport d'erreur.
-  D'un coté, cela améliore la sécurité, mais d'un autre, cela la réduit aussi.
+  D'un côté, cela améliore la sécurité, mais d'un autre, cela la réduit aussi.
  </para>
  <para>
   Une tactique d'attaque standard consiste à faire faire des erreurs
@@ -33,7 +33,7 @@
   Les erreurs PHP qui sont normalement retournées peuvent être
   très pratiques pour un développeur qui essaie de déboguer un
   script, car elles donnent de précieux renseignements tels que
-  la fonction qui a échouée, depuis quel fichier PHP, et même le numéro
+  la fonction qui a échoué, depuis quel fichier PHP, et même le numéro
   de la ligne à laquelle l'erreur s'est produite. Toutes ces informations sont exploitables.
   Il n'est pas rare que les développeurs PHP utilisent
   les fonctions <function>show_source</function>,

--- a/security/intro.xml
+++ b/security/intro.xml
@@ -9,7 +9,7 @@
   PHP est un langage puissant et l'interpréteur, qu'il soit inclus
   dans le serveur web en tant que module ou bien compilé en version <acronym>CGI</acronym>,
   est capable d'accéder aux fichiers, d'exécuter des commandes, et d'ouvrir
-  des connexions réseaux.  Toutes ces propriétés rendent fragile la
+  des connexions réseaux. Toutes ces propriétés rendent fragile la
   sécurité d'un serveur web. PHP a été conçu comme
   un langage beaucoup plus sécurisé pour écrire des programmes
   <acronym>CGI</acronym> que le Perl ou le langage C, et, avec une

--- a/security/variables.xml
+++ b/security/variables.xml
@@ -33,7 +33,7 @@ exec($evil_var);
  <para>
   Il est vivement recommandé d'examiner minutieusement votre code
   pour vous assurer qu'il n'y a pas de variable envoyée par le
-  client web qui ne soit pas suffisamment vérifiée avant utilisation,
+  client web qui ne soit pas suffisamment vérifié avant utilisation,
   en vous posant les questions suivantes :
   <itemizedlist>
    <listitem>


### PR DESCRIPTION
This pull request includes various minor corrections to grammar and spelling in multiple XML files. The changes are primarily focused on improving the readability and accuracy of the documentation.

Grammar and spelling corrections:

* [`language/attributes.xml`](diffhunk://#diff-1fcbf18c6657f80597db4568e84912c4a08e2d8cdb94c0dd7ab7d68d36099332L25-R25): Removed redundant word "sur".
* [`language/basic-syntax.xml`](diffhunk://#diff-d0dcc4ce9ad6b405ca06df40b714aaaa5ff3a33ac53000421aa7bc03ca195e53L104-R104): Corrected the spelling of "afficher" to "affiché".
* [`language/constants.xml`](diffhunk://#diff-3a9bc46559c78a908f5564fbc8c8c2f8c4cfa82dc128697750346102db19b719L122-R122): Corrected the phrase "en tous cas" to "en tout cas".
* [`language/context.xml`](diffhunk://#diff-fa6468b6f7acb5fb5fc16a6f4a50607093c8b4ad305359d808159819be05961dL11-R11): Corrected "divers" to "diverses".
* [`language/control-structures.xml`](diffhunk://#diff-05f99ca04fab757da83be09c9985d9def33aa2c9a602d619f5ee59ecf68dfde4L25-R25): Corrected "suivant" to "suivants".
* [`language/enumerations.xml`](diffhunk://#diff-57723d13442b7d9760b6993403b07a90ff451e1cb9d6a3ecc7d6e40ac393bdb4L121-R121): Corrected "s'appelle" to "s'appellent" and adjusted sentence capitalization. [[1]](diffhunk://#diff-57723d13442b7d9760b6993403b07a90ff451e1cb9d6a3ecc7d6e40ac393bdb4L121-R121) [[2]](diffhunk://#diff-57723d13442b7d9760b6993403b07a90ff451e1cb9d6a3ecc7d6e40ac393bdb4L255-R255)
* [`language/namespaces.xml`](diffhunk://#diff-0f846731734bf5d430b5109ac8048a3348bc34c267743d6db414470180f5e79aL745-R745): Corrected "utilisation" to "utilisations".
* [`language/variables.xml`](diffhunk://#diff-7b84d9b8b12bb560bf449910f1f61308eeae75c2e6be084c0e44a9837394f07cL31-R31): Corrected "à ce que" to "que".
* [`security/database.xml`](diffhunk://#diff-e86756a16e2b7abe66a2fb8376e150e4c49af22b97797d7c366555a91557c8b4L19-R19): Corrected "Voyez" to "Voir".
* [`security/errors.xml`](diffhunk://#diff-7347ba8d053e06b2fbed3d0675f8f99c56a6f5d158130666f2343b90e55e2991L10-R10): Corrected "coté" to "côté" and fixed redundancy in the phrase "a échouée". [[1]](diffhunk://#diff-7347ba8d053e06b2fbed3d0675f8f99c56a6f5d158130666f2343b90e55e2991L10-R10) [[2]](diffhunk://#diff-7347ba8d053e06b2fbed3d0675f8f99c56a6f5d158130666f2343b90e55e2991L36-R36)
* [`security/variables.xml`](diffhunk://#diff-ec4bd0df0953684c700fc450fec470a5ca8e531ee478429694e70f9be50827b4L36-R36): Corrected "vérifiée" to "vérifié".