### PR TITLE
update round.xml doc en

### DIFF
--- a/reference/bc/bcmath/number/round.xml
+++ b/reference/bc/bcmath/number/round.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: a414ee95eb79e2c62c80827a46e15da5d15af97e Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: 15b93836d93f01ea6d90a68cacf04ce0d9fb8eff Maintainer: Fan2Shrek Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="bcmath-number.round" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <refnamediv>
@@ -27,11 +27,11 @@
   <variablelist>
    <!-- precision parameter -->
    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.round')/db:refsect1[@role='parameters']/descendant::db:varlistentry[2])" />
-   <varlistentry>
+   <varlistentry xml:id="bcmath-number.round..parameters.mode">
     <term><parameter>mode</parameter></term>
     <listitem>
      <simpara>
-      Spécifie la méthode d'arrondi.
+      Spécifie la méthode d'arrondi. Pour plus d'informations sur les méthodes, voir <enumname>RoundingMode</enumname>.
      </simpara>
     </listitem>
    </varlistentry>


### PR DESCRIPTION
This pull request includes updates to the `reference/bc/bcmath/number/round.xml` file to enhance the documentation for the `round` function. The most important changes include updating the revision ID and improving the description of the `mode` parameter.

Documentation updates:

* Updated the revision ID in the XML header to reflect the latest changes.
* Improved the description of the `mode` parameter by specifying that it refers to the rounding mode and providing a reference to `RoundingMode` for more information.