### PR TITLE
synchronisation de fichiers doc-fr avec doc-en

### DIFF
--- a/features/commandline.xml
+++ b/features/commandline.xml
@@ -30,7 +30,7 @@
    Le nom, l'emplacement et l'existence des binaires &cli;/<acronym>CGI</acronym>
    vont dépendre de la façon dont PHP est installé sur votre système. Par
    défaut, en exécutant <command>make</command>, les deux binaires <acronym>CGI</acronym>
-   et &cli; sont compilés et nommés respectivement <filename>sapi/cgi/php</filename> et
+   et &cli; sont compilés et nommés respectivement <filename>sapi/cgi/php-cgi</filename> et
    <filename>sapi/cli/php</filename> dans votre répertoire source PHP. Vous
    remarquerez que les deux se nomment <filename>php</filename>. Ce qui se passe
    ensuite pendant le <command>make install</command> dépend de votre ligne

--- a/install/intro.xml
+++ b/install/intro.xml
@@ -31,6 +31,7 @@
   Web (via une interface directe appelée SAPI). Les
   serveurs qui supportent cette solution comptent notamment
   Apache, Microsoft Internet Information Server,
+  Netscape et les serveurs iPlanet.
   Si PHP ne supporte pas
   l'interface de module de votre serveur Web, vous pouvez
   toujours l'utiliser comme processeur CGI ou FastCGI. Cela signifie

--- a/language/operators/arithmetic.xml
+++ b/language/operators/arithmetic.xml
@@ -78,7 +78,6 @@
   qui sont converties en <type>int</type>) et que le numérateur soit un multiple
   du diviseur, auquel cas une valeur entière sera retournée.
   Pour la division entière, voir <function>intdiv</function>.
-  <function>intdiv</function>.
  </simpara>
  <simpara>
   Les opérandes du modulo sont converties en <type>int</type> avant exécution.

--- a/reference/apache/functions/virtual.xml
+++ b/reference/apache/functions/virtual.xml
@@ -32,6 +32,7 @@
    Pour exécuter une sous-requête, tous les tampons sont arrêtés et vidés vers le
    navigateur, les en-têtes restants le sont aussi.
   </para>
+  &apache.req.module;
  </refsect1>
 
  <refsect1 role="parameters">

--- a/reference/apcu/ini.xml
+++ b/reference/apcu/ini.xml
@@ -62,13 +62,13 @@
     <tbody>
      <row>
       <entry><link linkend="ini.apcu.enabled">apc.enabled</link></entry>
-      <entry>"1"</entry>
+      <entry>1</entry>
       <entry><constant>INI_SYSTEM</constant></entry>
       <entry/>
      </row>
      <row>
       <entry><link linkend="ini.apcu.shm-segments">apc.shm_segments</link></entry>
-      <entry>"1"</entry>
+      <entry>1</entry>
       <entry><constant>INI_SYSTEM</constant></entry>
       <entry/>
      </row>
@@ -86,13 +86,13 @@
      </row>
      <row>
       <entry><link linkend="ini.apcu.ttl">apc.ttl</link></entry>
-      <entry>"0"</entry>
+      <entry>0</entry>
       <entry><constant>INI_SYSTEM</constant></entry>
       <entry/>
      </row>
      <row>
       <entry><link linkend="ini.apcu.gc-ttl">apc.gc_ttl</link></entry>
-      <entry>"3600"</entry>
+      <entry>3600</entry>
       <entry><constant>INI_SYSTEM</constant></entry>
       <entry/>
      </row>
@@ -104,19 +104,19 @@
      </row>
      <row>
       <entry><link linkend="ini.apcu.slam-defense">apc.slam_defense</link></entry>
-      <entry>"0"</entry>
+      <entry>0</entry>
       <entry><constant>INI_SYSTEM</constant></entry>
       <entry/>
      </row>
      <row>
       <entry><link linkend="ini.apcu.enable-cli">apc.enable_cli</link></entry>
-      <entry>"0"</entry>
+      <entry>0</entry>
       <entry><constant>INI_SYSTEM</constant></entry>
       <entry/>
      </row>
      <row>
       <entry><link linkend="ini.apcu.use-request-time">apc.use_request_time</link></entry>
