### PR TITLE
fix: Renaming "ressource" to "resource".

### DIFF
--- a/language/types/mixed.xml
+++ b/language/types/mixed.xml
@@ -13,7 +13,7 @@
    <type>int</type><type>float</type><type>bool</type><type>null</type>
   </type>.
   -->
-  <literal>objet|ressource|array|string|float|int|bool|null</literal>.
+  <literal>objet|resource|array|string|float|int|bool|null</literal>.
   Disponible à partir de PHP 8.0.0.
  </para>
 


### PR DESCRIPTION
I renamed "ressource" to "resource" since the former is not a proper PHP type.