### PR TITLE
fix(migration84/incompatible.xml): use linkend instead of xlink:href …

### DIFF
--- a/appendices/migration84/incompatible.xml
+++ b/appendices/migration84/incompatible.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 64dc79d6c9710dddf196aa28e3c5f63b562e7aef Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: 64dc79d6c9710dddf196aa28e3c5f63b562e7aef Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <sect1 xml:id="migration84.incompatible" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Changements non rétrocompatibles</title>
 
  <simpara>
   Sauf mention contraire dans cette section,
-  chaque nouvelle <link xlink:href="migration84.new-functions">fonction</link>,
-  <link xlink:href="migration84.new-classes">classe, interface, énumération</link>,
-  ou <link xlink:href="migration84.constants">constante</link>
+  chaque nouvelle <link linkend="migration84.new-functions">fonction</link>,
+  <link linkend="migration84.new-classes">classe, interface, énumération</link>,
+  ou <link linkend="migration84.constants">constante</link>
   peut entraîner le lancement d'une exception de redéclaration <exceptionname>Error</exceptionname>.
  </simpara>
 


### PR DESCRIPTION
…for internal cross-references