-      <entry>"0"</entry>
+      <entry>0</entry>
       <entry><constant>INI_ALL</constant></entry>
       <entry>Antérieurement à APCu 5.1.19, la valeur par défaut était <literal>1</literal>.</entry>
      </row>
@@ -128,7 +128,7 @@
      </row>
      <row>
       <entry><link linkend="ini.apcu.coredump-unmap">apc.coredump_unmap</link></entry>
-      <entry>"0"</entry>
+      <entry>0</entry>
       <entry><constant>INI_SYSTEM</constant></entry>
       <entry/>
      </row>

--- a/reference/cmark/functions/commonmark.parse.xml
+++ b/reference/cmark/functions/commonmark.parse.xml
@@ -64,7 +64,7 @@
        (<type>int</type>)
       </term>
       <listitem>
-       <simpara>commonmark.render.html
+       <simpara>
        </simpara>
       </listitem>
      </varlistentry>

--- a/reference/com/com.xml
+++ b/reference/com/com.xml
@@ -49,11 +49,6 @@
     à travers COM.
    </para>
    <para>
-    PHP will automatically detect methods that accept
-    parameters by reference, and will automatically convert regular PHP
-    variables to a form that can be passed by reference.  This means that you
-    can call the method very naturally; you needn't go to any extra effort in
-    your code.
     PHP détectera automatiquement les méthodes qui acceptent
     les paramètres par référence, et convertira automatiquement les variables
     PHP classiques en une forme pouvant être passée par référence.

--- a/reference/com/functions/com-event-sink.xml
+++ b/reference/com/functions/com-event-sink.xml
@@ -85,7 +85,7 @@
      <row>
       <entry>8.0.0</entry>
       <entry>
-       <parameter>sink_interface</parameter> is nullable now.
+       <parameter>sink_interface</parameter> est désormais nullable.
       </entry>
      </row>
     </tbody>
@@ -137,12 +137,11 @@ $ie = null;
   &reftitle.notes;
   <caution>
    <para>
-    Antérieur à PHP 8.0.0, 
-    Prior to PHP 8.0.0, appeller <function>exit</function> depuis n'importe
-    quel gestionnaire d'événement n'est pas supporté, et peut causer PHP à
+    Antérieur à PHP 8.0.0, appeler <function>exit</function> depuis n'importe
+    quel gestionnaire d'événement n'est pas supporté et peut causer PHP à
     planter. Ceci peut être contourné en lançant une exception depuis un
-    gestionnaire d'événement, attrapant l'exception dans le code principal,
-    et appeller <function>exit</function> là.
+    gestionnaire d'événement, en attrapant l'exception dans le code principal,
+    et en appelant <function>exit</function> depuis là.
    </para>
   </caution>
  </refsect1>

--- a/reference/datetime/datetimeinterface/diff.xml
+++ b/reference/datetime/datetimeinterface/diff.xml
@@ -108,7 +108,8 @@ echo $interval->format('%R%a days');
 <![CDATA[
 +2 days
 ]]>
-   </screen>   <para>&style.procedural;</para>
+   </screen>
+   <para>&style.procedural;</para>
    <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/datetime/datetimeinterface/gettimestamp.xml
+++ b/reference/datetime/datetimeinterface/gettimestamp.xml
@@ -106,7 +106,8 @@ echo $date->getTimestamp();
 <![CDATA[
 1272509157
 ]]>
-   </screen>   <para>&style.procedural;</para>
+   </screen>
+   <para>&style.procedural;</para>
    <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/dbase/functions/dbase-create.xml
+++ b/reference/dbase/functions/dbase-create.xml
@@ -98,8 +98,8 @@
      <row>
       <entry>PECL dbase 7.0.0</entry>
       <entry>
-       <parameter>dbase_identifier</parameter> is now a <type>resource</type>
-       instead of an <type>int</type>.
+       Le type de retour de <parameter>dbase_identifier</parameter> est
+       désormais une <type>resource</type> au lieu d'un <type>int</type>.
       </entry>
      </row>
     </tbody>

