### PR TITLE
Fix json_last_error_msg: remove duplicate methodsynopsis and erroneou…

### DIFF
--- a/reference/json/functions/json-last-error-msg.xml
+++ b/reference/json/functions/json-last-error-msg.xml
@@ -14,10 +14,6 @@
    <type>string</type><methodname>json_last_error_msg</methodname>
    <void/>
   </methodsynopsis>
-  <methodsynopsis>
-   <type>string</type><methodname>json_last_error_msg</methodname>
-   <void/>
-  </methodsynopsis>
   <para>
    Retourne la chaîne d'erreur du dernier appel à <function>json_validate</function> <function>json_encode</function> ou <function>json_decode</function>,
    qui n'a pas spécifié <constant>JSON_THROW_ON_ERROR</constant>.
@@ -34,8 +30,7 @@
   &reftitle.returnvalues;
   <para>
    Retourne le message d'erreur en cas de succès, ou
-   <literal>"No error"</literal> si aucune erreur n'est survenue,
-   &return.falseforfailure;.
+   <literal>"No error"</literal> si aucune erreur n'est survenue.
   </para>
  </refsect1>
 


### PR DESCRIPTION
…s return.falseforfailure

- Remove duplicate <methodsynopsis> block (copy-paste error)
- Remove &return.falseforfailure; not present in EN (function never returns false)