### PR TITLE
features/remote-files.xml: sync translation and markup with EN

### DIFF
--- a/features/remote-files.xml
+++ b/features/remote-files.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: a0ae28d3bc85f927c22649ebd9a590b921534b7d Maintainer: yannick Status: ready -->
+<!-- EN-Revision: a0ae28d3bc85f927c22649ebd9a590b921534b7d Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 
 <chapter xml:id="features.remote-files" xmlns="http://docbook.org/ns/docbook">
@@ -39,7 +39,7 @@ if (!$file) {
 }
 while (!feof ($file)) {
     $line = fgets ($file, 1024);
-    /* Cela ne fonctionne que si les balises Title sont correctement utilisées */
+    /* Cela ne fonctionne que si le titre et ses balises sont sur une seule ligne */
     if (preg_match ("@\<title\>(.*)\</title\>@i", $line, $out)) {
         $title = $out[1];
         break;
@@ -53,9 +53,10 @@ fclose($file);
  </para>
  <para>
   Vous pouvez aussi écrire des fichiers sur un serveur FTP
-  aussi longtemps que vous êtes connecté avec un
-  utilisateur ayant les bons droits d'accès, alors que le
-  fichier n'existait pas encore.
+  (à condition d'être connecté en tant qu'utilisateur ayant les bons
+  droits d'accès). Vous ne pouvez créer que de nouveaux fichiers avec
+  cette méthode ; si vous essayez d'écraser un fichier existant,
+  l'appel à <function>fopen</function> échouera.
  </para>
  <para>
   Pour vous connecter avec un utilisateur autre qu'anonyme, vous devez
@@ -77,7 +78,7 @@ if (!$file) {
   exit;
 }
 /* Ecriture des données. */
-fputs ($file, $_SERVER['HTTP_USER_AGENT'] . "\n");
+fwrite ($file, $_SERVER['HTTP_USER_AGENT'] . "\n");
 fclose ($file);
 ?>
 ]]>
@@ -87,12 +88,12 @@ fclose ($file);
  <para>
   <note>
    <para>
-    Remarque : vous pouvez avoir l'idée, à partir de
+    Vous pourriez avoir l'idée, à partir de
     l'exemple ci-dessus, d'utiliser la même technique pour
-    écrire sur un log distant, mais comme mentionné ci-dessus
-    vous ne pouvez qu'écrire sur un nouveau fichier en utilisant
-    les fonctions <function>fopen</function> avec une URL. Pour faire des log
-    distribués, nous vous conseillons de regarder la partie
+    écrire dans un fichier de log distant. Malheureusement
+    cela ne fonctionnerait pas car l'appel à <function>fopen</function>
+    échouera si le fichier distant existe déjà. Pour faire de la
+    journalisation distribuée, vous devriez plutôt regarder du côté de
     <function>syslog</function>.
    </para>
   </note>


### PR DESCRIPTION
- Fix code comment to match EN (title and tags on one line)
- Add missing info about fopen failing on existing FTP files
- Replace fputs with fwrite to match EN code example
- Update note about distributed logging to match EN