--- a/reference/dir/functions/rewinddir.xml
+++ b/reference/dir/functions/rewinddir.xml
@@ -16,8 +16,6 @@
   <simpara>
    Réinitialise le flux de dossier indiqué par <parameter>dir_handle</parameter>
    au début du dossier.
-   Resets the directory stream indicated by <parameter>dir_handle</parameter>
-   to the beginning of the directory.
   </simpara>
  </refsect1>
 
@@ -65,7 +63,7 @@
      <row>
       <entry>8.0.0</entry>
       <entry>
-       <parameter>context</parameter> is now nullable.
+       <parameter>dir_handle</parameter> est désormais nullable.
       </entry>
      </row>
     </tbody>

--- a/reference/eio/functions/eio-open.xml
+++ b/reference/eio/functions/eio-open.xml
@@ -21,7 +21,7 @@
   <simpara>
    <function>eio_open</function> ouvre un fichier spécifié par l'argument
    <parameter>path</parameter> avec le mode d'accès spécifié par
-   l'argument<parameter>mode</parameter>.
+   l'argument <parameter>mode</parameter>.
   </simpara>
 
 

--- a/reference/enchant/functions/enchant-broker-init.xml
+++ b/reference/enchant/functions/enchant-broker-init.xml
@@ -5,7 +5,7 @@
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.enchant-broker-init">
  <refnamediv>
   <refname>enchant_broker_init</refname>
-  <refpurpose>Crée un nouvel objet sponsor</refpurpose>
+  <refpurpose>Crée un nouvel objet sponsor capable de requêter</refpurpose>
  </refnamediv>
  <refsect1 role="description">
   &reftitle.description;

--- a/reference/gettext/functions/ngettext.xml
+++ b/reference/gettext/functions/ngettext.xml
@@ -59,9 +59,9 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Retourne un message au pluriel identifié par
-   <parameter>msgid1</parameter> et <parameter>msgid2</parameter>
-   pour le compteur <parameter>n</parameter>.
+   Retourne la forme plurielle correcte du message identifié par
+   <parameter>singular</parameter> et <parameter>plural</parameter>
+   pour le compteur <parameter>count</parameter>.
   </para>
  </refsect1>
 

--- a/reference/gmagick/gmagickdraw/getfontstyle.xml
+++ b/reference/gmagick/gmagickdraw/getfontstyle.xml
@@ -29,7 +29,7 @@
   &reftitle.returnvalues;
   <simpara>
    Retourne la constante (STYLE_) représentant le style de la police
-   de caractères associée avec l'objet <classname>GmagickDraw</classname> ou 0 si le style
+   de caractères associée avec l'objet <classname>GmagickDraw</classname> ou <literal>0</literal> si le style
    n'est pas défini.
   </simpara>
  </refsect1>

--- a/reference/json/functions/json-last-error.xml
+++ b/reference/json/functions/json-last-error.xml
@@ -29,7 +29,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Retourne une des constantes suivantes :
+   Retourne un entier, la valeur peut être une des constantes suivantes :
   </para>
   <table>
    <title>Codes d'erreur JSON</title>

--- a/reference/oci8/functions/oci-bind-by-name.xml
+++ b/reference/oci8/functions/oci-bind-by-name.xml
@@ -160,13 +160,13 @@
        <itemizedlist>
         <listitem>
          <para>
-          <constant>SQLT_FILE</constant> ou <constant>OCI_B_BFILE</constant>
+          <constant>SQLT_BFILEE</constant> ou <constant>OCI_B_BFILE</constant>
           - pour les BFILEs ;
          </para>
         </listitem>
         <listitem>
          <para>
-          <constant>SQLT_CFILE</constant> ou <constant>OCI_B_CFILEE</constant>
+          <constant>SQLT_CFILEE</constant> ou <constant>OCI_B_CFILEE</constant>
           - pour les CFILEs ;
          </para>
         </listitem>

