### PR TITLE
bookinfo.xml: sync legalnotice with EN

### DIFF
--- a/bookinfo.xml
+++ b/bookinfo.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 7d2dd02b7bdd1f1c3becbe06444c354f5e6f0e34 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 7d2dd02b7bdd1f1c3becbe06444c354f5e6f0e34 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 
 <info xmlns="http://docbook.org/ns/docbook" xml:id="bookinfo">
@@ -84,13 +84,13 @@
  <legalnotice xml:id="copyright" xmlns:xlink="http://www.w3.org/1999/xlink">
   <info><title>Copyright</title></info>
   <simpara>
-   Copyright @ 1997 - <?dbtimestamp format="Y"?> par le PHP Documentation Group.
+   Copyright © 1997 - <?dbtimestamp format="Y"?> par le PHP Documentation Group.
    Ce document ne peut être redistribué qu'aux
    termes et aux conditions mentionnés dans la licence
-   <literal>Open Publication License</literal>, version 1.0 ou plus
-   récente. Une copie de la licence <link linkend="cc.license">Creative
-   Commons Attribution 3.0</link> est distribuée avec ce manuel ;
-   la dernière version est disponible à
+   Creative Commons Attribution 3.0
+   ou plus récente. Une copie de la licence <link linkend="cc.license">Creative
+   Commons Attribution 3.0</link> est distribuée avec ce manuel.
+   La dernière version est disponible à
    <link xlink:href="&url.cc.by;">&url.cc.by;</link>.
   </simpara>
  </legalnotice>


### PR DESCRIPTION
- Fix copyright symbol (@ → ©)
- Remove obsolete Open Publication License reference and <literal> tag
- Align text with EN source (Creative Commons Attribution 3.0 only)