### PR TITLE
fix(migration84): use literal tag for xml_set_* wildcard patterns

### DIFF
--- a/appendices/migration84/deprecated.xml
+++ b/appendices/migration84/deprecated.xml
@@ -469,7 +469,7 @@ class _MyClass {}
   <!-- RFC: https://wiki.php.net/rfc/deprecations_php_8_4#xml_set_object_and_xml_set_handler_with_string_method_names -->
   <simpara>
    Passer une chaîne non-<type>callable</type> aux fonctions
-   <function>xml_set_<replaceable>*</replaceable></function>
+   <literal>xml_set_*</literal>
    est désormais déprécié.
   </simpara>
  </sect2>

--- a/appendices/migration84/incompatible.xml
+++ b/appendices/migration84/incompatible.xml
@@ -820,7 +820,7 @@ nodeData: 3
   <title>XML</title>
 
   <simpara>
-   Les fonctions <function>xml_set_<replaceable>*</replaceable>_handler</function>
+   Les fonctions <literal>xml_set_*_handler</literal>
    déclarent désormais et vérifient une signature
    effective de <type class="union"><type>callable</type><type>string</type><type>null</type></type> pour les
    paramètres <parameter>handler</parameter>.


### PR DESCRIPTION
Use `<literal>xml_set_*</literal>` instead of `<function>xml_set_<replaceable>*</replaceable></function>` for wildcard patterns that don't reference actual function names.

Fixes rendering in both `migration84/deprecated.xml` and `migration84/incompatible.xml`.