### PR TITLE
update array object construct doc en

### DIFF
--- a/reference/spl/arrayobject/construct.xml
+++ b/reference/spl/arrayobject/construct.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 0aa6447b9dcd8f0889d4d10ab37f69a5f48571f2 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 65c558143647fe63b8073180ba314067d5ea4b62 Maintainer: yannick Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="arrayobject.construct" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -50,7 +50,7 @@
       <para>
        Spécifie la classe qui sera utilisée pour les itérations
        de l'objet <classname>ArrayObject</classname>.
-       La classe doit implémenter <classname>ArrayIterator</classname>.
+       La classe doit être un sous-type de la classe <classname>ArrayIterator</classname>.
       </para>
      </listitem>
     </varlistentry>


### PR DESCRIPTION
This pull request includes updates to the `reference/spl/arrayobject/construct.xml` file to reflect recent changes in the documentation. The most important changes include updating the revision reference and clarifying the description of the class requirements for `ArrayObject` iterations.

Documentation updates:

* Updated the revision reference to `65c558143647fe63b8073180ba314067d5ea4b62`.
* Clarified that the class used for `ArrayObject` iterations must be a subtype of `ArrayIterator`.