### PR TITLE
fix: correction de ~157 fautes de français dans 123 fichiers

### DIFF
--- a/appendices/migration71/new-features.xml
+++ b/appendices/migration71/new-features.xml
@@ -171,7 +171,7 @@ class ConstDemo
   <title>Le pseudo-type <type>iterable</type></title>
 
   <para>
-   Un nouveau pseudo-type (similaire à <type>callable</type>) appellé
+   Un nouveau pseudo-type (similaire à <type>callable</type>) appelé
    <type>iterable</type> a été introduit. Il peut être utilisé avec les
    paramètres et retours typés, où il accepte soit des &array; soit des
    objets qui implémentent l'interface <classname>Traversable</classname>.
@@ -365,7 +365,7 @@ string(10) "some value"
   <title>Gestion des signaux asynchrones</title>
 
   <para>
-   Une nouvelle fonction appellée <function>pcntl_async_signals</function>
+   Une nouvelle fonction appelée <function>pcntl_async_signals</function>
    a été introduite pour permettre la gestion des signaux asynchrones sans
    utiliser les ticks (ce qui introduisait beaucoup de surcoût).
   </para>

--- a/appendices/migration73/incompatible.xml
+++ b/appendices/migration73/incompatible.xml
@@ -74,7 +74,7 @@ while ($foo) {
     <literal>$obj</literal> implémente <classname>ArrayAccess</classname> et
     <literal>"123"</literal> est une &string; d'&integer; litérale ne
     résulteront plus en une conversion implicite en &integer;, c.à.d.,
-    <literal>$obj->offsetGet("123")</literal> sera appellé au lieu de
+    <literal>$obj->offsetGet("123")</literal> sera appelé au lieu de
     <literal>$obj->offsetGet(123)</literal>. Ceci correspond au comportement
     pour les non litérales. Le comportement des &array; n'est pas affecté
     d'une quelconque manière, ils continuent de convertir implicitement

--- a/appendices/migration81/deprecated.xml
+++ b/appendices/migration81/deprecated.xml
@@ -198,7 +198,7 @@ $arr[] = 2;
   <title>GD</title>
 
   <para>
-   Le parametre <parameter>num_points</parameter> de <function>imagepolygon</function>,
+   Le paramètre <parameter>num_points</parameter> de <function>imagepolygon</function>,
    <function>imageopenpolygon</function> et <function>imagefilledpolygon</function>
    a été déprécié.
   </para>

--- a/appendices/migration81/new-features.xml
+++ b/appendices/migration81/new-features.xml
@@ -285,7 +285,7 @@ echo $h, "\n";
      </programlisting>
     </informalexample>
 
-    Un valeur de graine valide est dans la plage de <literal>0</literal>
+    Une valeur de graine valide est dans la plage de <literal>0</literal>
     à la <constant>UINT_MAX</constant> définie par la plateforme, généralement
     <literal>4294967295</literal>.
    </para>

--- a/appendices/migration83/incompatible.xml
+++ b/appendices/migration83/incompatible.xml
@@ -37,7 +37,7 @@
   <sect3 xml:id="migration83.incompatible.core.zend-max-execution-timers">
    <title>Minuteries d'exécution maximales de Zend</title>
    <para>
-    Les minuteries d'exécution maximales de Zend sont maintenant activées par défault pour les versions ZTS sur
+    Les minuteries d'exécution maximales de Zend sont maintenant activées par défaut pour les versions ZTS sur
     Linux.
    </para>
   </sect3>

--- a/appendices/migration84/new-functions.xml
+++ b/appendices/migration84/new-functions.xml
@@ -2,7 +2,7 @@
 <!-- EN-Revision: ceeec43d340a7f0e0910d7eeeb0850af72ab34d9 Maintainer: Fan2Shrek Status: ready -->
 <!-- Reviewed: yes -->
 <sect1 xml:id="migration84.new-functions">
- <title>Nouvelle fonctions</title>
+ <title>Nouvelles fonctions</title>
 
  <sect2 xml:id="migration84.new-functions.core">
   <title>Core</title>

--- a/appendices/migration85/new-features.xml
+++ b/appendices/migration85/new-features.xml
@@ -2,7 +2,7 @@
 <!-- EN-Revision: ce397343296708654c8cdac774e23a9ee47ab27d Maintainer: Fan2Shrek Status: ready -->
 <!-- Reviewed: yes -->
 <sect1 xml:id="migration85.new-features" xmlns:xlink="http://www.w3.org/1999/xlink">
- <title>Nouvelle fonctionnalités</title>
+ <title>Nouvelles fonctionnalités</title>
 
  <sect2 xml:id="migration85.new-features.core">
   <title>PHP Core</title>

--- a/install/unix/apache2.xml
+++ b/install/unix/apache2.xml
@@ -221,7 +221,7 @@ LoadModule php7_module modules/libphp5.so
     <literal>.php</literal>.
     Au lieu d'utiliser seulement la directive <literal>AddType</literal> d'Apache,
     nous souhaitons éviter tout risque potentiellement dangereux, lors
-    d'un téléchargement de de la création de fichier comme <filename>exploit.php.jpg</filename>,
+    d'un téléchargement de la création de fichier comme <filename>exploit.php.jpg</filename>,
     d'exécution PHP. En utilisant cette exemple, vous pouvez avoir n'importe
     quelle extension d'analyser par PHP. Nous avons ajouté <literal>.php</literal> pour l'exemple.
    </para>

--- a/language/basic-syntax.xml
+++ b/language/basic-syntax.xml
@@ -130,7 +130,7 @@ echo "Dernière instruction\n";
     </programlisting>
    </example>
    Dans cet exemple, PHP va ignorer les blocs où la condition n'est pas remplie,
-   même si ils sont en dehors des balises ouvrantes/fermantes de PHP. PHP
+   même s'ils sont en dehors des balises ouvrantes/fermantes de PHP. PHP
    va les ignorer suivant la condition vu que l'interpréteur PHP va passer
    les blocs contenant ce qui n'est pas remplie par la condition.
   </para>

--- a/language/namespaces.xml
+++ b/language/namespaces.xml
@@ -357,7 +357,7 @@ echo MonProjet\Connexion::start();
       <literal>sousespacedenoms\foo::methodestatique();</literal>. Si l'espace de noms courant
       est <literal>espacedenomscourant</literal>, cela devient 
       <literal>espacedenomscourant\sousespacedenoms\foo</literal>. Si
-      le code est global, c'est à dire l'espace de noms sans nom, 
+      le code est global, c'est-à-dire l'espace de noms sans nom,
       cela devient <literal>sousespacedenoms\foo</literal>.
      </simpara>
     </listitem>
@@ -1301,7 +1301,7 @@ $a = \INI_ALL; // $a reçoit la valeur de la constante "INI_ALL"
   <sect2 xml:id="language.namespaces.faq.qualified">
    <title>Comment est-ce qu'un nom tel que <literal>mon\nom</literal> est résolu ?</title>
    <para>
-    Les noms qui contiennent un antislash mais ne commencent par par un
+    Les noms qui contiennent un antislash mais ne commencent par un
     antislash, comme <literal>mon\nom</literal> peuvent être résolus de deux manières
     différentes.
    </para>

--- a/language/predefined/variables/server.xml
+++ b/language/predefined/variables/server.xml
@@ -150,7 +150,7 @@
       </simpara>
       <note>
        <para>
-        Le script PHP se termine après avoir envoyé les en-têtes (c'est à dire après
+        Le script PHP se termine après avoir envoyé les en-têtes (c'est-à-dire après
         avoir produit n'importe quelle sortie sans bufferisation de sortie) si
         la méthode de la requête était <literal>HEAD</literal>.
        </para>

--- a/language/references.xml
+++ b/language/references.xml
@@ -247,7 +247,7 @@ $arr2[0]++;
    <para>
     Le deuxième intérêt des références est de
     permettre de passer des variables par référence. On réalise ceci en faisant
-    référencer le même contenu par une variable locale à un fonction et par une
+    référencer le même contenu par une variable locale à une fonction et par une
     variable du contexte appelant.
     Par exemple :
     <informalexample>

--- a/language/types/array.xml
+++ b/language/types/array.xml
@@ -275,7 +275,7 @@ array(4) {
     </screen>
     <para>
      Comme vous pouvez le voir, la dernière valeur <literal>"d"</literal>
-     a été assignée à la clé <literal>7</literal>. Ceci est du au fait que
+     a été assignée à la clé <literal>7</literal>. Ceci est dû au fait que
      la dernière clé entière la plus grande utilisé auparavant était <literal>6</literal>.
     </para>
    </example>

--- a/language/types/type-juggling.xml
+++ b/language/types/type-juggling.xml
@@ -174,14 +174,14 @@
     <listitem>
      <simpara>
       Type de déclaration <type>int</type> : valeur est interprétée comme <type>int</type>
-      si la conversion est bien-définie. Par exemple le chaîne est
+      si la conversion est bien-définie. Par exemple la chaîne est
       <link linkend="language.types.numeric-strings">numérique</link>.
      </simpara>
     </listitem>
     <listitem>
      <simpara>
       Type de déclaration <type>float</type> : valeur est interprétée comme <type>float</type>
-      si la conversion est bien-définie. Par exemple le chaîne est
+      si la conversion est bien-définie. Par exemple la chaîne est
       <link linkend="language.types.numeric-strings">numérique</link>.
      </simpara>
     </listitem>

--- a/reference/apcu/ini.xml
+++ b/reference/apcu/ini.xml
@@ -214,9 +214,9 @@
      n'ont pas été consultées depuis autant de secondes. En effet, cela permet à ces
      entrées d'être opportunément supprimées lors d'une insertion dans le cache,
      ou avant une suppression complète. Notez que parce que la suppression est
-     opportuniste, les entrées peuvent toujours être lisibles même si si elles sont
+     opportuniste, les entrées peuvent toujours être lisibles même si elles sont
      plus anciennes que <literal>apc.ttl</literal> secondes. Ce paramètre n'a aucun
-     effet sur les entrées de cache pour lesquelles un un TTL explicite est spécifié.
+     effet sur les entrées de cache pour lesquelles un TTL explicite est spécifié.
     </simpara>
    </listitem>
   </varlistentry>

--- a/reference/array/functions/array-merge-recursive.xml
+++ b/reference/array/functions/array-merge-recursive.xml
@@ -53,7 +53,7 @@
   &reftitle.returnvalues;
   <para>
    Un tableau de valeurs résultantes de la fusion des arguments.
-   Si appellé sans arguments, retourne un &array; vide.
+   Si appelé sans arguments, retourne un &array; vide.
   </para>
  </refsect1>
 

--- a/reference/array/functions/array-merge.xml
+++ b/reference/array/functions/array-merge.xml
@@ -51,7 +51,7 @@
   &reftitle.returnvalues;
   <para>
    Retourne le tableau résultant.
-   Si appellé sans arguments, retourne un &array; vide.
+   Si appelé sans arguments, retourne un &array; vide.
   </para>
  </refsect1>
 

--- a/reference/array/functions/array-slice.xml
+++ b/reference/array/functions/array-slice.xml
@@ -73,7 +73,7 @@
        la séquence exclura autant d'éléments de la fin du &array;.
       </para>
       <para>
-       Si il est omis, la séquence aura tout
+       S'il est omis, la séquence aura tout
        depuis la position <parameter>offset</parameter> jusqu'à la fin de
        <parameter>array</parameter>.
       </para>

--- a/reference/cmark/commonmark/cql/invoke.xml
+++ b/reference/cmark/commonmark/cql/invoke.xml
@@ -41,9 +41,9 @@
        <methodparam><type>CommonMark\Node</type><parameter>entering</parameter></methodparam>
       </methodsynopsis>
       <simplelist>
-       <member>Si <parameter>handler</parameter> ne retourne pas (void), ou retourne <type>null</type>, le CQL continuera de s'éxécuter</member>
-       <member>Si le gestionaire retourne une valeur vraie, le CQL continuera de s'éxécuter</member>
-       <member>Si le gestionaire retourne une valeur fausse, le CQL s'arrêtera</member>
+       <member>Si <parameter>handler</parameter> ne retourne pas (void), ou retourne <type>null</type>, le CQL continuera de s'exécuter</member>
+       <member>Si le gestionnaire retourne une valeur vraie, le CQL continuera de s'exécuter</member>
+       <member>Si le gestionnaire retourne une valeur fausse, le CQL s'arrêtera</member>
       </simplelist>
      </para>
     </listitem>

--- a/reference/cubrid/functions/cubrid-get-autocommit.xml
+++ b/reference/cubrid/functions/cubrid-get-autocommit.xml
@@ -20,7 +20,7 @@
    à la base de données CUBRID.
   </simpara>
   <simpara>
-   En CUBRID 8.4.0, le mode auto-commit est désactivé par défault pour la
+   En CUBRID 8.4.0, le mode auto-commit est désactivé par défaut pour la
    gestion des transactions.
   </simpara>
   <simpara>

--- a/reference/curl/constants_curl_error.xml
+++ b/reference/curl/constants_curl_error.xml
@@ -680,7 +680,7 @@
   </term>
   <listitem>
    <simpara>
-    Probleme avec le client de certificat local.
+    Problème avec le client de certificat local.
    </simpara>
   </listitem>
  </varlistentry>

--- a/reference/curl/constants_curl_setopt.xml
+++ b/reference/curl/constants_curl_setopt.xml
@@ -1705,7 +1705,7 @@
      Pour une limite de taille supérieure à <literal>2GB</literal>,
      <constant>CURLOPT_MAXFILESIZE_LARGE</constant> doit être utilisé.
      à partir de cURL 8.4.0, cette option arrête également les transferts en cours
-     si ils atteignent ce seuil.
+     s'ils atteignent ce seuil.
      Cette option accepte n'importe quelle valeur qui peut être convertie en un <type>int</type> valide.
      Par défaut à <literal>0</literal>.
      Disponible à partir de cURL 7.10.8.
@@ -3646,7 +3646,7 @@
    </term>
    <listitem>
     <para>
-     Un liste de courbes elliptiques délimitées par des deux-points. Par exemple,
+     Une liste de courbes elliptiques délimitées par des deux-points. Par exemple,
      <literal>X25519:P-521</literal> est une liste de deux courbes elliptiques valides.
      Cette option définit les algorithmes d'échange de clés du client dans la poignée de main SSL,
      si le backend SSL cURL est compilé pour l'utiliser.

--- a/reference/datetime/formats.xml
+++ b/reference/datetime/formats.xml
@@ -1170,7 +1170,7 @@ object(DateTimeImmutable)#1 (3) {
    <para>
     Les valeurs relatives des mois calculés sont basées sur le nombre de jours des mois que 
     l'on utilise. Par exemple, "+2 month 2011-11-30", donnera comme résultat la date "2012-01-30".
-    Ceci est du au fait que le mois de novembre comporte 30 jours, et 
+    Ceci est dû au fait que le mois de novembre comporte 30 jours, et
     que le mois de décembre en comporte 31, soit un ajout total de 61 jours.
    </para>
   </note>

--- a/reference/datetime/functions/date-sun-info.xml
+++ b/reference/datetime/functions/date-sun-info.xml
@@ -141,7 +141,7 @@
    Les valeurs des éléments du tableau sont soit des
    timestamps UNIX, &false;, si le soleil est sous le zenith
    respectif pour la journée entière, ou &true;, si le soleil
-   est au dessus du zenith respectif pour toute la journée.
+   est au-dessus du zenith respectif pour toute la journée.
   </para>
  </refsect1>
 

--- a/reference/dbase/functions/dbase-create.xml
+++ b/reference/dbase/functions/dbase-create.xml
@@ -20,7 +20,7 @@
    <function>dbase_create</function> crée une base de 
    données dBase avec la définition fournit.
    Si le fichier existe déjà, il n'est pas tronqué.
-   <function>dbase_pack</function> peut être appellé pour forcer une troncature.
+   <function>dbase_pack</function> peut être appelé pour forcer une troncature.
   </para>
   &note.open-basedir.func;
  </refsect1>

--- a/reference/dom/domtext.xml
+++ b/reference/dom/domtext.xml
@@ -87,7 +87,7 @@
      <listitem>
       <para>
        Contient tout le texte des nœuds de texte adjacents
-       (c'est à dire, des nœuds qui ne sont pas séparés par 
+       (c'est-à-dire, des nœuds qui ne sont pas séparés par
        des balises Element, Comment ou Processing Instruction).
       </para>
      </listitem>

--- a/reference/ev/evfork/createstopped.xml
+++ b/reference/ev/evfork/createstopped.xml
@@ -4,7 +4,7 @@
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="evfork.createstopped">
  <refnamediv>
   <refname>EvFork::createStopped</refname>
-  <refpurpose>Crée un instance arrêté de la classe de l'observateur EvFork</refpurpose>
+  <refpurpose>Crée une instance arrêtée de la classe de l'observateur EvFork</refpurpose>
  </refnamediv>
  <refsect1 role="description">
   &reftitle.description;

--- a/reference/exec/functions/proc-close.xml
+++ b/reference/exec/functions/proc-close.xml
@@ -24,7 +24,7 @@
    <function>proc_close</function> attend que le processus 
    <parameter>process</parameter> se termine, puis retourne son code de sortie.
    Les pipes ouverts avec ce processus sont fermés quand cette fonction est
-   appellée pour éviter des verrouillages : le processus peut ne pas pouvoir
+   appelée pour éviter des verrouillages : le processus peut ne pas pouvoir
    sortir tant que les pipes sont ouverts.
   </para>
  </refsect1>

--- a/reference/filesystem/functions/fdatasync.xml
+++ b/reference/filesystem/functions/fdatasync.xml
@@ -15,7 +15,7 @@
   <para>
    Cette fonction synchronise le contenu du <parameter>stream</parameter> sur le support de stockage, tout comme <function>fsync</function> le fait,
    mais elle ne synchronise pas les métadonnées des fichiers.
-   Il est à noter que que cette fonction est différente seulement dans les systèmes POSIX.
+   Il est à noter que cette fonction est différente seulement dans les systèmes POSIX.
    Sous Windows, cette fonction est un alias de <function>fsync</function>.
   </para>
  </refsect1>

--- a/reference/filesystem/functions/stat.xml
+++ b/reference/filesystem/functions/stat.xml
@@ -153,7 +153,7 @@
   <para>
    ***** Sous Windows, le bit de la permission d'écriture est définit en
    fonction de l'attribut lecture seule du fichier, et la même valeur est
-   rapporté pour tout les utilisateurs, groupe, et propriétaire.
+   rapporté pour tous les utilisateurs, groupe, et propriétaire.
    L'ACL n'est pas pris en compte, contrairement à <function>is_writable</function>.
   </para>
   <para>

--- a/reference/gearman/constants.xml
+++ b/reference/gearman/constants.xml
@@ -18,7 +18,7 @@
    </term>
    <listitem>
     <simpara>
-     Quelque soit l'action entreprise, elle a été couronnée de succès.
+     Quelle que soit l'action entreprise, elle a été couronnée de succès.
     </simpara>
    </listitem>
   </varlistentry>

--- a/reference/gearman/gearmanworker/echo.xml
+++ b/reference/gearman/gearmanworker/echo.xml
@@ -16,7 +16,7 @@
   </methodsynopsis>
   <simpara>
    Envoie les données à tous les serveurs de travaux pour vérifier
-   si ils les retournent. C'est une fonction de test pour vérifier
+   s'ils les retournent. C'est une fonction de test pour vérifier
    si les serveurs de travaux répondent correctement.
   </simpara>
  </refsect1>

--- a/reference/geoip/functions/geoip-db-avail.xml
+++ b/reference/geoip/functions/geoip-db-avail.xml
@@ -32,7 +32,7 @@
     <term><parameter>database</parameter></term>
     <listitem>
      <simpara>
-      Le type de de base de données, sous la forme d'un &integer;.
+      Le type de base de données, sous la forme d'un &integer;.
       Vous pouvez utiliser diverses <link linkend="geoip.constants">constantes</link>,
       définies avec cette extension (ie: GEOIP_*_EDITION).
      </simpara>

--- a/reference/gmagick/gmagick/raiseimage.xml
+++ b/reference/gmagick/gmagick/raiseimage.xml
@@ -5,7 +5,7 @@
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="gmagick.raiseimage">
  <refnamediv>
   <refname>Gmagick::raiseimage</refname>
-  <refpurpose>Crée un un bouton avec un effet 3D</refpurpose>
+  <refpurpose>Crée un bouton avec un effet 3D</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/gmagick/gmagickpixel/setcolorvalue.xml
+++ b/reference/gmagick/gmagickpixel/setcolorvalue.xml
@@ -16,7 +16,7 @@
    <methodparam><type>float</type><parameter>value</parameter></methodparam>
   </methodsynopsis>
   <simpara>
-   Définit la valeur du canal spécifié de cette objet à une valeur fournie,
+   Définit la valeur du canal spécifié de cet objet à une valeur fournie,
    qui doit être entre 0 et 1. Cette fonction peut être utilisée pour
    fournir un canal d'opacité à l'objet <classname>GmagickPixel</classname>.
   </simpara>

--- a/reference/hash/functions/hash-hmac-algos.xml
+++ b/reference/hash/functions/hash-hmac-algos.xml
@@ -25,7 +25,7 @@
  <refsect1 role="returnvalues"><!-- {{{ -->
   &reftitle.returnvalues;
   <para>
-   Retourne un tableau indexé numériquement contenant la liste de tout les
+   Retourne un tableau indexé numériquement contenant la liste de tous les
    algorithmes de hachage disponible qui sont adaptés pour <function>hash_hmac</function>.
   </para>
  </refsect1><!-- }}} -->

--- a/reference/ibm_db2/functions/db2-commit.xml
+++ b/reference/ibm_db2/functions/db2-commit.xml
@@ -17,7 +17,7 @@
   </methodsynopsis>
 
   <simpara>
-   Envoie une une requête en cours sur la ressource de connexion spécifiée et
+   Envoie une requête en cours sur la ressource de connexion spécifiée et
    commence une nouvelle transaction. Les applications PHP ont normalement
    pour valeur par défaut AUTOCOMMIT d'activé, alors
    <function>db2_commit</function> n'est pas nécessaire tant que AUTOCOMMIT

--- a/reference/ibm_db2/functions/db2-connect.xml
+++ b/reference/ibm_db2/functions/db2-connect.xml
@@ -360,7 +360,7 @@ db2set DB2COMM=TCPIP</literallayout>
           est utilisé.
          </simpara>
          <simpara>
-          <literal>DB2_I5_FMT_JOB</literal> : le valeur par défaut est utilisée.
+          <literal>DB2_I5_FMT_JOB</literal> : la valeur par défaut est utilisée.
          </simpara>
         </listitem>
        </varlistentry>

--- a/reference/image/book.xml
+++ b/reference/image/book.xml
@@ -51,7 +51,7 @@
    </note>
    <caution>
     <simpara>
-     Tandis que la version empaqueter de librairie GD utilise le gestionaire de
+     Tandis que la version empaqueter de librairie GD utilise le gestionnaire de
      mémoire Zend pour alouer de la mémoire, mais les versions système non, donc 
      <link linkend="ini.memory-limit">memory_limit</link> ne s'applique pas.
     </simpara>

--- a/reference/image/functions/imagegetclip.xml
+++ b/reference/image/functions/imagegetclip.xml
@@ -16,7 +16,7 @@
   </methodsynopsis>
   <para>
    <function>imagegetclip</function> récupère le rectangle de coupure actuel,
-   c'est à dire la zone au-delà de laquelle aucun pixel ne sera dessiné.
+   c'est-à-dire la zone au-delà de laquelle aucun pixel ne sera dessiné.
   </para>
  </refsect1><!-- }}} -->
 

--- a/reference/image/functions/imagesetclip.xml
+++ b/reference/image/functions/imagesetclip.xml
@@ -20,7 +20,7 @@
   </methodsynopsis>
   <para>
    <function>imagesetclip</function> définit le rectangle de coupure actuel,
-   c'est à dire la zone au-delà de laquelle aucun pixel ne sera dessiné.
+   c'est-à-dire la zone au-delà de laquelle aucun pixel ne sera dessiné.
   </para>
  </refsect1><!-- }}} -->
 

