### PR TITLE
Document deprecation of non-callable strings in xml_set_* handler functions

### DIFF
--- a/appendices/migration84/deprecated.xml
+++ b/appendices/migration84/deprecated.xml
@@ -469,7 +469,7 @@ class _MyClass {}
   <!-- RFC: https://wiki.php.net/rfc/deprecations_php_8_4#xml_set_object_and_xml_set_handler_with_string_method_names -->
   <simpara>
    Passer une chaîne non-<type>callable</type> aux fonctions
-   <function>xml_set_<replaceable>*</replaceable></function>
+   <literal>xml_set_*</literal>
    est désormais déprécié.
   </simpara>
  </sect2>

--- a/appendices/migration84/incompatible.xml
+++ b/appendices/migration84/incompatible.xml
@@ -820,7 +820,7 @@ nodeData: 3
   <title>XML</title>
 
   <simpara>
-   Les fonctions <function>xml_set_<replaceable>*</replaceable>_handler</function>
+   Les fonctions <literal>xml_set_*_handler</literal>
    déclarent désormais et vérifient une signature
    effective de <type class="union"><type>callable</type><type>string</type><type>null</type></type> pour les
    paramètres <parameter>handler</parameter>.


### PR DESCRIPTION
https://github.com/php/doc-en/pull/5096