### PR TITLE
Fix markup sync issues in PDO extension

### DIFF
--- a/reference/pdo/constants.fetch-modes.xml
+++ b/reference/pdo/constants.fetch-modes.xml
@@ -491,7 +491,7 @@ Array
   <title>PDO::FETCH_COLUMN (<type>int</type>)</title>
   <simpara>
    <constant>PDO::FETCH_COLUMN</constant> renvoie des valeurs d'une seule colonne.
-   Utilisez le deuxième argument pour <function>PDOStatement::setFetchMode</function>
+   Utilisez le deuxième argument pour <methodname>PDOStatement::setFetchMode</methodname>
    ou <methodname>PDOStatement::fetchAll</methodname> pour spécifier quelle colonne est
    retournée.
   </simpara>
@@ -573,7 +573,7 @@ Array
   <title>PDO::FETCH_FUNC (<type>int</type>)</title>
   <simpara>
    Spécifiez une fonction pour créer la valeur retournée. Ce mode ne peut être utilisé
-   qu'avec <function>PDOStatement::fetchAll</function>.
+   qu'avec <methodname>PDOStatement::fetchAll</methodname>.
   </simpara>
   <simpara>
    La fonction reçoit les valeurs en tant que paramètres.
@@ -644,14 +644,14 @@ Array
 
  <section xml:id="pdo.constants.fetch-obj" annotations="chunk:false">
   <title>PDO::FETCH_OBJ (<type>int</type>)</title>
-  <para>
+  <simpara>
    <constant>PDO::FETCH_OBJ</constant> renvoie un objet
    <classname>stdClass</classname>.
-  </para>
-  <para>
-   Voir aussi <function>PDOStatement::fetchObject</function> et
+  </simpara>
+  <simpara>
+   Voir aussi <methodname>PDOStatement::fetchObject</methodname> et
    <constant>PDO::FETCH_CLASS</constant>.
-  </para>
+  </simpara>
   <informalexample>
    <programlisting role="php">
 <![CDATA[
@@ -985,7 +985,7 @@ object(TestEntity)#5 (4) {
   <title>PDO::FETCH_BOUND (<type>int</type>)</title>
   <simpara>
    Ce mode de récupération ne peut pas être utilisé avec
-   <function>PDOStatement::fetchAll</function>.
+   <methodname>PDOStatement::fetchAll</methodname>.
   </simpara>
   <simpara>
    Ce mode de récupération ne renvoie pas directement un résultat, mais lie des valeurs à

--- a/reference/pdo/pdo/exec.xml
+++ b/reference/pdo/pdo/exec.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: 28529d3539b850e870e3aa97570f4db0e53daa03 Maintainer: yannick Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="pdo.exec" xmlns="http://docbook.org/ns/docbook">


### PR DESCRIPTION
- constants.fetch-modes.xml: <function> → <methodname> for PDOStatement methods (4 occurrences)
- constants.fetch-modes.xml: <para> → <simpara> for FETCH_OBJ section
- pdo/exec.xml: fix XML declaration single quotes → double quotes