### PR TITLE
fix(dom/): fix wrong method names in seealso sections and other marku…

### DIFF
--- a/reference/dom/domattr.xml
+++ b/reference/dom/domattr.xml
@@ -125,7 +125,7 @@
        <para>
         Notez que les entités XML sont étendues lorsqu'une valeur est définie.
         Ainsi, le caractère <literal>&amp;</literal> a une signification spéciale.
-        Définir <varname>valeur</varname> à lui-même échouera lorsque <varname>valeur</varname> contient un <constant>&amp;</constant>.
+        Définir <varname>valeur</varname> à lui-même échouera lorsque <varname>valeur</varname> contient un <literal>&amp;</literal>.
         Pour éviter l'expansion des entités, utilisez plutôt <methodname>DOMElement::setAttribute</methodname>.
        </para>
       </note>

--- a/reference/dom/domdocument/save.xml
+++ b/reference/dom/domdocument/save.xml
@@ -88,7 +88,7 @@ echo 'Écrit : ' . $doc->save("/tmp/test.xml") . ' bytes'; // Écrit : 72 bytes
   &reftitle.seealso;
   <para>
    <simplelist>
-    <member><methodname>DOMDocument::save</methodname></member>
+    <member><methodname>DOMDocument::saveXML</methodname></member>
     <member><methodname>DOMDocument::load</methodname></member>
     <member><methodname>DOMDocument::loadXML</methodname></member>
    </simplelist>

--- a/reference/dom/domdocument/savehtml.xml
+++ b/reference/dom/domdocument/savehtml.xml
@@ -81,7 +81,7 @@ echo $doc->saveHTML();
   &reftitle.seealso;
   <para>
    <simplelist>
-    <member><methodname>DOMDocument::saveHTML</methodname></member>
+    <member><methodname>DOMDocument::saveHTMLFile</methodname></member>
     <member><methodname>DOMDocument::loadHTML</methodname></member>
     <member><methodname>DOMDocument::loadHTMLFile</methodname></member>
    </simplelist>

--- a/reference/dom/domelement.xml
+++ b/reference/dom/domelement.xml
@@ -68,7 +68,6 @@
      <modifier>readonly</modifier>
      <type>mixed</type>
      <varname linkend="domelement.props.schematypeinfo">schemaTypeInfo</varname>
-     <initializer>null</initializer>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>public</modifier>

--- a/reference/dom/domelement/getelementsbytagnamens.xml
+++ b/reference/dom/domelement/getelementsbytagnamens.xml
@@ -81,7 +81,7 @@
   &reftitle.seealso;
   <para>
    <simplelist>
-    <member><methodname>DOMElement::getElementsByTagNameNS</methodname></member>
+    <member><methodname>DOMElement::getElementsByTagName</methodname></member>
    </simplelist>
   </para>
  </refsect1>

--- a/reference/dom/domelement/setattributens.xml
+++ b/reference/dom/domelement/setattributens.xml
@@ -88,8 +88,8 @@
   <para>
    <simplelist>
     <member><methodname>DOMElement::hasAttributeNS</methodname></member>
-    <member><methodname>DOMElement::getAttributeNodeNS</methodname></member>
-    <member><methodname>DOMElement::removeAttributeNode</methodname></member>
+    <member><methodname>DOMElement::getAttributeNS</methodname></member>
+    <member><methodname>DOMElement::removeAttributeNS</methodname></member>
    </simplelist>
   </para>
  </refsect1>

--- a/reference/dom/domnamednodemap/getnameditemns.xml
+++ b/reference/dom/domnamednodemap/getnameditemns.xml
@@ -54,7 +54,7 @@
   &reftitle.seealso;
   <para>
    <simplelist>
-    <member><methodname>DOMNamedNodeMap::getNamedItemNS</methodname></member>
+    <member><methodname>DOMNamedNodeMap::getNamedItem</methodname></member>
    </simplelist>
   </para>
  </refsect1>

--- a/reference/dom/domnode/haschildnodes.xml
+++ b/reference/dom/domnode/haschildnodes.xml
@@ -34,7 +34,7 @@
   &reftitle.seealso;
   <para>
    <simplelist>
-    <member><methodname>DOMImplementation::hasFeature</methodname></member>
+    <member><methodname>DOMNode::hasAttributes</methodname></member>
    </simplelist>
   </para>
  </refsect1>

--- a/reference/dom/domprocessinginstruction/construct.xml
+++ b/reference/dom/domprocessinginstruction/construct.xml
@@ -51,7 +51,7 @@
   &reftitle.examples;
   <para>
    <example>
-    <title>Création d'un nouveau DOMProcessingInstruction</title>
+    <title>Création d'un nouveau <classname>DOMProcessingInstruction</classname></title>
     <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/dom/domxpath/query.xml
+++ b/reference/dom/domxpath/query.xml
@@ -164,7 +164,7 @@ foreach ($entries as $entry) {
   &reftitle.seealso;
   <para>
    <simplelist>
-    <member><methodname>DOMXPath::query</methodname></member>
+    <member><methodname>DOMXPath::evaluate</methodname></member>
    </simplelist>
   </para>
  </refsect1>


### PR DESCRIPTION
…p issues

- domattr.xml: <constant>&> -> <literal>&> (not a PHP constant)
- domelement.xml: remove extra <initializer>null</initializer>
- setattributens.xml: fix getAttributeNodeNS->getAttributeNS, removeAttributeNode->removeAttributeNS
- getelementsbytagnamens.xml: fix self-reference->getElementsByTagName
- save.xml: fix self-reference->saveXML
- savehtml.xml: fix self-reference->saveHTMLFile
- getnameditemns.xml: fix self-reference->getNamedItem
- haschildnodes.xml: fix DOMImplementation::hasFeature->DOMNode::hasAttributes
- query.xml: fix self-reference->evaluate
- construct.xml: add missing <classname> tag in example title