### PR TITLE
Fix markup sync issues in session extension

### DIFF
--- a/reference/session/functions/session-cache-expire.xml
+++ b/reference/session/functions/session-cache-expire.xml
@@ -20,7 +20,7 @@
   </para>
   <para>
    Le délai d'expiration du cache est remis à sa valeur par défaut de
-   180, stockée dans <link linkend="ini.session.cache-expire">session.cache_limiter</link>,
+   180, stockée dans <link linkend="ini.session.cache-expire">session.cache_expire</link>,
    au démarrage de la requête. Par conséquent, vous devez appeler
    <function>session_cache_expire</function> à chaque requête (et avant
    que <function>session_start</function> ne soit appelée).

--- a/reference/session/functions/session-name.xml
+++ b/reference/session/functions/session-name.xml
@@ -23,7 +23,7 @@
   <para>
    Si un nouveau nom de session <parameter>name</parameter> est
    fourni, <function>session_name</function> modifie le cookie HTTP
-   (et le contenue de sortie quand <link linkend="ini.session.use-trans-sid">session.transid</link> est
+   (et le contenue de sortie quand <link linkend="ini.session.use-trans-sid">session.use_trans_sid</link> est
    activé). Une fois le cookie HTTP envoyé,
    appeler <function>session_name</function> déclenche un <constant>E_WARNING</constant>.
    <function>session_name</function> doit être appelé

--- a/reference/session/functions/session-unset.xml
+++ b/reference/session/functions/session-unset.xml
@@ -78,15 +78,15 @@
     Utilisez seulement <function>session_unset</function> pour du vieux code obsolète
     qui n'utilise pas <varname>$_SESSION</varname>.
    </para>
-   <caution>
+  </note>
+  <caution>
    <para>
     Cette fonction ne fonctionne que si une session est active. Elle ne videra pas le
     tableau <varname>$_SESSION</varname> si la session n'a pas encore été démarrée
     ou si elle a déjà été détruite. Utilisez <code>$_SESSION = []</code> pour supprimer
     toutes les variables de session même si la session n'est pas active.
    </para>
-</caution>
-  </note>
+  </caution>
  </refsect1>
 
 </refentry>

--- a/reference/session/ini.xml
+++ b/reference/session/ini.xml
@@ -451,7 +451,7 @@
    <varlistentry xml:id="ini.session.referer-check">
     <term>
      <parameter>session.referer_check</parameter>
-     <type>int</type>
+     <type>string</type>
     </term>
     <listitem>
      <simpara>


### PR DESCRIPTION
- ini.xml: session.referer_check type int → string
- session-cache-expire.xml: wrong link text session.cache_limiter → session.cache_expire
- session-name.xml: wrong link text session.transid → session.use_trans_sid
- session-unset.xml: unnest <caution> from <note> to match EN structure