### PR TITLE
update reference math round doc en

### DIFF
--- a/reference/math/functions/round.xml
+++ b/reference/math/functions/round.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: f721489eaeb79ff096971fe5a5b101c2ebab8eeb Maintainer: girgias Status: ready -->
+<!-- EN-Revision: 15b93836d93f01ea6d90a68cacf04ce0d9fb8eff Maintainer: girgias Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.round" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -13,7 +13,7 @@
    <type>float</type><methodname>round</methodname>
    <methodparam><type class="union"><type>int</type><type>float</type></type><parameter>num</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>precision</parameter><initializer>0</initializer></methodparam>
-   <methodparam choice="opt"><type>int</type><parameter>mode</parameter><initializer><constant>PHP_ROUND_HALF_UP</constant></initializer></methodparam>
+   <methodparam choice="opt"><type class="union"><type>int</type><type>RoundingMode</type></type><parameter>mode</parameter><initializer>RoundingMode::HalfAwayFromZero</initializer></methodparam>
   </methodsynopsis>
   <para>
    Retourne la valeur arrondie de <parameter>num</parameter>
@@ -78,7 +78,7 @@
      <term><parameter>mode</parameter></term>
      <listitem>
       <para>
-       Utilisez une des constantes suivantes pour spécifier le mode d'arrondi.
+       Utilisez <enumname>RoundingMode</enumname> ou l'une des constantes suivantes pour spécifier la méthode d'arrondi.
        <informaltable>
         <tgroup cols="2">
          <thead>
@@ -119,6 +119,7 @@
          </tbody>
         </tgroup>
        </informaltable>
+       Toutefois, noter que certaines méthodes nouvellement ajoutés n'existent que dans <link linkend="enum.roundingmode">RoundingMode</link>.
       </para>
      </listitem>
     </varlistentry>
@@ -152,6 +153,12 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.4.0</entry>
+      <entry>
+       Quatre nouvelles méthodes d'arrondi ont été ajoutés.
+      </entry>
+     </row>
      <row>
       <entry>8.4.0</entry>
       <entry>
@@ -247,14 +254,14 @@ float(0)
     <programlisting role="php">
 <![CDATA[
 <?php
-echo "Mode d'arrondi avec 9.5" . PHP_EOL;
+echo "Méthode d'arrondi avec 9.5" . PHP_EOL;
 var_dump(round(9.5, 0, PHP_ROUND_HALF_UP));
 var_dump(round(9.5, 0, PHP_ROUND_HALF_DOWN));
 var_dump(round(9.5, 0, PHP_ROUND_HALF_EVEN));
 var_dump(round(9.5, 0, PHP_ROUND_HALF_ODD));
 
 echo PHP_EOL;
-echo "Mode d'arrondi avec 8.5" . PHP_EOL;
+echo "Méthode d'arrondi avec 8.5" . PHP_EOL;
 var_dump(round(8.5, 0, PHP_ROUND_HALF_UP));
 var_dump(round(8.5, 0, PHP_ROUND_HALF_DOWN));
 var_dump(round(8.5, 0, PHP_ROUND_HALF_EVEN));
@@ -265,13 +272,13 @@ var_dump(round(8.5, 0, PHP_ROUND_HALF_ODD));
     &example.outputs;
     <screen role="php">
 <![CDATA[
-Mode d'arrondi avec 9.5
+Méthode d'arrondi avec 9.5
 float(10)
 float(9)
 float(10)
 float(9)
 
-Mode d'arrondi avec 8.5
+Méthode d'arrondi avec 8.5
 float(9)
 float(8)
 float(8)
@@ -328,6 +335,61 @@ float(-1.5)
 ]]>
     </screen>
    </example>
+     <example>
+   <title>Exemple d'utilisation de <enumname>RoundingMode</enumname></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+foreach (RoundingMode::cases() as $mode) {
+    foreach ([
+        8.5,
+        9.5,
+        -3.5,
+    ] as $number) {
+        printf("%-17s: %+.17g -> %+.17g\n", $mode->name, $number, round($number, 0, $mode));
+    }
+    echo "\n";
+}
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen role="php">
+<![CDATA[
+HalfAwayFromZero : +8.5 -> +9
+HalfAwayFromZero : +9.5 -> +10
+HalfAwayFromZero : -3.5 -> -4
+
+HalfTowardsZero  : +8.5 -> +8
+HalfTowardsZero  : +9.5 -> +9
+HalfTowardsZero  : -3.5 -> -3
+
+HalfEven         : +8.5 -> +8
+HalfEven         : +9.5 -> +10
+HalfEven         : -3.5 -> -4
+
+HalfOdd          : +8.5 -> +9
+HalfOdd          : +9.5 -> +9
+HalfOdd          : -3.5 -> -3
+
+TowardsZero      : +8.5 -> +8
+TowardsZero      : +9.5 -> +9
+TowardsZero      : -3.5 -> -3
+
+AwayFromZero     : +8.5 -> +9
+AwayFromZero     : +9.5 -> +10
+AwayFromZero     : -3.5 -> -4
+
+NegativeInfinity : +8.5 -> +8
+NegativeInfinity : +9.5 -> +9
+NegativeInfinity : -3.5 -> -4
+
+PositiveInfinity : +8.5 -> +9
+PositiveInfinity : +9.5 -> +10
+PositiveInfinity : -3.5 -> -3
+]]>
+   </screen>
+  </example>
   </para>
  </refsect1>
 


### PR DESCRIPTION
This pull request includes updates to the `reference/math/functions/round.xml` file to enhance the documentation for the `round` function. The changes focus on updating the parameter types, adding new rounding modes, and providing more detailed examples.

Key changes include:

### Documentation Updates:
* Updated the `mode` parameter to accept both `int` and `RoundingMode` types, with a new default value of `RoundingMode::HalfAwayFromZero`.
* Added a note to specify that some newly added rounding modes are only available in the `RoundingMode` enumeration.
* Included a new entry in the changelog to document the addition of four new rounding modes in version 8.4.0.

### Examples:
* Added a comprehensive example demonstrating the usage of the `RoundingMode` enumeration with various rounding modes and their effects on different numbers.