### PR TITLE
Fix example code

### DIFF
--- a/language/predefined/arrayaccess.xml
+++ b/language/predefined/arrayaccess.xml
@@ -44,9 +44,9 @@
 <?php
 class Obj implements ArrayAccess {
     public $container = [
-        "one"   => 1,
-        "two"   => 2,
-        "three" => 3,
+        "un"    => 1,
+        "deux"  => 2,
+        "trois" => 3,
     ];
 
     public function offsetSet($offset, $value): void {


### PR DESCRIPTION
The example code mixed English and French values, so its result did not match. Now uses French values everywhere.