--- a/reference/imap/functions/imap-mail-compose.xml
+++ b/reference/imap/functions/imap-mail-compose.xml
@@ -66,7 +66,7 @@
            <entry><type>int</type></entry>
            <entry>
             Le type MIME.
-            Un de <constant>TYPETEXT</constant> (par défault), <constant>TYPEMULTIPART</constant>,
+            Un de <constant>TYPETEXT</constant> (par défaut), <constant>TYPEMULTIPART</constant>,
             <constant>TYPEMESSAGE</constant>, <constant>TYPEAPPLICATION</constant>,
             <constant>TYPEAUDIO</constant>, <constant>TYPEIMAGE</constant>,
             <constant>TYPEMODEL</constant> ou <constant>TYPEOTHER</constant>.
@@ -77,7 +77,7 @@
            <entry><type>int</type></entry>
            <entry>
             Le <literal>Content-Transfer-Encoding</literal>.
-            Un de <constant>ENC7BIT</constant> (par défault), <constant>ENC8BIT</constant>,
+            Un de <constant>ENC7BIT</constant> (par défaut), <constant>ENC8BIT</constant>,
             <constant>ENCBINARY</constant>, <constant>ENCBASE64</constant>,
             <constant>ENCQUOTEDPRINTABLE</constant> or <constant>ENCOTHER</constant>.
            </entry>

