### PR TITLE
Fix markup sync issues in soap extension

### DIFF
--- a/reference/soap/functions/use-soap-error-handler.xml
+++ b/reference/soap/functions/use-soap-error-handler.xml
@@ -19,7 +19,7 @@
   <para>
    <function>use_soap_error_handler</function> active ou non le gestionnaire
    d'erreurs natif SOAP du serveur SOAP. Elle retourne la valeur précédemment
-   utilisée. Si le paramètre <parameter>handler</parameter> est mis à 
+   utilisée. Si le paramètre <parameter>enable</parameter> est mis à 
    &true;, le détail des erreurs du serveur <classname>SoapServer</classname>
    seront envoyées au client, comme message d'erreur SOAP.
    Si vaut &false; le gestionnaire d'erreur standard PHP sera utilisé.

--- a/reference/soap/soapserver/getfunctions.xml
+++ b/reference/soap/soapserver/getfunctions.xml
@@ -17,8 +17,8 @@
    <function>SoapServer::getFunctions</function> retourne la liste 
    de toutes les fonctions ajoutées à l'objet serveur <classname>SoapServer</classname>.
    Elle retourne la liste de toutes les fonctions ajoutées à l'aide
-   des méthodes <function>SoapServer::addFunction</function> et
-   <function>SoapServer::setClass</function>.
+   des méthodes <methodname>SoapServer::addFunction</methodname> et
+   <methodname>SoapServer::setClass</methodname>.
   </para>
  </refsect1>
 

--- a/reference/soap/soapserver/setclass.xml
+++ b/reference/soap/soapserver/setclass.xml
@@ -21,7 +21,7 @@
    <function>SoapServer::setClass</function> configure une classe qui servira
    de gestionnaire aux requêtes SOAP. L'objet pourra alors être rendu
    persistant à travers les requêtes pour une session PHP, avec
-   la méthode <function>SoapServer::setPersistence</function>.
+   la méthode <methodname>SoapServer::setPersistence</methodname>.
   </para>
  </refsect1>
 

--- a/reference/soap/soapserver/setobject.xml
+++ b/reference/soap/soapserver/setobject.xml
@@ -16,7 +16,7 @@
   <para>
    <function>SoapServer::setObject</function> configure un objet qui servira
    de gestionnaire aux requêtes SOAP, plutôt qu'une simple classe,
-   comme avec <function>SoapServer::setClass</function>.
+   comme avec <methodname>SoapServer::setClass</methodname>.
   </para>
  </refsect1>
 


### PR DESCRIPTION
- soapserver/getfunctions.xml: <function> → <methodname> for SoapServer methods
- soapserver/setclass.xml: <function> → <methodname> for SoapServer::setPersistence
- soapserver/setobject.xml: <function> → <methodname> for SoapServer::setClass
- use-soap-error-handler.xml: wrong parameter name handler → enable