### PR TITLE
sync doc php en

### DIFF
--- a/appendices/ini.core.xml
+++ b/appendices/ini.core.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 90787fda14dcb0976a9738423e6c6013c037d048 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: a1ab750f296de54d79fe3749d5c9164b0593d803 Maintainer: yannick Status: ready -->
 <!-- Reviewed: no -->
 
  <section xml:id="ini.core" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -212,8 +212,10 @@
       </term>
       <listitem>
        <para>
-        Cette directive vous permet de désactiver certaines fonctions.
-        Elle prend une liste de noms de fonction délimités par une virgule.
+        Cette directive permet de désactiver certaines fonctions.
+        Elle prend une liste de noms de fonctions délimitée par des virgules.
+        Depuis PHP 8.0.0, la désactivation d'une fonction supprime sa définition.
+        Avant PHP 8.0.0, désactiver une fonction empêchait simplement la fonction d'être invoquée.
        </para>
        <para>
         Seules les <link linkend="functions.internal">fonctions internes</link> peuvent
@@ -234,8 +236,9 @@
       </term>
       <listitem>
        <simpara>
-        Cette directive vous permet de désactiver certaines classes.
-        Elle prend une liste de noms de classes délimités par une virgule.
+        Cette directive permet de désactiver certaines classes.
+        Elle prend en compte une liste de noms de classes délimitée par des virgules.
+        La désactivation d'une classe empêche simplement son instanciation.
        </simpara>
        <simpara>
         Cette directive doit être définie dans le &php.ini;.

--- a/language/oop5/late-static-bindings.xml
+++ b/language/oop5/late-static-bindings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 9ee9eccf455188ab6eb352194eb6f9eb99e15606 Maintainer: jpauli Status: ready -->
+<!-- EN-Revision: 009f215fc983eeded6161676bcffdd8cf3b6b080 Maintainer: jpauli Status: ready -->
 <!-- Reviewed: no -->
  <sect1 xml:id="language.oop5.late-static-bindings" xmlns="http://docbook.org/ns/docbook">
   <title>Late Static Bindings (Résolution statique à la volée)</title>
