### PR TITLE
fix: sync para/simpara with EN

### DIFF
--- a/reference/openssl/functions/openssl-private-decrypt.xml
+++ b/reference/openssl/functions/openssl-private-decrypt.xml
@@ -72,10 +72,10 @@
     <varlistentry>
      <term><parameter>digest_algo</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        L'algorithme de hachage pour le remplissage OAEP, ou &null; pour utiliser
        l'algorithme par défaut.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>

--- a/reference/openssl/functions/openssl-public-encrypt.xml
+++ b/reference/openssl/functions/openssl-public-encrypt.xml
@@ -75,10 +75,10 @@
     <varlistentry>
      <term><parameter>digest_algo</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        L'algorithme de hachage pour le remplissage OAEP, ou &null; pour utiliser
        l'algorithme par défaut.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>

--- a/reference/openssl/functions/openssl-sign.xml
+++ b/reference/openssl/functions/openssl-sign.xml
@@ -76,9 +76,7 @@
     <varlistentry>
      <term><parameter>padding</parameter></term>
      <listitem>
-      <para>
-       Le remplissage RSA PSS à utiliser.
-      </para>
+      <simpara>Le remplissage RSA PSS à utiliser.</simpara>
      </listitem>
     </varlistentry>
    </variablelist>

--- a/reference/openssl/functions/openssl-verify.xml
+++ b/reference/openssl/functions/openssl-verify.xml
@@ -76,9 +76,7 @@ MIIBCgK...</literal>.
     <varlistentry>
      <term><parameter>padding</parameter></term>
      <listitem>
-      <para>
-       Le remplissage RSA PSS à utiliser.
-      </para>
+      <simpara>Le remplissage RSA PSS à utiliser.</simpara>
      </listitem>
     </varlistentry>
    </variablelist>

--- a/reference/spl/splobjectstorage/attach.xml
+++ b/reference/spl/splobjectstorage/attach.xml
@@ -23,9 +23,9 @@
    Ajoute un &object; dans le stockage, et lui associe 
    éventuellement des données.
   </para>
-  <para>
+  <simpara>
    Cette méthode est un alias de <methodname>SplObjectStorage::offsetSet</methodname>.
-  </para>
+  </simpara>
  </refsect1>
  
  <refsect1 role="parameters">

--- a/reference/strings/functions/ltrim.xml
+++ b/reference/strings/functions/ltrim.xml
@@ -14,9 +14,9 @@
    <methodparam><type>string</type><parameter>string</parameter></methodparam>
    <methodparam choice="opt"><type>string</type><parameter>characters</parameter><initializer>" \n\r\t\v\x00"</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Supprime les espaces (ou d'autres caractères) de début de chaîne.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">


### PR DESCRIPTION
## Summary
Replace `<para>` with `<simpara>` to match EN structure in 6 files.

## Files
- reference/openssl/functions/openssl-private-decrypt.xml - `<para>` -> `<simpara>` for digest_algo parameter
- reference/openssl/functions/openssl-public-encrypt.xml - `<para>` -> `<simpara>` for digest_algo parameter
- reference/openssl/functions/openssl-sign.xml - `<para>` -> `<simpara>` for padding parameter
- reference/openssl/functions/openssl-verify.xml - `<para>` -> `<simpara>` for padding parameter
- reference/spl/splobjectstorage/attach.xml - `<para>` -> `<simpara>` for alias description
- reference/strings/functions/ltrim.xml - `<para>` -> `<simpara>` for description

## Skipped (no mismatch found)
- reference/dba/functions/dba-open.xml - FR and EN already match
- reference/parallel/parallel/runtime/construct.xml - FR and EN already match
- reference/spl/splfileobject/fgetcsv.xml - FR and EN already match