### PR TITLE
Fix markup sync issues in mysqli extension

### DIFF
--- a/reference/mysqli/mysqli/next-result.xml
+++ b/reference/mysqli/mysqli/next-result.xml
@@ -12,7 +12,7 @@
   &reftitle.description;
   <para>&style.oop;</para>
   <methodsynopsis role="mysqli">
-   <type>bool</type><methodname>mysqli::next_result</methodname>
+   <modifier>public</modifier> <type>bool</type><methodname>mysqli::next_result</methodname>
    <void/>
   </methodsynopsis>
   <para>&style.procedural;</para>

--- a/reference/mysqli/summary.xml
+++ b/reference/mysqli/summary.xml
@@ -137,7 +137,7 @@
     <row>
      <entry><methodname>mysqli::character_set_name</methodname></entry>
      <entry><function>mysqli_character_set_name</function></entry>
-     <entry><function>N/A</function></entry>
+     <entry>N/A</entry>
      <entry>Retourne le jeu de caractères courant pour la connexion</entry>
     </row>
     <row>


### PR DESCRIPTION
- summary.xml: <function>N/A</function> → plain text N/A
- next-result.xml: add missing <modifier>public</modifier> in method synopsis