### PR TITLE
features/commandline.xml: sync markup with EN

### DIFF
--- a/features/commandline.xml
+++ b/features/commandline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 74ba8fee2972b6ba4f955392d760dea54e757a95 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 74ba8fee2972b6ba4f955392d760dea54e757a95 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 
 <chapter xml:id="features.commandline" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -136,7 +136,7 @@
         </thead>
         <tbody>
          <row>
-          <entry><link linkend="ini.html-errors"><option>html_errors</option></link></entry>
+          <entry><link linkend="ini.html-errors">html_errors</link></entry>
           <entry>&false;</entry>
           <entry>
            Par défaut à &false;, vu qu'il peut être bien difficile de lire des messages


### PR DESCRIPTION
- Remove extra <option> tag around html_errors in link to match EN