### PR TITLE
fix(opcache/opcache_reset): add missing opcache_invalidate in seealso

### DIFF
--- a/reference/opcache/functions/opcache-reset.xml
+++ b/reference/opcache/functions/opcache-reset.xml
@@ -39,6 +39,7 @@
  <refsect1 role="seealso">
   &reftitle.seealso;
   <simplelist>
+   <member><function>opcache_invalidate</function></member>
    <member><function>opcache_get_status</function></member>
   </simplelist>
  </refsect1>


### PR DESCRIPTION
Sync markup with EN: add missing `<function>opcache_invalidate</function>` member in seealso section to match EN version.