### PR TITLE
Fix markup sync issues in openssl extension

### DIFF
--- a/reference/openssl/certparams.xml
+++ b/reference/openssl/certparams.xml
@@ -73,7 +73,8 @@
        <simpara>
         Une instance de <classname>OpenSSLAsymmetricKey</classname>
         (ou antérieur à PHP 8.0.0, une &resource; de type <literal>OpenSSL key</literal>)
-        retournée par <function>openssl_csr_new</function>
+        retournée par <function>openssl_get_publickey</function> ou
+        <function>openssl_get_privatekey</function>
        </simpara>
       </listitem>
       <listitem>

--- a/reference/openssl/configure.xml
+++ b/reference/openssl/configure.xml
@@ -112,6 +112,7 @@
        </entry>
        </row>
        <row>
+       <entry>7.4.0</entry>
        <entry>
         Le chemin de configuration par défaut d'OpenSSL a été modifié de  <filename>C:\usr\local\ssl</filename>
         à <filename>C:\Program Files\Common Files\SSL</filename> et

--- a/reference/openssl/functions/openssl-free-key.xml
+++ b/reference/openssl/functions/openssl-free-key.xml
@@ -8,6 +8,10 @@
   <refpurpose>Libère les ressources</refpurpose>
  </refnamediv>
 
+ <refsynopsisdiv>
+  &warn.deprecated.function-8-0-0;
+ </refsynopsisdiv>
+
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>

--- a/reference/openssl/functions/openssl-pkey-free.xml
+++ b/reference/openssl/functions/openssl-pkey-free.xml
@@ -8,6 +8,10 @@
   <refpurpose>Libère une clé privée</refpurpose>
  </refnamediv>
 
+ <refsynopsisdiv>
+  &warn.deprecated.function-8-0-0;
+ </refsynopsisdiv>
+
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>

--- a/reference/openssl/functions/openssl-pkey-new.xml
+++ b/reference/openssl/functions/openssl-pkey-new.xml
@@ -424,7 +424,7 @@
      <row>
       <entry>7.1.0</entry>
       <entry>
-       L'option <parameter>curve_name</parameter> a été ajouté
+       L'option <literal>curve_name</literal> a été ajouté
        pour permettre la création de clés EC.
       </entry>
      </row>

--- a/reference/openssl/functions/openssl-x509-check-private-key.xml
+++ b/reference/openssl/functions/openssl-x509-check-private-key.xml
@@ -21,7 +21,7 @@
   </para>
   <warning>
     <para>
-     Cette fonction ne vérifie pas si KEY est effectivement une clé privée ou pas.
+     Cette fonction ne vérifie pas si <parameter>private_key</parameter> est effectivement une clé privée ou pas.
      Elle compare simplement le matériel publique (par exemple exponent et modulo
      d'une clé RSA) et/ou les paramètres de clé (par exemple les paramètres EC d'une
      clé EC) d'une paire de clé.

--- a/reference/openssl/functions/openssl-x509-free.xml
+++ b/reference/openssl/functions/openssl-x509-free.xml
@@ -8,6 +8,10 @@
   <refpurpose>Libère les ressources prises par un certificat</refpurpose>
  </refnamediv>
 
+ <refsynopsisdiv>
+  &warn.deprecated.function-8-0-0;
+ </refsynopsisdiv>
+
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>


### PR DESCRIPTION
- configure.xml: add missing <entry>7.4.0</entry> in changelog
- certparams.xml: wrong function openssl_csr_new → openssl_get_publickey/openssl_get_privatekey
- openssl-x509-check-private-key.xml: plain text KEY → <parameter>private_key</parameter>
- openssl-pkey-new.xml: <parameter>curve_name</parameter> → <literal> (array key, not param)
- openssl-free-key.xml: add missing <refsynopsisdiv> deprecation warning
- openssl-pkey-free.xml: add missing <refsynopsisdiv> deprecation warning
- openssl-x509-free.xml: add missing <refsynopsisdiv> deprecation warning