### PR TITLE
update EN revision number

### DIFF
--- a/appendices/resources.xml
+++ b/appendices/resources.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: be3338bf720808467447fdcdd6cab9d3e8d821bc Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 8d0b3a6ff0419e1d25384a942fd3d3dbcc2eb5f9 Maintainer: yannick Status: ready -->
 <!-- Reviewed: yes -->
 <appendix xml:id="resource" xmlns="http://docbook.org/ns/docbook">
  <title>Types des ressources PHP</title>
@@ -15,7 +15,7 @@
    <tgroup cols="5">
     <colspec colwidth='1*'/>
     <colspec colwidth='1*'/>
-    <colspec colwidth='1.4*'/>
+    <colspec colwidth='2*'/>
     <colspec colwidth='1*'/>
     <colspec colwidth='1*'/>
     <thead>

--- a/language/predefined/iteratoraggregate/getiterator.xml
+++ b/language/predefined/iteratoraggregate/getiterator.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 460f49a93d103cac99556147cb9325b095ca3d42 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 63b48309213faf184b4c2b6333e19675654aa473 Maintainer: yannick Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="iteratoraggregate.getiterator" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>IteratorAggregate::getIterator</refname>
-  <refpurpose>Retourne un itérateur externe</refpurpose>
+  <refpurpose>Retourne un itérateur externe ou un objet traversable</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -14,7 +14,7 @@
    <void/>
   </methodsynopsis>
   <para>
-   Retourne un itérateur externe.
+   Retourne un itérateur externe ou un objet traversable.
   </para>
  </refsect1>
 

--- a/reference/reflection/book.xml
+++ b/reference/reflection/book.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: c477749c82111cbbdd657a0e98eeaeeec0d90c91 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: e0e74c05cb704b614ff6925552884fbffb26bb53 Maintainer: yannick Status: ready -->
 <!-- Reviewed: no -->
 <book xml:id="book.reflection" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <?phpdoc extension-membership="core" ?>
@@ -51,7 +51,7 @@
  &reference.reflection.reflectionattribute;
  &reference.reflection.reflector;
  &reference.reflection.reflectionexception;
-
+ &reference.reflection.propertyhooktype;
 </book>
 
 <!-- Keep this comment at the end of the file

--- a/reference/reflection/reflectionproperty/ispublic.xml
+++ b/reference/reflection/reflectionproperty/ispublic.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 16f66c05a4060a7d673ae1c70b656d65009407b0 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: e0e74c05cb704b614ff6925552884fbffb26bb53 Maintainer: yannick Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="reflectionproperty.ispublic" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -37,12 +37,29 @@
   </note>
  </refsect1>
 
+ <refsect1 role="notes">
+  &reftitle.notes;
+  <note>
+   <simpara>
+    Il faut être conscient que le fait qu'une propriété soit <literal>publique</literal>
+    ne signifie pas toujours qu'elle est accessible en écriture. Une propriété
+    peut être virtuelle sans crochet <literal>set</literal>, ou pourrait être
+    <literal>readonly</literal> et avoir déjà été écrite, ou encore avoir une
+    <link linkend="language.oop5.visibility-members-aviz">visibilité <literal>set</literal>
+    définie</link> comme non publique. Dans tous ces cas, cette méthode retournera
+    <literal>true</literal>, mais la propriété ne sera pas modifiable.
+   </simpara>
+  </note>
+ </refsect1>
+
  <refsect1 role="seealso">
   &reftitle.seealso;
   <para>
    <simplelist>
     <member><methodname>ReflectionProperty::isProtected</methodname></member>
+    <member><methodname>ReflectionProperty::isProtectedSet</methodname></member>
     <member><methodname>ReflectionProperty::isPrivate</methodname></member>
+    <member><methodname>ReflectionProperty::isPrivateSet</methodname></member>
     <member><methodname>ReflectionProperty::isReadOnly</methodname></member>
     <member><methodname>ReflectionProperty::isStatic</methodname></member>
    </simplelist>


### PR DESCRIPTION
This pull request includes several changes to XML files within the documentation. The changes involve updating revision comments, modifying descriptions, and adding new sections for clarity. The most important changes are listed below:

### Updates to Revision Comments and Descriptions:

* Updated the revision comment and description for `IteratorAggregate::getIterator` to include that it returns an external iterator or a traversable object. (`language/predefined/iteratoraggregate/getiterator.xml`) [[1]](diffhunk://#diff-832a29f52c2970ba59e774ad21a7516a326bc27cdd102fde8abdfc7d5888167bL2-R7) [[2]](diffhunk://#diff-832a29f52c2970ba59e774ad21a7516a326bc27cdd102fde8abdfc7d5888167bL17-R17)

### Structural and Content Modifications:

* Modified the column width in the table within `appendices/resources.xml` to improve layout. (`appendices/resources.xml`)
* Added a new reference to `propertyhooktype` in the `reference/reflection/book.xml` file. (`reference/reflection/book.xml`)

### Additional Notes and See Also Sections:

* Added a new notes section to `ReflectionProperty::isPublic` to clarify that a public property is not always writable. (`reference/reflection/reflectionproperty/ispublic.xml`)
* Included additional `seealso` references for `ReflectionProperty::isProtectedSet` and `ReflectionProperty::isPrivateSet`. (`reference/reflection/reflectionproperty/ispublic.xml`)