### PR TITLE
Fix french typos

### DIFF
--- a/appendices/migration83/deprecated.xml
+++ b/appendices/migration83/deprecated.xml
@@ -2,7 +2,7 @@
 <!-- EN-Revision: 9c828621cbce488cf6306b21c39e208f847eabd5 Maintainer: Fan2Shrek Status: ready -->
 <!-- Reviewed: yes -->
 <sect1 xml:id="migration83.deprecated">
- <title>Fonctionalités dépréciées</title>
+ <title>Fonctionnalités dépréciées</title>
 
  <sect2 xml:id="migration83.deprecated.core">
   <title>PHP Core</title>

--- a/appendices/migration85/other-changes.xml
+++ b/appendices/migration85/other-changes.xml
@@ -272,7 +272,7 @@
    <title>Zlib</title>
 
    <simpara>
-    L'arguement <parameter>$use_include_path</parameter> des fonctions
+    L'argument <parameter>$use_include_path</parameter> des fonctions
     <function>gzfile</function>, <function>gzopen</function> et
     <function>readgzfile</function> a été changé
     de <type>int</type> à <type>bool</type>.

--- a/features/file-upload.xml
+++ b/features/file-upload.xml
@@ -242,7 +242,7 @@ foreach ($_FILES["pictures"]["error"] as $key => $error) {
     if ($error == UPLOAD_ERR_OK) {
         $tmp_name = $_FILES["pictures"]["tmp_name"][$key];
         // basename() peut empêcher les attaques "filesystem traversal";
-        // une autre validation/nettoyage du nom de fichier peux être appropriée
+        // une autre validation/nettoyage du nom de fichier peut être appropriée
         $name = basename($_FILES["pictures"]["name"][$key]);
         move_uploaded_file($tmp_name, "data/$name");
     }

--- a/features/gc.xml
+++ b/features/gc.xml
@@ -254,7 +254,7 @@ a: (refcount=1, is_ref=0)=array (
     </para>
     <para>
      <example>
-      <title>Ajout du tableau comme référence à lui-même en tant qu'élement</title>
+      <title>Ajout du tableau comme référence à lui-même en tant qu'élément</title>
       <programlisting role="php">
 <![CDATA[
 <?php

--- a/language/control-structures/include-once.xml
+++ b/language/control-structures/include-once.xml
@@ -11,7 +11,7 @@
   évalue le fichier spécifié durant l'exécution du script. 
   Le comportement est similaire à
   <function>include</function>,
-  mais la différence est que si le code a déjà été inclus, il ne le sera pas une seconde fois, et include_once retourne &true;. Comme son nom l'indique, le fichier sera inclut une seule fois.
+  mais la différence est que si le code a déjà été inclus, il ne le sera pas une seconde fois, et include_once retourne &true;. Comme son nom l'indique, le fichier sera inclus une seule fois.
  </para>
  <para>
   La structure <literal>include_once</literal> est utilisée de

--- a/language/types/integer.xml
+++ b/language/types/integer.xml
@@ -217,7 +217,7 @@ var_dump(intval(8.1)); // 8 dans les deux cas
     </programlisting>
    </example>
    <para>
-    Si le nombre à virgule flottante est au delà des limites des &integer;s (habituellement,
+    Si le nombre à virgule flottante est au-delà des limites des &integer;s (habituellement,
     <literal>+/- 2.15e+9 = 2^31</literal> sur les plate-formes 32-bit et
     <literal>+/- 9.22e+18 = 2^63</literal> sur les plate-formes 64-bit),
     le résultat sera indéfini, sachant que le &float; n'a pas une précision

--- a/language/variables.xml
+++ b/language/variables.xml
@@ -613,7 +613,7 @@ var_dump(Bar::counter()); // int(4), Avant PHP 8.1.0 int(2)
     PHP implémente les modificateurs de variables
     <link linkend="language.variables.scope.static">static</link>
     et <link linkend="language.variables.scope.global">global</link>,
-    en terme de <link linkend="language.references">référence</link>.
+    en termes de <link linkend="language.references">référence</link>.
     Par exemple, une vraie variable globale est importée dans un
     contexte de fonction avec <literal>global</literal>.
     Cette commande crée en fait une référence sur la variable globale. Cela

--- a/reference/array/functions/array-unique.xml
+++ b/reference/array/functions/array-unique.xml
@@ -108,7 +108,7 @@
         précédemment <parameter>array</parameter> était copié et les éléments
         non-unique était supprimé (sans compresser le tableau après), mais
         maintenant un nouveau tableau est construit en ajoutant les éléments unique.
-        Par conséquence le résultat final peut avoir des index numérique différent.
+        Par conséquent, le résultat final peut avoir des index numériques différents.
        </entry>
       </row>
      </tbody>

--- a/reference/com/com.xml
+++ b/reference/com/com.xml
@@ -74,7 +74,7 @@
 $word = new com("word.application") or die("Unable to instantiate Word");
 echo "Loaded Word, version {$word->Version}\n";
 
-// l'ammener devant
+// l'amener devant
 $word->Visible = 1;
 
 // ouvrir un document vide

--- a/reference/cubrid/functions/cubrid-move-cursor.xml
+++ b/reference/cubrid/functions/cubrid-move-cursor.xml
@@ -27,7 +27,7 @@
    n'est pas explicitement désigné, alors la fonction utilisera <constant>CUBRID_CURSOR_CURRENT</constant> comme valeur par défaut.
   </simpara>
   <simpara>
-   Si la valeur courant du déplacement du curseur est au delà des limites valides, alors
+   Si la valeur courant du déplacement du curseur est au-delà des limites valides, alors
    le curseur se déplace à la prochaine position après l'intervalle valide du curseur. Par exemple,
    si vous le déplacez de 20 unités dans le résultat dont la taille est de 10, alors le curseur
    se placera sur la 11ème place et retournera <constant>CUBRID_NO_MORE_DATA</constant>.

--- a/reference/cubrid/functions/cubrid-seq-insert.xml
+++ b/reference/cubrid/functions/cubrid-seq-insert.xml
@@ -41,7 +41,7 @@
    </varlistentry>
    <varlistentry>
     <term><parameter>index</parameter></term>
-    <listitem><simpara>Position de l'élement pour son insertion (en commençant à 1).</simpara></listitem>
+    <listitem><simpara>Position de l'élément pour son insertion (en commençant à 1).</simpara></listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>seq_element</parameter></term>

--- a/reference/curl/constants_curl_setopt.xml
+++ b/reference/curl/constants_curl_setopt.xml
@@ -3987,7 +3987,7 @@
    <listitem>
     <para>
      Le nombre maximum de millisecondes à attendre pour les fonctions cURL
-     s'éxécutent.
+     s'exécutent.
      Si cURL est compilé pour utiliser le résolveur de noms système standard,
      cette partie de la connexion utilisera toujours une résolution de seconde complète
      pour les délais d'attente avec un délai minimum autorisé d'une seconde.

--- a/reference/dba/setup.xml
+++ b/reference/dba/setup.xml
@@ -43,7 +43,7 @@
        <entry>
         Ndbm est un nouveau type et plus flexible que dbm. Il
         comporte néanmoins des limitations arbitraires de dbm
-        (et par conséquence, il est obsolète).
+        (et par conséquent, il est obsolète).
        </entry>
       </row>
 

--- a/reference/dom/examples.xml
+++ b/reference/dom/examples.xml
@@ -8,7 +8,7 @@
  <para>
   Beaucoup d'exemples de cette documentation requièrent un fichier XML.
   Nous allons utiliser le fichier <filename>book.xml</filename>
-  qui contient les élements suivants : 
+  qui contient les éléments suivants : 
  </para>
  <para>
   <example>

--- a/reference/ev/evloop/nowupdate.xml
+++ b/reference/ev/evloop/nowupdate.xml
@@ -18,7 +18,7 @@
   <simpara>
    Etablit le temps courant en demandant au kernel, et mise à jour
    du temps retourné par <methodname>EvLoop::now</methodname> pendant l'exécution.
-   C'est une opération qui est coûteuse en terme de performance et qui
+   C'est une opération qui est coûteuse en termes de performance et qui
    est habituellement exécutée automatiquement dans la méthode
    <methodname>EvLoop::run</methodname>.
   </simpara>

--- a/reference/filesystem/functions/fgetcsv.xml
+++ b/reference/filesystem/functions/fgetcsv.xml
@@ -49,7 +49,7 @@
      <term><parameter>length</parameter></term>
      <listitem>
       <para>
-       Doit être plus grand que la plus grande ligne (en terme de caractères) 
+       Doit être plus grand que la plus grande ligne (en termes de caractères) 
        à lire dans le fichier (y compris le caractère de fin de ligne).
        Dans le cas contraire la ligne sera scindée en tranches de <parameter>length</parameter> caractères,
        sauf si la scission se produit à l'intérieur d'un encadrement.

--- a/reference/filesystem/functions/fileatime.xml
+++ b/reference/filesystem/functions/fileatime.xml
@@ -79,7 +79,7 @@ if (file_exists($filename)) {
    <para>
     La date de dernière modification d'un fichier est supposé changer
     à chaque fois que les blocs de données du fichier ont commencés
-    à être lus. Cela peut être très coûteux en terme de performance lorsqu'une
+    à être lus. Cela peut être très coûteux en termes de performance lorsqu'une
     application accède régulièrement à beaucoup de fichiers ou de répertoires.
    </para>
    <para>

--- a/reference/filesystem/functions/fseek.xml
+++ b/reference/filesystem/functions/fseek.xml
@@ -23,7 +23,7 @@
    à la position <parameter>whence</parameter>.
   </para>
    <para>
-   En général, il est possible de se déplacer au delà de la fin du flux (eof); si des
+   En général, il est possible de se déplacer au-delà de la fin du flux (eof); si des
    données sont écrites dans ce cas, l'espace entre la fin du flux et
    la position courante sera rempli d'octets nuls. Cependant, certains flux ne supportent
    pas ce comportement, en particulier lorsque l'espace de stockage sous-jascent est de

--- a/reference/ftp/functions/ftp-exec.xml
+++ b/reference/ftp/functions/ftp-exec.xml
@@ -82,7 +82,7 @@ $ftp = ftp_connect($ftp_server);
 // Identification
 $login_result = ftp_login($ftp, $ftp_user_name, $ftp_user_pass);
 
-// Éxécution d'une commande
+// Exécution d'une commande
 if (ftp_exec($ftp, $command)) {
     echo "$command a été exécuté avec succès\n";
 } else {

--- a/reference/geoip/ini.xml
+++ b/reference/geoip/ini.xml
@@ -38,7 +38,7 @@
        <listitem>
          <simpara>
            Vide par défaut, mais peut être utilisé pour charger une base
-           de données différente de celle inclut dans la librairie.
+           de données différente de celle incluse dans la librairie.
          </simpara>
        </listitem>
      </varlistentry>

--- a/reference/gmagick/gmagick/quantizeimages.xml
+++ b/reference/gmagick/gmagick/quantizeimages.xml
@@ -56,7 +56,7 @@
       de référence, avec un minimum de mémoire, et une rapidité d'exécution optimale.
       Dans certains cas, comme une image avec peu de dispersion de couleurs (un nombre
       peu élevé de couleurs), une valeur autre que Log4(number_colors) est nécessaire.
-      Pour étendre l'arbre des couleurs complétement, utilisez la valeur 8.
+      Pour étendre l'arbre des couleurs complètement, utilisez la valeur 8.
      </simpara>
     </listitem>
    </varlistentry>

--- a/reference/hash/functions/hash-update.xml
+++ b/reference/hash/functions/hash-update.xml
@@ -33,7 +33,7 @@
      <term><parameter>data</parameter></term>
      <listitem>
       <para>
-       Message qui sera inclut dans l'empreinte de hachage.
+       Message qui sera inclus dans l'empreinte de hachage.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/image/book.xml
+++ b/reference/image/book.xml
@@ -51,8 +51,8 @@
    </note>
    <caution>
     <simpara>
-     Tandis que la version empaqueter de librairie GD utilise le gestionnaire de
-     mémoire Zend pour alouer de la mémoire, mais les versions système non, donc 
+     Tandis que la version empaquetée de la librairie GD utilise le gestionnaire de
+     mémoire Zend pour allouer de la mémoire, mais les versions système non, donc 
      <link linkend="ini.memory-limit">memory_limit</link> ne s'applique pas.
     </simpara>
    </caution>

--- a/reference/image/functions/imagettftext.xml
+++ b/reference/image/functions/imagettftext.xml
@@ -99,7 +99,7 @@
       <para>
        Peut inclure des références à des caractères numériques,
        décimales (sous la forme : <literal>&amp;#8364;</literal>) pour accéder aux caractères
-       d'une police au delà du premier 127.
+       d'une police au-delà du premier 127.
        Le format hexadécimal (comme <literal>&amp;#xA9;</literal>) est pris en charge.
        Les chaînes de caractères encodées en UTF-8 peuvent être passées directement.
       </para>

--- a/reference/image/ini.xml
+++ b/reference/image/ini.xml
@@ -42,7 +42,7 @@
     </term>
     <listitem>
      <para>
-      Ignore les alertes (main pas les érreurs) créées par libjpeg(-turbo).
+      Ignore les alertes (mais pas les erreurs) créées par libjpeg(-turbo).
      </para>
     </listitem>
    </varlistentry>
@@ -75,7 +75,7 @@
 
  <warning>
   <para>
-   Les fonctions sur les images sont très gourmandes en terme de mémoire.
+   Les fonctions sur les images sont très gourmandes en termes de mémoire.
    Assurez-vous de définir une valeur assez importante pour <link
    linkend="ini.memory-limit">memory_limit</link> si vous utilisez la librairie GD intégrée.
   </para>

--- a/reference/imagick/imagick/setimagetickspersecond.xml
+++ b/reference/imagick/imagick/setimagetickspersecond.xml
@@ -21,7 +21,7 @@
   <note>
    <para>
     Pour les GIFs animés, cette méthode ne modifie pas le nombre de 'ticks'
-    par secondes, qui sera toujours défini à 100. Au lieu de celà, la méthode
+    par secondes, qui sera toujours défini à 100. Au lieu de cela, la méthode
     va ajuster la durée d'affichage de la frame pour simuler une modification
     du ticks par seconde.
    </para>

--- a/reference/intl/normalizer.xml
+++ b/reference/intl/normalizer.xml
@@ -34,7 +34,7 @@
       composition canonique
      </member>
     </simplelist>
-    Les différentes formes sont définies en terme de transformations de texte,
+    Les différentes formes sont définies en termes de transformations de texte,
     transformations qui sont exprimées avec des algorithmes et des fichiers
     de données.
    </para>

--- a/reference/luasandbox/luasandboxruntimeerror.xml
+++ b/reference/luasandbox/luasandboxruntimeerror.xml
@@ -11,7 +11,7 @@
   <section xml:id="luasandboxruntimeerror.intro">
    &reftitle.intro;
    <simpara>
-    Les exceptions d'éxécutions LuaSandbox qui peuvent être attrapées.
+    Les exceptions d'exécutions LuaSandbox qui peuvent être attrapées.
    </simpara>
    <simpara>
     Ces exceptions peuvent être attrapées en Lua en utilisant

--- a/reference/mbstring/ini.xml
+++ b/reference/mbstring/ini.xml
@@ -313,7 +313,7 @@ mbstring.internal_encoding    = UTF-8
 mbstring.encoding_translation = On
 
 ;; Jeu de caractères par défaut pour les données d'entrée HTTP
-;; Note : le script ne peux pas changer cette configuration
+;; Note : le script ne peut pas changer cette configuration
 mbstring.http_input           = pass    ; Aucune conversion.
 mbstring.http_input           = auto    ; Utilise auto
                                 ; "auto" est remplacé suivant mbstring.language

--- a/reference/mongodb/bson/document/frombson.xml
+++ b/reference/mongodb/bson/document/frombson.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="mongodb-bson-document.frombson" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>MongoDB\BSON\Document::fromBSON</refname>
-  <refpurpose>Construit une nouvelle instance de document depuis une chaine de charactère BSON</refpurpose>
+  <refpurpose>Construit une nouvelle instance de document depuis une chaine de caractères BSON</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/mongodb/bson/document/fromjson.xml
+++ b/reference/mongodb/bson/document/fromjson.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="mongodb-bson-document.fromjson" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>MongoDB\BSON\Document::fromJSON</refname>
-  <refpurpose>Construit une nouvelle instance de document depuis une chaine de charactère JSON</refpurpose>
+  <refpurpose>Construit une nouvelle instance de document depuis une chaine de caractères JSON</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/mongodb/bson/regex/construct.xml
+++ b/reference/mongodb/bson/regex/construct.xml
@@ -70,7 +70,7 @@
        <entry>PECL mongodb 1.2.0</entry>
        <entry>
         <para>
-         L'arguement <parameter>flags</parameter> est optionnel et la valeur 
+         L'argument <parameter>flags</parameter> est optionnel et la valeur 
          par défaut est une chaîne vide.
         </para>
         <para>

--- a/reference/mongodb/bson/utcdatetime/construct.xml
+++ b/reference/mongodb/bson/utcdatetime/construct.xml
@@ -34,7 +34,7 @@
       de millisecondes depuis l'époque UNIX sera dérivé de cette valeur.
      </para>
      <para>
-      Si cet arguement est &null;, la l'heure actuelle sera utilisée par défaut.
+      Si cet argument est &null;, l'heure actuelle sera utilisée par défaut.
      </para>
     </listitem>
    </varlistentry>

--- a/reference/mongodb/mongodb/driver/bulkwrite.xml
+++ b/reference/mongodb/mongodb/driver/bulkwrite.xml
@@ -82,12 +82,12 @@ $bulk->delete(['x' => 1]);
     </programlisting>
     <para>
      Résulte en quatre commandes d'écriture (c'est-à-dire des allers-retours)
-     éxécutées. Puisque les opérations sont ordonnées, la troisième insertion ne peut pas être envoyée
+     exécutées. Puisque les opérations sont ordonnées, la troisième insertion ne peut pas être envoyée
      avant que la mise à jour précédente ne soit exécutée.
     </para>
    </example>
    <example>
-    <title>Opérations d'écriture ordonnées causant une érreur</title>
+    <title>Opérations d'écriture ordonnées causant une erreur</title>
     <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/mongodb/mongodb/driver/bulkwrite/update.xml
+++ b/reference/mongodb/mongodb/driver/bulkwrite/update.xml
@@ -111,7 +111,7 @@
            </para>
            <para>
             Cette option est disponible dans MongoDB 4.4+ et entraînera une
-            exception au moment de l'éxécution si elle est spécifiée pour une version de serveur
+            exception au moment de l'exécution si elle est spécifiée pour une version de serveur
             plus ancienne.
            </para>
           </entry>

--- a/reference/mongodb/mongodb/driver/manager/executebulkwrite.xml
+++ b/reference/mongodb/mongodb/driver/manager/executebulkwrite.xml
@@ -73,7 +73,7 @@
   &reftitle.errors;
   <simplelist>
    <member>Lance une <classname>MongoDB\Driver\Exception\InvalidArgumentException</classname> si <parameter>bulk</parameter> ne contient aucune opérations d'écriture.</member>
-   <member>Lance une <classname>MongoDB\Driver\Exception\InvalidArgumentException</classname> si <parameter>bulk</parameter> a déjà été éxécuté. Les objets <classname>MongoDB\Driver\BulkWrite</classname> ne peuvent pas être exécutés plusieurs fois.</member>
+   <member>Lance une <classname>MongoDB\Driver\Exception\InvalidArgumentException</classname> si <parameter>bulk</parameter> a déjà été exécuté. Les objets <classname>MongoDB\Driver\BulkWrite</classname> ne peuvent pas être exécutés plusieurs fois.</member>
    &mongodb.throws.session-unacknowledged;
    &mongodb.throws.std;
    &mongodb.throws.bulkwriteexception;

--- a/reference/oci8/connection.xml
+++ b/reference/oci8/connection.xml
@@ -15,7 +15,7 @@
   </para>
   <para>
    La connexion à un serveur Oracle est une opération raisonnablement coûteuse
-   en terme de temps que cela nécessite. La fonction <function>oci_pconnect</function>
+   en termes de temps que cela nécessite. La fonction <function>oci_pconnect</function>
    utilise un cache persistant de connexions qui peut être réutilisé à travers
    différents scripts. Cela signifie qu'une seule connexion sera utilisée par
    processus PHP (ou un fils Apache).

--- a/reference/oci8/functions/oci-bind-by-name.xml
+++ b/reference/oci8/functions/oci-bind-by-name.xml
@@ -21,8 +21,8 @@
   <para>
    Lie une variable PHP <parameter>var</parameter> au marqueur Oracle
    <parameter>param</parameter>. Le fait de lier une
-   variable est important en terme de performance de la
-   base de données Oracle, mais aussi en terme de sécurité
+   variable est important en termes de performance de la
+   base de données Oracle, mais aussi en termes de sécurité
    relative aux injections SQL.
   </para>
 

--- a/reference/opcache/configure.xml
+++ b/reference/opcache/configure.xml
@@ -35,7 +35,7 @@
 
   <simpara>
    La configuration suivante est généralement recommandée, vu qu'elle
-   fournit un bon gain en terme de performance :
+   fournit un bon gain en termes de performance :
   </simpara>
 
   <informalexample>

--- a/reference/phar/Phar/copy.xml
+++ b/reference/phar/Phar/copy.xml
@@ -91,7 +91,7 @@ try {
     // Traite les erreurs
 }
 
-// l'équivalent en terme de flux du code ci-dessus
+// l'équivalent en termes de flux du code ci-dessus
 // des E_WARNING sont retournés plutôt que des exceptions
 copy('phar://monphar.phar/a', 'phar//monphar.phar/c');
 echo file_get_contents('phar://monphar.phar/c'); // Affiche "salut"

--- a/reference/phar/PharData/copy.xml
+++ b/reference/phar/PharData/copy.xml
@@ -67,7 +67,7 @@
     <title>Un exemple avec <function>PharData::copy</function></title>
     <para>
      Cet exemple montre l'utilisation de <function>PharData::copy</function> et de son équivalent
-     en terme de gestionnaire de flux. La différence principale entre les deux façons de faire
+     en termes de gestionnaire de flux. La différence principale entre les deux façons de faire
      concerne la gestion des erreurs. Toutes les méthodes PharData soulèvent des exceptions, alors
      que le gestionnaire de flux utilise <function>trigger_error</function>.
     </para>
@@ -84,7 +84,7 @@ try {
     // On traite les erreurs
 }
 
-// l'équivalent en terme de flux de l'exemple ci-dessus.
+// l'équivalent en termes de flux de l'exemple ci-dessus.
 // des E_WARNING sont lancés en cas d'erreur à la place d'exceptions.
 copy('phar://monphar.tar/a', 'phar//monphar.tar/c');
 echo file_get_contents('phar://monphar.tar/c'); // Affiche "salut"

--- a/reference/phar/using.xml
+++ b/reference/phar/using.xml
@@ -322,7 +322,7 @@ $f = file_get_contents('phar://monphar.phar/nimportequoi.txt');
      un fichier existant au sein de <literal>monphar.phar</literal>.  <literal>$v</literal>
      peut être soit une chaîne ou un pointeur vers un fichier ouvert, dans quel cas
      le contenu du fichier sera utilisé pour créer le nouveau fichier. Notez que
-     <literal>$p-&gt;addFromString('fichier.php', $v)</literal> est équivalent en terme de
+     <literal>$p-&gt;addFromString('fichier.php', $v)</literal> est équivalent en termes de
      fonctionnalité au cas ci-dessus.  Il est aussi possible d'ajouter le contenu d'un fichier
      avec <literal>$p-&gt;addFile('/chemin/vers/fichier.php', 'fichier.php')</literal>.
      Enfin, un répertoire vide peut être créé avec

--- a/reference/reflection/reflectionfiber/getexecutingfile.xml
+++ b/reference/reflection/reflectionfiber/getexecutingfile.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="reflectionfiber.getexecutingfile" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>ReflectionFiber::getExecutingFile</refname>
-  <refpurpose>Renvoie le nom du fichier du point d'éxécution actuel</refpurpose>
+  <refpurpose>Renvoie le nom du fichier du point d'exécution actuel</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -14,7 +14,7 @@
    <void/>
   </methodsynopsis>
   <para>
-   Renvoie le chemin complet et le nom du fichier du point d'éxécution actuel de la <classname>Fiber</classname> reflétée.
+   Renvoie le chemin complet et le nom du fichier du point d'exécution actuel de la <classname>Fiber</classname> reflétée.
    Si la fibre n'a pas été démarrée ou s'est terminée, une <classname>Erreur</classname> est lancée.
   </para>
  </refsect1>

--- a/reference/reflection/reflectionfiber/getexecutingline.xml
+++ b/reference/reflection/reflectionfiber/getexecutingline.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="reflectionfiber.getexecutingline" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>ReflectionFiber::getExecutingLine</refname>
-  <refpurpose>Renvoie le numéro de ligne du point d'éxécution actuel</refpurpose>
+  <refpurpose>Renvoie le numéro de ligne du point d'exécution actuel</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -14,7 +14,7 @@
    <void/>
   </methodsynopsis>
   <para>
-   Renvoie le numéro de ligne du point d'éxécution actuel de la <classname>Fiber</classname> reflétée.
+   Renvoie le numéro de ligne du point d'exécution actuel de la <classname>Fiber</classname> reflétée.
    Si la fibre reflétée est utilisée en dehors d'une fonction définie par l'utilisateur, &null; est renvoyé.
    Si la fibre n'a pas été démarrée ou s'est terminée, une <classname>Erreur</classname> est lancée.
   </para>
@@ -28,7 +28,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Le numéro de ligne du point d'éxécution actuel de la fibre.
+   Le numéro de ligne du point d'exécution actuel de la fibre.
   </para>
  </refsect1>
 

--- a/reference/reflection/reflectionfiber/gettrace.xml
+++ b/reference/reflection/reflectionfiber/gettrace.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="reflectionfiber.gettrace" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>ReflectionFiber::getTrace</refname>
-  <refpurpose>Renvoie la trace d'appels du point d'éxécution actuel</refpurpose>
+  <refpurpose>Renvoie la trace d'appels du point d'exécution actuel</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -14,7 +14,7 @@
    <methodparam choice="opt"><type>int</type><parameter>options</parameter><initializer><constant>DEBUG_BACKTRACE_PROVIDE_OBJECT</constant></initializer></methodparam>
   </methodsynopsis>
   <para>
-   Renvoie la trace d'appels du point d'éxécution actuel de la <classname>Fiber</classname> reflétée.
+   Renvoie la trace d'appels du point d'exécution actuel de la <classname>Fiber</classname> reflétée.
   </para>
  </refsect1>
 
@@ -70,7 +70,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   La trace d'appels du point d'éxécution actuel de la fibre.
+   La trace d'appels du point d'exécution actuel de la fibre.
   </para>
  </refsect1>
 

--- a/reference/session/security.xml
+++ b/reference/session/security.xml
@@ -227,7 +227,7 @@
     </para>
     
     <para>
-     Au lieu de celà, les développeurs doivent implémenter un timestamp
+     Au lieu de cela, les développeurs doivent implémenter un timestamp
      basé sur la gestion des données de session.
    </para>
    
@@ -406,7 +406,7 @@
     </para>
     
     <para>
-     Il existe différentes façons de faire celà. Une implémentation possible
+     Il existe différentes façons de faire cela. Une implémentation possible
      est de définir une base de données qui conserve une trace des données
      nécessaires, et y stoquer toutes les informations pertinentes.
      Depuis que les données de session sont GCed, les développeurs doivent
@@ -420,7 +420,7 @@
      la variable $_SESSION. La plupart des bases de données sont relativement
      performantes pour sélectionner un préfixe sous la forme d'une &string;.
      Les développeurs DOIVENT utiliser la fonction <function>session_regenerate_id</function>
-     ainsi que la fonction <function>session_create_id</function> pour celà.
+     ainsi que la fonction <function>session_create_id</function> pour cela.
     </para>
     
     <warning>
@@ -483,7 +483,7 @@
      Une clé d'auto-identification est une clé d'authentification avec une
      longue durée, elle doit être protégée autant que possible.
      Utilisez les attributs de cookie path/httponly/secure/SameSite pour la sécuriter.
-     i.e. ne transmettez jamais la clé d'auto-identification tant que celà
+     i.e. ne transmettez jamais la clé d'auto-identification tant que cela
      n'est pas nécessaire.
     </para>
     
@@ -560,7 +560,7 @@
     <para>
      Si une fonctionnalité d'auto-identification est désirée, les développeurs
      doivent implémenter leur propre système d'auto-identification sécurité.
-     N'utilisez pas des idenfiants de session à longue durée pour celà.
+     N'utilisez pas des identifiants de session à longue durée pour cela.
      Pour plus d'informations, veuillez vous rapporter à la bonne section
      de cette documentation.
     </para>

--- a/reference/session/upload-progress.xml
+++ b/reference/session/upload-progress.xml
@@ -124,7 +124,7 @@ $_SESSION["upload_progress_123"] = array(
  <caution>
   <para>
    Les informations de la progression du téléversement sont écrite en session avant
-   qu'un script soit éxécuté. Par conséquence changer le nom de session grâce à
+   qu'un script soit exécuté. Par conséquent, changer le nom de session grâce à
    <function>ini_set</function> ou <function>session_name</function> donnera une
    session sans les informations de progression du téléversement.
   </para>

--- a/reference/sodium/functions/sodium-pad.xml
+++ b/reference/sodium/functions/sodium-pad.xml
@@ -15,7 +15,7 @@
    <methodparam><type>int</type><parameter>block_size</parameter></methodparam>
   </methodsynopsis>
   <simpara>
-   Remplit à droite une chaîne jusqu'à la longueur désirée. Sécurisé en terme de temps.
+   Remplit à droite une chaîne jusqu'à la longueur désirée. Sécurisé en termes de temps.
   </simpara>
 
  </refsect1>

--- a/reference/sodium/functions/sodium-unpad.xml
+++ b/reference/sodium/functions/sodium-unpad.xml
@@ -15,7 +15,7 @@
    <methodparam><type>int</type><parameter>block_size</parameter></methodparam>
   </methodsynopsis>
   <simpara>
-   Supprime les données de remplissage d'une chaîne. Sécurisé en terme de temps.
+   Supprime les données de remplissage d'une chaîne. Sécurisé en termes de temps.
   </simpara>
 
  </refsect1>

--- a/reference/solr/solrquery/getmltminwordlength.xml
+++ b/reference/solr/solrquery/getmltminwordlength.xml
@@ -6,7 +6,7 @@
 <refentry xml:id="solrquery.getmltminwordlength" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>SolrQuery::getMltMinWordLength</refname>
-  <refpurpose>Retourne la longueur minimum d'un mot en deça duquel il sera ignoré</refpurpose>
+  <refpurpose>Retourne la longueur minimum d'un mot en deçà duquel il sera ignoré</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -16,7 +16,7 @@
    <void />
   </methodsynopsis>
   <para>
-   Retourne la longueur minimum d'un mot en deça duquel il sera ignoré.
+   Retourne la longueur minimum d'un mot en deçà duquel il sera ignoré.
   </para>
 
  </refsect1>

--- a/reference/sqlsrv/functions/sqlsrv-query.xml
+++ b/reference/sqlsrv/functions/sqlsrv-query.xml
@@ -62,7 +62,7 @@
       <tgroup cols="2">
        <thead>
         <row>
-         <entry>Élement</entry>
+         <entry>Élément</entry>
          <entry>Description</entry>
         </row>
        </thead>

--- a/reference/strings/functions/count-chars.xml
+++ b/reference/strings/functions/count-chars.xml
@@ -116,7 +116,7 @@
 $data = "Deux D et un F.";
 
 foreach (count_chars($data, 1) as $i => $val) {
-   echo "Il y a $val occurence(s) de \"" , chr($i) , "\" dans la phrase.\n";
+   echo "Il y a $val occurrence(s) de \"" , chr($i) , "\" dans la phrase.\n";
 }
 ?>
 ]]>

--- a/reference/strings/functions/strtr.xml
+++ b/reference/strings/functions/strtr.xml
@@ -25,7 +25,7 @@
    Si trois arguments sont utilisés, <function>strtr</function> retourne la chaîne
    <parameter>string</parameter> après avoir remplacé chaque caractère (de un octet)
    du paramètre <parameter>from</parameter> par son équivalent dans le paramètre
-   <parameter>to</parameter>, chaque occurence de <literal>$from[$n]</literal> est
+   <parameter>to</parameter>, chaque occurrence de <literal>$from[$n]</literal> est
    remplacée par <literal>$to[$n]</literal>, où <literal>$n</literal> est une valeur
    valide pour chaque argument.
   </para>

--- a/reference/swoole/constants.xml
+++ b/reference/swoole/constants.xml
@@ -1355,7 +1355,7 @@
     </term>
     <listitem>
      <simpara>
-      Error de poignée de main Http proxy.
+      Erreur de poignée de main Http proxy.
      </simpara>
     </listitem>
    </varlistentry>

--- a/reference/tokenizer/phptoken/getTokenName.xml
+++ b/reference/tokenizer/phptoken/getTokenName.xml
@@ -26,7 +26,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Un charactère ASCII pour les tokens à un seul caractère,
+   Un caractère ASCII pour les tokens à un seul caractère,
    ou une des constantes T_* pour les tokens connus (voir <xref linkend="tokens"/>),
    ou &null; pour les tokens inconnus.
   </para>
@@ -43,7 +43,7 @@
 $token = new PhpToken(T_ECHO, 'echo');
 var_dump($token->getTokenName());   // -> string(6) "T_ECHO"
 
-// token à un seul charactère
+// token à un seul caractère
 $token = new PhpToken(ord(';'), ';');
 var_dump($token->getTokenName());   // -> string(1) ";"
 

--- a/reference/trader/book.xml
+++ b/reference/trader/book.xml
@@ -13,7 +13,7 @@
    L'extension Trader est une bibliothèque open source libre, basée sur TA-Lib.
    Elle est dédiée aux développeurs de logiciels commerciaux qui nécessitent
    d'effectuer une analyse technique des données sur les marchés financiers.
-   En plus de celà, plusieurs indicateurs comme ADX, MACD, RSI, Stochastic,
+   En plus de cela, plusieurs indicateurs comme ADX, MACD, RSI, Stochastic,
    TRIX le chadellier à reconnaissance de masque, mais aussi, divers fonctions
    arithmétique et algébrique sont présents.
   </para>

--- a/reference/uodbc/functions/odbc-connection-string-is-quoted.xml
+++ b/reference/uodbc/functions/odbc-connection-string-is-quoted.xml
@@ -14,7 +14,7 @@
    <methodparam><type>string</type><parameter>str</parameter></methodparam>
   </methodsynopsis>
   <para>
-    Détermine si une chaîne de caractères est correctement entre guillemets pour une chaîne de charactère de 
+    Détermine si une chaîne de caractères est correctement entre guillemets pour une chaîne de caractères de 
     connexion ODBC. La mise entre guillemets de chaîne de caractères de connexion ODBC est effectuée en
     utilisant des accolades, et les accolades de fin dans une chaîne doivent être échappées
     en les répétant deux fois, similaire à la mise entre guillemets SQL.

--- a/reference/wincache/functions/wincache-rplist-meminfo.xml
+++ b/reference/wincache/functions/wincache-rplist-meminfo.xml
@@ -35,7 +35,7 @@
    <itemizedlist spacing="compact">
     <listitem>
      <simpara>
-      <literal>memory_total</literal> - nombre total de mémoire, en octets, alouée
+      <literal>memory_total</literal> - nombre total de mémoire, en octets, allouée
       au cache de chemins de fichiers résolus
      </simpara>
     </listitem>

--- a/reference/wincache/setup.xml
+++ b/reference/wincache/setup.xml
@@ -281,7 +281,7 @@ session.save_path = C:\inetpub\temp\session\
   </itemizedlist>
   <para>
    Pour configurer le re routage de fonctions avec Wincache, utilisez le fichier
-   <filename>reroute.ini</filename> inclut dans le paquet. Copiez le dans le dossier
+   <filename>reroute.ini</filename> inclus dans le paquet. Copiez-le dans le dossier
    où se trouve <filename>php.ini</filename>. Après, ajoutez wincache.rerouteini dans
    <filename>php.ini</filename> et précisez le chemin absolu ou relatif vers
    <filename>reroute.ini</filename>.

--- a/reference/xmlreader/setup.xml
+++ b/reference/xmlreader/setup.xml
@@ -17,7 +17,7 @@
  <section xml:id="xmlreader.installation">
   &reftitle.install;
   <para>
-   L'extension XMLReader est inclut avec la source de PHP.
+   L'extension XMLReader est incluse avec la source de PHP.
    &installation.enabled.disable;
    <option role="configure">--disable-xmlreader</option>
   </para>

--- a/reference/xmlwriter/setup.xml
+++ b/reference/xmlwriter/setup.xml
@@ -17,7 +17,7 @@
  <section xml:id="xmlwriter.installation">
   &reftitle.install;
   <para>
-   L'extension XMLWriter est inclut avec la source de PHP.
+   L'extension XMLWriter est incluse avec la source de PHP.
    &installation.enabled.disable;
    <option role="configure">--disable-xmlwriter</option>
   </para>

--- a/reference/yaf/yaf_config_ini/count.xml
+++ b/reference/yaf/yaf_config_ini/count.xml
@@ -6,7 +6,7 @@
 <refentry xml:id="yaf-config-ini.count" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Yaf_Config_Ini::count</refname>
-  <refpurpose>Compte tous les élements dans Yaf_Config.ini</refpurpose>
+  <refpurpose>Compte tous les éléments dans Yaf_Config.ini</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/yaf/yaf_dispatcher/catchexception.xml
+++ b/reference/yaf/yaf_dispatcher/catchexception.xml
@@ -86,7 +86,7 @@ class ErrorController extends Yaf_Controller_Abstract {
    &example.outputs.similar;
    <screen>
 <![CDATA[
-/* Maintenant, si une erreur survient, en supposant un accès à un controlleur existant pas (ou vous pouvez lancer une exception vous-même) : */
+/* Maintenant, si une erreur survient, en supposant un accès à un contrôleur n'existant pas (ou vous pouvez lancer une exception vous-même) : */
 404:Could not find controller script **/application/controllers/No-exists-controller.php
 ]]>
    </screen>

--- a/reference/yaf/yaf_route_regex/construct.xml
+++ b/reference/yaf/yaf_route_regex/construct.xml
@@ -107,7 +107,7 @@
         new Yaf_Route_Regex(
            "#^/product/([^/]+)/([^/])+#", //correspond à la requête URI "/product"
            array(
-               'controller' => "product",  //route vers le controlleur produit,
+               'controller' => "product",  //route vers le contrôleur produit,
            ),
            array(
               1 => "name",   // maintenant, vous pouvez appeler $request->getParam("name")
@@ -181,7 +181,7 @@
            "type"  => "regex",          //la route Yaf_Route_Regex
            "match" => "#(.*)#",         //correspondance arbitraire à la requête URI
            "route" => array(
-               'controller' => "product",  //route vers le controlleur produit,
+               'controller' => "product",  //route vers le contrôleur produit,
                'action'     => "dummy",    //route pour l'action dummy
            ),
            "map" => array(

--- a/reference/yaf/yaf_route_rewrite/construct.xml
+++ b/reference/yaf/yaf_route_rewrite/construct.xml
@@ -86,7 +86,7 @@
         new Yaf_Route_rewrite(
            "/product/:name/:id/*", //correspond à la requête URI "/product"
            array(
-               'controller' => "product",  //route vers le controlleur produit,
+               'controller' => "product",  //route vers le contrôleur produit,
            ),
         )
     );

--- a/reference/zip/ziparchive/close.xml
+++ b/reference/zip/ziparchive/close.xml
@@ -18,7 +18,7 @@
    à la fin du script.
   </para>
   <para>
-   Si l'archive ne contient aucun fichier, elle est complétement supprimée par défaut
+   Si l'archive ne contient aucun fichier, elle est complètement supprimée par défaut
    (pas d'enregistrement d'une archive vide) en fonction de la valeur de la constante
    <constant>ZipArchive::AFL_CREATE_OR_KEEP_FILE_FOR_EMPTY_ARCHIVE</constant>
   </para>

--- a/reference/zlib/functions/gzseek.xml
+++ b/reference/zlib/functions/gzseek.xml
@@ -72,7 +72,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   0 en cas de réussite, -1 sinon. Notez que placer le pointeur au delà de la fin
+   0 en cas de réussite, -1 sinon. Notez que placer le pointeur au-delà de la fin
    du fichier n'est pas considéré comme une erreur.
   </para>
  </refsect1>

--- a/security/variables.xml
+++ b/security/variables.xml
@@ -17,8 +17,8 @@
    <programlisting role="php">
 <![CDATA[
 <?php
-// efface un fichier à la racine d'un utilisateur... ou peut être
-// de quelqu'un d'autre?
+// efface un fichier à la racine d'un utilisateur... ou peut-être
+// de quelqu'un d'autre ?
 unlink($evil_var);
 // Note l'accès de ce fichier ... ou pas?
 fputs($fp, $evil_var);


### PR DESCRIPTION
Corrections orthographiques et grammaticales :
- charactère -> caractère (5)
- occurence -> occurrence (2)
- élement/élements -> élément/éléments (5)
- complétement -> complètement (2)
- éxécution/éxécuté -> exécution/exécuté (11)
- controlleur -> contrôleur (4)
- celà -> cela (7)
- en terme de -> en termes de (16)
- par conséquence -> par conséquent (3)
- au delà -> au-delà (5)
- inclut (participe passé) -> inclus/incluse (6)
- arguement -> argument (3)
- érreur/main -> erreur/mais (2)
- alouer -> allouer (2)
- empaqueter -> empaquetée (1)
- fonctionalité -> fonctionnalité (1)
- ammener -> amener (1)
- idenfiants -> identifiants (1)
- peux -> peut (2)
- Error -> Erreur (1)
- en deça -> en deçà (1)
- peut être -> peut-être (1)
- la l'heure -> l'heure (1)
- n'existant pas (négation manquante) (1)