### PR TITLE
Synchronize ssl:// transport description with English documentation

### DIFF
--- a/appendices/transports.xml
+++ b/appendices/transports.xml
@@ -25,7 +25,13 @@
    <literal>ssl://</literal>, <literal>tls://</literal>,
    <literal>sslv2://</literal> &amp; <literal>sslv3://</literal>.
   </simpara>
-
+  <note>
+   <simpara>
+    Les modes <literal>sslv2://</literal> et <literal>sslv3://</literal> sont
+    obsolètes et ne doivent plus être utilisés. Ils sont documentés
+    uniquement pour des raisons de compatibilité ascendante.
+   </simpara>
+  </note>
   <note>
    <simpara>
     Si aucun transport n'est spécifié, <literal>tcp://</literal>
@@ -42,8 +48,6 @@
    <listitem><simpara><literal>tcp://www.example.com</literal></simpara></listitem>
    <listitem><simpara><literal>udp://www.example.com</literal></simpara></listitem>
    <listitem><simpara><literal>ssl://www.example.com</literal></simpara></listitem>
-   <listitem><simpara><literal>sslv2://www.example.com</literal></simpara></listitem>
-   <listitem><simpara><literal>sslv3://www.example.com</literal></simpara></listitem>
    <listitem><simpara><literal>tls://www.example.com</literal></simpara></listitem>
   </itemizedlist>
 
@@ -82,9 +86,17 @@
   </simpara>
 
   <simpara>
-   <literal>ssl://</literal> va tenter de négocier une connexion SSL V2 ou SSL V3,
-   suivant les capacités et les références de l'hôte distant. <literal>sslv2://</literal> et
-   <literal>sslv3://</literal> sélectionnent explicitement le protocole.
+   <literal>ssl://</literal> tente de négocier automatiquement une connexion
+   SSL/TLS sécurisée en fonction des capacités du client et de l’hôte distant.
+   Les protocoles réellement utilisés dépendent également de la configuration
+   OpenSSL et des options fournies via <function>stream_context_create</function>,
+   comme <literal>ssl.crypto_method</literal>.
+  </simpara>
+
+  <simpara>
+   Les protocoles SSLv2 et SSLv3 sont obsolètes et non sécurisés. Leur utilisation
+   est fortement déconseillée et ils ne sont plus activés par défaut dans les
+   versions modernes de PHP et d’OpenSSL.
   </simpara>
  </section>
 


### PR DESCRIPTION
Mirror of php/doc-en [PR](https://github.com/php/doc-en/pull/5088).

This change synchronizes the French documentation with the updated
`ssl://` transport description in the English manual.

No additional changes.
