### PR TITLE
Fix markup sync issues in SPL extension

### DIFF
--- a/reference/spl/arrayiterator/offsetget.xml
+++ b/reference/spl/arrayiterator/offsetget.xml
@@ -50,7 +50,7 @@
   <para>
    <simplelist>
     <member><methodname>ArrayIterator::offsetSet</methodname></member>
-    <member><methodname>ArrayIterator::offsetUnSet</methodname></member>
+    <member><methodname>ArrayIterator::offsetUnset</methodname></member>
    </simplelist>
   </para>
  </refsect1>

--- a/reference/spl/spldoublylinkedlist/setiteratormode.xml
+++ b/reference/spl/spldoublylinkedlist/setiteratormode.xml
@@ -44,7 +44,7 @@
       </itemizedlist>
 
       <para>
-       Le mode par défaut est : <constant>SplDoublyLinkedList::IT_MODE_FIFO</constant> | <constant>SplDoublyLnkedList::IT_MODE_KEEP</constant>
+       Le mode par défaut est : <constant>SplDoublyLinkedList::IT_MODE_FIFO</constant> | <constant>SplDoublyLinkedList::IT_MODE_KEEP</constant>
       </para>
 
       <warning>

--- a/reference/spl/splfileinfo/openfile.xml
+++ b/reference/spl/splfileinfo/openfile.xml
@@ -104,7 +104,7 @@
   &reftitle.examples;
   <para>
    <example>
-    <title>Exemple avec <function>SplFileInfo::openFile</function></title>
+    <title>Exemple avec <methodname>SplFileInfo::openFile</methodname></title>
     <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/spl/splfileinfo/setfileclass.xml
+++ b/reference/spl/splfileinfo/setfileclass.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="splfileinfo.setfileclass" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>SplFileInfo::setFileClass</refname>
-  <refpurpose>Configure la classe utilisée avec <function>SplFileInfo::openFile</function></refpurpose>
+  <refpurpose>Configure la classe utilisée avec <methodname>SplFileInfo::openFile</methodname></refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/spl/splfileinfo/setinfoclass.xml
+++ b/reference/spl/splfileinfo/setinfoclass.xml
@@ -15,8 +15,8 @@
   </methodsynopsis>
   <para>
    Utilisez cette méthode pour configurer une classe personnalisée
-   à utiliser avec les méthodes <methodname>getFileInfo</methodname>
-   et <methodname>getPathInfo</methodname>. La classe utilisée doit hériter de <classname>SplFileInfo</classname>.
+   à utiliser avec les méthodes <methodname>SplFileInfo::getFileInfo</methodname>
+   et <methodname>SplFileInfo::getPathInfo</methodname>. La classe utilisée doit hériter de <classname>SplFileInfo</classname>.
   </para>
  </refsect1>
 

--- a/reference/spl/splheap/recoverfromcorruption.xml
+++ b/reference/spl/splheap/recoverfromcorruption.xml
@@ -42,7 +42,7 @@
      <row>
       <entry>8.4.0</entry>
       <entry>
-       <methodname>SplHeap::insert</methodname>
+       <methodname>SplHeap::recoverFromCorruption</methodname>
        possède désormais un type de retour provisoire de type <type>true</type>.
       </entry>
      </row>

--- a/reference/spl/splobjectstorage.xml
+++ b/reference/spl/splobjectstorage.xml
@@ -27,7 +27,7 @@
 <!-- {{{ Synopsis -->
    <classsynopsis class="class">
     <ooclass>
-     <classname>SeekableSplObjectStorage</classname>
+     <classname>SplObjectStorage</classname>
     </ooclass>
 
     <oointerface>
@@ -36,7 +36,7 @@
     </oointerface>
 
     <oointerface>
-     <interfacename>Iterator</interfacename>
+     <interfacename>SeekableIterator</interfacename>
     </oointerface>
 
     <oointerface>


### PR DESCRIPTION
- arrayiterator/offsetget.xml: offsetUnSet → offsetUnset
- spldoublylinkedlist/setiteratormode.xml: SplDoublyLnkedList → SplDoublyLinkedList (typo)
- splheap/recoverfromcorruption.xml: SplHeap::insert → SplHeap::recoverFromCorruption
- splobjectstorage.xml: SeekableSplObjectStorage → SplObjectStorage, Iterator → SeekableIterator
- splfileinfo/openfile.xml: <function> → <methodname> in title
- splfileinfo/setfileclass.xml: <function> → <methodname> in refpurpose
- splfileinfo/setinfoclass.xml: add SplFileInfo:: prefix to methodname refs