### PR TITLE
Fix markup in curl: use <constant> instead of <literal> for CURLOPT_*…

### DIFF
--- a/reference/curl/functions/curl-setopt.xml
+++ b/reference/curl/functions/curl-setopt.xml
@@ -29,7 +29,7 @@
      <term><parameter>option</parameter></term>
      <listitem>
       <para>
-       L'option <literal>CURLOPT_<replaceable>*</replaceable></literal> à définir.
+       L'option <constant>CURLOPT_<replaceable>*</replaceable></constant> à définir.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/curl/functions/curl-version.xml
+++ b/reference/curl/functions/curl-version.xml
@@ -67,7 +67,7 @@
       </row>
       <row>
        <entry>features</entry>
-       <entry>Un masque de constantes <literal>CURL_VERSION_<replaceable>*</replaceable></literal></entry>
+       <entry>Un masque de constantes <constant>CURL_VERSION_<replaceable>*</replaceable></constant></entry>
       </row>
       <row>
        <entry>protocols</entry>


### PR DESCRIPTION
… and CURL_VERSION_*

- curl-setopt.xml: <literal>CURLOPT_*</literal> → <constant>CURLOPT_*</constant>
- curl-version.xml: <literal>CURL_VERSION_*</literal> → <constant>CURL_VERSION_*</constant>