### PR TITLE
fix(pcre/): fix wrong type and function name

### DIFF
--- a/reference/pcre/constants.xml
+++ b/reference/pcre/constants.xml
@@ -198,7 +198,7 @@
     <row xml:id="constant.pcre-version">
      <entry>
       <constant>PCRE_VERSION</constant>
-      (<type>int</type>)
+      (<type>string</type>)
      </entry>
      <entry>
       Version PCRE ainsi que la date de publication 

--- a/reference/pcre/functions/preg-match.xml
+++ b/reference/pcre/functions/preg-match.xml
@@ -181,7 +181,7 @@ array(4) {
        <para>
         Utiliser le paramètre <parameter>offset</parameter> ne revient pas
         à passer <code>substr($subject, $offset)</code> à
-        <function>preg_match_all</function> à la place de la chaîne
+        <function>preg_match</function> à la place de la chaîne
         <parameter>subject</parameter>, car
         <parameter>pattern</parameter> peut contenir des assertions comme
         <emphasis>^</emphasis>, <emphasis>$</emphasis> ou


### PR DESCRIPTION
- constants.xml: PCRE_VERSION type int -> string
- preg-match.xml: wrong function reference preg_match_all -> preg_match