### PR TITLE
fix(migration83/other-changes.xml): use <classname> instead of <const…

### DIFF
--- a/appendices/migration83/other-changes.xml
+++ b/appendices/migration83/other-changes.xml
@@ -377,7 +377,7 @@
     <function>password_hash</function> chaîne désormais l'exception sous-jacente
     <classname>Random\RandomException</classname>
     dans la <parameter>$previous</parameter> <classname>Exception</classname>
-    de <constant>ValueError</constant> lorsque la génération de sel échoue.
+    de <classname>ValueError</classname> lorsque la génération de sel échoue.
    </para>
 
    <para>


### PR DESCRIPTION
…ant> for ValueError