--- a/reference/info/functions/assert-options.xml
+++ b/reference/info/functions/assert-options.xml
@@ -126,7 +126,7 @@
          <term><parameter>file</parameter></term>
          <listitem>
           <simpara>
-           Le fichier <function>assert</function> a été appellé.
+           Le fichier <function>assert</function> a été appelé.
           </simpara>
          </listitem>
         </varlistentry>
@@ -134,7 +134,7 @@
          <term><parameter>line</parameter></term>
          <listitem>
           <simpara>
-           La ligne où <function>assert</function> a été appellé.
+           La ligne où <function>assert</function> a été appelé.
           </simpara>
          </listitem>
         </varlistentry>

--- a/reference/info/functions/gc-mem-caches.xml
+++ b/reference/info/functions/gc-mem-caches.xml
@@ -7,7 +7,7 @@
  <refnamediv>
   <refname>gc_mem_caches</refname>
   <refpurpose>
-   Récupère de la mémoire utilisé par le gestionaire de mémoire de Zend Engine
+   Récupère de la mémoire utilisé par le gestionnaire de mémoire de Zend Engine
  </refpurpose>
  </refnamediv>
 
@@ -18,7 +18,7 @@
    <void/>
   </methodsynopsis>
   <para>
-   Récupère de la mémoire utilisé par le gestionaire de mémoire de Zend Engine.
+   Récupère de la mémoire utilisé par le gestionnaire de mémoire de Zend Engine.
   </para>
  </refsect1>
 

--- a/reference/intl/collator-constants.xml
+++ b/reference/intl/collator-constants.xml
@@ -155,7 +155,7 @@
       Dans ces situations, mettez l'attribut Strength à <emphasis>Primary</emphasis>,
       et Case_Level à <emphasis>On</emphasis>. Dans la plupart des locales, cet
       attribut est à Off par défaut. Il y a un petit coût de performances
-      pour la comparaison des chaînes, un un impact sur la taille des index de tri
+      pour la comparaison des chaînes, un impact sur la taille des index de tri
       si cet attribut est à <emphasis>On</emphasis>.
      </para>
      <para>

--- a/reference/intl/grapheme/grapheme-stripos.xml
+++ b/reference/intl/grapheme/grapheme-stripos.xml
@@ -54,7 +54,7 @@
        Si l'offset est négatif, il est traité par rapport à la fin de
        la chaîne de caractères.
        La position retournée est toujours donnée par rapport au début de
-       <parameter>haystack</parameter>, quelque soit la valeur de <parameter>offset</parameter>.
+       <parameter>haystack</parameter>, quelle que soit la valeur de <parameter>offset</parameter>.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/intl/grapheme/grapheme-strpos.xml
+++ b/reference/intl/grapheme/grapheme-strpos.xml
@@ -53,7 +53,7 @@
        Si l'offset est négatif, il est traité par rapport à la fin de
        la chaîne de caractères.
        La position retournée est toujours donnée par rapport au début de
