### PR TITLE
fix: French type names -> English (6 files)

### DIFF
--- a/reference/apcu/apcuiterator/construct.xml
+++ b/reference/apcu/apcuiterator/construct.xml
@@ -17,7 +17,7 @@
    <methodparam choice="opt"><type>int</type><parameter>list</parameter><initializer>APC_LIST_ACTIVE</initializer></methodparam>
   </constructorsynopsis>
   <simpara>
-   Construit un <type>objet</type> de la classe <classname>APCUIterator</classname>.
+   Construit un <type>object</type> de la classe <classname>APCUIterator</classname>.
   </simpara>
  </refsect1>
 

--- a/reference/apcu/functions/apcu-delete.xml
+++ b/reference/apcu/functions/apcu-delete.xml
@@ -27,8 +27,8 @@
      <simpara>
       Le paramètre <parameter>key</parameter> peut être soit une
       <type>chaîne de caractères</type> pour une seule clé,
-      soit un <type>tableau</type> de chaîne de caractères pour plusieurs clés,
-      soit un <type>objet</type> de la classe <classname>APCUIterator</classname>.
+      soit un <type>array</type> de chaîne de caractères pour plusieurs clés,
+      soit un <type>object</type> de la classe <classname>APCUIterator</classname>.
      </simpara>
     </listitem>
    </varlistentry>

--- a/reference/apcu/functions/apcu-exists.xml
+++ b/reference/apcu/functions/apcu-exists.xml
@@ -25,7 +25,7 @@
     <term><parameter>keys</parameter></term>
     <listitem>
      <simpara>
-      Une <type>chaîne de caractères</type> ou un <type>tableau</type> de
+      Une <type>chaîne de caractères</type> ou un <type>array</type> de
       chaînes de caractères qui contient les clés.
      </simpara>
     </listitem>
@@ -37,7 +37,7 @@
   &reftitle.returnvalues;
   <simpara>
    Retourne la valeur &true; si la clé existe, ou &false; sinon.
-   Ou bien, si un <type>tableau</type> a été passé à <parameter>keys</parameter>,
+   Ou bien, si un <type>array</type> a été passé à <parameter>keys</parameter>,
    alors la valeur retournée est un tableau contenant toutes les clés
    existantes, ou un tableau vide si aucune n'existe.
   </simpara>

--- a/reference/array/functions/array-key-exists.xml
+++ b/reference/array/functions/array-key-exists.xml
@@ -92,13 +92,13 @@
      <row>
       <entry>8.0.0</entry>
       <entry>
-       Il n'est plus possible de passer un <type>objet</type> au paramètre <parameter>array</parameter>.
+       Il n'est plus possible de passer un <type>object</type> au paramètre <parameter>array</parameter>.
       </entry>
      </row>
      <row>
       <entry>7.4.0</entry>
       <entry>
-       Il est déconseillé de passer un <type>objet</type> au paramètre <parameter>array</parameter>. Utiliser plutôt <function>property_exists</function>.
+       Il est déconseillé de passer un <type>object</type> au paramètre <parameter>array</parameter>. Utiliser plutôt <function>property_exists</function>.
       </entry>
      </row>
     </tbody>

--- a/reference/bc/functions/bcdivmod.xml
+++ b/reference/bc/functions/bcdivmod.xml
@@ -28,8 +28,8 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   Renvoie un <type>tableau</type> indexé où le premier élément est le quotient sous forme de <type>chaîne</type>
-   et le second élément est le reste sous forme de <type>chaîne</type>.
+   Renvoie un <type>array</type> indexé où le premier élément est le quotient sous forme de <type>string</type>
+   et le second élément est le reste sous forme de <type>string</type>.
   </simpara>
  </refsect1>
 

--- a/reference/datetime/dateperiod/getdateinterval.xml
+++ b/reference/datetime/dateperiod/getdateinterval.xml
@@ -19,7 +19,7 @@
    <void />
   </methodsynopsis>
   <para>
-   Retourne un <type>objet</type> <classname>DateIntervalle</classname> représentant l'intervalle utilisé pour la période.
+   Retourne un <type>object</type> <classname>DateIntervalle</classname> représentant l'intervalle utilisé pour la période.
   </para>
  </refsect1>
 
@@ -31,7 +31,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Retourne un <type>objet</type> <classname>DateInterval</classname>
+   Retourne un <type>object</type> <classname>DateInterval</classname>
   </para>
  </refsect1>
 


### PR DESCRIPTION
## Summary
- Replace French type names with English PHP type names in 6 files
- `<type>objet</type>` → `<type>object</type>`
- `<type>tableau</type>` → `<type>array</type>`
- `<type>chaîne</type>` → `<type>string</type>`

## Files
- reference/apcu/apcuiterator/construct.xml
- reference/apcu/functions/apcu-delete.xml
- reference/apcu/functions/apcu-exists.xml
- reference/array/functions/array-key-exists.xml
- reference/bc/functions/bcdivmod.xml
- reference/datetime/dateperiod/getdateinterval.xml