### PR TITLE
chapters/intro.xml: sync markup and translation with EN

### DIFF
--- a/chapters/intro.xml
+++ b/chapters/intro.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 77f5f3b3a8bbe1ad7727201c7603d1419dd7840f Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 77f5f3b3a8bbe1ad7727201c7603d1419dd7840f Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 
 <chapter xml:id="introduction" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -79,7 +79,7 @@ echo "Bonjour, je suis un script PHP !";
  </section>
  
  <section xml:id="intro-whatcando" annotations="chunk:false">
-  <title>Que peut faire PHP ?</title>
+  <info><title>Que peut faire PHP ?</title></info>
   <para>
    Tout. PHP est principalement conçu pour servir de
    langage de script coté serveur, il peut donc faire tout ce qu'un autre programme CGI peut faire, comme
@@ -111,8 +111,8 @@ echo "Bonjour, je suis un script PHP !";
       sans l'aide du serveur web et d'un navigateur. Il suffit
       de disposer de l'exécutable PHP. Cette utilisation est idéale
       pour les scripts qui sont exécutés régulièrement 
-      avec un <command>cron</command> sous Unix ou Linux ou 
-      un <literal>gestionnaire de tâches</literal> (sous Windows). Ces scripts
+      avec un <command>cron</command> (sous Unix ou macOS) ou
+      un gestionnaire de tâches (sous Windows). Ces scripts
       peuvent aussi être utilisés pour réaliser des opérations sur des
       fichiers texte. Voyez la section sur l'utilisation de PHP en
       <link linkend="features.commandline">ligne de commande</link>


### PR DESCRIPTION
- Add missing <info> wrapper around <title> in intro-whatcando section
- Remove extra <literal> tag around "gestionnaire de tâches" (EN has none)
- Fix "Linux" → "macOS" to match EN source