@@ -49,22 +49,29 @@
     <programlisting role="php">
 <![CDATA[
 <?php
-class A {
-    public static function qui() {
+
+class A
+{
+    public static function qui()
+    {
         echo __CLASS__;
     }
-    public static function test() {
+    public static function test()
+    {
         self::qui();
     }
 }
 
-class B extends A {
-    public static function qui() {
+class B extends A
+{
+    public static function qui()
+    {
          echo __CLASS__;
     }
 }
 
 B::test();
+
 ?>
 ]]>
     </programlisting>
@@ -97,22 +104,29 @@ A
     <programlisting role="php">
 <![CDATA[
 <?php
-class A {
-    public static function qui() {
+
+class A
+{
+    public static function qui()
+    {
         echo __CLASS__;
     }
-    public static function test() {
+    public static function test()
+    {
         static::qui(); // Ici, résolution à la volée
     }
 }
 
-class B extends A {
-    public static function qui() {
+class B extends A
+{
+    public static function qui()
+    {
          echo __CLASS__;
     }
 }
 
 B::test();
+
 ?>
 ]]>
     </programlisting>
@@ -138,43 +152,54 @@ B
     <programlisting role="php">
 <![CDATA[
 <?php
-class A {
-    private function foo() {
+
+class A
+{
+    private function foo()
+    {
         echo "success!\n";
     }
-    public function test() {
+    public function test()
+    {
         $this->foo();
         static::foo();
     }
 }
 
-class B extends A {
+class B extends A
+{
    /* foo() sera copiée dans B, par conséquent son contexte sera toujours A
     * et l'appel se fera sans problème */
 }
 
-class C extends A {
-    private function foo() {
+class C extends A
+{
+    private function foo()
+    {
         /* La méthode originale est remplacée; le contexte est celui de C */
     }
 }
 
 $b = new B();
 $b->test();
+
 $c = new C();
-$c->test();   //échoue
+try {
+    $c->test();
+} catch (Error $e) {
+    echo $e->getMessage();
+}
+
 ?>
 ]]>
     </programlisting>
     &example.outputs;
     <screen>
 <![CDATA[
-success!
-success!
-success!
-
-
-Fatal error:  Call to private method C::foo() from context 'A' in /tmp/test.php on line 9
+Success!
+Success!
+Success!
+Call to private method C::foo() from scope A
 ]]>
     </screen>
    </example>
@@ -190,34 +215,44 @@ Fatal error:  Call to private method C::foo() from context 'A' in /tmp/test.php 
      <programlisting role="php">
 <![CDATA[
 <?php
-class A {
-    public static function foo() {
+
+class A
+{
+    public static function foo()
+    {
         static::qui();
     }
 
-    public static function qui() {
+    public static function qui()
+    {
         echo __CLASS__."\n";
     }
 }
 
-class B extends A {
-    public static function test() {
+class B extends A
+{
+    public static function test()
+    {
         A::foo();
         parent::foo();
         self::foo();
     }
 
-    public static function qui() {
+    public static function qui()
+    {
         echo __CLASS__."\n";
     }
 }
-class C extends B {
-    public static function qui() {
+class C extends B
+{
+    public static function qui()
+    {
         echo __CLASS__."\n";
     }
 }
 
 C::test();
+
 ?>
 ]]>
      </programlisting>

--- a/reference/funchand/functions/register-tick-function.xml
+++ b/reference/funchand/functions/register-tick-function.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: e72a6312b92af40004161b6a8843f18e08fcc5d5 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 689cf3b5aebc4ff00c6fe52b46bdfbf3460c338c Maintainer: yannick Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="function.register-tick-function" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -64,12 +64,11 @@
 <?php
 declare(ticks=1);
 
-// Utilisation d'une fonction de callback
-register_tick_function('my_function', true);
+function my_tick_function($param) {
+    echo "Tick callback function called with param: $param\n";
+}
 
-// Utilisation d'une méthode d'objet
-$object = new my_class();
-register_tick_function(array($object, 'my_method'), true);
+register_tick_function('my_tick_function', true);
 ?>
 ]]>
     </programlisting>

--- a/reference/image/functions/getimagesize.xml
+++ b/reference/image/functions/getimagesize.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 89ae180a851621c308f0ea4604ff2e919aa57a7f Maintainer: yannick Status: ready -->
+<!-- EN-Revision: f8d1e172bd6d11986f0dfeb11756b90c039a39bc Maintainer: yannick Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://docbook.org/ns/docbook" xml:id="function.getimagesize">
  <refnamediv>
@@ -124,6 +124,14 @@
     <function>getimagesize</function>  retourne alors zéro comme taille de
     hauteur et largeur.
    </para>
+  </note>
+  <note>
+   <simpara>
+    <function>getimagesize</function> est indépendante des métadonnées de l'image.
+    Par exemple, si le drapeau Exif <literal>Orientation</literal> est défini sur une valeur qui
+    fait pivoter l'image de 90 ou 270 degrés, les indices 0 et 1 sont échangés,
+    c'est-à-dire qu'ils contiennent respectivement la hauteur et la largeur.
+</simpara>
   </note>
   <para>
    L'index 2 est une constante parmi <constant>IMAGETYPE_<replaceable>*</replaceable></constant>,

--- a/security/sessions.xml
+++ b/security/sessions.xml
@@ -7,7 +7,7 @@
   <title>Sécurité des Sessions</title>
 
   <para>
-   Il est important d'avoir une utilisation sécurisée des sessions HTTP. 
+   Il est important d'avoir une utilisation sécurisée des sessions HTTP.
    La sécurité liée aux sessions est abordée dans le chapitre <link linkend="session.security">Sessions et sécurité</link> de
    la référence <link linkend="book.session">Gestion des sessions</link>.
   </para>


### PR DESCRIPTION
This pull request includes several updates to XML documentation files to improve clarity and accuracy. The changes primarily involve updates to descriptions, code formatting, and examples.

### Documentation Updates:

* [`appendices/ini.core.xml`](diffhunk://#diff-d073e8bdff903d42517ff1661208a48b607c5172f67081218345872d5476c244L215-R218): Updated the description of directives related to disabling functions and classes, including details about changes in behavior starting from PHP 8.0.0. [[1]](diffhunk://#diff-d073e8bdff903d42517ff1661208a48b607c5172f67081218345872d5476c244L215-R218) [[2]](diffhunk://#diff-d073e8bdff903d42517ff1661208a48b607c5172f67081218345872d5476c244L237-R241)
* [`language/oop5/late-static-bindings.xml`](diffhunk://#diff-e3ad26513ce477b0c5789dd457164fef034e8f4815d1b2ba309af2d9dabe3a9bL52-R74): Reformatted code examples for better readability and updated the example outputs to include error handling. [[1]](diffhunk://#diff-e3ad26513ce477b0c5789dd457164fef034e8f4815d1b2ba309af2d9dabe3a9bL52-R74) [[2]](diffhunk://#diff-e3ad26513ce477b0c5789dd457164fef034e8f4815d1b2ba309af2d9dabe3a9bL100-R129) [[3]](diffhunk://#diff-e3ad26513ce477b0c5789dd457164fef034e8f4815d1b2ba309af2d9dabe3a9bL141-R202) [[4]](diffhunk://#diff-e3ad26513ce477b0c5789dd457164fef034e8f4815d1b2ba309af2d9dabe3a9bL193-R255)
* [`reference/funchand/functions/register-tick-function.xml`](diffhunk://#diff-7cf270a618a45e426a886fdec4fe0d8a1268ba7eb48082c38e7c1cacbac05759L67-R71): Modified the example to use a more descriptive callback function and removed the object method example.
* [`reference/image/functions/getimagesize.xml`](diffhunk://#diff-2f1a1c13b27849d5219862307a855658ebf516c21a346df33747930f16fb5bafR128-R135): Added a note to clarify that `getimagesize` is independent of image metadata, specifically mentioning the Exif `Orientation` flag.