--- a/reference/pdo_ibm/ini.xml
+++ b/reference/pdo_ibm/ini.xml
@@ -76,7 +76,7 @@
     <listitem>
      <para>
       Le CCSID ASCII à utiliser pour la conversion de l'EBCDIC sur IBM i. En
-      définissant ceci à 1208, vous utiliserez l'UTF-8. Par défaut, c'est 0,ce qui sélectionnera 
+      définissant ceci à 1208, vous utiliserez l'UTF-8. Par défaut, c'est 0, ce qui sélectionnera 
       le CCSID de travail ASCII par défaut.
      </para>
      <para>

--- a/reference/pdo_sqlite/pdo-sqlite.xml
+++ b/reference/pdo_sqlite/pdo-sqlite.xml
@@ -20,7 +20,7 @@
     <itemizedlist>
      <listitem>
       <simpara>
-       Les littéraux de chaînes simples, doubles et en dollars, avec le doublement comme mécanisme d'échappement.
+       Les littéraux de chaînes entre guillemets simples, doubles et backticks, avec le doublement comme mécanisme d'échappement.
       </simpara>
      </listitem>
      <listitem>

--- a/reference/pdo_sqlsrv/reference.xml
+++ b/reference/pdo_sqlsrv/reference.xml
@@ -60,7 +60,7 @@
       <term><literal>Database</literal></term>
       <listitem>
        <simpara>
-        The name of the database.Le nom de la base de données.
+        Le nom de la base de données.
        </simpara>
       </listitem>
      </varlistentry>

