### PR TITLE
Sync faq with EN

### DIFF
--- a/faq/using.xml
+++ b/faq/using.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 0a3a57fae02391db80baeba98c9a071dc2760889 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 1709768e97fce7848c62aa2bf988419527bd1e8e Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 
 <chapter xml:id="faq.using" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -15,7 +15,6 @@
   <qandaset>
 
    <qandaentry xml:id="faq.using.parameterorder">
-    <!-- TODO: Mention named arguments -->
     <question>
      <para>
       Je ne me rappelle pas de l'ordre des paramètres dans les fonctions PHP,
@@ -35,6 +34,11 @@
       <link linkend="book.strings">fonctions gérant les chaînes</link>
       sont exactement à l'opposé
       "<emphasis>haystack, needle</emphasis>".
+     </para>
+     <para>
+      À partir de PHP 8.0, les <link linkend="functions.named-arguments">arguments nommés</link>
+      permettent de passer des arguments par nom de paramètre, rendant l'ordre des paramètres
+      moins problématique.
      </para>
     </answer>
    </qandaentry>
@@ -87,7 +91,6 @@ echo '</pre>';
    </qandaentry>
 
    <qandaentry xml:id="faq.using.addslashes">
-    <!-- TODO Probably should mention not doing this... -->
     <question>
      <para>
       Il faut que je convertisse tous les guillemets simples (')
@@ -106,6 +109,12 @@ echo '</pre>';
       Il y a également les fonctions génériques comme
       <function>addslashes</function> et <function>stripslashes</function>,
       qui sont plus communes avec l'ancien code PHP.
+     </para>
+     <para>
+      L'échappement manuel des valeurs est sujet aux erreurs et dépend du contexte.
+      Préférez utiliser les API de base de données qui prennent en charge les
+      requêtes préparées et la liaison de paramètres plutôt que de construire des
+      requêtes en concaténant des chaînes échappées.
      </para>
     </answer>
    </qandaentry>


### PR DESCRIPTION
## Summary
- Update `faq/using.xml` to match current EN revision
- Remove TODO comments about named arguments and escaping advice
- Add paragraph about PHP 8.0 named arguments in parameter order FAQ
- Add paragraph recommending prepared statements over manual escaping

## Test plan
- [ ] Verify revcheck page no longer lists this file as outdated