-       <parameter>haystack</parameter>, quelque soit la valeur de <parameter>offset</parameter>.
+       <parameter>haystack</parameter>, quelle que soit la valeur de <parameter>offset</parameter>.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/intl/grapheme/grapheme-strripos.xml
+++ b/reference/intl/grapheme/grapheme-strripos.xml
@@ -51,7 +51,7 @@
        Le paramètre <parameter>offset</parameter> permet de spécifier la position dans la <parameter>haystack</parameter>
        de début de recherche, exprimée en graphème (et non pas en octets ou caractères).
        La position retournée est toujours donnée par rapport au début de
-       <parameter>haystack</parameter>, quelque soit la valeur de <parameter>offset</parameter>.
+       <parameter>haystack</parameter>, quelle que soit la valeur de <parameter>offset</parameter>.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/intl/grapheme/grapheme-strrpos.xml
+++ b/reference/intl/grapheme/grapheme-strrpos.xml
@@ -51,7 +51,7 @@
        Le paramètre <parameter>offset</parameter> permet de spécifier la position dans la <parameter>haystack</parameter>
        de début de recherche, exprimée en graphème (et non pas en octets ou caractères).
        La position retournée est toujours donnée par rapport au début de
-       <parameter>haystack</parameter>, quelque soit la valeur de <parameter>offset</parameter>.
+       <parameter>haystack</parameter>, quelle que soit la valeur de <parameter>offset</parameter>.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/intl/intldatepatterngenerator/create.xml
+++ b/reference/intl/intldatepatterngenerator/create.xml
@@ -41,7 +41,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Renvoie un instance de <classname>IntlDatePatternGenerator</classname> en cas de succès, ou &null; en cas d'échec.
+   Renvoie une instance de <classname>IntlDatePatternGenerator</classname> en cas de succès, ou &null; en cas d'échec.
   </para>
  </refsect1>
 </refentry>

--- a/reference/intl/numberformatter/get-locale.xml
+++ b/reference/intl/numberformatter/get-locale.xml
@@ -46,7 +46,7 @@
      <term><parameter>type</parameter></term>
      <listitem>
       <para>
-       Vous pouvez choisir entre une valeur valide ou un valeur littérale
+       Vous pouvez choisir entre une valeur valide ou une valeur littérale
        <constant>Locale::VALID_LOCALE</constant>,
        <constant>Locale::ACTUAL_LOCALE</constant>,
        respectivement). La valeur par défaut est la valeur littérale.

--- a/reference/ldap/functions/ldap-escape.xml
+++ b/reference/ldap/functions/ldap-escape.xml
@@ -71,13 +71,13 @@
   <para>
    Lors de la construction d'un filtre LDAP, vous devriez utiliser ldap_escape avec le drapeau LDAP_ESCAPE_FILTER.
    <example>
