### PR TITLE
Sync ., appendices and language/* with EN

### DIFF
--- a/appendices/reserved.constants.core.xml
+++ b/appendices/reserved.constants.core.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: b2fa00ca2e052f87785a7f8b296466edc4e55767 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 04250271154f102f7aa1d629665a30fdb670b927 Maintainer: yannick Status: ready -->
 <!-- Reviewed: no -->
 <sect2 xml:id="reserved.constants.core" xmlns="http://docbook.org/ns/docbook">
  <title>Constantes prédéfinies</title>
@@ -82,6 +82,34 @@
      utilisée par les packagers des distributions
      pour indiquer une version de paquet.
     </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.php-build-date">
+   <term>
+    <constant>PHP_BUILD_DATE</constant>
+    (<type>string</type>)
+   </term>
+   <listitem>
+    <simpara>
+     La date et l'heure de compilation de PHP, au format <literal>"M d Y H:i:s"</literal>. Disponible à partir de PHP 8.5.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.php-build-provider">
+   <term>
+    <constant>PHP_BUILD_PROVIDER</constant>
+    (<type>string</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Le fournisseur qui a compilé PHP. Disponible à partir de PHP 8.5.0.
+    </simpara>
+    <note>
+     <simpara>
+      Cette constante peut ne pas être disponible dans toutes les compilations de PHP.
+      (ex : non définie lors de la compilation depuis les sources sans spécifier de valeur lors de la configuration).
+     </simpara>
+    </note>
    </listitem>
   </varlistentry>
   <varlistentry xml:id="constant.zend-thread-safe">
@@ -410,6 +438,11 @@
     <simpara>
      Spécifie le chemin d'installation des pages man.
     </simpara>
+    <note>
+     <simpara>
+      Cette constante n'est pas présente sur les compilations Windows de PHP.
+     </simpara>
+    </note>
    </listitem>
   </varlistentry>
   <varlistentry xml:id="constant.php-libdir">
@@ -698,10 +731,10 @@
    </listitem>
   </varlistentry>
  </variablelist>
- <para>
+ <simpara>
   Voir aussi les
   <link linkend="language.constants.magic">constantes magiques</link>.
- </para>
+ </simpara>
 </sect2>
 <!-- Keep this comment at the end of the file
 Local variables:

--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 69fe083419b7888f6d424595771d54fe2d850d9d Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 9a8c593c09cf7d84085989e42f3b2b23536279db Maintainer: yannick Status: ready -->
 <!-- Reviewed: no -->
 <!-- Relecture des Notes, Précautions, Avertissements, Astuces, Divers et Retour le 2018-12-29 par girgias -->
 
@@ -1374,6 +1374,15 @@ est retournée. En cas d&#39;échec, retourne &null;.</para>'>
 constante <literal>IntlChar::PROPERTY_*</literal>).</para>'>
 
 <!ENTITY intl.property.example 'Test de différentes propriétés'>
+
+<!ENTITY intl.param.grapheme.locale '<simpara xmlns="http://docbook.org/ns/docbook">Locale à utiliser.</simpara>'>
+
+<!ENTITY intl.changelog.grapheme.locale '<row xmlns="http://docbook.org/ns/docbook">
+ <entry>8.5.0</entry>
+ <entry>
+  Le paramètre optionnel <parameter>locale</parameter> a été ajouté.
+ </entry>
+</row>'>
 
 <!-- LDAP notes -->
 

--- a/language/oop5/visibility.xml
+++ b/language/oop5/visibility.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 5c04cf0fd637b258d2a3bf7f4b7aba1beef6d823 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: b9af4bd4eef9a501e9a6787d5d8998bce9f37dfb Maintainer: yannick Status: ready -->
 <!-- Reviewed: no -->
  <sect1 xml:id="language.oop5.visibility" xmlns="http://docbook.org/ns/docbook">
   <title>Visibilité</title>
@@ -122,6 +122,42 @@ $b->pubYear = 2023; // Erreur Fatale
 ?>
 ]]>
      </programlisting>
+    </example>
+    <simpara>
+     À partir de PHP 8.5, la visibilité <literal>set</literal> peut également être appliquée aux propriétés statiques des classes.
+    </simpara>
+    <example>
+     <title>Visibilité Asymétrique des Propriétés Statiques</title>
+     <programlisting role="php" annotations="non-interactive">
+<![CDATA[
+<?php
+class Manager
+{
+    public private(set) static int $calls = 0;
+
+    public function doAThing(): string
+    {
+        self::$calls++;
+        // Effectue d'autres opérations.
+        return "une chaîne";
+    }
+}
+
+$m = new Manager();
+
+$m->doAThing(); // Fonctionne
+echo Manager::$calls; // Fonctionne
+Manager::$calls = 5; // Erreur fatale
+?>
+]]>
+     </programlisting>
+     &example.outputs;
+     <screen>
+<![CDATA[
+1
+Fatal error: Uncaught Error: Cannot modify private(set) property Manager::$calls from global scope in /some/file.php
+]]>
+     </screen>
     </example>
     <para>Il y a quelques réserves concernant la visibilité asymétrique :</para>
     <itemizedlist>

--- a/language/operators/precedence.xml
+++ b/language/operators/precedence.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 16934048f79c6e117cd16a23c09c1b2ea502e284 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: a7428462fea1c0387cf5e8473b4c48c3c8ac8c2c Maintainer: yannick Status: ready -->
 <!-- Reviewed: no -->
 <sect1 xml:id="language.operators.precedence">
  <title>La priorité des opérateurs</title>
@@ -153,6 +153,13 @@
       </entry>
      </row>
      <row>
+      <entry>gauche</entry>
+      <entry><literal>|&gt;</literal></entry>
+      <entry>
+       <link linkend="language.operators.functional">pipe</link>
+      </entry>
+     </row>
+     <row>
       <entry>non-associatif</entry>
       <entry>
        <literal>&lt;</literal>
@@ -290,6 +297,13 @@
        <link linkend="language.operators.logical">logique</link>
       </entry>
      </row>
+     <row>
+      <entry>(n/a)</entry>
+      <entry><literal>throw</literal></entry>
+      <entry>
+       <link linkend="language.exceptions">throw</link>
+      </entry>
+     </row>
     </tbody>
    </tgroup>
   </table>
@@ -301,7 +315,6 @@
     <![CDATA[
 <?php
 $a = 3 * 3 % 5; // (3 * 3) % 5 = 4
-// L'association des opérateurs ternaires diffère de C/C++
 var_dump($a);
 
 $a = 1;

--- a/language/predefined/generator/rewind.xml
+++ b/language/predefined/generator/rewind.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 873a99f094902ad72129ab391b1fb80525fab30e Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 5e6944e79f2b19783627d76bd7fd1411feb23c65 Maintainer: yannick Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="generator.rewind" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Generator::rewind</refname>
-  <refpurpose>Ré-initialise l'itérateur au premier yield</refpurpose>
+  <refpurpose>Exécute le générateur jusqu'au premier yield inclus</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -14,11 +14,11 @@
    <void/>
   </methodsynopsis>
   <para>
-   La méthode remet le générateur à l'endroit précédant le premier &yield;.
-   Si le générateur n'est pas au premier &yield; lorsqu'on appelle cette méthode,
-   il sera d'abord avancé jusqu'à la première expression &yield; avant de revenir en arrière.
-   Si le générateur est déjà au début du deuxième &yield;,
-   cela lancera une <classname>Exception</classname>.
+   Exécute le générateur jusqu'au <emphasis>premier</emphasis> &yield; inclus.
+   Si le générateur est déjà au <emphasis>premier</emphasis> &yield;,
+   aucune action ne sera effectuée.
+   Si le générateur a déjà avancé au-delà d'une expression &yield;,
+   cette méthode lancera une <classname>Exception</classname>.
   </para>
   <note>
    <para>

--- a/language/types/integer.xml
+++ b/language/types/integer.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e587d0655e426f97b3fcb431453da5030e743b23 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 78a11d3ca004ee937549d932e77a79c51b9777cd Maintainer: yannick Status: ready -->
 <!-- Reviewed: yes Maintainer: girgias -->
 <!-- CREDITS: DavidA -->
 
@@ -156,8 +156,8 @@ var_dump(round(25/7));  // float(4)
   <title>Conversion en entier</title>
 
   <simpara>
-   Pour convertir explicitement une valeur en un &integer;, utiliser soit
-   le mot-clé <literal>(int)</literal>, soit <literal>(integer)</literal>.
+   Pour convertir explicitement une valeur en un &integer;, utiliser
+   le mot-clé <literal>(int)</literal>.
    Cependant, dans la plupart des cas, ce mot-clé n'est pas nécessaire
    vu qu'une valeur sera automatiquement convertie si un opérateur, une
    fonction ou une structure de contrôle demande un &integer; en guise
@@ -227,7 +227,7 @@ var_dump(intval(8.1)); // 8 dans les deux cas
 
    <note>
     <para>
-     <literal>NaN</literal>, <literal>Infinity</literal> et <literal>-Inf</literal> sont toujours égal à zéro lors d'une conversion en
+     <literal>NaN</literal>, <literal>Inf</literal> et <literal>-Inf</literal> sont toujours égal à zéro lors d'une conversion en
      <type>int</type>.
     </para>
    </note>

--- a/language/types/type-juggling.xml
+++ b/language/types/type-juggling.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 87fd768a70bb136ad6ba94699e8c6332e0c115e0 Maintainer: girgias Status: ready -->
+<!-- EN-Revision: 78a11d3ca004ee937549d932e77a79c51b9777cd Maintainer: girgias Status: ready -->
 <!-- Reviewed: no -->
 <sect1 xml:id="language.types.type-juggling">
  <title>Jonglage de type</title>
@@ -227,6 +227,7 @@
 
     Si le type existe dans l'union et que la valeur peut être forcée en ce
     type en utilisant la sémantique de vérification de type existante de PHP, alors le type est choisi.
+    Sinon, le type suivant est essayé.
    </para>
 
    <caution>
@@ -243,8 +244,8 @@
     <para>
      Les types qui ne font pas partie de la liste de préférences ci-dessus ne
      sont pas des cibles admissibles à la coercition implicite. En particulier,
-     aucune contrainte implicite aux types <literal>null</literal> et
-     <literal>false</literal> ne se produit.
+     aucune contrainte implicite aux types <type>null</type>,
+     <type>false</type>, et <type>true</type> ne se produit.
     </para>
    </note>
 
@@ -317,16 +318,16 @@ var_dump($bar);
    <member><literal>(unset)</literal> - cast en <type>NULL</type></member>
   </simplelist>
 
-  <note>
+  <warning>
    <para>
     <literal>(integer)</literal> est un alias du cast <literal>(int)</literal>.
     <literal>(boolean)</literal> est un alias du cast <literal>(bool)</literal>.
     <literal>(binary)</literal> est un alias du cast <literal>(string)</literal>.
     <literal>(double)</literal> et <literal>(real)</literal> sont des alias du
     cast <literal>(float)</literal>.
-    Ces casts n'utilisent pas le nom de type canonique et ne sont pas recommandés.
+    Ces casts n'utilisent pas le nom de type canonique et sont obsolètes à partir de PHP 8.5.0.
    </para>
-  </note>
+  </warning>
 
   <warning>
    <simpara>


### PR DESCRIPTION
- language-snippets.ent: Added grapheme locale entities
- appendices/reserved.constants.core.xml: Added PHP_BUILD_DATE and PHP_BUILD_PROVIDER constants, note on PHP_MANDIR
- language/oop5/visibility.xml: Added PHP 8.5 asymmetric static property visibility
- language/operators/precedence.xml: Added pipe operator and throw
- language/predefined/generator/rewind.xml: Updated description and example
- language/types/integer.xml: Updated casting description, Inf typo
- language/types/type-juggling.xml: Added true type, cast aliases deprecated