--- a/reference/snmp/snmp/close.xml
+++ b/reference/snmp/snmp/close.xml
@@ -41,7 +41,7 @@
    <programlisting role="php">
 <![CDATA[
 <?php
-  $session = new SNMP(SNMP_VERSION_1, "127.0.0.1", "public");
+  $session = new SNMP(SNMP::VERSION_1, "127.0.0.1", "public");
   # ...
   # get, walk, etc vont ici !
   # ...

--- a/reference/snmp/snmp/construct.xml
+++ b/reference/snmp/snmp/construct.xml
@@ -151,7 +151,7 @@
 <![CDATA[
 <?php
 
-$session = new SNMP(SNMP_VERSION_1, "127.0.0.1", "public");
+$session = new SNMP(SNMP::VERSION_1, "127.0.0.1", "public");
 $sysdescr = $session->get("sysDescr.0");
 echo "$sysdescr\n";
 

--- a/reference/snmp/snmp/get.xml
+++ b/reference/snmp/snmp/get.xml
@@ -40,11 +40,11 @@
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term><parameter>preserve_keys</parameter></term>
+    <term><parameter>preserveKeys</parameter></term>
     <listitem>
      <simpara>
       Lorsque <parameter>objectId</parameter> est un tableau, et que la paramètre
-      <parameter>preserve_keys</parameter> est défini à &true;, les clés dans le résultat
+      <parameter>preserveKeys</parameter> est défini à &true;, les clés dans le résultat
       seront reprises exactement de l'objet <parameter>objectId</parameter>, sinon,
       la propriété <varname>SNMP::oid_output_format</varname> sera utilisée pour déterminer
       le format des clés.
@@ -78,7 +78,7 @@
    <programlisting role="php">
 <![CDATA[
 <?php
-  $session = new SNMP(SNMP_VERSION_1, "127.0.0.1", "public");
+  $session = new SNMP(SNMP::VERSION_1, "127.0.0.1", "public");
   $sysdescr = $session->get("sysDescr.0");
   echo "$sysdescr\n";
   $sysdescr = $session->get(array("sysDescr.0"));
@@ -101,7 +101,7 @@ Array
    <title>Plusieurs objets <acronym>SNMP</acronym></title>
    <programlisting role="php">
 <![CDATA[
-  $session = new SNMP(SNMP_VERSION_1, "127.0.0.1", "public");
+  $session = new SNMP(SNMP::VERSION_1, "127.0.0.1", "public");
   $results = $session->get(array("sysDescr.0", "sysName.0"));
   print_r($results);
   $session->close();

--- a/reference/snmp/snmp/geterrno.xml
+++ b/reference/snmp/snmp/geterrno.xml
@@ -40,7 +40,7 @@
    <programlisting role="php">
 <![CDATA[
 <?php
-$session = new SNMP(SNMP_VERSION_2c, '127.0.0.1', 'boguscommunity');
+$session = new SNMP(SNMP::VERSION_2c, '127.0.0.1', 'boguscommunity');
 var_dump(@$session->get('.1.3.6.1.2.1.1.1.0'));
 var_dump($session->getErrno() == SNMP::ERRNO_TIMEOUT);
 //var_dump($session->getError());

--- a/reference/snmp/snmp/geterror.xml
+++ b/reference/snmp/snmp/geterror.xml
@@ -40,7 +40,7 @@
    <programlisting role="php">
 <![CDATA[
 <?php
-$session = new SNMP(SNMP_VERSION_2c, '127.0.0.1', 'boguscommunity');
+$session = new SNMP(SNMP::VERSION_2c, '127.0.0.1', 'boguscommunity');
 var_dump(@$session->get('.1.3.6.1.2.1.1.1.0'));
 //var_dump($session->getError());
 ?>

--- a/reference/snmp/snmp/getnext.xml
+++ b/reference/snmp/snmp/getnext.xml
@@ -68,7 +68,7 @@
    <programlisting role="php">
 <![CDATA[
 <?php
-  $session = new SNMP(SNMP_VERSION_1, "127.0.0.1", "public");
+  $session = new SNMP(SNMP::VERSION_1, "127.0.0.1", "public");
   $nsysdescr = $session->getnext("sysDescr.0");
   echo "$nsysdescr\n";
   $nsysdescr = $session->getnext(array("sysDescr.0"));
@@ -92,7 +92,7 @@ Array
    <programlisting role="php">
 <![CDATA[
 <?php
-  $session = new SNMP(SNMP_VERSION_1, "127.0.0.1", "public");
+  $session = new SNMP(SNMP::VERSION_1, "127.0.0.1", "public");
   $results = $session->getnext(array("sysDescr.0", "sysName.0"));
   print_r($results);
   $session->close();

--- a/reference/snmp/snmp/set.xml
+++ b/reference/snmp/snmp/set.xml
@@ -93,7 +93,7 @@
    <programlisting role="php">
 <![CDATA[
 <?php
-  $session = new SNMP(SNMP_VERSION_2C, "127.0.0.1", "private");
+  $session = new SNMP(SNMP::VERSION_2C, "127.0.0.1", "private");
   $session->set('SNMPv2-MIB::sysContact.0', 's', "Nobody");
 ?>
 ]]>
@@ -105,7 +105,7 @@
    <programlisting role="php">
 <![CDATA[
 <?php
-  $session = new SNMP(SNMP_VERSION_2C, "127.0.0.1", "private");
+  $session = new SNMP(SNMP::VERSION_2C, "127.0.0.1", "private");
   $session->set(array('SNMPv2-MIB::sysContact.0', 'SNMPv2-MIB::sysLocation.0'), array('s', 's'), array("Nobody", "Nowhere"));
 // ou
   $session->set(array('SNMPv2-MIB::sysContact.0', 'SNMPv2-MIB::sysLocation.0'), 's', array("Nobody", "Nowhere"));
@@ -118,7 +118,7 @@
    <programlisting role="php">
 <![CDATA[
 <?php
-  $session = new SNMP(SNMP_VERSION_2C, "127.0.0.1", "private");
+  $session = new SNMP(SNMP::VERSION_2C, "127.0.0.1", "private");
   $session->set('FOO-MIB::bar.42', 'b', '0 1 2 3 4');
 // ou
   $session->set('FOO-MIB::bar.42', 'x', 'F0');

--- a/reference/snmp/snmp/setsecurity.xml
+++ b/reference/snmp/snmp/setsecurity.xml
@@ -103,7 +103,7 @@
    <programlisting role="php">
 <![CDATA[
 <?php
-  $session = new SNMP(SNMP_VERSION_3, $hostname, $rwuser, $timeout, $retries);
+  $session = new SNMP(SNMP::VERSION_3, $hostname, $rwuser, $timeout, $retries);
   $session->setSecurity('authPriv', 'MD5', $auth_pass, 'AES', $priv_pass, '', 'aeeeff');
 ?>
 ]]>

--- a/reference/snmp/snmp/walk.xml
+++ b/reference/snmp/snmp/walk.xml
@@ -89,7 +89,7 @@
    <programlisting role="php">
 <![CDATA[
 <?php
-  $session = new SNMP(SNMP_VERSION_1, "127.0.0.1", "public");
+  $session = new SNMP(SNMP::VERSION_1, "127.0.0.1", "public");
   $fulltree = $session->walk(".");
   print_r($fulltree);
   $session->close();
@@ -121,7 +121,7 @@ Array
    <programlisting role="php">
 <![CDATA[
 <?php
-  $session = new SNMP(SNMP_VERSION_1, "127.0.0.1", "public");
+  $session = new SNMP(SNMP::VERSION_1, "127.0.0.1", "public");
   $session->valueretrieval = SNMP_VALUE_PLAIN;
   $ifDescr = $session->walk(".1.3.6.1.2.1.2.2.1.2", TRUE);
   $session->valueretrieval = SNMP_VALUE_LIBRARY;

--- a/reference/soap/soapclient/construct.xml
+++ b/reference/soap/soapclient/construct.xml
@@ -379,13 +379,13 @@
            Utilisé pour définir des correspondances de types à l'aide de fonctions de rappel
            définies par l'utilisateur.
            Chaque correspondance de type doit être un tableau avec les clés
-           <literal>type_name</literal> (une <type>chaîne de caractères</type> spécifiant le
+           <literal>type_name</literal> (une <type>string</type> spécifiant le
            type d'élément XML),
-           <literal>type_ns</literal> (une <type>chaîne de caractères</type> contenant
+           <literal>type_ns</literal> (une <type>string</type> contenant
            l'URI de l'espace de noms),
-           <literal>from_xml</literal> (un <type>appelable</type> acceptant un paramètre
+           <literal>from_xml</literal> (un <type>callable</type> acceptant un paramètre
            de type chaîne de caractères et renvoyant un objet) et
-           <literal>to_xml</literal> (un <type>appelable</type> acceptant un paramètre
+           <literal>to_xml</literal> (un <type>callable</type> acceptant un paramètre
            de type objet et renvoyant une chaîne de caractères).
           </para>
          </listitem>

--- a/reference/sockets/functions/socket-addrinfo-bind.xml
+++ b/reference/sockets/functions/socket-addrinfo-bind.xml
@@ -56,7 +56,7 @@
       <entry>8.0.0</entry>
       <entry>
        En cas de succès, cette fonction renvoie maintenant une instance de <classname>Socket</classname>;
-       avant, une <type>ressource</type> était renvoyée.
+       avant, une <type>resource</type> était renvoyée.
       </entry>
      </row>
      &sockets.changelog.address-param;

--- a/reference/sockets/functions/socket-wsaprotocol-info-import.xml
+++ b/reference/sockets/functions/socket-wsaprotocol-info-import.xml
@@ -60,7 +60,7 @@
       <entry>8.0.0</entry>
       <entry>
        En cas de succès, cette fonction renvoie maintenant une instance de <classname>Socket</classname>;
-       avant, une <type>ressource</type> était renvoyée.
+       avant, une <type>resource</type> était renvoyée.
       </entry>
      </row>
     </tbody>

--- a/reference/stream/functions/stream-set-chunk-size.xml
+++ b/reference/stream/functions/stream-set-chunk-size.xml
@@ -4,14 +4,14 @@
 <!-- Reviewed: no -->
 <refentry xml:id="function.stream-set-chunk-size" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
-  <refname>stream_set_size</refname>
+  <refname>stream_set_chunk_size</refname>
   <refpurpose>Change la taille du segment du flux</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>int</type><methodname>stream_set_size</methodname>
+   <type>int</type><methodname>stream_set_chunk_size</methodname>
    <methodparam><type>resource</type><parameter>stream</parameter></methodparam>
    <methodparam><type>int</type><parameter>size</parameter></methodparam>
   </methodsynopsis>

--- a/reference/yac/yac/construct.xml
+++ b/reference/yac/yac/construct.xml
@@ -51,7 +51,7 @@
   &reftitle.errors;
   <para>
    Lance une <classname>Exception</classname> si Yac n'est pas activé.
-   Throws <classname>Exception</classname> si <parameter>prefix</parameter>
+   Lance une <classname>Exception</classname> si <parameter>prefix</parameter>
    excède la longueur maximale de clé de 48
    (<constant>YAC_MAX_KEY_LEN</constant>) octets.
   </para>

--- a/reference/zip/ziparchive/addemptydir.xml
+++ b/reference/zip/ziparchive/addemptydir.xml
@@ -67,7 +67,7 @@
      </thead>
      <tbody>
       <row>
-       <entry>8.0.0 / PECL zip 1.18.0</entry>
+       <entry>8.0.0, PECL zip1.18.0</entry>
        <entry>
         <parameter>flags</parameter> a été ajouté.
        </entry>

--- a/reference/zip/ziparchive/addfile.xml
+++ b/reference/zip/ziparchive/addfile.xml
@@ -101,19 +101,19 @@
      </thead>
      <tbody>
       <row>
-       <entry>8.0.0 / PECL zip 1.18.0</entry>
+       <entry>8.0.0, PECL zip1.18.0</entry>
        <entry>
         <parameter>flags</parameter> a été ajouté.
        </entry>
       </row>
       <row>
-       <entry>8.3.0 / PECL zip 1.22.1</entry>
+       <entry>8.3.0, PECL zip1.22.1</entry>
        <entry>
         <constant>ZipArchive::FL_OPEN_FILE_NOW</constant> a été ajouté.
        </entry>
       </row>
       <row>
-       <entry>8.3.0 / PECL zip 1.22.2</entry>
+       <entry>8.3.0, PECL zip1.22.2</entry>
        <entry>
         <constant>ZipArchive::LENGTH_TO_END</constant> et <constant>ZipArchive::LENGTH_UNCHECKED</constant> ont été ajoutés.
        </entry>

--- a/reference/zip/ziparchive/addfromstring.xml
+++ b/reference/zip/ziparchive/addfromstring.xml
@@ -77,7 +77,7 @@
      </thead>
      <tbody>
       <row>
-       <entry>8.0.0 / PECL zip 1.18.0</entry>
+       <entry>8.0.0, PECL zip1.18.0</entry>
        <entry>
         <parameter>flags</parameter> a été ajouté.
        </entry>

--- a/reference/zip/ziparchive/addglob.xml
+++ b/reference/zip/ziparchive/addglob.xml
@@ -152,13 +152,13 @@
      </thead>
      <tbody>
       <row>
-       <entry>8.0.0 / PECL zip 1.18.0</entry>
+       <entry>8.0.0, PECL zip1.18.0</entry>
        <entry>
         <parameter>flags</parameter> a été ajouté.
        </entry>
       </row>
       <row>
-       <entry>8.0.0 / PECL zip 1.18.1</entry>
+       <entry>8.0.0, PECL zip1.18.1</entry>
        <entry>
         <literal>"comp_method"</literal>, <literal>"comp_flags"</literal>,
         <literal>"enc_method"</literal> et <literal>"enc_password"</literal>
@@ -166,7 +166,7 @@
        </entry>
       </row>
       <row>
-       <entry>8.3.0 / PECL zip 1.22.1</entry>
+       <entry>8.3.0, PECL zip1.22.1</entry>
        <entry>
         <constant>ZipArchive::FL_OPEN_FILE_NOW</constant> a été ajouté.
        </entry>

--- a/reference/zip/ziparchive/getstatusstring.xml
+++ b/reference/zip/ziparchive/getstatusstring.xml
@@ -42,13 +42,13 @@
      </thead>
      <tbody>
       <row>
-       <entry>8.0.0 / PECL zip 1.18.0</entry>
+       <entry>8.0.0, PECL zip1.18.0</entry>
        <entry>
         Cette méthode ne retourne plus &false; en cas d'échec.
        </entry>
       </row>
       <row>
-       <entry>8.0.0 / PECL zip 1.18.0</entry>
+       <entry>8.0.0, PECL zip1.18.0</entry>
        <entry>
         Cette méthode peut être appelé sur une archive fermée.
        </entry>

--- a/reference/zip/ziparchive/replacefile.xml
+++ b/reference/zip/ziparchive/replacefile.xml
@@ -98,13 +98,13 @@
      </thead>
      <tbody>
       <row>
-       <entry>8.3.0 / PECL zip 1.22.1</entry>
+       <entry>8.3.0, PECL zip1.22.1</entry>
        <entry>
         <constant>ZipArchive::FL_OPEN_FILE_NOW</constant> a été ajouté.
        </entry>
       </row>
       <row>
-       <entry>8.3.0 / PECL zip 1.22.2</entry>
+       <entry>8.3.0, PECL zip1.22.2</entry>
        <entry>
         <constant>ZipArchive::LENGTH_TO_END</constant> et <constant>ZipArchive::LENGTH_UNCHECKED</constant> ont été ajoutés.
        </entry>

--- a/reference/zlib/functions/gzcompress.xml
+++ b/reference/zlib/functions/gzcompress.xml
@@ -21,8 +21,8 @@
   </para>
   <para>
    Pour plus de détails sur l'algorithme, lisez le document
-   <link xlink:href="&url.rfc;1950"><literal>"ZLIB Compressed Data Format
-   Specification version 3.3"</literal></link> (RFC 1950).
+   "<link xlink:href="&url.rfc;1950">ZLIB Compressed Data Format
+   Specification version 3.3</link>" (RFC 1950).
   </para>
   <note>
    <para>

--- a/reference/zlib/functions/gzdeflate.xml
+++ b/reference/zlib/functions/gzdeflate.xml
@@ -21,8 +21,8 @@
   </para>
   <para>
    Pour plus de détails sur l'algorithme, lisez le document
-   <link xlink:href="&url.rfc;1951"><literal>"ZLIB Compressed Data Format
-   Specification version 1.3"</literal></link> (RFC 1951).
+   "<link xlink:href="&url.rfc;1951">ZLIB Compressed Data Format
+   Specification version 1.3</link>" (RFC 1951).
   </para>
  </refsect1>
 

--- a/reference/zlib/functions/gzencode.xml
+++ b/reference/zlib/functions/gzencode.xml
@@ -23,8 +23,8 @@
   </para>
   <para>
    Pour plus de détails sur l'algorithme, lisez le document
-   <link xlink:href="&url.rfc;1952"><literal>"ZLIB Compressed Data Format
-   Specification version 4.3"</literal></link> (RFC 1952).
+   "<link xlink:href="&url.rfc;1952">ZLIB Compressed Data Format
+   Specification version 4.3</link>" (RFC 1952).
   </para>
  </refsect1>
 


### PR DESCRIPTION
Corrections apportées :
- Traduction de textes restés en anglais (dbase, dir, com, yac, pdo_sqlsrv)
- Correction de noms de fonctions/constantes (stream_set_chunk_size, SQLT_BFILEE/CFILEE)
- Remplacement des types traduits par leurs noms PHP (ressource->resource, chaîne->string, appelable->callable)
- Mise à jour des constantes SNMP_VERSION_* vers SNMP::VERSION_* (9 fichiers)
- Correction des noms de paramètres obsolètes (ngettext, snmp::get)
- Suppression de texte dupliqué EN/FR (com.xml, com-event-sink.xml, rewinddir.xml)
- Correction de balises XML (literal dans liens RFC zlib, literal autour de 0 dans gmagick)
- Ajout de contenu manquant (apache virtual entity, install/intro serveurs iPlanet)
- Corrections mineures (espaces manquants, virgules, ligne dupliquée, formatage)
- Correction du nom binaire CGI sapi/cgi/php -> sapi/cgi/php-cgi
- Suppression des guillemets autour des valeurs numériques dans apcu/ini.xml