### PR TITLE
features/http-auth.xml: sync markup with EN

### DIFF
--- a/features/http-auth.xml
+++ b/features/http-auth.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: bdf9a4e40204c805f2c2a5c94c2f2f8f5556195a Maintainer: yannick Status: ready -->
+<!-- EN-Revision: bdf9a4e40204c805f2c2a5c94c2f2f8f5556195a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 
 <chapter xml:id="features.http-auth" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -81,9 +81,6 @@ if (!isset($_SERVER['PHP_AUTH_USER'])) {
   <para>
    PHP utilise la présence de la directive <literal>AuthType</literal>
    pour déterminer si une identification externe est activée.
-   Évitez donc cette directive de contexte si vous voulez utiliser
-   l'identification de PHP (sinon, les deux identifications se contrediront,
-   et échoueront).
   </para>
  </note>
  
@@ -155,7 +152,7 @@ if ( !isset($_SERVER['PHP_AUTH_USER']) ||
   <simpara>
    Pour que l'identification HTTP fonctionne avec IIS, la directive PHP
    <link linkend="ini.cgi.rfc2616-headers">cgi.rfc2616_headers</link>
-   doit être définie à &zero; (la valeur par défaut).
+   doit être définie à <literal>0</literal> (la valeur par défaut).
   </simpara>
  </note>
  


### PR DESCRIPTION
- Replace &zero; entity with <literal>0</literal> to match EN
- Remove extra FR text not present in EN source (configuration note)