### PR TITLE
fix: sync inline tag names with EN (66 files)

### DIFF
--- a/reference/bzip2/functions/bzclose.xml
+++ b/reference/bzip2/functions/bzclose.xml
@@ -14,7 +14,7 @@
    <methodparam><type>resource</type><parameter>bz</parameter></methodparam>
   </methodsynopsis>
   <simpara>
-   <function>bzclose</function> ferme le fichier bzip2
+   <methodname>bzclose</methodname> ferme le fichier bzip2
    représenté par le pointeur <parameter>bz</parameter>.
   </simpara>
  </refsect1>

--- a/reference/bzip2/functions/bzerrno.xml
+++ b/reference/bzip2/functions/bzerrno.xml
@@ -14,7 +14,7 @@
    <methodparam><type>resource</type><parameter>bz</parameter></methodparam>
   </methodsynopsis>
   <simpara>
-   <function>bzerrno</function> retourne le code d'erreur
+   <methodname>bzerrno</methodname> retourne le code d'erreur
    du fichier bz2 représenté par le pointeur <parameter>bz</parameter>.
   </simpara>
  </refsect1>

--- a/reference/bzip2/functions/bzerrstr.xml
+++ b/reference/bzip2/functions/bzerrstr.xml
@@ -14,7 +14,7 @@
    <methodparam><type>resource</type><parameter>bz</parameter></methodparam>
   </methodsynopsis>
   <simpara>
-   <function>bzerrstr</function> retourne le message d'erreur
+   <methodname>bzerrstr</methodname> retourne le message d'erreur
    du fichier bz2 représenté par le pointeur <parameter>bz</parameter>.
   </simpara>
  </refsect1>

--- a/reference/calendar/functions/frenchtojd.xml
+++ b/reference/calendar/functions/frenchtojd.xml
@@ -19,7 +19,7 @@
    <methodparam><type>int</type><parameter>year</parameter></methodparam>
   </methodsynopsis>
   <para>
-   <function>frenchtojd</function> convertit une date du calendrier
+   <methodname>frenchtojd</methodname> convertit une date du calendrier
    français républicain en nombre de jours du calendrier Julien.
   </para>
   <para>

--- a/reference/componere/functions/componere.cast.xml
+++ b/reference/componere/functions/componere.cast.xml
@@ -41,7 +41,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   Un <type>objet</type> de type <exceptionname>Type</exceptionname>, converti depuis <parameter>object</parameter>
+   Un <type>object</type> de type <exceptionname>Type</exceptionname>, converti depuis <parameter>object</parameter>
   </simpara>
  </refsect1>
 

--- a/reference/componere/functions/componere.cast_by_ref.xml
+++ b/reference/componere/functions/componere.cast_by_ref.xml
@@ -41,7 +41,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   Un <type>objet</type> de type <exceptionname>Type</exceptionname>, converti depuis <parameter>object</parameter>, où les membres sont des références aux membres de <parameter>object</parameter>
+   Un <type>object</type> de type <exceptionname>Type</exceptionname>, converti depuis <parameter>object</parameter>, où les membres sont des références aux membres de <parameter>object</parameter>
   </simpara>
  </refsect1>
 

--- a/reference/datetime/datetimeinterface.xml
+++ b/reference/datetime/datetimeinterface.xml
@@ -386,7 +386,7 @@
         <entry>7.2.0</entry>
         <entry>
          Les constantes de classe de <classname>DateTime</classname> sont
-         maintenant définies sur <classname>DateTimeInterface</classname>.
+         maintenant définies sur <interfacename>DateTimeInterface</interfacename>.
         </entry>
        </row>
       </tbody>

--- a/reference/datetime/datetimeinterface/format.xml
+++ b/reference/datetime/datetimeinterface/format.xml
@@ -409,7 +409,7 @@
   &reftitle.examples;
   <para>
    <example>
