### PR TITLE
Fix: Correct trait name in Exemple #11 Propriétés statiques

### DIFF
--- a/language/oop5/traits.xml
+++ b/language/oop5/traits.xml
@@ -482,7 +482,7 @@ Doing something
 <![CDATA[
 <?php
 
-trait StaticExample
+trait T
 {
     public static $counter = 1;
 }


### PR DESCRIPTION
Changed trait declaration from "StaticExample" to "T" to match usage.

Problem:
The example declared trait "StaticExample" but referenced trait "T" in the class definition, causing a fatal error:

Fatal error: Uncaught Error: Trait "T" not found in script:8 Stack trace:
#0 {main}