-    <title>Chercher une addresse email</title>
+    <title>Chercher une adresse email</title>
 <programlisting role="php">
 <![CDATA[
 <?php
 // $ds doit être une instance de connexion LDAP\Connection valide
 
-// $mail est une addresse email fournit par l'utilisateur dans un formulaire
+// $mail est une adresse email fournit par l'utilisateur dans un formulaire
 
 $base   = "o=My Company, c=US";
 $filter = "(mail=".ldap_escape($mail, "", LDAP_ESCAPE_FILTER).")";

--- a/reference/ldap/functions/ldap-list.xml
+++ b/reference/ldap/functions/ldap-list.xml
@@ -68,7 +68,7 @@
      <listitem>
       <para>
        Un tableau d'attributs requis, e.g. array("mail", "sn", "cn").
-       Notez que le "dn" est toujours retourné, quelque soit le type de l'attribut
+       Notez que le "dn" est toujours retourné, quel que soit le type de l'attribut
        demandé.
       </para>
       <para>

--- a/reference/ldap/functions/ldap-read.xml
+++ b/reference/ldap/functions/ldap-read.xml
@@ -67,7 +67,7 @@
      <listitem>
       <para>
        Un tableau d'attributs requis, e.g. array("mail", "sn", "cn").
-       Notez que le "dn" est toujours retourné, quelque soit le type de l'attribut
+       Notez que le "dn" est toujours retourné, quel que soit le type de l'attribut
        demandé.
       </para>
       <para>

--- a/reference/libxml/book.xml
+++ b/reference/libxml/book.xml
@@ -11,7 +11,7 @@
   &reftitle.intro;
   <para>
    Ces fonctions et constantes sont disponibles depuis PHP 5.1.0 et si vous
-   avez compilé PHP avec les extensions basées sur libxml, c'est à dire 
+   avez compilé PHP avec les extensions basées sur libxml, c'est-à-dire
    <link linkend="book.dom">DOM</link>,
    <link linkend="book.libxml">libxml</link>,
    <link linkend="book.simplexml">SimpleXML</link>,

--- a/reference/math/functions/acosh.xml
+++ b/reference/math/functions/acosh.xml
@@ -16,7 +16,7 @@
   </methodsynopsis>
   <para>
    Retourne l'arc cosinus hyperbolique de <parameter>num</parameter>,
-   c'est à dire la valeur dont le cosinus hyperbolique est
+   c'est-à-dire la valeur dont le cosinus hyperbolique est
    <parameter>num</parameter>.
   </para>
  </refsect1>

--- a/reference/math/functions/asinh.xml
+++ b/reference/math/functions/asinh.xml
@@ -15,7 +15,7 @@
   </methodsynopsis>
   <para>
    Retourne l'arc sinus hyperbolique de <parameter>num</parameter>,
-   c'est à dire la valeur dont le sinus hyperbolique est <parameter>num</parameter>.
+   c'est-à-dire la valeur dont le sinus hyperbolique est <parameter>num</parameter>.
   </para>
  </refsect1>
  <refsect1 role="parameters">

--- a/reference/math/functions/atanh.xml
+++ b/reference/math/functions/atanh.xml
@@ -15,7 +15,7 @@
   </methodsynopsis>
   <para>
    Retourne l'arc tangente hyperbolique de <parameter>num</parameter>,
-   c'est à dire la valeur dont la tangente hyperbolique est <parameter>num</parameter>.
+   c'est-à-dire la valeur dont la tangente hyperbolique est <parameter>num</parameter>.
   </para>
  </refsect1>
  <refsect1 role="parameters">

--- a/reference/math/functions/base-convert.xml
+++ b/reference/math/functions/base-convert.xml
@@ -22,7 +22,7 @@
    <parameter>to_base</parameter> doivent être compris entre 2 et 36 inclus.
    Les chiffres supérieurs à 10 des bases supérieures à 10 seront représentés
    par les lettres de A à Z, avec A = 10 et Z = 35.
-   Le casse des lettres n'a pas d'importance, c'est à dire
+   Le casse des lettres n'a pas d'importance, c'est-à-dire
    <parameter>num</parameter> est interprété de façon insensible à la casse.
   </para>
   <warning>

--- a/reference/mbstring/functions/mb-strtolower.xml
+++ b/reference/mbstring/functions/mb-strtolower.xml
@@ -115,7 +115,7 @@ echo $str; // Affiche τάχιστη αλώπηξ βαφής ψημένη γη, 
    Contrairement à <function>strtolower</function>, le concept de caractère
    'alphabétique' est déterminé par les propriétés Unicode. De ce fait,
    le comportement de cette fonction n'est pas modifié par les configurations
-   locales, et elle peut convertir tout les caractères qui sont considérés
+   locales, et elle peut convertir tous les caractères qui sont considérés
    comme alphabétiques comme le c cédille (ç).
   </para>
   <para>

--- a/reference/memcache/memcache/setserverparams.xml
+++ b/reference/memcache/memcache/setserverparams.xml
@@ -104,7 +104,7 @@
     <listitem>
      <simpara>
       Permet à l'utilisateur de spécifier une fonction de rappel permettant de
-      contourner une erreur. Le fonction est exécutée avant d'atteindre la limite
+      contourner une erreur. La fonction est exécutée avant d'atteindre la limite
       de tentative. La fonction prend deux paramètres ; le nom de l'hôte et le port
       du serveur qui a échoué.
      </simpara>

--- a/reference/memcached/ini.xml
+++ b/reference/memcached/ini.xml
@@ -191,7 +191,7 @@
       <entry><constant>INI_ALL</constant></entry>
       <entry>
        Disponible depuis memcached 2.2.0.
-       Par défault à <literal>0</literal> depuis memcached 3.2.0
+       Par défaut à <literal>0</literal> depuis memcached 3.2.0
        (avant <literal>2</literal>).
       </entry>
      </row>

--- a/reference/misc/functions/sapi-windows-vt100-support.xml
+++ b/reference/misc/functions/sapi-windows-vt100-support.xml
@@ -92,7 +92,7 @@
  <refsect1 role="examples"><!-- {{{ -->
   &reftitle.examples;
   <example>
-   <title>Etat par défault de <function>sapi_windows_vt100_support</function></title>
+   <title>Etat par défaut de <function>sapi_windows_vt100_support</function></title>
    <para>
     Par défaut, <constant>STDOUT</constant> et <constant>STDERR</constant> ont la fonctionnalité VT100 activée.
    </para>

--- a/reference/mongodb/mongodb/driver/manager/construct.xml
+++ b/reference/mongodb/mongodb/driver/manager/construct.xml
@@ -170,7 +170,7 @@ mongodb://[username:password@]host1[:port1][,host2[:port2],...[,hostN[:portN]]][
           <entry><type>string</type></entry>
           <entry>
            <para>
-            Un liste priorisée et délimitée par des virgules de compresseurs que le client
+            Une liste priorisée et délimitée par des virgules de compresseurs que le client
             souhaite utiliser. Les messages ne sont compressés que si le client et le serveur
             partagent des compresseurs en commun, et le compresseur utilisé dans chaque
             direction dépendra de la configuration individuelle du serveur

--- a/reference/mongodb/mongodb/driver/query/construct.xml
+++ b/reference/mongodb/mongodb/driver/query/construct.xml
@@ -376,7 +376,7 @@
          pour cette option a été supprimé dans MongoDB 4.2.
         </para>
         <para>
-         L'option <literal>"modifiers"</literal> a été supprimée. Cette options était
+         L'option <literal>"modifiers"</literal> a été supprimée. Cette option était
          utilisée pour les modificateurs d'ancienne requête, qui sont tous dépréciés.
         </para>
         <para>

--- a/reference/mqseries/functions/mqseries-connx.xml
+++ b/reference/mqseries/functions/mqseries-connx.xml
@@ -60,7 +60,7 @@
     </term>
     <listitem>
      <simpara>Gestionnaire de connexion.</simpara>
-     <simpara>Ce gestionnaire représente la connexion au gestionaire de files d'attente.</simpara>
+     <simpara>Ce gestionnaire représente la connexion au gestionnaire de files d'attente.</simpara>
     </listitem>
    </varlistentry>
    <varlistentry>

--- a/reference/mqseries/functions/mqseries-put1.xml
+++ b/reference/mqseries/functions/mqseries-put1.xml
@@ -48,7 +48,7 @@
     </term>
     <listitem>
      <simpara>Gestionnaire de connexion.</simpara>
-     <simpara>Ce gestionnaire représente la connexion au gestionaire de files d'attente.</simpara>
+     <simpara>Ce gestionnaire représente la connexion au gestionnaire de files d'attente.</simpara>
     </listitem>
    </varlistentry>
    <varlistentry>

--- a/reference/mqseries/functions/mqseries-set.xml
+++ b/reference/mqseries/functions/mqseries-set.xml
@@ -39,7 +39,7 @@
     </term>
     <listitem>
      <simpara>Gestionnaire de connexion.</simpara>
-     <simpara>Ce gestionnaire représente la connexion au gestionaire de files d'attente.</simpara>
+     <simpara>Ce gestionnaire représente la connexion au gestionnaire de files d'attente.</simpara>
     </listitem>
    </varlistentry>
    <varlistentry>

--- a/reference/mysqlinfo/concepts.xml
+++ b/reference/mysqlinfo/concepts.xml
@@ -160,7 +160,7 @@ $mysqli->set_charset('UTF-8');
   <note>
    <title>Confusion possible avec UTF-8</title>
    <simpara>
-    Du au fait que les noms des jeux de caractères dans MySQL ne contiennent pas de tiret,
+    Dû au fait que les noms des jeux de caractères dans MySQL ne contiennent pas de tiret,
     la chaîne "utf8" est correcte dans MySQL et définira le jeu de caractère en UTF-8.
     La chaîne "UTF-8" n'est pas correcte, et utiliser "utf-8" échouera à modifier le
     jeu de caractère.

--- a/reference/mysqlnd/plugin.xml
+++ b/reference/mysqlnd/plugin.xml
@@ -250,7 +250,7 @@
    Memcache. Ce mécanisme donne un avantage au proxy MySQL.
   </simpara>
   <simpara>
-   Un proxy MySQL fonctionne au dessus de la couche physique. Avec un
+   Un proxy MySQL fonctionne au-dessus de la couche physique. Avec un
    proxy MySQL, vous devez analyser et effectuer du "reverse engineering"
    du protocole client serveur MySQL. Les actions sont limitées à celles
    qui peuvent être effectuées par la manipulation du protocole
@@ -258,7 +258,7 @@
    les scripts du proxy MySQL peut devoir être adaptés.
   </simpara>
   <simpara>
-   Les plugins <literal>Mysqlnd</literal> fonctionnent au dessus de l'API C,
+   Les plugins <literal>Mysqlnd</literal> fonctionnent au-dessus de l'API C,
    reflétant ainsi les APIs client <literal>libmysqlclient</literal>.
    Cette API C est essentiellement une enveloppe du protocole Serveur Client MySQL,
    ou de la couche physique, vu qu'elle est appelée quelques fois. Vous pouvez
@@ -1123,7 +1123,7 @@ static MY_CONN_PROPERTIES** get_conn_properties(const MYSQLND *conn TSRMLS_DC) {
    </listitem>
    <listitem>
     <simpara>
-     Quelque soit l'extension PHP MySQL utilisée par l'application,
+     Quelle que soit l'extension PHP MySQL utilisée par l'application,
      elle reçoit une connexion à 127.0.0.1. L'extension PHP MySQL
      redonne la main à l'application PHP. Le cycle est clos.
     </simpara>

--- a/reference/network/functions/header-remove.xml
+++ b/reference/network/functions/header-remove.xml
@@ -27,7 +27,7 @@
      <term><parameter>name</parameter></term>
      <listitem>
       <para>
-       Le nom de l'en-tête à supprimer. Si &null; tout les en-têtes définit
+       Le nom de l'en-tête à supprimer. Si &null; tous les en-têtes définit
        précédemment sont supprimés.
       </para>
       <note>

--- a/reference/oci8/functions/oci-result.xml
+++ b/reference/oci8/functions/oci-result.xml
@@ -51,7 +51,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Retourne tout les types, sauf les types abstraits (ROWIDs, LOBs et FILEs).
+   Retourne tous les types, sauf les types abstraits (ROWIDs, LOBs et FILEs).
    Retourne &false; en cas d'erreur.
   </para>
  </refsect1>

--- a/reference/opcache/ini.xml
+++ b/reference/opcache/ini.xml
@@ -559,8 +559,8 @@
      Zend Engine pour désallouer le jeux entier des variables de requêtes, en masse.
     </simpara>
     <simpara>
-     Cette directive a été supprimé dans PHP 7.2.0. Une variante de la
-     séquence d'arrêt rapide a été intégré dans PHP et sera automatiquement
+     Cette directive a été supprimée dans PHP 7.2.0. Une variante de la
+     séquence d'arrêt rapide a été intégrée dans PHP et sera automatiquement
      utilisé si possible.
     </simpara>
    </listitem>

--- a/reference/openssl/constants.xml
+++ b/reference/openssl/constants.xml
@@ -474,7 +474,7 @@
        <entry>
         Normalement quand un message est signé, un jeu d'attributs sont
         inclus qui inclus l'heure de signature et les algorithmes symétriques
-        supportés. Avec cette options ils ne sont pas inclus.
+        supportés. Avec cette option ils ne sont pas inclus.
        </entry>
       </row>
       <row xml:id="constant.openssl-cms-detached">

--- a/reference/password/constants.xml
+++ b/reference/password/constants.xml
@@ -163,7 +163,7 @@
     <listitem>
      <para>
       Nombre par défaut de threads que Argon2lib va utiliser.
-      Pas disponible avec avec l'implémentation libsodium.
+      Pas disponible avec l'implémentation libsodium.
      </para>
      <para>
       &php.version.added; 7.2.0.

--- a/reference/pcre/pattern.syntax.xml
+++ b/reference/pcre/pattern.syntax.xml
@@ -1319,7 +1319,7 @@
   <para>
    Le caractère de nouvelle ligne n'est pas traité de
    manière spéciale dans les classes de caractères,
-   quelque soit l'option <link linkend="reference.pcre.pattern.modifiers">PCRE_DOTALL</link>
+   quelle que soit l'option <link linkend="reference.pcre.pattern.modifiers">PCRE_DOTALL</link>
    ou <link linkend="reference.pcre.pattern.modifiers">PCRE_MULTILINE</link>. Une classe
    telle que <literal>[^a]</literal> acceptera toujours une nouvelle ligne.
   </para>

--- a/reference/pdo/pdo/setattribute.xml
+++ b/reference/pdo/pdo/setattribute.xml
@@ -98,7 +98,7 @@
      <listitem>
       <note>
        <simpara>
-        Cet attribut est disponible avec tout les pilotes, pas juste Oracle.
+        Cet attribut est disponible avec tous les pilotes, pas juste Oracle.
        </simpara>
       </note>
       <para>
@@ -170,7 +170,7 @@
       </para>
       <note>
        <para>
-        Pas tout les pilotes supportent cette option, et sa signification peut
+        Pas tous les pilotes supportent cette option, et sa signification peut
         différer en fonctions des pilotes. Par exemple, SQLite attendra pendant
         cette période pour obtenir un verrou en écriture, mais d'autres pilotes
         peuvent interpréter ceci comme un timeout de connexion ou de lecture.

--- a/reference/pgsql/functions/pg-delete.xml
+++ b/reference/pgsql/functions/pg-delete.xml
@@ -37,7 +37,7 @@
   <para>
    Notez que ni l'échappement ni les requêtes préparer peuvent protéger des
    requêtes LIKE, JSON, Tableaux, Regex, etc. Ces paramètres devraient être
-   traité en fonction de leur contexte. C'est à dire échapper/valider les valeurs.
+   traité en fonction de leur contexte. C'est-à-dire échapper/valider les valeurs.
   </para>
  </refsect1>
 

--- a/reference/pgsql/functions/pg-escape-identifier.xml
+++ b/reference/pgsql/functions/pg-escape-identifier.xml
@@ -23,7 +23,7 @@
    <function>pg_escape_identifier</function> ajoute des guillemets
    avant et après les données. Les utilisateurs ne doivent donc pas ajouter
    de guillemets. L'utilisation de cette fonction est recommandée pour les
-   les identifiants des requêtes. Pour les données brutes SQL (c'est à dire
+   les identifiants des requêtes. Pour les données brutes SQL (c'est-à-dire
    les paramètres, excepté de type bytea), <function>pg_escape_literal</function>
    ou <function>pg_escape_string</function> doit être utilisé. Pour les champs
    de type bytea il est nécessaire d'utiliser <function>pg_escape_bytea</function>.

--- a/reference/pgsql/functions/pg-insert.xml
+++ b/reference/pgsql/functions/pg-insert.xml
@@ -37,7 +37,7 @@
   <para>
    Notez que ni l'échappement ni les requêtes préparer peuvent protéger des
    requêtes LIKE, JSON, Tableaux, Regex, etc. Ces paramètres devraient être
-   traité en fonction de leur contexte. C'est à dire échapper/valider les valeurs.
+   traité en fonction de leur contexte. C'est-à-dire échapper/valider les valeurs.
   </para>
  </refsect1>
 

--- a/reference/pgsql/functions/pg-pconnect.xml
+++ b/reference/pgsql/functions/pg-pconnect.xml
@@ -34,7 +34,7 @@
    Le nombre maximal de connexions peut être limité grâce 
    à la directive de configuration
    <link linkend="ini.pgsql.max-persistent">pgsql.max_persistent</link>
-   dans le fichier &php.ini; (par défaut, elle vaut <literal>-1</literal>, c'est à dire pas de limite).
+   dans le fichier &php.ini; (par défaut, elle vaut <literal>-1</literal>, c'est-à-dire pas de limite).
    Le nombre total de connexions peut être configuré avec la directive
    <link linkend="ini.pgsql.max-links">pgsql.max_links</link> du fichier
    &php.ini;.

--- a/reference/pgsql/functions/pg-select.xml
+++ b/reference/pgsql/functions/pg-select.xml
@@ -47,7 +47,7 @@
   <para>
    Notez que ni l'échappement ni les requêtes préparer peuvent protéger des
    requêtes LIKE, JSON, Tableaux, Regex, etc. Ces paramètres devraient être
-   traité en fonction de leur contexte. C'est à dire échapper/valider les valeurs.
+   traité en fonction de leur contexte. C'est-à-dire échapper/valider les valeurs.
   </para>
  </refsect1>
 

--- a/reference/pgsql/functions/pg-update.xml
+++ b/reference/pgsql/functions/pg-update.xml
@@ -39,7 +39,7 @@
   <para>
    Notez que ni l'échappement ni les requêtes préparer peuvent protéger des
    requêtes LIKE, JSON, Tableaux, Regex, etc. Ces paramètres devraient être
-   traité en fonction de leur contexte. C'est à dire échapper/valider les valeurs.
+   traité en fonction de leur contexte. C'est-à-dire échapper/valider les valeurs.
   </para>
  </refsect1>
 

--- a/reference/phar/Phar/interceptFileFuncs.xml
+++ b/reference/phar/Phar/interceptFileFuncs.xml
@@ -74,7 +74,7 @@ echo file_get_contents('fichier2.txt');
   </para>
   <para>
    Normalement, PHP chercherait dans le répertoire courant le fichier nommé <literal>file2.txt</literal>,
-   c'est à dire dans le répertoire de fichier.php ou le répertoire courant de l'utilisateur de la ligne
+   c'est-à-dire dans le répertoire de fichier.php ou le répertoire courant de l'utilisateur de la ligne
    de commande. <function>Phar::interceptFileFuncs</function> dit à
    PHP de considérer <literal>phar:///chemin/vers/monphar.phar/</literal> comme répertoire courant
    et ainsi ouvre dans l'exemple ci-dessus le fichier <literal>phar:///chemin/vers/monphar.phar/fichier2.txt</literal>.

--- a/reference/phar/fileformat.xml
+++ b/reference/phar/fileformat.xml
@@ -211,7 +211,7 @@ __HALT_COMPILER();
   </para>
   <para>
    Il y a un support limité pour lire les tarballs dans le format pax interchange,
-   mais tout les en-têtes pax reconnues (actuellement, typeflag <literal>x</literal>
+   mais tous les en-têtes pax reconnues (actuellement, typeflag <literal>x</literal>
    et <literal>g</literal>) sont silencieusement ignorés.
    Il y a aussi un support limité pour les GNU Tar Archives;
    actuellement, les en-têtes <literal>././@LongLink</literal> sont résolus.

--- a/reference/phar/installation.xml
+++ b/reference/phar/installation.xml
@@ -7,7 +7,7 @@
  &reftitle.install;
  <para>
   L'extension Phar est intégrée dans PHP, et activé par défaut.
-  Pour désactiver le support de de Phar, utilisé l'option de configuration
+  Pour désactiver le support de Phar, utilisé l'option de configuration
   <option role="configure">--disable-phar</option>.
  </para>
  <para>

--- a/reference/phpdbg/functions/phpdbg-exec.xml
+++ b/reference/phpdbg/functions/phpdbg-exec.xml
@@ -43,7 +43,7 @@
    retourné.
    Si le contexte d'exécution n'a pas été défini, &true; sera retourné.
    Si une erreur est survenue pendant la définition du contexte, &false;
-   sera retourné et un erreur de niveau <constant>E_WARNING</constant> sera
+   sera retourné et une erreur de niveau <constant>E_WARNING</constant> sera
    émise.
   </simpara>
  </refsect1>

--- a/reference/ps/functions/ps-get-value.xml
+++ b/reference/ps/functions/ps-get-value.xml
@@ -152,7 +152,7 @@
      <term><literal>textrise</literal></term>
      <listitem>
       <para>
-       L'espace par lequel le texte est augmenté au dessus de la ligne de
+       L'espace par lequel le texte est augmenté au-dessus de la ligne de
        base.
       </para>
      </listitem>

--- a/reference/pspell/functions/pspell-new.xml
+++ b/reference/pspell/functions/pspell-new.xml
@@ -19,7 +19,7 @@
   </methodsynopsis>
   <para>
    <function>pspell_new</function> ouvre un nouveau dictionnaire et
-   retourne un instance de <classname>PSpell\Dictionary</classname>, pour être utilisé avec d'autres
+   retourne une instance de <classname>PSpell\Dictionary</classname>, pour être utilisée avec d'autres
    fonctions pspell.
   </para>
   <para>

--- a/reference/pthreads/pool.xml
+++ b/reference/pthreads/pool.xml
@@ -13,7 +13,7 @@
   <section xml:id="pool.intro">
    &reftitle.intro;
    <simpara>
-    Un Pool est un conteneur pour, et controllé par, un nombre ajustable de Workers.
+    Un Pool est un conteneur pour, et contrôlé par, un nombre ajustable de Workers.
    </simpara>
    <simpara>
     Le pooling fournit un niveau élevé d'abstraction sur la fonctionnalité Worker, en incluant la gestion des références dans le sens requis par pthreads.

--- a/reference/rar/rarentry/extract.xml
+++ b/reference/rar/rarentry/extract.xml
@@ -75,7 +75,7 @@
      <simpara>
       Si vaut &true;, les informations étendues comme NTFS ACLs
       et les informations sur le propriétaire Unix seront
-      définies dans les fichiers extraits, si ils sont bien définies
+      définies dans les fichiers extraits, s'ils sont bien définies
       dans l'archives.
      </simpara>
     </listitem>

--- a/reference/reflection/reflectionclass/isiterable.xml
+++ b/reference/reflection/reflectionclass/isiterable.xml
@@ -14,7 +14,7 @@
    <void/>
   </methodsynopsis>
   <para>
-   Vérifie si cette classe est itérable (c'est à dire qu'elle peut être utilisée dans &foreach;).
+   Vérifie si cette classe est itérable (c'est-à-dire qu'elle peut être utilisée dans &foreach;).
   </para>
  </refsect1>
 

--- a/reference/reflection/reflectionextension/clone.xml
+++ b/reference/reflection/reflectionextension/clone.xml
@@ -27,7 +27,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Aucune valeur retournée, si appellé une erreur fatale se produira.
+   Aucune valeur retournée, si appelé une erreur fatale se produira.
   </para>
  </refsect1>
  

--- a/reference/reflection/reflectionproperty/getdefaultvalue.xml
+++ b/reference/reflection/reflectionproperty/getdefaultvalue.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="reflectionproperty.getdefaultvalue" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>ReflectionProperty::getDefaultValue</refname>
-  <refpurpose>Renvoie la valeur par défault définie pour une propriété</refpurpose>
+  <refpurpose>Renvoie la valeur par défaut définie pour une propriété</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -14,7 +14,7 @@
    <void/>
   </methodsynopsis>
   <para>
-   Renvoie la valeur par défault implicite ou explicitement définie pour une propriété.
+   Renvoie la valeur par défaut implicite ou explicitement définie pour une propriété.
   </para>
  </refsect1>
 
@@ -26,9 +26,9 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   La valeur par défault si la propriété a une valeur par défault (y compris &null;).
-   S'il n'y a pas de valeur par défault, alors &null; est retourné. Il n'est pas possible de différencier
-   un &null; par défault d'une propriété typée non initialisée.
+   La valeur par défaut si la propriété a une valeur par défaut (y compris &null;).
+   S'il n'y a pas de valeur par défaut, alors &null; est retourné. Il n'est pas possible de différencier
+   un &null; par défaut d'une propriété typée non initialisée.
    Utiliser <methodname>ReflectionProperty::hasDefaultValue</methodname> pour détecter la différence.
   </para>
  </refsect1>

--- a/reference/reflection/reflectionproperty/hasdefaultvalue.xml
+++ b/reference/reflection/reflectionproperty/hasdefaultvalue.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="reflectionproperty.hasdefaultvalue" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>ReflectionProperty::hasDefaultValue</refname>
-  <refpurpose>Verifie si la propriété a une valeur par défault</refpurpose>
+  <refpurpose>Vérifie si la propriété a une valeur par défaut</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -14,8 +14,8 @@
    <void/>
   </methodsynopsis>
   <para>
-   Vérifie si la propriété a été déclarée avec une valeur par défault, incluant une valeur par défault 
-   implicite &null;. Retourne &false; pour les propriétés typées sans valeur par défault 
+   Vérifie si la propriété a été déclarée avec une valeur par défaut, incluant une valeur par défaut 
+   implicite &null;. Retourne &false; pour les propriétés typées sans valeur par défaut 
    (ou les propriétés dynamiques).
   </para>
  </refsect1>
@@ -28,8 +28,8 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Si la propriété a une valeur par défault (incluant &null;), &true; est retourné;
-   si la propriété est typé sans valeur par défault déclarée ou est une propriété dynamique, &false; est retourné.
+   Si la propriété a une valeur par défaut (incluant &null;), &true; est retourné;
+   si la propriété est typé sans valeur par défaut déclarée ou est une propriété dynamique, &false; est retourné.
   </para>
  </refsect1>
 

--- a/reference/reflection/reflectionproperty/ispromoted.xml
+++ b/reference/reflection/reflectionproperty/ispromoted.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="reflectionproperty.ispromoted" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>ReflectionProperty::isPromoted</refname>
-  <refpurpose>Verifie si la propriété est promue</refpurpose>
+  <refpurpose>Vérifie si la propriété est promue</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/session/functions/session-module-name.xml
+++ b/reference/session/functions/session-module-name.xml
@@ -32,7 +32,7 @@
        Si <parameter>module</parameter> est fourni et non &null;, cette valeur
        sera alors utilisée, et remplacera la valeur courante.
        Passer <literal>"user"</literal> à ce paramètre est interdit.
-       À la place <function>session_set_save_handler</function> doit être appellé pour
+       À la place <function>session_set_save_handler</function> doit être appelé pour
        définir un gestionnaire de session définit par l'utilisateur.
       </para>
      </listitem>

--- a/reference/sodium/functions/sodium-crypto-pwhash-str-needs-rehash.xml
+++ b/reference/sodium/functions/sodium-crypto-pwhash-str-needs-rehash.xml
@@ -55,7 +55,7 @@
   &reftitle.returnvalues;
   <simpara>
    Renvoie &true; si le memlimit/opslimit fourni ne correspond pas à ce qui est stocké dans le hachage.
-   Renvoie &false; si ils correspondent.
+   Renvoie &false; s'ils correspondent.
   </simpara>
  </refsect1>
 

--- a/reference/solr/solrdocument/offsetset.xml
+++ b/reference/solr/solrdocument/offsetset.xml
@@ -39,7 +39,7 @@
      <term><parameter>fieldValue</parameter></term>
      <listitem>
       <para>
-       Le valeur du champ.
+       La valeur du champ.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/solr/solrquery/sethighlightusephrasehighlighter.xml
+++ b/reference/solr/solrquery/sethighlightusephrasehighlighter.xml
@@ -6,7 +6,7 @@
 <refentry xml:id="solrquery.sethighlightusephrasehighlighter" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>SolrQuery::setHighlightUsePhraseHighlighter</refname>
-  <refpurpose>Si l'on doit coloriser les termes d'une phrase uniquement si ils apparaissent dans la requête</refpurpose>
+  <refpurpose>Si l'on doit coloriser les termes d'une phrase uniquement s'ils apparaissent dans la requête</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -17,7 +17,7 @@
   </methodsynopsis>
   <para>
    Si l'on doit utiliser SpanScorer pour coloriser les termes d'une phrase
-   uniquement si ils apparaissent dans la requête du document.
+   uniquement s'ils apparaissent dans la requête du document.
   </para>
   
  </refsect1>
@@ -31,7 +31,7 @@
      <listitem>
       <para>
        Si l'on doit utiliser SpanScorer pour coloriser les termes d'une phrase
-       uniquement si ils apparaissent dans la requête du document.
+       uniquement s'ils apparaissent dans la requête du document.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/solr/solrquery/setmltmindocfrequency.xml
+++ b/reference/solr/solrquery/setmltmindocfrequency.xml
@@ -16,7 +16,7 @@
    <methodparam><type>int</type><parameter>minDocFrequency</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Définit la fréquence à partir de laquelle les mots seront ignorés si ils n'apparaissent pas dans les documents.
+   Définit la fréquence à partir de laquelle les mots seront ignorés s'ils n'apparaissent pas dans les documents.
   </para>
 
  </refsect1>
@@ -29,7 +29,7 @@
      <term><parameter>minDocFrequency</parameter></term>
      <listitem>
       <para>
-       La fréquence à partir de laquelle les mots seront ignorés si ils n'apparaissent pas dans les documents
+       La fréquence à partir de laquelle les mots seront ignorés s'ils n'apparaissent pas dans les documents
       </para>
      </listitem>
     </varlistentry>

--- a/reference/spl/functions/iterator-apply.xml
+++ b/reference/spl/functions/iterator-apply.xml
@@ -38,7 +38,7 @@
      <listitem>
       <para>
        La fonction de rappel à appeler à chaque élément.
-       Cette fonction ne reçoit que les arguments <parameter>args</parameter> donnés, elle est donc nullaire par défault.
+       Cette fonction ne reçoit que les arguments <parameter>args</parameter> donnés, elle est donc nullaire par défaut.
        Si <literal>count($args) === 3</literal>, par exemple, la fonction est ternaire.
        <note>
         <simpara>

--- a/reference/spl/functions/spl-autoload-register.xml
+++ b/reference/spl/functions/spl-autoload-register.xml
@@ -23,7 +23,7 @@
   <para>
    Si votre code dispose déjà d'une fonction <function>__autoload</function>,
    alors cette fonction doit explicitement enregistrer la pile __autoload. 
-   Ceci est du au fait que <function>spl_autoload_register</function> 
+   Ceci est dû au fait que <function>spl_autoload_register</function> 
    remplace le cache du moteur pour la fonction
    <function>__autoload</function> par soit <function>spl_autoload</function>, 
    soit <function>spl_autoload_call</function>.

--- a/reference/spl/spltempfileobject/construct.xml
+++ b/reference/spl/spltempfileobject/construct.xml
@@ -46,7 +46,7 @@
  <refsect1 role="errors">
   &reftitle.errors;
   <para>
-   Lance un exception <classname>RuntimeException</classname>
+   Lance une exception <classname>RuntimeException</classname>
    si une erreur survient.
   </para>
  </refsect1>

--- a/reference/sqlite3/sqlite3/createcollation.xml
+++ b/reference/sqlite3/sqlite3/createcollation.xml
@@ -38,7 +38,7 @@
       Le nom d'une fonction PHP ou d'une fonction définie par l'utilisateur
       à appliquer comme fonction de rappel, définissant le comportement
       du classement. Elle doit accepter deux arguments et retournera
-      la même chose que la fonction <function>strcmp</function>, c'est à dire
+      la même chose que la fonction <function>strcmp</function>, c'est-à-dire
       elle doit retourner -1, 1, ou 0 si la première chaîne trie avant,
       après, ou est équivalent à la seconde.
      </para>

--- a/reference/ssh2/functions/ssh2-auth-pubkey-file.xml
+++ b/reference/ssh2/functions/ssh2-auth-pubkey-file.xml
@@ -107,7 +107,7 @@ if (ssh2_auth_pubkey_file($connection, 'username',
   <note>
    <simpara>
     La bibliothèque libssh sous-jacente ne supporte pas très proprement les
-    authentifications partielles. C'est à dire que si vous devez fournir à la
+    authentifications partielles. C'est-à-dire que si vous devez fournir à la
     fois une clé publique et un mot de passe alors cela apparaitra comme si
     la fonction est en erreur. Dans ce cas particulier, une erreur sur cet
     appel peut juste signifier que l'authentification n'est pas encore terminée.

--- a/reference/stomp/book.xml
+++ b/reference/stomp/book.xml
@@ -10,7 +10,7 @@
  <preface xml:id="intro.stomp">
   &reftitle.intro;
   <simpara>
-   Cette extension permet aux applications php de communiquer avec tout les Brokers de message compatibles Stomp à travers un API objet ou procédural simple. <link xlink:href="&url.stomp;">Site officiel de Stomp</link>
+   Cette extension permet aux applications php de communiquer avec tous les Brokers de message compatibles Stomp à travers un API objet ou procédural simple. <link xlink:href="&url.stomp;">Site officiel de Stomp</link>
   </simpara>
  </preface>
 

--- a/reference/stream/functions/stream-select.xml
+++ b/reference/stream/functions/stream-select.xml
@@ -95,7 +95,7 @@
       </para>
       <warning>
        <para>
-        Utiliser un valeur de <literal>0</literal> vous permet de 
+        Utiliser une valeur de <literal>0</literal> vous permet de 
         tester instantanément le statut des flux, mais il faut savoir
         qu'il n'est pas recommandé d'utiliser <literal>0</literal> 
         dans une boucle, car cela va faire consommer énormément de

--- a/reference/svm/svm/crossvalidate.xml
+++ b/reference/svm/svm/crossvalidate.xml
@@ -22,7 +22,7 @@
    n sous-jeux, et commence des entraînements successifs sur les sous-jeux.
    Bien que la précision soit généralement plus faible qu'un SVM entraîné
    des jeux de données fournies, le score de précision retourné devrait être
-   suffisament utile pour être utilisé pour tester différents paramètres
+   suffisamment utile pour être utilisé pour tester différents paramètres
    d'entraînement.
   </simpara>
 

--- a/reference/uopz/setup.xml
+++ b/reference/uopz/setup.xml
@@ -115,7 +115,7 @@
 
   <note>
    <simpara>
-    Lors de l'exécution avec OPcache d'activé, il est peut être nécéssaire de
+    Lors de l'exécution avec OPcache d'activé, il est peut être nécessaire de
     désactiver toutes les
     <link linkend="ini.opcache.optimization-level">optimisations OPcache</link>
     (<code>opcache.optimization_level=0</code>).

--- a/reference/url/functions/parse-url.xml
+++ b/reference/url/functions/parse-url.xml
@@ -145,7 +145,7 @@ http://example.com/foo?# → query = "",   fragment = ""
    </informalexample>
   </para>
   <para>
-   Précédemment tout les cas résultaient en la requête et le fragment étant &null;.
+   Précédemment tous les cas résultaient en la requête et le fragment étant &null;.
   </para>
   <para>
    À noter que les caractères de contrôle (cf. <function>ctype_cntrl</function>)

--- a/reference/var/functions/unserialize.xml
+++ b/reference/var/functions/unserialize.xml
@@ -198,7 +198,7 @@
        <entry>7.1.0</entry>
        <entry>
         L'élément <literal>allowed_classes</literal> de
-        <parameter>options</parameter> est maintenant strictement typé, c'est à dire si
+        <parameter>options</parameter> est maintenant strictement typé, c'est-à-dire si
         quelque chose autre qu'un tableau <type>array</type> ou un <type>bool</type>
         est donné <function>unserialize</function> retourne &false; et émet une
         <constant>E_WARNING</constant>.

--- a/reference/wincache/book.xml
+++ b/reference/wincache/book.xml
@@ -35,7 +35,7 @@
     </para>
     <para>
      Support pour le cache d'Opcode a été retiré dans <literal>Wincache 2.0.0</literal>,
-     tout les utilisateurs qui souhaitent avoir un opcache devraient utiliser l'extension
+     tous les utilisateurs qui souhaitent avoir un opcache devraient utiliser l'extension
      <link linkend="book.opcache">OPcache</link> qui est inclus avec PHP.
     </para>
    </listitem>

--- a/reference/wincache/setup.xml
+++ b/reference/wincache/setup.xml
@@ -73,7 +73,7 @@
    <step>
     <simpara>
      Copiez le fichier <filename>php_wincache.dll</filename> dans le dossier d'extensions PHP. 
-     En général, ce dossier se nomme "ext" et est situé dans le même dossier avec tout les
+     En général, ce dossier se nomme "ext" et est situé dans le même dossier avec tous les
      fichiers binaires PHP. Par exemple : <filename>C:\Program Files\PHP\ext</filename>.
      
     </simpara>
@@ -81,7 +81,7 @@
    <step>
     <simpara>
      Avec un éditeur de texte, ouvrez le fichier php.ini, qui se trouve généralement dans le même
-     dossier que tout les fichiers binaires PHP. Par exemple :  
+     dossier que tous les fichiers binaires PHP. Par exemple :  
      <filename>C:\Program Files\PHP\php.ini</filename>.
     </simpara>
    </step>

--- a/reference/yaf/appconfig.xml
+++ b/reference/yaf/appconfig.xml
@@ -310,7 +310,7 @@ yaf.dispatcher.catchException = 0
      </term>
      <listitem>
       <para>
-       Si vaut On, Yaf transmettra les erreurs aux controlleurs/actions,
+       Si vaut On, Yaf transmettra les erreurs aux contrôleurs/actions,
        lorsqu'il rencontrera une exception non attrapable.
        Voir aussi la méthode <methodname>Yaf_Dispatcher::catchException</methodname>.
       </para>
@@ -347,7 +347,7 @@ yaf.dispatcher.catchException = 0
      </term>
      <listitem>
       <para>
-       Le nom par défaut du controlleur. Voir aussi la méthode
+       Le nom par défaut du contrôleur. Voir aussi la méthode
        <methodname>Yaf_Dispatcher::setDefaultController</methodname>.
       </para>
      </listitem>

--- a/reference/yaf/tutorials.xml
+++ b/reference/yaf/tutorials.xml
@@ -96,7 +96,7 @@ foo=bar
  </example>
 
  <example>
-  <title>Controlleur par défaut</title>
+  <title>Contrôleur par défaut</title>
    <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/yaf/yaf-controller-abstract.xml
+++ b/reference/yaf/yaf-controller-abstract.xml
@@ -19,17 +19,17 @@
     d'affichage.
    </para>
    <para>
-    Tous les controlleurs personnalisés doivent hérités de la classe
+    Tous les contrôleurs personnalisés doivent hérités de la classe
     <classname>Yaf_Controller_Abstract</classname>.
    </para>
    <para>
     Vous devriez vous apercevoir que vous ne pouvez pas définir de fonction
-    __construct pour votre controlleur personnalisé, aussi, la classe
+    __construct pour votre contrôleur personnalisé, aussi, la classe
     <classname>Yaf_Controller_Abstract</classname> fournit une méthode magique
     pour cela : <methodname>Yaf_Controller_Abstract::init</methodname>.
    </para>
    <para>
-    Si vous avez défini une méthode init() dans votre controlleur personnalisé,
+    Si vous avez défini une méthode init() dans votre contrôleur personnalisé,
     elle sera appelée lors de l'instanciation de votre contrôleur.
    </para>
    <para>

--- a/reference/yaf/yaf_controller_abstract/getmodulename.xml
+++ b/reference/yaf/yaf_controller_abstract/getmodulename.xml
@@ -16,7 +16,7 @@
    <void />
   </methodsynopsis>
   <para>
-   Récupère le nom du controlleur du module.
+   Récupère le nom du contrôleur du module.
   </para>
  </refsect1>
 

--- a/reference/yaf/yaf_dispatcher/dispatch.xml
+++ b/reference/yaf/yaf_dispatcher/dispatch.xml
@@ -28,7 +28,7 @@
   </simplelist>
    Le premier ne prend place qu'une seule fois, utilisant les valeurs de l'objet
    de requête lorsque <function>Yaf_Dispatcher::dispatch</function> est appelé. Le second prend place dans une boucle ;
-   une requête peut soit indiquer plusieurs actions à répartir, soit le controlleur
+   une requête peut soit indiquer plusieurs actions à répartir, soit le contrôleur
    ou un plugin peut réinitialiser l'objet de requête pour forcer des actions
    supplémentaires au répartiteur (voir <classname>Yaf_Plugin_Abstract</classname>).
    Lorsque tout ceci est fait, la classe <classname>Yaf_Dispatcher</classname>

--- a/reference/yaf/yaf_dispatcher/setdefaultcontroller.xml
+++ b/reference/yaf/yaf_dispatcher/setdefaultcontroller.xml
@@ -6,7 +6,7 @@
 <refentry xml:id="yaf-dispatcher.setdefaultcontroller" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Yaf_Dispatcher::setDefaultController</refname>
-  <refpurpose>Modifie le nom par défaut du controlleur</refpurpose>
+  <refpurpose>Modifie le nom par défaut du contrôleur</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/yaml/callbacks.xml
+++ b/reference/yaml/callbacks.xml
@@ -70,7 +70,7 @@ array(1) {
  <section xml:id="yaml.callbacks.emit">
   <title>Emission des fonctions de rappel</title>
   <para>
-   L'émission des fonctions de rappel est invoquée lorsqu'un instance
+   L'émission des fonctions de rappel est invoquée lorsqu'une instance
    d'une classe enregistrée est émise via la fonction <function>yaml_emit</function> ou
    la fonction <function>yaml_emit_file</function>. La fonction de rappel
    reçoit l'objet à émettre. La fonction de rappel doit retourner un tableau

--- a/reference/zlib/functions/gzeof.xml
+++ b/reference/zlib/functions/gzeof.xml
@@ -15,7 +15,7 @@
   </methodsynopsis>
   <para>
    Indique si la fin d'un fichier
-   compressé est atteinte, c'est à dire si le pointeur est à la 
+   compressé est atteinte, c'est-à-dire si le pointeur est à la
    position <acronym>EOF</acronym>.
   </para>
  </refsect1>

--- a/reference/zookeeper/zookeeper.xml
+++ b/reference/zookeeper/zookeeper.xml
@@ -427,7 +427,7 @@
      <varlistentry xml:id="zookeeper.constants.perm-admin">
       <term><constant>Zookeeper::PERM_ADMIN</constant></term>
       <listitem>
-       <para>Peut éxécuter set_acl()</para>
+       <para>Peut exécuter set_acl()</para>
       </listitem>
      </varlistentry>
      <varlistentry xml:id="zookeeper.constants.perm-all">


### PR DESCRIPTION
### Orthographe (44 corrections)
- `défault` → `défaut` (16 occurrences)
- `controlleur`/`controllé` → `contrôleur`/`contrôlé` (10)
- `gestionaire` → `gestionnaire` (8)
- `éxécuter` → `exécuter` (3)
- `appellé` → `appelé` (11)
- Autres : `addresse`, `nécéssaire`, `suffisament`, `Verifie`, `parametre`, `probleme`

### Grammaire (70 corrections)
- `tout les` → `tous les` (13)
- `si ils`/`Si il` → `s'ils`/`S'il` (11)
- `quelque soit` → `quel que soit`/`quelle que soit` (9)
- Accords de genre (article masculin + nom féminin) : `un valeur` → `une valeur`, `le chaîne` → `la chaîne`, `un instance` → `une instance`, etc. (17)
- Accords participe passé avec sujet féminin : `a été supprimé` → `supprimée` (3)
- `Nouvelle fonctions` → `Nouvelles fonctions`, `Cette options` → `Cette option` (4)

### Typographie (43 corrections)
- `c'est a dire` → `c'est-à-dire` (22)
- `au dessus` → `au-dessus` (4)
- Mots doublés : `de de`, `un un`, `une une`, `que que`, `par par`, `avec avec`, `si si` (11)
- `du au` → `dû au` (accent circonflexe manquant) (4)