### PR TITLE
security/errors.xml: sync markup with EN

### DIFF
--- a/security/errors.xml
+++ b/security/errors.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: ae725a44023db78b9f6e9d2a0baac8c8dc337d38 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: ae725a44023db78b9f6e9d2a0baac8c8dc337d38 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes Maintainer: pmartin -->
 
 <chapter xml:id="security.errors" xmlns="http://docbook.org/ns/docbook">
@@ -19,7 +19,7 @@
   variables par ses propres valeurs :
   <example>
    <title>Attaque de variables avec une page HTML personnalisée</title>
-   <programlisting role="php">
+   <programlisting role="html">
 <![CDATA[
 <form method="post" action="http://www.site.cible.com/?username=badfoo&password=badfoo">
  <input type="hidden" name="username" value="badfoo">
@@ -47,7 +47,7 @@
   tenter une attaque frontale sur une page, en envoyant des chaînes de débogage connues :
   <example>
    <title>Exploiter des variables classiques de débogage</title>
-   <programlisting role="php">
+   <programlisting role="html">
 <![CDATA[
 <form method="post" action="http://www.site.cible.com/?errors=Y&showerrors=1"&debug=1">
  <input type="hidden" name="errors" value="Y">


### PR DESCRIPTION
- Fix programlisting role="php" → role="html" for HTML form examples