### PR TITLE
security/intro.xml: sync with EN

### DIFF
--- a/security/intro.xml
+++ b/security/intro.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 96c9d88bad9a7d7d44bfb7f26c226df7ee9ddf26 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 96c9d88bad9a7d7d44bfb7f26c226df7ee9ddf26 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes Maintainer: pmartin -->
 
 <chapter xml:id="security.intro" xmlns="http://docbook.org/ns/docbook">
- &reftitle.intro;
+ <title>Introduction</title>
  <simpara>
   PHP est un langage puissant et l'interpréteur, qu'il soit inclus
   dans le serveur web en tant que module ou bien compilé en version <acronym>CGI</acronym>,
@@ -23,9 +23,7 @@
   le comportement. Un grand nombre d'options permet d'utiliser PHP
   dans de nombreuses situations, mais signifie aussi que
   certaines combinaisons d'options de compilation et d'exécution peuvent
-  fragiliser la sécurité du serveur. Ce chapitre explique comment les
-  différentes options de configuration peuvent être combinées, tout en
-  conservant une sécurité maximum.
+  fragiliser la sécurité du serveur.
  </simpara>
  <simpara>
   La flexibilité de configuration de PHP est épaulée par la flexibilité


### PR DESCRIPTION
- Replace &reftitle.intro; entity with <title>Introduction</title> to match EN
- Remove extra sentence not present in EN source