### PR TITLE
update workflow integrate yaml ubuntu

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -12,7 +12,7 @@ jobs:
   build:
     name: "Build"
 
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-22.04"
 
     strategy:
       matrix:
@@ -40,4 +40,4 @@ jobs:
           repository: "php/doc-base"
 
       - name: "Build documentation for ${{ matrix.language }}"
-        run: "php8.0 doc-base/configure.php --disable-libxml-check --enable-xml-details --redirect-stderr-to-stdout --with-lang=${{ matrix.language }}"
+        run: "php8.1 doc-base/configure.php --disable-libxml-check --enable-xml-details --redirect-stderr-to-stdout --with-lang=${{ matrix.language }}"


### PR DESCRIPTION
This pull request includes an update to the `.github/workflows/integrate.yaml` file to ensure compatibility with the latest Ubuntu version.

Issue:  [https://github.com/actions/runner-images/issues/11101](https://github.com/actions/runner-images/issues/11101)

* [`.github/workflows/integrate.yaml`](diffhunk://#diff-d684acc09c646fd347d0ee93598101fb403664cc70e38cb6f671355ab6de1854L15-R15): Updated the `runs-on` parameter from "ubuntu-20.04" to "ubuntu-22.04" to use the latest Ubuntu version for the build process.