### PR TITLE
Fix markup sync issues in simplexml extension

### DIFF
--- a/reference/simplexml/functions/simplexml-import-dom.xml
+++ b/reference/simplexml/functions/simplexml-import-dom.xml
@@ -40,7 +40,7 @@
      <listitem>
       <para>
        Vous pouvez utiliser ce paramètre optionnel afin que
-       <function>simplexml_load_string</function> retourne un objet
+       <function>simplexml_import_dom</function> retourne un objet
        de la classe spécifiée. Cette classe doit étendre la classe
        <type>SimpleXMLElement</type>.
       </para>

--- a/reference/simplexml/simplexmlelement/asXML.xml
+++ b/reference/simplexml/simplexmlelement/asXML.xml
@@ -118,7 +118,7 @@ echo $xml->asXML();
    <example>
     <title>
      Utilisation de <function>SimpleXMLElement::asXML</function>
-     avec les résultats de <function>SimpleXMLElement::xpath</function></title>
+     avec les résultats de <methodname>SimpleXMLElement::xpath</methodname></title>
     <programlisting role="php">
 <![CDATA[
 <?php


### PR DESCRIPTION
- simplexml-import-dom.xml: wrong function name simplexml_load_string → simplexml_import_dom
- asXML.xml: <function> → <methodname> for SimpleXMLElement::xpath in title