### PR TITLE
faq/using.xml: sync markup and fix code with EN

### DIFF
--- a/faq/using.xml
+++ b/faq/using.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: aab33d644359aba597e810e2fc0c0caa0d347c9c Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 0a3a57fae02391db80baeba98c9a071dc2760889 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 
 <chapter xml:id="faq.using" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -61,7 +61,7 @@
 <?php
 $empty = $post = array();
 foreach ($_POST as $nomvar => $valeurvar) {
-    if (empty($varvalue)) {
+    if (empty($valeurvar)) {
         $empty[$nomvar] = $valeurvar;
     } else {
         $post[$nomvar] = $valeurvar;
@@ -280,8 +280,8 @@ foreach ($headers as $nom => $contenu) {
      <para>
       Pour inclure &lt;?xml dans votre code PHP, vous devrez désactiver les
       short tags en configurant la directive PHP
-      <link linkend="ini.short-open-tag">short_open_tags</link> à 
-      &zero;. Vous ne pouvez pas modifier cette directive avec
+      <link linkend="ini.short-open-tag">short_open_tags</link> à
+      <literal>0</literal>. Vous ne pouvez pas modifier cette directive avec
       <function>ini_set</function>.  Que <link linkend="ini.short-open-tag">
       short_open_tags</link> soit à on ou off, vous pouvez toujours faire ceci :
       <literal>&lt;?php echo '&lt;?xml'; ?&gt;</literal>.  La valeur par


### PR DESCRIPTION
- Update EN-Revision to 0a3a57fae0
- Fix variable name bug: $varvalue -> $valeurvar in code example
- Replace &zero; with <literal>0</literal> to match EN