### PR TITLE
chapters/tutorial.xml: sync markup with EN

### DIFF
--- a/chapters/tutorial.xml
+++ b/chapters/tutorial.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 876557ae38f6ca5035618f7cea48ca627118b437 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 876557ae38f6ca5035618f7cea48ca627118b437 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 
  <chapter xml:id="tutorial" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
-  <title>Une introduction à PHP</title>
+  <info><title>Une introduction à PHP</title></info>
 
   <para>
    Dans cette section, nous voulons illustrer les principes de base
@@ -33,7 +33,7 @@
    </para>
    <para>
     <example>
-     <title>Notre premier script PHP : <filename>bonjour.php</filename></title>
+     <info><title>Notre premier script PHP : <filename>bonjour.php</filename></title></info>
      <programlisting role="php">
 <![CDATA[
 <?php
@@ -57,7 +57,7 @@ php -S localhost:8000
       avec la référence au fichier <literal>hello.php</literal>.
       Par rapport à la précédente commande exécutée, l'URL sera
       <literal>http://localhost:8000/hello.php</literal>.
-      Si tout est configurer correctement, ce fichier sera analysé par PHP
+      Si tout est configuré correctement, ce fichier sera analysé par PHP
       et vous verrez la sortie "Hello World!" affichée dans votre navigateur.
      </simpara>
      <simpara>
@@ -119,7 +119,7 @@ php -S localhost:8000
    </para>
 
    <note>
-    <title>Une note sur les retours à la ligne</title>
+    <info><title>Une note sur les retours à la ligne</title></info>
     <para>
      Les retours à la ligne ont une signification minime en HTML, cependant,
      c'est toujours une bonne idée de rendre votre HTML aussi joli et proche
@@ -136,7 +136,7 @@ php -S localhost:8000
    </note>
 
    <note>
-    <title>Une note sur les éditeurs de texte</title>
+    <info><title>Une note sur les éditeurs de texte</title></info>
     <para>
      Il existe de nombreux éditeurs de texte et environnements de
      développement (IDE) que vous pouvez utiliser pour créer, éditer
@@ -150,7 +150,7 @@ php -S localhost:8000
    </note>
 
    <note>
-    <title>Une note sur les traitements de texte</title>
+    <info><title>Une note sur les traitements de texte</title></info>
     <para>
      Les traitements de texte tels que StarOffice Writer, Microsoft Word et
      Abiword sont de très mauvais choix pour éditer des scripts PHP.
@@ -173,7 +173,7 @@ php -S localhost:8000
    </para>
    <para>
     <example>
-     <title>Récupération des informations du système depuis PHP</title>
+     <info><title>Récupération des informations du système depuis PHP</title></info>
      <programlisting role="php">
 <![CDATA[
 <?php
@@ -188,7 +188,7 @@ phpinfo();
   </section>
 
   <section xml:id="tutorial.useful">
-   <title>Trucs pratiques</title>
+   <info><title>Trucs pratiques</title></info>
    <para>
     Réalisons maintenant quelque chose de plus puissant. Nous allons
     vérifier le type de navigateur que le visiteur de notre site utilise.
@@ -214,7 +214,7 @@ phpinfo();
    </para>
    <para>
     <example>
-    <title>Afficher le contenu d'une variable (élément de tableau)</title>
+    <info><title>Afficher le contenu d'une variable (élément de tableau)</title></info>
     <programlisting role="php">
 <![CDATA[
 <?php
@@ -257,9 +257,9 @@ Mozilla/5.0 (Linux) Firefox/112.0
    </para>
    <para>
     <example>
-     <title>Exemple utilisant les
+     <info><title>Exemple utilisant les
      <link linkend="language.control-structures">structures de contrôle</link> et
-     les <link linkend="language.functions">fonctions</link></title>
+     les <link linkend="language.functions">fonctions</link></title></info>
      <programlisting role="php">
 <![CDATA[
 <?php
@@ -317,7 +317,7 @@ Vous utilisez Firefox.
    </para>
    <para>
     <example>
-     <title>Passer du mode PHP au mode HTML et vice-versa</title>
+     <info><title>Passer du mode PHP au mode HTML et vice-versa</title></info>
      <programlisting role="php">
 <![CDATA[
 <?php
@@ -357,7 +357,7 @@ if (str_contains($_SERVER['HTTP_USER_AGENT'], 'Firefox')) {
   </section>
 
   <section xml:id="tutorial.forms">
-   <title>Utiliser un formulaire</title>
+   <info><title>Utiliser un formulaire</title></info>
    <para>
     L'un des points forts de PHP est sa capacité à gérer les formulaires.
     Le concept de base qui est important à comprendre est que tous les
@@ -369,7 +369,7 @@ if (str_contains($_SERVER['HTTP_USER_AGENT'], 'Firefox')) {
    </para>
    <para>
     <example>
-     <title>Un simple formulaire HTML</title>
+     <info><title>Un simple formulaire HTML</title></info>
      <programlisting role="html">
 <![CDATA[
 <form action="action.php" method="post">
@@ -377,7 +377,7 @@ if (str_contains($_SERVER['HTTP_USER_AGENT'], 'Firefox')) {
    <input name="nom" id="nom" type="text" />
 
    <label>Votre âge :</label>
-   <input name="age" id="age" type="number" /></p>
+   <input name="age" id="age" type="number" />
 
    <button type="submit">Valider</button>
 </form>
@@ -394,7 +394,7 @@ if (str_contains($_SERVER['HTTP_USER_AGENT'], 'Firefox')) {
    </para>
    <para>
     <example>
-     <title>Afficher des données issues d'un formulaire</title>
+     <info><title>Afficher des données issues d'un formulaire</title></info>
      <programlisting role="php">
 <![CDATA[
 Bonjour, <?php echo htmlspecialchars($_POST['nom']); ?>.
@@ -441,7 +441,7 @@ Tu as 29 ans.
   </section>
 
   <section xml:id="tutorial.whatsnext">
-   <title>Et après ?</title>
+   <info><title>Et après ?</title></info>
    <para>
     Avec ce que vous savez, vous êtes maintenant capable de comprendre
     l'essentiel de la documentation PHP, et les différents scripts d'exemples


### PR DESCRIPTION
- Wrap all bare <title> in <info><title> to match EN (14 occurrences)
- Fix typo "configurer" → "configuré"
- Remove stray </p> in HTML form example