### PR TITLE
add translate new page pdo_sqlite

### DIFF
--- a/reference/pdo_sqlite/pdo/sqlite/loadextension.xml
+++ b/reference/pdo_sqlite/pdo/sqlite/loadextension.xml
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 2527c5e374710b5f0db46048d48019eee30c2a94 Maintainer: PhilDaiguille Status: ready -->
+<!-- Reviewed: no -->
+<refentry xml:id="pdo-sqlite.loadextension" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Pdo\Sqlite::loadExtension</refname>
+  <refpurpose>Description</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Pdo\\Sqlite">
+   <modifier>public</modifier> <type>void</type><methodname>Pdo\Sqlite::loadExtension</methodname>
+   <methodparam><type>string</type><parameter>name</parameter></methodparam>
+  </methodsynopsis>
+  &warn.undocumented.func;
+  <simpara>
+   Description.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>name</parameter></term>
+    <listitem>
+     <simpara>
+      Description.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   &return.void;
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simpara>
+   Quand cette fonction émet-elle des erreurs de niveau <constant>E_*</constant>,
+   et/ou lance-t-elle des <exceptionname>Exception</exceptionname>s.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="pdo-sqlite.loadextension.example.basic">
+   <title>Exemple de <methodname>Pdo\Sqlite::loadExtension</methodname></title>
+   <simpara>
+    Description.
+   </simpara>
+   <programlisting role="php">
+<![CDATA[
+<?php
+echo "Exemple de code";
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+Exemple de code
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="notes">
+  &reftitle.notes;
+  <note>
+   <simpara>
+    Toutes les notes qui ne trouvent pas leur place ailleurs doivent être placées ici.
+   </simpara>
+  </note>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>ClassName::otherMethodName</methodname></member>
+   <member><function>some_function</function></member>
+   <!--<member><link linkend="some.id.chunk.to.link">something appendix</link></member>-->
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/pdo_sqlite/pdo/sqlite/openblob.xml
+++ b/reference/pdo_sqlite/pdo/sqlite/openblob.xml
@@ -1,0 +1,149 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 2527c5e374710b5f0db46048d48019eee30c2a94 Maintainer: PhilDaiguille Status: ready -->
+<!-- Reviewed: no -->
+<refentry xml:id="pdo-sqlite.openblob" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Pdo\Sqlite::openBlob</refname>
+  <refpurpose>Description</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Pdo\\Sqlite">
+   <modifier>public</modifier> <type class="union"><type>resource</type><type>false</type></type><methodname>Pdo\Sqlite::openBlob</methodname>
+   <methodparam><type>string</type><parameter>table</parameter></methodparam>
+   <methodparam><type>string</type><parameter>column</parameter></methodparam>
+   <methodparam><type>int</type><parameter>rowid</parameter></methodparam>
+   <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>dbname</parameter><initializer>"main"</initializer></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer><constant>Pdo\Sqlite::OPEN_READONLY</constant></initializer></methodparam>
+  </methodsynopsis>
+  &warn.undocumented.func;
+  <simpara>
+   Description.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>table</parameter></term>
+    <listitem>
+     <simpara>
+      Description.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>column</parameter></term>
+    <listitem>
+     <simpara>
+      Description.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>rowid</parameter></term>
+    <listitem>
+     <simpara>
+      Description.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>dbname</parameter></term>
+    <listitem>
+     <simpara>
+      Description.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>flags</parameter></term>
+    <listitem>
+     <simpara>
+      L'un des <constant>Pdo\Sqlite::OPEN_<replaceable>*</replaceable></constant>
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Description.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simpara>
+   Quand cette fonction émet-elle des erreurs de niveau <constant>E_*</constant>,
+   et/ou lance-t-elle des <exceptionname>Exception</exceptionname>s.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="pdo-sqlite.openblob.example.basic">
+   <title>Exemple de <methodname>Pdo\Sqlite::openBlob</methodname></title>
+   <simpara>
+    Description.
+   </simpara>
+   <programlisting role="php">
+<![CDATA[
+<?php
+echo "Exemple de code";
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+Exemple de code
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="notes">
+  &reftitle.notes;
+  <note>
+   <simpara>
+    Toutes les notes qui ne trouvent pas leur place ailleurs doivent être placées ici.
+   </simpara>
+  </note>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>ClassName::otherMethodName</methodname></member>
+   <member><function>some_function</function></member>
+   <!--<member><link linkend="some.id.chunk.to.link">something appendix</link></member>-->
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
This pull request includes the addition of two new XML reference files for the `Pdo\Sqlite` class, documenting the `loadExtension` and `openBlob` methods. These files provide detailed descriptions, parameters, return values, errors, examples, notes, and related methods.

Documentation for `Pdo\Sqlite` methods:

* [`reference/pdo_sqlite/pdo/sqlite/loadextension.xml`](diffhunk://#diff-1600ccfa44c8ee61a1a96b6cf2a1faf8236d58b7628a85a766ef21233e98505fR1-R113): Added a reference entry for the `Pdo\Sqlite::loadExtension` method, including descriptions, parameters, return values, errors, examples, notes, and related methods.
* [`reference/pdo_sqlite/pdo/sqlite/openblob.xml`](diffhunk://#diff-93b42d98f6cfdd73640b34726d036fd7f0405715f10704028cdc62d12c644cdcR1-R149): Added a reference entry for the `Pdo\Sqlite::openBlob` method, including descriptions, parameters, return values, errors, examples, notes, and related methods.