### PR TITLE
Sync doc FR : alias attach() / offsetSet()

### DIFF
--- a/reference/spl/splobjectstorage/attach.xml
+++ b/reference/spl/splobjectstorage/attach.xml
@@ -23,6 +23,9 @@
    Ajoute un &object; dans le stockage, et lui associe 
    éventuellement des données.
   </para>
+  <para>
+   Cette méthode est un alias de <methodname>SplObjectStorage::offsetSet</methodname>.
+  </para>
  </refsect1>
  
  <refsect1 role="parameters">


### PR DESCRIPTION
Mirror of php/doc-en [PR](https://github.com/php/doc-en/pull/5089).

Cette modification synchronise la documentation française avec la version anglaise en précisant que `SplObjectStorage::offsetSet()` est un alias de `SplObjectStorage::attach()`, désormais dépréciée depuis PHP 8.5.
