### PR TITLE
fix wording grammar folder control structures and context

### DIFF
--- a/language/context/ssl.xml
+++ b/language/context/ssl.xml
@@ -182,7 +182,7 @@
      </term>
      <listitem>
       <para>
-       Si définit à &true;, un option de contexte <literal>peer_certificate</literal>
+       Si définit à &true;, une option de contexte <literal>peer_certificate</literal>
        sera créée, contenant le certificat de l'émetteur.
       </para>
      </listitem>
@@ -340,4 +340,3 @@ vim600: syn=xml fen fdm=syntax fdl=2 si
 vim: et tw=78 syn=sgml
 vi: ts=1 sw=1
 -->
-

--- a/language/context/zip.xml
+++ b/language/context/zip.xml
@@ -26,7 +26,7 @@ annotations="verify_info:false" role="stream_context_option">
      <term><parameter>password</parameter></term>
      <listitem>
       <para>
-       Utilisé pour spécifier un mot de passe à utiliser pour les archives chiffré.
+       Utilisé pour spécifier un mot de passe à utiliser pour les archives chiffrées.
       </para>
      </listitem>
     </varlistentry>

--- a/language/context/zip.xml
+++ b/language/context/zip.xml
@@ -26,7 +26,7 @@ annotations="verify_info:false" role="stream_context_option">
      <term><parameter>password</parameter></term>
      <listitem>
       <para>
-       Utilisé pour spécifier un mot de passe à utiliser pour les archives chiffrés.
+       Utilisé pour spécifier un mot de passe à utiliser pour les archives chiffré.
       </para>
      </listitem>
     </varlistentry>
@@ -66,7 +66,7 @@ annotations="verify_info:false" role="stream_context_option">
     <programlisting role="php">
 <![CDATA[
 <?php
-// Lire l'archive chiffré
+// Lire l'archive chiffrée
 $opts = array(
     'zip' => array(
         'password' => 'secret',
@@ -107,4 +107,3 @@ vim600: syn=xml fen fdm=syntax fdl=2 si
 vim: et tw=78 syn=sgml
 vi: ts=1 sw=1
 -->
-

--- a/language/control-structures/break.xml
+++ b/language/control-structures/break.xml
@@ -16,7 +16,7 @@
   <literal>break</literal> accepte un argument numérique optionnel
   qui vous indiquera combien de structures emboîtées doivent être
   interrompues. La valeur par défaut est  <literal>1</literal>, seulement la 
-  structure emboitée immédiate  est interrompue.
+  structure emboitée immédiate est interrompue.
  </simpara>
  <para>
   <informalexample>

--- a/language/control-structures/for.xml
+++ b/language/control-structures/for.xml
@@ -112,7 +112,7 @@ endfor;
  </para>
  <simpara>
   Beaucoup de personnes ont l'habitude d'itérer grâce à des tableaux, comme dans
-  l'exemple ci dessous.
+  l'exemple ci-dessous.
  </simpara>
  <para>
   <informalexample>

--- a/language/control-structures/return.xml
+++ b/language/control-structures/return.xml
@@ -55,7 +55,7 @@
 
  <para>
   À partir de PHP 7.1.0, les déclarations de retour sans argument dans la
-  fonction déclenche une <constant>E_COMPILE_ERROR</constant>, sauf si le
+  fonction déclenchent une <constant>E_COMPILE_ERROR</constant>, sauf si le
   type de retour est <type>void</type>, auquel cas les déclarations retour
   avec un argument déclenche cette erreur.
  </para>

--- a/language/control-structures/switch.xml
+++ b/language/control-structures/switch.xml
@@ -106,7 +106,7 @@ switch ($i) {
  <simpara>
   Dans cet exemple, si <varname>$i</varname> est égal à 0, PHP va
   exécuter quand même toutes les instructions qui
-  suivent! Si <varname>$i</varname> est égal à 1, PHP exécutera
+  suivent ! Si <varname>$i</varname> est égal à 1, PHP exécutera
   les deux dernières instructions. Et seulement si <varname>$i</varname> est
   égal à 2, vous obtiendrez le résultat
   escompté, c'est-à-dire, l'affichage de
@@ -213,7 +213,7 @@ switch ($target) {
         break;
 }
 
-// Prints "B"
+// Affiche "B"
 ?>
 ]]>
    </programlisting>
@@ -244,7 +244,7 @@ switch (true) {
         break;
 }
 
-// Prints "B"
+// Affiche "B"
 ?>
 ]]>
    </programlisting>


### PR DESCRIPTION
This pull request includes several corrections and improvements to the French language documentation files. The most important changes involve fixing grammatical errors and improving the accuracy of translations.

Grammatical corrections:

* [`language/context/ssl.xml`](diffhunk://#diff-72d51ea12d82a7932d0d7c631c414a7f2260b8fd6ea9ce20d270d01fa81b75adL185-R185): Corrected a grammatical error in the description of the `peer_certificate` context option.
* [`language/context/zip.xml`](diffhunk://#diff-449acc17af0e27af7273a30836a4c170dc453f0c0ac1236ac48ab07596960806L29-R29): Fixed grammatical errors in the description and example for specifying a password for encrypted archives. [[1]](diffhunk://#diff-449acc17af0e27af7273a30836a4c170dc453f0c0ac1236ac48ab07596960806L29-R29) [[2]](diffhunk://#diff-449acc17af0e27af7273a30836a4c170dc453f0c0ac1236ac48ab07596960806L69-R69)
* [`language/control-structures/for.xml`](diffhunk://#diff-487d4c18dd0b915837e088fd1bf099755abe097e586f16e3b8b79ca10b60503fL115-R115): Corrected a hyphenation error in the phrase "ci-dessous."
* [`language/control-structures/return.xml`](diffhunk://#diff-9512baf567e29e0f4625f45b4413eb76eff0f9de93f092e58302bd3f11f66ecbL58-R58): Fixed a grammatical error in the description of return statements in PHP 7.1.0.

Translation improvements:

* [`language/control-structures/switch.xml`](diffhunk://#diff-e8ddf6e109dbb4f8d7fe53bc59e1644020d9f3b5bb15fb77f1dfab97505e0287L216-R216): Translated "Prints" to "Affiche" in the examples for the `switch` statement. [[1]](diffhunk://#diff-e8ddf6e109dbb4f8d7fe53bc59e1644020d9f3b5bb15fb77f1dfab97505e0287L216-R216) [[2]](diffhunk://#diff-e8ddf6e109dbb4f8d7fe53bc59e1644020d9f3b5bb15fb77f1dfab97505e0287L247-R247)