### PR TITLE
Fix multi_query sync: remove orphan line and improve translation

### DIFF
--- a/reference/mysqli/mysqli/multi-query.xml
+++ b/reference/mysqli/mysqli/multi-query.xml
@@ -27,12 +27,11 @@
   </para>
   &mysqli.sqlinjection.warning;
   <para>
-   Les requêtes sont traitées dans un seul appel à la base de données et traitées séquentiellement.
-   <methodname>mysqli_multi_query</methodname> attend pour la première requête
-   de compléter avant de retourner le contrôle à PHP. En attendant, le serveur MySQL
-   continuera à traiter les requêtes restantes de manière asynchrone de PHP et rendra
-   les résultats disponibles pour la récupération.
-   <function>mysqli_next_result</function> depuis PHP.
+   Les requêtes sont envoyées en un seul appel à la base de données et traitées séquentiellement.
+   <methodname>mysqli_multi_query</methodname> attend que la première requête
+   soit terminée avant de rendre le contrôle à PHP. Entre-temps, le serveur MySQL
+   continue de traiter les requêtes restantes de manière asynchrone par rapport à PHP
+   et rend les résultats disponibles pour la récupération.
   </para>
   <para>
    Il est recommandé d'utiliser une


### PR DESCRIPTION
Closes #2486

Sync with doc-en PR: https://github.com/php/doc-en/pull/5380

- Remove orphan `<function>mysqli_next_result</function>` line left over from previous sync
- Improve French translation quality (fix English calques)