-    <title>Exemple avec <function>DateTime::format</function></title>
+    <title>Exemple avec <methodname>DateTime::format</methodname></title>
     <para>&style.oop;</para>
     <programlisting role="php">
 <![CDATA[

--- a/reference/datetime/datetimezone/getoffset.xml
+++ b/reference/datetime/datetimezone/getoffset.xml
@@ -21,7 +21,7 @@
    <methodparam><type>DateTimeInterface</type><parameter>datetime</parameter></methodparam>
   </methodsynopsis>
   <para>
-   <function>timezone_offset_get</function> retourne le décalage horaire par
+   <methodname>timezone_offset_get</methodname> retourne le décalage horaire par
    rapport au GMT pour le paramètre <parameter>datetime</parameter>. Le 
    décalage GMT est calculé à partir des informations de fuseau horaire 
    contenu dans l'objet <classname>DateTime</classname>.

--- a/reference/datetime/functions/timezone-version-get.xml
+++ b/reference/datetime/functions/timezone-version-get.xml
@@ -15,7 +15,7 @@
    <void/>
   </methodsynopsis>
   <para>
-   <function>timezone_version_get</function> lit la version de la timezonedb.
+   <methodname>timezone_version_get</methodname> lit la version de la timezonedb.
   </para>
  </refsect1>
 

--- a/reference/dbase/functions/dbase-close.xml
+++ b/reference/dbase/functions/dbase-close.xml
@@ -15,7 +15,7 @@
    <methodparam><type>resource</type><parameter>database</parameter></methodparam>
   </methodsynopsis>
   <para>
-   <function>dbase_close</function> ferme la base de données correspondant à la
+   <methodname>dbase_close</methodname> ferme la base de données correspondant à la
    ressource <parameter>database</parameter>.
   </para>
  </refsect1>

--- a/reference/dbase/functions/dbase-delete-record.xml
+++ b/reference/dbase/functions/dbase-delete-record.xml
@@ -17,7 +17,7 @@
    <methodparam><type>int</type><parameter>number</parameter></methodparam>
   </methodsynopsis>
   <para>
-   <function>dbase_delete_record</function> marque l'enregistrement
+   <methodname>dbase_delete_record</methodname> marque l'enregistrement
    <parameter>record</parameter> pour l'effacement, dans la base
    <parameter>dbase_identifier</parameter>.
   </para>

--- a/reference/dbase/functions/dbase-get-header-info.xml
+++ b/reference/dbase/functions/dbase-get-header-info.xml
@@ -15,7 +15,7 @@
    <methodparam><type>resource</type><parameter>database</parameter></methodparam>
   </methodsynopsis>
   <para>
-   <function>dbase_get_header_info</function> retourne des informations sur
+   <methodname>dbase_get_header_info</methodname> retourne des informations sur
    la structure des colonnes de la base de données référencée par la ressource 
    <parameter>database</parameter>.
   </para>

--- a/reference/dbase/functions/dbase-pack.xml
+++ b/reference/dbase/functions/dbase-pack.xml
@@ -15,7 +15,7 @@
    <methodparam><type>resource</type><parameter>database</parameter></methodparam>
   </methodsynopsis>
   <para>
-   <function>dbase_pack</function> compacte la base de données
+   <methodname>dbase_pack</methodname> compacte la base de données
    <parameter>dbase_identifier</parameter> (effacement définitif
    de tous les enregistrements marqués pour l'effacement
    à l'aide de la fonction <function>dbase_delete_record</function>).

--- a/reference/dir/functions/closedir.xml
+++ b/reference/dir/functions/closedir.xml
@@ -14,7 +14,7 @@
    <methodparam choice="opt"><type class="union"><type>resource</type><type>null</type></type><parameter>dir_handle</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
   <simpara>
-   <function>closedir</function> ferme le pointeur de dossier
+   <methodname>closedir</methodname> ferme le pointeur de dossier
    <parameter>dir_handle</parameter>.
   </simpara>
  </refsect1>

--- a/reference/dir/functions/opendir.xml
+++ b/reference/dir/functions/opendir.xml
@@ -17,7 +17,7 @@
    <methodparam choice="opt"><type class="union"><type>resource</type><type>null</type></type><parameter>context</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
   <simpara>
-   <function>opendir</function> retourne un pointeur sur un dossier
+   <methodname>opendir</methodname> retourne un pointeur sur un dossier
    qui pour être utilisé avec les fonctions
    <function>closedir</function>, <function>readdir</function>
    et <function>rewinddir</function>.

--- a/reference/ibm_db2/functions/db2-num-fields.xml
+++ b/reference/ibm_db2/functions/db2-num-fields.xml
@@ -50,7 +50,7 @@
  <refsect1 role="examples">
   &reftitle.examples;
   <example>
-   <title>Exemple avec <function>db2_num_fields</function></title>
+   <title>Exemple avec <methodname>db2_num_fields</methodname></title>
    <simpara>
     L'exemple suivant démontre comment obtenir le nombre de champs retournés
     dans le jeu de résultats.

--- a/reference/ibm_db2/ini.xml
+++ b/reference/ibm_db2/ini.xml
@@ -398,7 +398,7 @@
      <itemizedlist>
       <listitem>
        <simpara>
-        0 - Utilise l'option de tri <constant>*HEX</constant>, triant par octets.
+        0 - Utilise l'option de tri <literal>*HEX</literal>, triant par octets.
        </simpara>
       </listitem>
       <listitem>

--- a/reference/image/functions/imagecolorresolve.xml
+++ b/reference/image/functions/imagecolorresolve.xml
@@ -17,7 +17,7 @@
    <methodparam><type>int</type><parameter>blue</parameter></methodparam>
   </methodsynopsis>
   <para>
-   <function>imagecolorresolve</function> retourne un index
+   <methodname>imagecolorresolve</methodname> retourne un index
    de couleur à tous les coups. Soit il arrive à trouver
    la couleur demandée dans la palette, soit il trouve
    la couleur la plus proche.

--- a/reference/image/functions/imagecolorresolvealpha.xml
+++ b/reference/image/functions/imagecolorresolvealpha.xml
@@ -21,7 +21,7 @@
    <methodparam><type>int</type><parameter>alpha</parameter></methodparam>
   </methodsynopsis>
   <para>
-   <function>imagecolorresolvealpha</function> retourne toujours
+   <methodname>imagecolorresolvealpha</methodname> retourne toujours
    un index de couleur, disponible dans la palette
    de l'image <parameter>image</parameter> : soit c'est la couleur
    exacte, soit c'est la meilleure approximation.

--- a/reference/image/functions/imageconvolution.xml
+++ b/reference/image/functions/imageconvolution.xml
@@ -17,7 +17,7 @@
    <methodparam><type>float</type><parameter>offset</parameter></methodparam>
   </methodsynopsis>
   <para>
-   <function>imageconvolution</function> applique une matrice de la convolution
+   <methodname>imageconvolution</methodname> applique une matrice de la convolution
    3x3, en utilisant le coefficient <parameter>div</parameter> et l'excentrage
    <parameter>offset</parameter>.
   </para>
@@ -84,7 +84,7 @@
   &reftitle.examples;
   <para>
    <example>
-    <title>Impression du logo PHP.net avec <function>imageconvolution</function></title>
+    <title>Impression du logo PHP.net avec <methodname>imageconvolution</methodname></title>
     <programlisting role="php">
 <![CDATA[
 <?php
@@ -107,7 +107,7 @@ imagepng($image, null, 9);
     </mediaobject>
    </example>
    <example>
-    <title>Flou gaussien avec <function>imageconvolution</function></title>
+    <title>Flou gaussien avec <methodname>imageconvolution</methodname></title>
     <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/image/functions/imagecopymerge.xml
+++ b/reference/image/functions/imagecopymerge.xml
@@ -100,7 +100,7 @@
        suivant le paramètre <parameter>pct</parameter>, qui peut valoir de
        0 à 100. Si <parameter>pct</parameter> = 0, aucune action n'est
        faite, alors que si <parameter>pct</parameter> = 100,
-       <function>imagecopymerge</function> se comporte exactement comme
+       <methodname>imagecopymerge</methodname> se comporte exactement comme
        <function>imagecopy</function> pour les images de palette, sauf
        pour l'ignorance des composants alpha, tandis qu'il implémente la
        transparence alpha pour les  images en couleur vraies.

--- a/reference/image/functions/imagepng.xml
+++ b/reference/image/functions/imagepng.xml
@@ -17,7 +17,7 @@
    <methodparam choice="opt"><type>int</type><parameter>filters</parameter><initializer>-1</initializer></methodparam>
   </methodsynopsis>
   <para>
-   <function>imagepng</function> affiche ou sauvegarde une 
+   <methodname>imagepng</methodname> affiche ou sauvegarde une 
    image au format <acronym>PNG</acronym> en utilisant 
    l'image <parameter>image</parameter>.
   </para>

--- a/reference/image/functions/imagerotate.xml
+++ b/reference/image/functions/imagerotate.xml
@@ -16,7 +16,7 @@
    <methodparam><type>int</type><parameter>background_color</parameter></methodparam>
   </methodsynopsis>
   <para>
-   <function>imagerotate</function> fait tourner l'image <parameter>image</parameter> 
+   <methodname>imagerotate</methodname> fait tourner l'image <parameter>image</parameter> 
    d'un angle de <parameter>angle</parameter>, en degrés.
   </para>
   <para>

--- a/reference/image/functions/imagetypes.xml
+++ b/reference/image/functions/imagetypes.xml
@@ -76,7 +76,7 @@
   &reftitle.examples;
   <para>
    <example>
-    <title>Exemple avec <function>imagetypes</function></title>
+    <title>Exemple avec <methodname>imagetypes</methodname></title>
     <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/image/functions/iptcembed.xml
+++ b/reference/image/functions/iptcembed.xml
@@ -16,7 +16,7 @@
    <methodparam choice="opt"><type>int</type><parameter>spool</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
   <para>
-   <function>iptcembed</function> intègre des données binaires IPTC
+   <methodname>iptcembed</methodname> intègre des données binaires IPTC
    dans une image JPEG.
   </para>
  </refsect1>
@@ -64,7 +64,7 @@
  <refsect1 role="examples">
   &reftitle.examples;
   <example>
-   <title>Exemple avec <function>iptcembed</function></title>
+   <title>Exemple avec <methodname>iptcembed</methodname></title>
    <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/imap/functions/imap-clearflag-full.xml
+++ b/reference/imap/functions/imap-clearflag-full.xml
@@ -16,7 +16,7 @@
    <methodparam choice="opt"><type>int</type><parameter>options</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
   <para>
-   <function>imap_clearflag_full</function> efface le flag
+   <methodname>imap_clearflag_full</methodname> efface le flag
    <parameter>flag</parameter> dans les messages de la séquence
    <parameter>sequence</parameter>, du flux imap <parameter>stream</parameter>.
   </para>

--- a/reference/imap/functions/imap-fetchbody.xml
+++ b/reference/imap/functions/imap-fetchbody.xml
@@ -47,7 +47,7 @@
      <term><parameter>flags</parameter></term>
      <listitem>
       <para>
-       L'option <function>imap_fetchbody</function> est un masque qui peut
+       L'option <methodname>imap_fetchbody</methodname> est un masque qui peut
        contenir les valeurs suivantes :
        <itemizedlist>
         <listitem>

--- a/reference/imap/functions/imap-fetchheader.xml
+++ b/reference/imap/functions/imap-fetchheader.xml
@@ -15,7 +15,7 @@
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
   <para>
-   <function>imap_fetchheader</function> retourne l'en-tête brut et
+   <methodname>imap_fetchheader</methodname> retourne l'en-tête brut et
    complet <link xlink:href="&url.rfc;2822">RFC2822</link> du message
    <parameter>msgno</parameter>, sous la forme d'une chaîne.
   </para>

--- a/reference/imap/functions/imap-getsubscribed.xml
+++ b/reference/imap/functions/imap-getsubscribed.xml
@@ -18,7 +18,7 @@
    Liste toutes les boîtes aux lettres souscrites.
   </para>
   <para>
-   <function>imap_getsubscribed</function> est identique à
+   <methodname>imap_getsubscribed</methodname> est identique à
    <function>imap_getmailboxes</function>, mais ne retourne que les
    boîtes aux lettres auxquelles l'utilisateur est inscrit.
   </para>

--- a/reference/imap/functions/imap-mail.xml
+++ b/reference/imap/functions/imap-mail.xml
@@ -20,7 +20,7 @@
    <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>return_path</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
   <para>
-   <function>imap_mail</function> permet d'envoyer des mails 
+   <methodname>imap_mail</methodname> permet d'envoyer des mails 
    avec une gestion correcte des destinataires Cc et Bcc.
   </para>
   <para>

--- a/reference/imap/functions/imap-renamemailbox.xml
+++ b/reference/imap/functions/imap-renamemailbox.xml
@@ -15,7 +15,7 @@
    <methodparam><type>string</type><parameter>to</parameter></methodparam>
   </methodsynopsis>
   <para>
-   <function>imap_renamemailbox</function> renomme la boîte aux lettres
+   <methodname>imap_renamemailbox</methodname> renomme la boîte aux lettres
    <parameter>from</parameter> en <parameter>to</parameter>
    (voir la fonction <function>imap_open</function> pour le format des noms
    <parameter>mbox</parameter>).

--- a/reference/imap/functions/imap-uid.xml
+++ b/reference/imap/functions/imap-uid.xml
@@ -14,7 +14,7 @@
    <methodparam><type>int</type><parameter>message_num</parameter></methodparam>
   </methodsynopsis>
   <para>
-   <function>imap_uid</function> retourne l'UID pour le message
+   <methodname>imap_uid</methodname> retourne l'UID pour le message
    <parameter>msgno</parameter>. Un UID est un identifiant unique
    que ne change jamais, alors que le numéro du message dans
    la liste des messages peut changer à toute modification

--- a/reference/imap/functions/imap-utf7-decode.xml
+++ b/reference/imap/functions/imap-utf7-decode.xml
@@ -14,7 +14,7 @@
    <methodparam><type>string</type><parameter>string</parameter></methodparam>
   </methodsynopsis>
   <para>
-   <function>imap_utf7_decode</function> décode la chaîne UTF-7
+   <methodname>imap_utf7_decode</methodname> décode la chaîne UTF-7
    <parameter>string</parameter> en ISO-8859-1.
   </para>
   <para>

--- a/reference/info/functions/get-cfg-var.xml
+++ b/reference/info/functions/get-cfg-var.xml
@@ -19,7 +19,7 @@
    Retourne la valeur de l'option <parameter>option</parameter> de configuration PHP.
   </para>
   <para>
-   <function>get_cfg_var</function> ne retourne pas les options qui
+   <methodname>get_cfg_var</methodname> ne retourne pas les options qui
    ont été choisies lors de la compilation de PHP, ni
    ne lit dans le fichier de configuration d'Apache.
   </para>

--- a/reference/intl/intlchar/charage.xml
+++ b/reference/intl/intlchar/charage.xml
@@ -38,7 +38,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   La version Unicode, sous la forme d'un <type>tableau</type>.
+   La version Unicode, sous la forme d'un <type>array</type>.
    Par exemple, la version <emphasis>1.3.31.2</emphasis> serait représentée par <literal>[1, 3, 31, 2]</literal>.
    Renvoie &null; en cas d'échec.
   </para>

--- a/reference/intl/locale/lookup.xml
+++ b/reference/intl/locale/lookup.xml
@@ -133,7 +133,7 @@ echo locale_lookup($arr, 'de-DE-1996-x-prv1-prv2', true, 'en_US');
    </programlisting>
   </example>
   <example>
-   <title>Exemple avec <function>Locale::lookup</function>, POO</title>
+   <title>Exemple avec <methodname>Locale::lookup</methodname>, POO</title>
    <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/ldap/functions/ldap-rename.xml
+++ b/reference/ldap/functions/ldap-rename.xml
@@ -118,7 +118,7 @@
   &reftitle.notes;
   <note>
    <para>
-    <function>ldap_rename</function> ne fonctionne actuellement qu'avec
+    <methodname>ldap_rename</methodname> ne fonctionne actuellement qu'avec
     LDAPv3. Vous pouvez être obligé d'utiliser <function>ldap_set_option</function>
     avant de vous lier pour pouvoir utiliser LDAPv3. Cette fonction est uniquement
     disponible lorsque vous utilisez OpenLDAP 2.x.x OU

--- a/reference/libxml/functions/libxml-get-last-error.xml
+++ b/reference/libxml/functions/libxml-get-last-error.xml
@@ -16,7 +16,7 @@
    <void/>
   </methodsynopsis>
   <para>
-   <function>libxml_get_last_error</function> lit la dernière erreur libxml.
+   <methodname>libxml_get_last_error</methodname> lit la dernière erreur libxml.
   </para>
  </refsect1>
 
@@ -28,7 +28,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   <function>libxml_get_last_error</function> retourne un objet
+   <methodname>libxml_get_last_error</methodname> retourne un objet
    <type>LibXMLError</type> s'il y a une erreur, et 
    &false; sinon.
   </para>

--- a/reference/openal/functions/openal-buffer-create.xml
+++ b/reference/openal/functions/openal-buffer-create.xml
@@ -23,7 +23,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   <function>openal_buffer_create</function> retourne une ressource
+   <methodname>openal_buffer_create</methodname> retourne une ressource
    <link linkend="openal.resources">Open AL(Buffer)</link> ou &false; en cas d'erreur.
   </simpara>
  </refsect1>

--- a/reference/openal/functions/openal-device-open.xml
+++ b/reference/openal/functions/openal-device-open.xml
@@ -21,7 +21,7 @@
     <term><parameter>device_desc</parameter></term>
     <listitem>
      <simpara>
-      <function>openal_device_open</function> ouvre un périphérique audio
+      <methodname>openal_device_open</methodname> ouvre un périphérique audio
       optionnellement spécifié par le paramètre <parameter>device_desc</parameter>.
       Si le paramètre <parameter>device_desc</parameter> n'est pas spécifié, le
       premier périphérique audio disponible sera utilisé.

--- a/reference/pdo_odbc/reference.xml
+++ b/reference/pdo_odbc/reference.xml
@@ -136,7 +136,7 @@
        <row>
         <entry>8.4.0</entry>
         <entry>
-         Lors du passage d'une <type>chaîne</type> vide à l'argument mot de passe dans le constructeur PDO, <literal>pwd</literal>
+         Lors du passage d'une <type>string</type> vide à l'argument mot de passe dans le constructeur PDO, <literal>pwd</literal>
          n'était pas inclus dans la chaîne de connexion créée jusqu'à présent, mais le comportement a été modifié pour l'inclure
          en tant que chaîne vide. Passer &null; pour l'argument mot de passe dans le constructeur PDO entraîne le même
          comportement qu'auparavant.

--- a/reference/pgsql/functions/pg-field-type-oid.xml
+++ b/reference/pgsql/functions/pg-field-type-oid.xml
@@ -23,7 +23,7 @@
   </para>
   <para>
    Vous pouvez obtenir plus d'informations à propos du type de champ en
-   interrogeant la table système de PostgreSQL <function>pg_type</function> avec
+   interrogeant la table système de PostgreSQL <literal>pg_type</literal> avec
    le OID obtenu par cette fonction.
   </para>
   <note>

--- a/reference/ps/functions/ps-add-launchlink.xml
+++ b/reference/ps/functions/ps-add-launchlink.xml
@@ -21,7 +21,7 @@
    <methodparam><type>string</type><parameter>filename</parameter></methodparam>
   </methodsynopsis>
   <para>
-   <function>ps_add_launchlink</function> place un hyperlien à la position donnée
+   <methodname>ps_add_launchlink</methodname> place un hyperlien à la position donnée
    pointant vers un programme qui sera démarré lors du clic sur celui-ci. 
    La position source de l'hyperlien est un rectangle avec son coin inférieur
    gauche à (<parameter>llx</parameter>, <parameter>lly</parameter>) et son coin haut droit à

--- a/reference/ps/functions/ps-add-locallink.xml
+++ b/reference/ps/functions/ps-add-locallink.xml
@@ -22,7 +22,7 @@
    <methodparam><type>string</type><parameter>dest</parameter></methodparam>
   </methodsynopsis>
   <para>
-   <function>ps_add_locallink</function> place un hyperlien à une position
+   <methodname>ps_add_locallink</methodname> place un hyperlien à une position
    donnée pointant à une page dans le même document. Cliquer sur le lien 
    sautera à la page donnée. La première page dans un document a le numéro 1.
   </para>

--- a/reference/ps/functions/ps-add-note.xml
+++ b/reference/ps/functions/ps-add-note.xml
@@ -24,7 +24,7 @@
    <methodparam><type>int</type><parameter>open</parameter></methodparam>
   </methodsynopsis>
   <para>
-   <function>ps_add_note</function> ajoute une note à une certaine position sur 
+   <methodname>ps_add_note</methodname> ajoute une note à une certaine position sur 
    la page. Les notes sont comme de petites feuilles rectangulaires avec du texte
    par dessus, qui peuvent être placées n'importe où sur une page. Elles sont
    affichées, soit pliées ou dépliées. Si elles sont pliées, l'icône spécifiée

--- a/reference/ps/functions/ps-begin-template.xml
+++ b/reference/ps/functions/ps-begin-template.xml
@@ -18,7 +18,7 @@
    <methodparam><type>float</type><parameter>height</parameter></methodparam>
   </methodsynopsis>
   <para>
-   <function>ps_begin_template</function> démarre un nouveau modèle. 
+   <methodname>ps_begin_template</methodname> démarre un nouveau modèle. 
    Un modèle est appelé par un formulaire dans le langage PostScript. 
    Il est créé de la même manière qu'un motif, mais est
    utilisé comme une image. Les modèles sont souvent utilisés pour les dessins

--- a/reference/ps/functions/ps-curveto.xml
+++ b/reference/ps/functions/ps-curveto.xml
@@ -22,7 +22,7 @@
    <methodparam><type>float</type><parameter>y3</parameter></methodparam>
   </methodsynopsis>
   <para>
-   <function>ps_curveto</function> ajoute une section d'une courbe Bézier
+   <methodname>ps_curveto</methodname> ajoute une section d'une courbe Bézier
    cubique décrit par les trois points de contrôle donnés au chemin courant.
   </para>
  </refsect1>

--- a/reference/ps/functions/ps-set-info.xml
+++ b/reference/ps/functions/ps-set-info.xml
@@ -18,7 +18,7 @@
    <methodparam><type>string</type><parameter>val</parameter></methodparam>
   </methodsynopsis>
   <para>
-   <function>ps_set_info</function> fixe certains champs d'informations du document.
+   <methodname>ps_set_info</methodname> fixe certains champs d'informations du document.
    Les champs seront montrés en tant que commentaire dans l'en-tête du fichier
    PostScript. Si le document est converti en PDF, ces champs seront aussi
    utilisés pour les informations du document.

--- a/reference/ps/functions/ps-string-geometry.xml
+++ b/reference/ps/functions/ps-string-geometry.xml
@@ -19,7 +19,7 @@
    <methodparam choice="opt"><type>float</type><parameter>size</parameter><initializer>0.0</initializer></methodparam>
   </methodsynopsis>
   <para>
-   <function>ps_string_geometry</function> est similaire à 
+   <methodname>ps_string_geometry</methodname> est similaire à 
    <function>ps_stringwidth</function>, mais retourne un tableau
    des dimensions contenant la largeur, la hampe et le
    jambage du texte.

--- a/reference/readline/functions/readline-info.xml
+++ b/reference/readline/functions/readline-info.xml
@@ -45,7 +45,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   Appelée sans paramètre, <function>readline_info</function>
+   Appelée sans paramètre, <methodname>readline_info</methodname>
    retourne une tableau contenant les valeurs des paramètres de
    Readline. Les éléments seront indexés par les clés suivantes :
    <literal>"done"</literal>, <literal>"end"</literal>,

--- a/reference/spl/runtimeexception.xml
+++ b/reference/spl/runtimeexception.xml
@@ -3,7 +3,7 @@
 <!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: yannick Status: ready -->
 <!-- Reviewed: yes -->
 <reference xml:id="class.runtimeexception" role="exception" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
- <title>&class.theclass; <classname>RuntimeException</classname></title>
+ <title>&class.theclass; <exceptionname>RuntimeException</exceptionname></title>
  <titleabbrev>RuntimeException</titleabbrev>
  
  <partintro>

--- a/reference/spl/underflowexception.xml
+++ b/reference/spl/underflowexception.xml
@@ -2,7 +2,7 @@
 <!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: yannick Status: ready -->
 <!-- Reviewed: yes -->
 <reference xml:id="class.underflowexception" role="exception" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
- <title>&class.theclass; <classname>UnderflowException</classname></title>
+ <title>&class.theclass; <exceptionname>UnderflowException</exceptionname></title>
  <titleabbrev>UnderflowException</titleabbrev>
  
  <partintro>

--- a/reference/stream/functions/stream-context-set-option.xml
+++ b/reference/stream/functions/stream-context-set-option.xml
@@ -28,7 +28,7 @@
    </methodsynopsis>
   </para>
   <simpara>
-   <function>stream_context_set_option</function> définit une option
+   <methodname>stream_context_set_option</methodname> définit une option
    pour le contexte spécifié. La valeur <parameter>value</parameter>
    est définie pour l'<parameter>option</parameter> pour le contexte
    <parameter>wrapper</parameter>.

--- a/reference/stream/functions/stream-context-set-params.xml
+++ b/reference/stream/functions/stream-context-set-params.xml
@@ -17,7 +17,7 @@
    <methodparam><type>array</type><parameter>params</parameter></methodparam>
   </methodsynopsis>
   <para>
-   <function>stream_context_set_params</function> définit 
+   <methodname>stream_context_set_params</methodname> définit 
    les paramètres pour le contexte spécifié.
   </para>
  </refsect1>

--- a/reference/stream/functions/stream-filter-remove.xml
+++ b/reference/stream/functions/stream-filter-remove.xml
@@ -15,7 +15,7 @@
    <methodparam><type>resource</type><parameter>stream_filter</parameter></methodparam>
   </methodsynopsis>
   <para>
-   <function>stream_filter_remove</function> retire un filtre d'un flux,
+   <methodname>stream_filter_remove</methodname> retire un filtre d'un flux,
    précédemment ajouté avec <function>stream_filter_prepend</function> ou
    <function>stream_filter_append</function>. Toutes les données qui restent
    dans les buffer internes seront traitées par le filtre,

--- a/reference/stream/functions/stream-get-line.xml
+++ b/reference/stream/functions/stream-get-line.xml
@@ -16,7 +16,7 @@
    <methodparam choice="opt"><type>string</type><parameter>ending</parameter><initializer>""</initializer></methodparam>
   </methodsynopsis>
   <para>
-   <function>stream_get_line</function> lit une ligne dans la ressource
+   <methodname>stream_get_line</methodname> lit une ligne dans la ressource
    <parameter>handle</parameter>.
   </para>
   <para>
@@ -74,7 +74,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   <function>stream_get_line</function> lit une ligne de taille maximale
+   <methodname>stream_get_line</methodname> lit une ligne de taille maximale
    <parameter>length</parameter> dans le flux <parameter>stream</parameter>&return.falseforfailure;.
   </para>
  </refsect1>

--- a/reference/stream/functions/stream-set-blocking.xml
+++ b/reference/stream/functions/stream-set-blocking.xml
@@ -15,7 +15,7 @@
    <methodparam><type>bool</type><parameter>enable</parameter></methodparam>
   </methodsynopsis>
   <para>
-   <function>stream_set_blocking</function> configure le mode bloquant
+   <methodname>stream_set_blocking</methodname> configure le mode bloquant
    du flux <parameter>stream</parameter>.
   </para>
   <para>

--- a/reference/stream/functions/stream-socket-get-name.xml
+++ b/reference/stream/functions/stream-socket-get-name.xml
@@ -15,7 +15,7 @@
    <methodparam><type>bool</type><parameter>remote</parameter></methodparam>
   </methodsynopsis>
   <para>
-   <function>stream_socket_get_name</function> retourne le nom du socket
+   <methodname>stream_socket_get_name</methodname> retourne le nom du socket
    local ou distant pour la connexion <parameter>socket</parameter>.
   </para>
  </refsect1>

--- a/reference/stream/functions/stream-socket-server.xml
+++ b/reference/stream/functions/stream-socket-server.xml
@@ -18,11 +18,11 @@
    <methodparam choice="opt"><type class="union"><type>resource</type><type>null</type></type><parameter>context</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
   <para>
-   <function>stream_socket_server</function> crée un flux ou un datagramme
+   <methodname>stream_socket_server</methodname> crée un flux ou un datagramme
    sur le socket spécifié <parameter>address</parameter>. 
   </para>
   <para>
-   <function>stream_socket_server</function> ne fait que créer un socket
+   <methodname>stream_socket_server</methodname> ne fait que créer un socket
    et, pour accepter des connexions, vous devez utiliser
    <function>stream_socket_accept</function>.
   </para>
@@ -142,7 +142,7 @@
   &reftitle.examples;
   <para>
    <example>
-    <title>Exemple avec <function>stream_socket_server</function></title>
+    <title>Exemple avec <methodname>stream_socket_server</methodname></title>
     <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/strings/functions/hebrevc.xml
+++ b/reference/strings/functions/hebrevc.xml
@@ -20,7 +20,7 @@
    <methodparam choice="opt"><type>int</type><parameter>max_chars_per_line</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
   <para>
-   <function>hebrevc</function> est similaire à <function>hebrev</function>
+   <methodname>hebrevc</methodname> est similaire à <function>hebrev</function>
    à la différence qu'elle convertit les nouvelles lignes (\n) en
    <literal>"&lt;br&gt;\n"</literal>.
   </para>

--- a/reference/strings/functions/money-format.xml
+++ b/reference/strings/functions/money-format.xml
@@ -332,7 +332,7 @@ echo money_format($fmt, 1234.56) . "\n";
   <note>
    <para>
     La fonction <function>money_format</function> est uniquement définie si
-    le système a les capacités <literal>strfmon</literal>. Par exemple, Windows
+    le système a les capacités <function>strfmon</function>. Par exemple, Windows
     ne les a pas, donc, <function>money_format</function> n'est pas définie
     sous Windows.
    </para>

--- a/reference/strings/functions/print.xml
+++ b/reference/strings/functions/print.xml
@@ -23,7 +23,7 @@
    et n'est pas délimité par des parenthèses.
   </para>
   <para>
-   La différence majeure avec <literal>echo</literal> est que
+   La différence majeure avec <function>echo</function> est que
    <literal>print</literal> n'accepte qu'un seul argument et retourne toujours 1.
   </para>
  </refsect1>

--- a/reference/tcpwrap/functions/tcpwrap-check.xml
+++ b/reference/tcpwrap/functions/tcpwrap-check.xml
@@ -18,7 +18,7 @@
    <methodparam choice="opt"><type>bool</type><parameter>nodns</parameter><initializer>&false;</initializer></methodparam>
   </methodsynopsis>
   <para>
-   <function>tcpwrap_check</function> consulte les fichiers <filename>/etc/hosts.allow</filename>
+   <methodname>tcpwrap_check</methodname> consulte les fichiers <filename>/etc/hosts.allow</filename>
    et <filename>/etc/hosts.deny</filename> pour vérifier si l'accès au service
    <parameter>daemon</parameter> est permis ou pas pour un client.
   </para>

--- a/reference/tidy/tidy/gethtmlver.xml
+++ b/reference/tidy/tidy/gethtmlver.xml
@@ -50,7 +50,7 @@
   </para>
   <warning>
    <para>
-    <function>tidy_get_html_ver</function> n'est pas encore implémentée
+    <methodname>tidy_get_html_ver</methodname> n'est pas encore implémentée
     dans la bibliothèque Tidylib elle-même ; de ce fait, elle retournera toujours
     &zero;.
    </para>

--- a/reference/tidy/tidy/isxml.xml
+++ b/reference/tidy/tidy/isxml.xml
@@ -22,7 +22,7 @@
    <methodparam><type>tidy</type><parameter>tidy</parameter></methodparam>
   </methodsynopsis>
   <para>
-   <function>tidy_is_xml</function> retourne &true; si l'objet
+   <methodname>tidy_is_xml</methodname> retourne &true; si l'objet
    <parameter>object</parameter> Tidy est un document XML générique
    (non HTML/XHTML) ou &false; sinon.
   </para>


### PR DESCRIPTION
## Summary
Fix inline XML tag name mismatches between FR and EN across 66 files.

### Changes by type
- **function → methodname** (~40 files): EN changed `<function>` to `<methodname>` for procedural function names
- **classname → interfacename** (1 file): `DateTimeInterface`
- **classname → exceptionname** (2 files): `RuntimeException`, `UnderflowException`
- **literal ↔ function/constant** (4 files): tag name corrections
- **French type → English** (3 files): `objet→object`, `tableau→array`, `chaîne→string`

### Affected extensions
bzip2, calendar, componere, datetime, dbase, dir, ibm_db2, image, imap, info, intl, ldap, libxml, openal, pdo_odbc, pgsql, ps, readline, spl, stream, strings, tcpwrap, tidy