### PR TITLE
Fix markup sync issues in intl extension

### DIFF
--- a/reference/intl/dateformatter/set-pattern.xml
+++ b/reference/intl/dateformatter/set-pattern.xml
@@ -67,7 +67,7 @@
  <refsect1 role="examples">
   &reftitle.examples;
   <example>
-   <title>Exemple avec <function>datefmt_get_pattern</function></title>
+   <title>Exemple avec <function>datefmt_set_pattern</function></title>
    <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/intl/intlchar/chr.xml
+++ b/reference/intl/intlchar/chr.xml
@@ -17,7 +17,7 @@
    Renvoie une chaîne contenant le caractère spécifié par la valeur de point de code Unicode.
   </para>
   <para>
-   Cette méthode complète <function>IntlChar::ord</function>.
+   Cette méthode complète <methodname>IntlChar::ord</methodname>.
   </para>
  </refsect1>
 

--- a/reference/intl/numberformatter/create.xml
+++ b/reference/intl/numberformatter/create.xml
@@ -133,7 +133,7 @@
  <refsect1 role="examples">
   &reftitle.examples;
   <example>
-   <title>Exemple avec <function>numfmt_create::create</function>, &style.procedural;</title>
+   <title>Exemple avec <function>numfmt_create</function>, &style.procedural;</title>
    <programlisting role="php">
 <![CDATA[
 <?php
@@ -146,7 +146,7 @@ echo numfmt_format($fmt, 1142)."\n";
    </programlisting>
   </example>
   <example>
-   <title>Exemple avec <function>numfmt_create::create</function>, style POO</title>
+   <title>Exemple avec <function>NumberFormatter::create</function>, style POO</title>
    <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/intl/numberformatter/get-error-message.xml
+++ b/reference/intl/numberformatter/get-error-message.xml
@@ -71,7 +71,7 @@ if(intl_is_failure(numfmt_get_error_code($fmt))) {
    </programlisting>
   </example>
   <example>
-   <title>Exemple avec <function>numfmt_get_error_code</function>, style POO</title>
+   <title>Exemple avec <function>numfmt_get_error_message</function>, style POO</title>
    <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/intl/numberformatter/get-locale.xml
+++ b/reference/intl/numberformatter/get-locale.xml
@@ -67,7 +67,7 @@
  <refsect1 role="examples">
   &reftitle.examples;
   <example>
-   <title>Exemple avec <function>numfmt_get_error_code</function>, &style.procedural;</title>
+   <title>Exemple avec <function>numfmt_get_locale</function>, &style.procedural;</title>
    <programlisting role="php">
 <![CDATA[
 <?php


### PR DESCRIPTION
- intlchar/chr.xml: <function>IntlChar::ord</function> → <methodname>
- dateformatter/set-pattern.xml: wrong function name datefmt_get_pattern → datefmt_set_pattern
- numberformatter/create.xml: numfmt_create::create → numfmt_create / NumberFormatter::create
- numberformatter/get-error-message.xml: wrong function name numfmt_get_error_code → numfmt_get_error_message
- numberformatter/get-locale.xml: wrong function name numfmt_get_error_code → numfmt_get_locale