### PR TITLE
Fix typos, grammar errors, and wrong content across entire documentation

### DIFF
--- a/appendices/about.xml
+++ b/appendices/about.xml
@@ -208,7 +208,7 @@ Retourne la taille de la chaîne $string.
    </screen>
   </para>
   <para>
-   Qu'est ce que cela signifie ? <function>in_array</function> retourne
+   Qu'est-ce que cela signifie ? <function>in_array</function> retourne
    un <link linkend="language.types.boolean">booléen</link> &true; en
    cas de réussite (le paramètre
    <parameter>needle</parameter> a été trouvé dans le tableau
@@ -220,7 +220,7 @@ Retourne la taille de la chaîne $string.
    donc la mention <emphasis>mixed</emphasis>.
    Le paramètre <parameter>needle</parameter> (ce que nous recherchons)
    peut être une valeur scalaire ( &string;, &integer;,
-   ou <link linkend="language.types.float">float</link>), ou encore un <type>array</type>.
+   ou <link linkend="language.types.float">float</link>), ou encore un <link linkend="language.types.array">array</link>.
    <parameter>haystack</parameter> (le <link linkend="language.types.array">array</link>,
    dans lequel nous recherchons) est
    le second paramètre. Le troisième paramètre, <emphasis>optionnel</emphasis>,
@@ -361,8 +361,8 @@ Retourne la taille de la chaîne $string.
    Le manuel PHP est traduit en de nombreux langages. La connaissance
    de l'anglais ainsi que d'une autre langue peut vous permettre d'aider
    la documentation de PHP en travaillant avec une équipe de traduction.
-   Pour plus d'informations sur le commencement d'une traduction, ou
-   sur l'aide d'une version déjà traduite, commencez par lire
+   Pour plus d'informations sur la manière de démarrer une nouvelle traduction
+   ou de contribuer à une version déjà traduite, commencez par lire
    <link xlink:href="&url.php.dochowto;">&url.php.dochowto;</link>.
   </para>
   <para>

--- a/appendices/comparisons.xml
+++ b/appendices/comparisons.xml
@@ -23,8 +23,8 @@
  </para>
  <note>
   <para>
-   Les formulaires HTML ne connaissent pas les entiers, nombres à virgules
-   et autres booléens. Pour savoir si une structure est un entier, utilisez
+   Les formulaires HTML ne connaissent pas les entiers, nombres à virgule
+   flottante et autres booléens. Pour savoir si une chaîne est numérique, utilisez
    <function>is_numeric</function>.
   </para>
  </note>

--- a/appendices/configure/php.xml
+++ b/appendices/configure/php.xml
@@ -11,8 +11,8 @@
     </term>
     <listitem>
      <para>
-      Active des règles de compilation (<literal>make</literal>) et des dépendances pas
-      toujours utiles aux utilisateurs occasionnels.
+      Active des règles de compilation (<literal>make</literal>) et des dépendances
+      inutiles (et parfois déroutantes) pour les utilisateurs occasionnels.
      </para>
     </listitem>
    </varlistentry>
@@ -44,7 +44,7 @@
     <listitem>
      <para>
       Précise le chemin vers les bibliothèques de construction Unix pour
-      construire PHP. Pour les systèmes 64bits, vous devez renseigner le dossier
+      construire PHP. Pour les systèmes 64 bits, vous devez renseigner le dossier
       <literal>lib64</literal> comme cela: 
       <literal>--with-libdir=lib64</literal>.
      </para>

--- a/appendices/configure/servers.xml
+++ b/appendices/configure/servers.xml
@@ -18,7 +18,7 @@
       Compile un module Apache partagé. FILE est un chemin d'accès optionnel vers
       les outils apxs d'Apache. Par défaut, c'est apxs. Assurez-vous de spécifier
       la version d'apxs qui est réellement installée sur votre système, et NON pas
-      celle qui est fournie avec Apache.
+      celle qui se trouve dans l'archive des sources d'Apache.
      </para>
     </listitem>
    </varlistentry>
@@ -28,7 +28,7 @@
     </term>
     <listitem>
      <para>
-      Compile le module Apache. DIR est le chemin du dossier d'installation d'Apache.
+      Compile le module Apache. DIR est le répertoire racine de construction d'Apache.
       Par défaut, DIR vaut <filename>/usr/local/apache</filename>.
      </para>
     </listitem>

--- a/appendices/examples.xml
+++ b/appendices/examples.xml
@@ -2,15 +2,15 @@
 <!-- EN-Revision: bce2cb849721c70737eb32ce958131e22677770c Maintainer: Fan2Shrek Status: ready -->
 <!-- Reviewed: yes -->
 <appendix xml:id="examples" xmlns="http://docbook.org/ns/docbook">
- <title>A propos des examples du manuel</title>
+ <title>À propos des exemples du manuel</title>
  <simpara>
-  Il est important de noter que la plupart des exemples dans la documentation PHP omettent les gestions
+  Il est important de noter que la plupart des exemples dans la documentation PHP omettent la gestion
   des erreurs et des exceptions pour des raisons de clarté et de concision.
  </simpara>
  <simpara>
   Cela ne signifie pas que la gestion des erreurs doit être omise dans le code de production,
   car cela peut entraîner le lancement de <exceptionname>TypeError</exceptionname>s,
-  des valeurs d'échecs étant converties, telles que &false; en une chaîne vide,
+  des valeurs d'échec étant converties, telles que &false; en une chaîne vide,
   ou des hypothèses étant violées qui pourraient causer des bogues difficiles à suivre.
   Certaines extensions fournissent des exemples complets où la gestion des erreurs est incluse
   pour démontrer l'utilisation correcte des différentes fonctions et méthodes

--- a/appendices/filters.xml
+++ b/appendices/filters.xml
@@ -285,7 +285,7 @@ fclose($fp);
   </note>
 
   <section xml:id="filters.compression.zlib">
-   <title>zlib.deflate and zlib.inflate</title>
+   <title>zlib.deflate et zlib.inflate</title>
    <simpara>
     <literal>zlib.deflate</literal> (compression) et
     <literal>zlib.inflate</literal> (décompression) sont les implémentations
@@ -310,7 +310,7 @@ fclose($fp);
     nécessaire.
     Les valeurs valides vont de 1, pour l'allocation minimale, à 9, pour une
     allocation maximale. L'allocation de mémoire affecte la vitesse d'exécution,
-    et non pas le coût global.
+    et n'a pas d'impact sur la taille de la charge utile générée.
    </simpara>
 
    <note>
@@ -394,7 +394,7 @@ Le fichier compressé fait 56 octets de long.
   </section>
 
   <section xml:id="filters.compression.bzip2">
-   <title>bzip2.compress and bzip2.decompress</title>
+   <title>bzip2.compress et bzip2.decompress</title>
    <simpara>
     <literal>bzip2.compress</literal> et
     <literal>bzip2.decompress</literal>
@@ -437,7 +437,7 @@ Le fichier compressé fait 56 octets de long.
 <?php
 $param = array('blocks' => 9, 'work' => 0);
 
-echo "Le fichier original fait " . strlen(LICENSE) . " octets de long.\n";
+echo "Le fichier original fait " . filesize('LICENSE') . " octets de long.\n";
 
 $fp = fopen('LICENSE.compressed', 'w');
 stream_filter_append($fp, 'bzip2.compress', STREAM_FILTER_WRITE, $param);
@@ -468,7 +468,7 @@ Le fichier compressé fait 1488 octets de long.
   </para>
 
   <section xml:id="filters.encryption.mcrypt">
-   <title>mcrypt.* and mdecrypt.*</title>
+   <title>mcrypt.* et mdecrypt.*</title>
    &warn.deprecated.feature-7-1-0;
 
    <simpara>

--- a/appendices/history.xml
+++ b/appendices/history.xml
@@ -4,11 +4,11 @@
 <!-- Reviewed: yes Maintainer: pmartin -->
 
 <appendix xml:id="history" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
- <title>Histoire de PHP</title>
+ <title>Histoire de PHP et des projets liés</title>
  <para>
-  PHP a suivi un long chemin depuis sa naissance au milieu de l'année 1990.
+  PHP a suivi un long chemin depuis sa naissance au milieu des années 1990.
   Depuis ses débuts modestes, jusqu'à devenir l'un des plus éminents
-  langage de programmation pour le web, l'évolution de PHP
+  langages de programmation pour le web, l'évolution de PHP
   est un véritable conte de fées technologique. Figurez-vous
   qu'une telle croissance n'a pas été tâche facile. Ceux d'entre
   vous qui sont intéressés par un bref récapitulatif de ce qu'a été
@@ -29,7 +29,7 @@
     en ligne, il nomme cette suite de scripts "Personal
     Home Page Tools" (ndt : Outils pour page personnelle), plus
     fréquemment appelée "PHP Tools". Au fil du temps, de plus en plus
-    de fonctionnalités sont demandées, et Rasmus ré-écrit les outils PHP,
+    de fonctionnalités sont demandées, et Rasmus réécrit les outils PHP,
     produisant ainsi une implémentation plus large et plus riche.
     Ce nouveau modèle était capable d’interagir avec une base de données,
     mais aussi, fournissait un framework permettant aux utilisateurs de
@@ -57,7 +57,7 @@
     pas accueillie avec un grand enthousiasme, FI continua de rassembler
     de plus en plus de monde, et fut accepté comme outil CGI --- mais toujours
     pas comme un langage. Cependant, ceci commença à changer les mois suivants ;
-    en octobre 1995, Rasmus livra une nouvelle version totalement ré-écrite.
+    en octobre 1995, Rasmus livra une nouvelle version totalement réécrite.
     Reprenant le nom de PHP, elle était maintenant nommée (brièvement)
     "Personal Home Page Construction Kit", et était la première version à mettre
     en avant le fait que PHP était considéré comme une interface de scripts avancée.
@@ -78,15 +78,15 @@
     Ce mois de Juin, PHP/FI prenait un statut de version 2.0. Un point
     intéressant, cependant, était qu'il n'existait qu'une seule et unique
     version de PHP 2.0. Quand elle est finalement sortie du statut bêta en Novembre
-    1997, le moteur d'analyse interne était déjà en cours de ré-écriture complète.
+    1997, le moteur d'analyse interne était déjà en cours de réécriture complète.
    </para>
    <para>
     Bien qu'il fournît un cycle de développement très court, il
     continua de gagner en popularité dans ce monde où le développement web
     était encore très récent. En 1997 et 1998, PHP/FI comptait plusieurs
     milliers d'utilisateurs à travers le monde. Le site de surveillance Netcraft,
-    en Mai 1998, indiquait qu'environ 60.000 domaines exportaient l'en-tête
-    "PHP", indiquant ainsi que le serveur hôte l'avait d'installé.
+    en mai 1998, indiquait qu'environ 60 000 domaines avaient des en-têtes
+    contenant "PHP", indiquant ainsi que le serveur hôte l'avait bien installé.
     Ce nombre correspondait à environ 1% des domaines d'Internet de l'époque.
     Malgré ce chiffre impressionnant, la maturation de PHP/FI était condamnée
     à ses limitations ; bien qu'il y ait plusieurs contributeurs mineurs,
@@ -125,7 +125,7 @@
     manquait de fonctionnalités nécessaires pour mettre en oeuvre une application
     d'eCommerce, qu'ils développaient dans le cadre d'un projet universitaire,
     Andi Gutmans et Zeev Suraski de la ville de Tel Aviv (Israël) commencèrent
-    encore une autre ré-écriture complète de l'analyseur interne en 1997.
+    encore une autre réécriture complète de l'analyseur interne en 1997.
     Se rapprochant de Rasmus via le web, ils discutèrent de divers aspects
     de l'implémentation courante et de leur re-développement de PHP.
     Dans une logique d'amélioration du moteur, et pour profiter des utilisateurs existant
@@ -255,7 +255,7 @@
     incluant les <link linkend="language.enumerations">énumérations</link> (8.1),
     les <link linkend="language.fibers">fibres</link> (8.1),
     les <link linkend="language.oop5.basic.class.readonly">classes en lecture seules</link> (8.2),
-    les types de Forme Normale Disjonctive (DNF), et les constantes typés 
+    les types de Forme Normale Disjonctive (DNF) (8.2), et les constantes typées
     de classe (8.3).
    </para>
   </sect2>

--- a/appendices/ini.core.xml
+++ b/appendices/ini.core.xml
@@ -64,7 +64,7 @@
        <row>
         <entry><link linkend="ini.disable-classes">disable_classes</link></entry>
         <entry>""</entry>
-        <entry>&php.ini; only</entry>
+        <entry>&php.ini; uniquement</entry>
         <entry></entry>
        </row>
        <row>
@@ -214,7 +214,8 @@
        <para>
         Cette directive permet de désactiver certaines fonctions.
         Elle prend une liste de noms de fonctions délimitée par des virgules.
-        Depuis PHP 8.0.0, la désactivation d'une fonction supprime sa définition.
+        Depuis PHP 8.0.0, la désactivation d'une fonction supprime sa définition,
+        permettant à l'espace utilisateur de la redéfinir.
         Avant PHP 8.0.0, désactiver une fonction empêchait simplement la fonction d'être invoquée.
        </para>
        <para>
@@ -228,18 +229,22 @@
        </para>
       </listitem>
      </varlistentry>
-     
+
      <varlistentry xml:id="ini.disable-classes">
       <term>
        <parameter>disable_classes</parameter>
        <type>string</type>
       </term>
       <listitem>
-       <simpara>
+       <para>
         Cette directive permet de désactiver certaines classes.
         Elle prend en compte une liste de noms de classes délimitée par des virgules.
         La désactivation d'une classe empêche simplement son instanciation.
-       </simpara>
+       </para>
+       <para>
+        Seules les classes internes peuvent être désactivées en utilisant cette directive.
+        Les classes définies par l'utilisateur ne sont pas affectées.
+       </para>
        <simpara>
         Cette directive doit être définie dans le &php.ini;.
         Par exemple, vous ne pouvez pas la définir dans le fichier &httpd.conf;.
@@ -284,9 +289,9 @@
       </term>
       <listitem>
        <simpara>
-        La longueur maximale des arguments fonction de chaînes dans les
-        traces de piles converties sous forme de chaîne.
-        Doit être dans l'intervalle entre  <literal>"0"</literal> et <literal>"1000000"</literal>.
+        La longueur maximale des arguments de type chaîne des fonctions dans les
+        traces de pile converties en chaîne.
+        Doit être dans l'intervalle entre <literal>"0"</literal> et <literal>"1000000"</literal>.
        </simpara>
       </listitem>
      </varlistentry>
@@ -323,7 +328,7 @@ Fatal error: Maximum execution time of 30+2 seconds exceeded (terminated) in Unk
       </term>
       <listitem>
        <para>
-        Exclut les arguments dans les stack traces générées depuis les exceptions.
+        Exclut les arguments dans les traces de pile générées à partir des exceptions.
        </para>
       </listitem>
      </varlistentry>
@@ -360,7 +365,7 @@ Fatal error: Maximum execution time of 30+2 seconds exceeded (terminated) in Unk
         utilisé, les options zend.multibyte et zend.script_encoding doivent être utilisées.
        </para>
        <para>
-        Les chaines de caractères seront converties depuis zend.script_encoding vers
+        Les chaînes de caractères seront converties depuis zend.script_encoding vers
         mbstring.internal_encoding, comme si
         <function>mb_convert_encoding</function> avait été appelé.
        </para>
@@ -689,7 +694,7 @@ Fatal error: Maximum execution time of 30+2 seconds exceeded (terminated) in Unk
       </term>
       <listitem>
        <para>
-        Liste des séparateur(s) utilisé(s) par PHP pour analyser
+        Liste des séparateurs utilisés par PHP pour analyser
         les URL entrantes et en déduire les valeurs.
        </para>
        <note>
@@ -724,7 +729,7 @@ Fatal error: Maximum execution time of 30+2 seconds exceeded (terminated) in Unk
          En SAPIs CGI et FastCGI, <varname>$_SERVER</varname>
          est également peuplé de valeurs de l'environnement ; <literal>S</literal>
          est toujours équivalent à <literal>ES</literal> au regard de la position
-         de <literal>E</literal> autre part dans cette directive.
+         de <literal>E</literal> ailleurs dans cette directive.
         </para>
        </warning>
        <note>
@@ -1200,6 +1205,7 @@ Fatal error: Maximum execution time of 30+2 seconds exceeded (terminated) in Unk
         alerte de type
         <constant>E_WARNING</constant>
         ou de type <constant>E_ERROR</constant>.
+        Il est possible de modifier le chemin d'inclusion à l'exécution en
         utilisant la fonction <function>set_include_path</function>.
        </para>
        <para>
@@ -1226,7 +1232,7 @@ include_path=".;c:\php\includes"
         L'utilisation d'un point (<literal>.</literal>) dans le chemin
         d'inclusion vous permet de faire des inclusions relatives au
         répertoire courant. Cependant, il est plus efficace d'inclure
-        explicitement un fichier avec  <literal>include './file'</literal>,
+        explicitement un fichier avec <literal>include './file'</literal>,
         que de demander à PHP de vérifier le dossier courant à chaque inclusion.
        </para>
        <note>
@@ -1260,15 +1266,15 @@ include_path = ".:${USER}/pear/php"
       </term>
       <listitem>
        <para>
-        Limite les fichiers pouvant être accédés par PHP à une architecture
-        de dossiers spécifique, incluant le fichier lui-même.
+        Limite les fichiers pouvant être accédés par PHP à une arborescence
+        de répertoires spécifique, incluant le fichier lui-même.
        </para>
        <para>
         Lorsqu'un script tente d'accéder à un fichier avec, par exemple, la
         fonction <function>include</function> ou la fonction <function>fopen</function>,
         le chemin vers le fichier est analysé. Lorsque le fichier se trouve à l'extérieur
-        de l'architecture de dossiers spécifié, PHP refusera d'y accéder. Tous les
-        liens symboliques sont résolus, aussi, il n'est pas possible d'outre-passer
+        de l'arborescence de répertoires spécifiée, PHP refusera d'y accéder. Tous les
+        liens symboliques sont résolus, aussi, il n'est pas possible d'outrepasser
         cette restriction avec un lien symbolique. Si le fichier n'existe pas, alors
         le lien symbolique ne pourra être résolu et le nom du fichier est comparé avec
         l'<option>open_basedir</option>.
@@ -1278,13 +1284,13 @@ include_path = ".:${USER}/pear/php"
         fonctions du système de fichiers ; par exemple, si
         <literal>MySQL</literal> est configuré pour utiliser le driver
         <literal>mysqlnd</literal>, <literal>LOAD DATA INFILE</literal> sera affecté
-        par l'option <option>open_basedir</option>. Le plupart des extensions
-        de PHP utilise l'option <literal>open_basedir</literal> de cette façon.
+        par l'option <option>open_basedir</option>. La plupart des extensions
+        de PHP utilisent l'option <literal>open_basedir</literal> de cette façon.
        </para>
        <para>
         La valeur spéciale <systemitem class="filesystem">.</systemitem>
         indique que le dossier courant du script sera utilisé comme dossier
-        de base.Ceci est cependant légèrement dangereux dans le sens où le dossier
+        de base. Ceci est cependant légèrement dangereux dans le sens où le dossier
         courant peut être facilement changé grâce à la fonction
         <function>chdir</function>.
        </para>
@@ -1334,8 +1340,8 @@ include_path = ".:${USER}/pear/php"
        </note>
        <caution>
         <para>
-         <literal>open_basedir</literal> est juste mesure de protection supplémentaire,
-         et n'est en aucun cas exhaustive, et ne peut donc pas être dépendu quand
+         <literal>open_basedir</literal> est juste une mesure de protection supplémentaire,
+         et n'est en aucun cas exhaustive, et on ne peut donc pas s'y fier lorsque
          la sécurité est nécessaire.
         </para>
        </caution>
@@ -1404,7 +1410,7 @@ include_path = ".:${USER}/pear/php"
       <listitem>
        <para>
         Spécifie le répertoire dans lequel PHP doit chercher des extensions
-        externes à charger. Il est recommandé de spécifier un chemin absolut.
+        externes à charger. Il est recommandé de spécifier un chemin absolu.
         Voir aussi <link linkend="ini.enable-dl">enable_dl</link> et
         <function>dl</function>.
        </para>
@@ -1504,7 +1510,7 @@ include_path = ".:${USER}/pear/php"
        <note>
         <para>
          Utilisateurs de Windows : Lors de l'utilisation de IIS,
-         cette option <emphasis>doit</emphasis> est désactivée ;
+         cette option <emphasis>doit</emphasis> être désactivée ;
          pareil pour OmniHTTPD et Xitami.
         </para>
        </note>
@@ -1559,7 +1565,7 @@ include_path = ".:${USER}/pear/php"
         du code réponse HTTP. S'il est désactivé, PHP enverra un en-tête
         "Status:" (<link xlink:href="&url.rfc;3875">RFC 3875</link>)
         qui est supporté par Apache et les
-        autres serveurs web. Lorsque il est activé, PHP enverra un
+        autres serveurs web. Lorsqu'il est activé, PHP enverra un
         en-tête répondant à la spécification de la
         <link xlink:href="&url.rfc;2616">RFC 2616</link>.
        </para>
@@ -1583,7 +1589,7 @@ include_path = ".:${USER}/pear/php"
       <listitem>
        <para>
         FastCGI sous IIS (sur les systèmes d'exploitation basés sur
-        WINNT) supporte la possibilité de déterminer la marque de
+        WINNT) supporte la possibilité d'emprunter l'identité du jeton de
         sécurité du client appelant. Cela permet à IIS de définir le
         contexte de sécurité sur lequel la requête est exécutée.
         mod_fastcgi sous Apache ne supporte actuellement pas cette
@@ -1786,7 +1792,7 @@ include_path = ".:${USER}/pear/php"
        </para>
        <warning>
         <simpara>
-         Cette fonctionnalité a été  <emphasis>SUPPRIMÉE</emphasis> à partir de PHP 7.2.0.
+         Cette fonctionnalité a été <emphasis>SUPPRIMÉE</emphasis> à partir de PHP 7.2.0.
         </simpara>
        </warning>
       </listitem>

--- a/appendices/ini.list.xml
+++ b/appendices/ini.list.xml
@@ -175,7 +175,7 @@
       <entry><link linkend="ini.default-charset">default_charset</link></entry>
       <entry>"UTF-8"</entry>
       <entry><constant>INI_ALL</constant></entry>
-      <entry>Par défaut "UTF-8".</entry>
+      <entry></entry>
      </row>
      <row>
       <entry><link linkend="ini.input-encoding">input_encoding</link></entry>
@@ -456,7 +456,7 @@
      <row>
       <entry>mail.force_extra_parameters</entry>
       <entry>&null;</entry>
-      <entry>&php.ini; uniquement</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
       <entry></entry>
      </row>
      <row>
@@ -796,6 +796,12 @@
       <entry></entry>
      </row>
      <row>
+      <entry><link linkend="ini.zend.reserved-stack-size">zend.reserved_stack_size</link></entry>
+      <entry><literal>"0"</literal></entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
+      <entry>Disponible à partir de PHP 8.3.0</entry>
+     </row>
+     <row>
       <entry><link linkend="ini.zend.script-encoding">zend.script_encoding</link></entry>
       <entry>&null;</entry>
       <entry><constant>INI_ALL</constant></entry>
@@ -810,7 +816,7 @@
      <row>
       <entry><link linkend="ini.zend-extension">zend_extension</link></entry>
       <entry>&null;</entry>
-      <entry>&php.ini; only</entry>
+      <entry>&php.ini; uniquement</entry>
       <entry></entry>
      </row>
      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('zlib.configuration.list')/*)"><xi:fallback/></xi:include>

--- a/appendices/migration56/extensions.xml
+++ b/appendices/migration56/extensions.xml
@@ -10,8 +10,8 @@
   <title><link linkend="book.curl">cURL</link></title>
 
   <para>
-   Un certain nombre de constantes de la bibliothèque cURL, précédemment marqué 
-   comme obsolète, ont été supprimés :
+   Un certain nombre de constantes de la bibliothèque cURL, précédemment marquées
+   comme obsolètes, ont été supprimées :
   </para>
 
   <itemizedlist>
@@ -62,7 +62,7 @@
    <listitem>
     <simpara>
      Utiliser <literal>oci_execute($s, OCI_NO_AUTO_COMMIT)</literal> pour un 
-     SELECT ne lance plus nécessairement un ROLLBACK interne lors la fermeture 
+     SELECT ne lance plus nécessairement un ROLLBACK interne lors de la fermeture 
      de la connexion.
     </simpara>
    </listitem>

--- a/appendices/migration56/incompatible.xml
+++ b/appendices/migration56/incompatible.xml
@@ -81,7 +81,7 @@ array(3) {
   </para>
 
   <para>
-   Ce changement va affecter uniquement les cas ou du JSON invalide serait passé 
+   Ce changement va affecter uniquement les cas où du JSON invalide serait passé 
    à <function>json_decode</function> : du JSON valide ne sera pas affecté et sera
    analysé normalement.
   </para>

--- a/appendices/migration56/new-features.xml
+++ b/appendices/migration56/new-features.xml
@@ -401,8 +401,8 @@ object(C)#1 (1) {
    Un large éventail d'améliorations ont été réalisé sur le support SSL/TLS en
    PHP 5.6. Ceci inclut
    <link linkend="migration56.incompatible.peer-verification">l'activation de
-    la vérification par paire par défaut</link>, supportant la correspondance
-   des certificats d'empreintes, permettant de limiter les attaques à la
+    la vérification du pair par défaut</link>, supportant la correspondance
+   des empreintes de certificats, permettant de limiter les attaques à la
    renégociation TLS, ainsi que plusieurs nouvelles
    <link linkend="context.ssl">options de contexte SSL</link> permettant
    un contrôle plus fin du protocole et des vérifications des configurations

--- a/appendices/migration56/openssl.xml
+++ b/appendices/migration56/openssl.xml
@@ -39,7 +39,7 @@
    Cette liste est accessible via la nouvelle constante 
    <constant>OPENSSL_DEFAULT_STREAM_CIPHERS</constant> et peut être remplacée 
    (comme dans les versions précédentes de PHP) en définissant l'option de contexte 
-   <link linkend="context.ssl.ciphers"><parameter>chiffrements</parameter></link>.
+   <link linkend="context.ssl.ciphers"><parameter>ciphers</parameter></link>.
   </para>
  </sect2>
 
@@ -70,7 +70,7 @@
 
   <para>
    Le protocole et le chiffrement qui ont été négociés pour un flux chiffré 
-   peuvent désormais être accédé via <function>stream_get_meta_data</function> 
+   peuvent désormais être accédés via <function>stream_get_meta_data</function> 
    ou <function>stream_context_get_options</function> lorsque l'option de 
    contexte SSL <parameter>capture_session_meta</parameter> est définie à &true;.
   </para>
@@ -375,7 +375,7 @@ var_dump(openssl_spki_verify($spkac));
     <term><parameter>openssl_spki_export_challenge</parameter></term>
     <listitem>
      <para>
-      Exportations du défi associé au SPKAC fourni.
+      Exporte le défi associé au SPKAC fourni.
      </para>
 
      <informalexample>

--- a/appendices/migration70/changed-functions.xml
+++ b/appendices/migration70/changed-functions.xml
@@ -40,7 +40,7 @@
    </listitem>
    <listitem>
     <simpara>
-     la fonction <function>preg_replace</function> ne supporte plus
+     La fonction <function>preg_replace</function> ne supporte plus
      "\e" (<constant>PREG_REPLACE_EVAL</constant>). 
      <function>preg_replace_callback</function> devrait être utilisé à la place.
     </simpara>
@@ -69,7 +69,7 @@
    </listitem>
    <listitem>
     <simpara>
-     <function>substr</function> et <function>iconv_substr</function> retourne
+     <function>substr</function> et <function>iconv_substr</function> retournent
      désormais une &string; vide, si 
      la longueur de la chaîne est égale à <parameter>$start</parameter>.
     </simpara>

--- a/appendices/migration70/deprecated.xml
+++ b/appendices/migration70/deprecated.xml
@@ -106,7 +106,7 @@ Je ne suis pas statique !
  <sect2 xml:id="migration70.deprecated.ldap">
   <title>Dépréciation dans <link linkend="book.ldap">LDAP</link></title>
    <simpara>
-    Les fonctions suivantes sont dépréciées :
+    La fonction suivante est dépréciée :
    </simpara>
 
    <itemizedlist>

--- a/appendices/migration70/new-features.xml
+++ b/appendices/migration70/new-features.xml
@@ -399,7 +399,7 @@ bool(true)
   <para>
    Les attentes sont 
    une amélioration rétro-compatible apportée à l'ancienne fonction
-   <function>assert</function>. Ils offrent des assertions à très faible
+   <function>assert</function>. Elles offrent des assertions à très faible
    coût dans le code de production et permettent de lever des exceptions 
    personnalisées lorsque l’assertion échoue.
   </para>
@@ -427,7 +427,7 @@ assert(false, new CustomError('Un message d\'erreur'));
    &example.outputs;
    <screen>
 <![CDATA[
-Fatal error: Uncaught CustomError: Un message d\'erreur
+Fatal error: Uncaught CustomError: Un message d'erreur
 ]]>
    </screen>
   </informalexample>

--- a/appendices/migration71/changed-functions.xml
+++ b/appendices/migration71/changed-functions.xml
@@ -125,7 +125,7 @@
      <function>pg_last_notice</function> accepte maintenant un paramètre optionnel
      pour spécifier une opération. Ceci peut être fait avec une des nouvelles
      constantes suivantes : <constant>PGSQL_NOTICE_LAST</constant>,
-     <constant>PGSQL_NOTICE_ALL</constant>, or
+     <constant>PGSQL_NOTICE_ALL</constant>, ou
      <constant>PGSQL_NOTICE_CLEAR</constant>.
     </simpara>
    </listitem>

--- a/appendices/migration71/constants.xml
+++ b/appendices/migration71/constants.xml
@@ -7,7 +7,7 @@
  <title>Nouvelles constantes globales</title>
 
  <sect2 xml:id="migration71.constants.core">
-  <title><link linkend="reserved.constants">Core Predefined Constants</link></title>
+  <title><link linkend="reserved.constants">Constantes prédéfinies du cœur</link></title>
 
   <itemizedlist>
    <listitem>
@@ -53,7 +53,7 @@
  </sect2>
 
  <sect2 xml:id="migration71.constants.image">
-  <title><link linkend="book.image">Image Processing et GD</link></title>
+  <title><link linkend="book.image">Traitement d'image et GD</link></title>
 
   <itemizedlist>
    <listitem>

--- a/appendices/migration71/deprecated.xml
+++ b/appendices/migration71/deprecated.xml
@@ -18,7 +18,7 @@
  </sect2>
 
  <sect2 xml:id="migration71.deprecated.eval-option-for-mb-ereg-replace">
-  <title>L'options Eval pour <function>mb_ereg_replace</function> et <function>mb_eregi_replace</function></title>
+  <title>L'option Eval pour <function>mb_ereg_replace</function> et <function>mb_eregi_replace</function></title>
 
   <para>
    Le modificateur de motif <literal>e</literal> a été déprécié pour les fonctions

--- a/appendices/migration71/incompatible.xml
+++ b/appendices/migration71/incompatible.xml
@@ -144,9 +144,9 @@ Warning: Cannot call func_num_args() dynamically in %s on line %d
   <title>Correctifs à l'algorithme <function>mt_rand</function></title>
 
   <para>
-   <function>mt_rand</function> utilise désormais par défaut la version fixe de 
-   l'algorithme Mersenne Twister. Si la sortie déterministe de 
-   <function>mt_srand</function> a été invoquée, alors <constant>MT_RAND_PHP</constant> peut être utilisé comme
+   <function>mt_rand</function> utilise désormais par défaut la version fixe de
+   l'algorithme Mersenne Twister. Si la sortie déterministe de
+   <function>mt_rand</function> a été invoquée, alors <constant>MT_RAND_PHP</constant> peut être utilisé comme
    second paramètre optionnel de <function>mt_srand</function> pour préserver l'ancienne (et incorrecte) implémentation.
   </para>
  </sect2>
@@ -170,7 +170,7 @@ Warning: Cannot call func_num_args() dynamically in %s on line %d
   <title>Interdire le caractère de contrôle de suppression ASCII dans les identificateurs</title>
 
   <para>
-   Le caractère de contrôle de suppression ASCII (<literal>0X7f</literal>) ne peut 
+   Le caractère de contrôle de suppression ASCII (<literal>0x7F</literal>) ne peut 
    plus être utilisé dans les identificateurs qui ne sont pas entre guillemets.
   </para>
  </sect2>

--- a/appendices/migration71/other-changes.xml
+++ b/appendices/migration71/other-changes.xml
@@ -7,7 +7,7 @@
  <title>Autres changements</title>
 
  <sect2 xml:id="migration71.other-changes.apprise-on-arithmetic-with-invalid-strings">
-  <title>Notices et avertisements sur opérations arithmétiques avec chaînes invalides</title>
+  <title>Notices et avertissements sur les opérations arithmétiques avec chaînes invalides</title>
 
   <para>
    Des nouvelles erreurs <constant>E_WARNING</constant> et <constant>E_NOTICE</constant>
@@ -122,7 +122,7 @@ string(1) "@"
    <listitem>
     <simpara>
      <parameter>session.sid_bits_per_character</parameter> - définit le nombre
-     de bits à enregistrer par caractère (c.à.d augmente l'intervale de caractères
+     de bits à enregistrer par caractère (c.à.d augmente l'intervalle de caractères
      qui peuvent être utilisés dans l'ID de session), par défaut 4 pour la
      rétrocompatibilité.
     </simpara>

--- a/appendices/migration71/windows-support.xml
+++ b/appendices/migration71/windows-support.xml
@@ -103,7 +103,7 @@
   <para>
    Le support des chemins longs est transparent. Les chemins plus longs que 260 octets sont
    automatiquement préfixés par <literal>\\?\</literal>. La longueur maximale du chemin est
-   limitée à 2018 octets. Soyez conscient, que la limite des segments de chemin (longueur du
+   limitée à 2048 octets. Soyez conscient, que la limite des segments de chemin (longueur du
    basename) persiste.
   </para>
   <para>

--- a/appendices/migration72/incompatible.xml
+++ b/appendices/migration72/incompatible.xml
@@ -348,7 +348,7 @@ int(2)
  </sect2>
 
  <sect2 xml:id="migration72.incompatible.cookie-decode">
-  <title>Incoming Cookies</title>
+  <title>Cookies entrants</title>
 
   <para>
    Depuis PHP 7.2.34, les <emphasis>noms</emphasis> des cookies entrants ne sont plus

--- a/appendices/migration72/other-changes.xml
+++ b/appendices/migration72/other-changes.xml
@@ -22,7 +22,7 @@
   <para>
    Le paramètre $additional_headers de <function>mail</function> et
    <function>mb_send_mail</function>
-   accepte maintenant un <type>array</type> à la place d'un <type>string</type>
+   accepte aussi maintenant un <type>array</type> à la place d'un <type>string</type>
   </para>
  </sect2>
  

--- a/appendices/migration73/deprecated.xml
+++ b/appendices/migration73/deprecated.xml
@@ -22,7 +22,7 @@
   </sect3>
 
   <sect3 xml:id="migration73.deprecated.core.assert">
-   <title>assert() dans un espace de nom</title>
+   <title>assert() dans un espace de noms</title>
 
    <para>
     La déclaration d'une fonction appelée <literal>assert()</literal> dans un 

--- a/appendices/migration73/incompatible.xml
+++ b/appendices/migration73/incompatible.xml
@@ -76,7 +76,7 @@ while ($foo) {
     résulteront plus en une conversion implicite en &integer;, c.à.d.,
     <literal>$obj->offsetGet("123")</literal> sera appelé au lieu de
     <literal>$obj->offsetGet(123)</literal>. Ceci correspond au comportement
-    pour les non litérales. Le comportement des &array; n'est pas affecté
+    pour les non littéraux. Le comportement des &array; n'est pas affecté
     d'une quelconque manière, ils continuent de convertir implicitement
     des clés de &string; en &integer;.
    </para>
@@ -226,7 +226,7 @@ foo(...gen());
   </para>
 
   <para>
-   <function>bcmul</function> et <function>bcpow</function> retourne désormais
+   <function>bcmul</function> et <function>bcpow</function> retournent désormais
    les nombres avec la précision demandée. Auparavant, certains nombres pouvaient
    omettre les zéros de fin décimaux.
   </para>
@@ -305,12 +305,12 @@ foo(...gen());
  </sect2>
 
  <sect2 xml:id="migration73.incompatible.spl">
-  <title>Bibliothéque Standard de PHP (SPL)</title>
+  <title>Bibliothèque Standard de PHP (SPL)</title>
 
   <para>
    Si un autochargeur <link linkend="book.spl">SPL</link> lance une exception,
    les autochargeurs suivants ne seront pas exécutés. Précédemment tous les
-   autochargeurs étaient exécutés et les exceptions étaient chainées.
+   autochargeurs étaient exécutés et les exceptions étaient chaînées.
   </para>
  </sect2>
 

--- a/appendices/migration73/new-features.xml
+++ b/appendices/migration73/new-features.xml
@@ -14,7 +14,7 @@
 
    <para>
     Le marqueur fermant pour les chaînes doc n'est plus requis d'être suivi par
-    un point virgule ou un retour à la ligne. Additionellement le marqueur
+    un point virgule ou un retour à la ligne. Additionnellement le marqueur
     fermant peut être indenté, dans ce cas l'indentation sera retirée de toutes
     les lignes dans la chaîne doc.
    </para>
@@ -45,7 +45,7 @@
 
    <para>
     Une nouvelle exception <classname>CompileError</classname> a été ajoutée,
-    duquel <classname>ParseError</classname> inhérite. Un petit nombre d'erreurs
+    dont <classname>ParseError</classname> hérite. Un petit nombre d'erreurs
     de compilation lanceront désormais <classname>CompileError</classname> au
     lieu de générer une erreur fatale. Actuellement ceci affecte uniquement les
     erreurs de compilation qui peuvent être lancées par
@@ -268,7 +268,7 @@ mb_strtoupper("Straße");
    <para>
     Les tables de données pour les
     <link linkend="book.mbstring">Chaînes Multi-octets</link>
-    ont été mis à jour pour Unicode 11.
+    ont été mises à jour pour Unicode 11.
    </para> 
   </sect3>
 

--- a/appendices/migration73/other-changes.xml
+++ b/appendices/migration73/other-changes.xml
@@ -52,7 +52,7 @@
         avec les types de filtres pris en charge - <literal>all</literal>,
         <literal>no-ctrl</literal> et <literal>ascii</literal>.
         À partir de PHP 7.3.8, <literal>raw</literal> est aussi disponible,
-        restaurant le comportement de syslog correspondant au versions
+        restaurant le comportement de syslog correspondant aux versions
         antérieures de PHP. Ce filtre affectera aussi les appels à
         <function>syslog</function>.
        </simpara>
@@ -98,7 +98,7 @@
    <para>
     <function>array_push</function> et <function>array_unshift</function> peuvent
     maintenant être appelés avec un seul argument, ce qui est particulièrement 
-    pratique avec l'opétateur de décomposition.
+    pratique avec l'opérateur de décomposition.
    </para>
   </sect3>
 
@@ -176,7 +176,7 @@
   <title>Notation d'objets JavaScript</title>
 
   <para>
-   Un nouveau drapeau été ajouté, <constant>JSON_THROW_ON_ERROR</constant>,
+   Un nouveau drapeau a été ajouté, <constant>JSON_THROW_ON_ERROR</constant>,
    qui peut être utilisé avec <function>json_decode</function> ou
    <function>json_encode</function> et provoque la levée de la nouvelle exception 
    <classname>JsonException</classname> lors d'une erreur, au lieu de définir
@@ -271,7 +271,7 @@
   <title>Manipulation de session</title>
 
   <para>
-   <function>session_set_cookie_params</function> gère désormais en charge la signature 
+   <function>session_set_cookie_params</function> prend désormais en charge la signature 
    suivante :
    <methodsynopsis>
     <type>bool</type><methodname>session_set_cookie_params</methodname>
@@ -296,7 +296,7 @@
 
   <para>
    Construire avec <link xlink:href="&url.tidyp;">tidyp</link> est maintenant
-   géré de façon transparente. Etant donné que tidyp n'offre pas d'API pour obtenir la date de sortie, <function>tidy_get_release</function> et <methodname>tidy::getRelease</methodname> retourne <literal>'unknown'</literal> dans ce cas.
+   géré de façon transparente. Étant donné que tidyp n'offre pas d'API pour obtenir la date de sortie, <function>tidy_get_release</function> et <methodname>tidy::getRelease</methodname> retournent <literal>'unknown'</literal> dans ce cas.
   </para>
  </sect2>
 

--- a/appendices/migration73/windows-support.xml
+++ b/appendices/migration73/windows-support.xml
@@ -18,7 +18,7 @@
     de supprimer des fichiers avec des pointeurs en cours d'utilisation. Il n'est 
     pas 100% identique, certaines différences de plate-forme persistent encore. Après 
     la suppression, l'entrée de nom de fichier est bloquée, jusqu'à ce que tous les 
-    pointeurs ouverts soit fermés.
+    pointeurs ouverts soient fermés.
    </para>
   </sect3>
 

--- a/appendices/migration74/deprecated.xml
+++ b/appendices/migration74/deprecated.xml
@@ -31,7 +31,7 @@
    </para>
    <para>
     Les parenthèses ne sont <emphasis>pas</emphasis> requises lors de l'imbrication
-    dans l'opérant du milieu car ceci est toujours sans ambiguïté et n'est pas
+    dans l'opérande du milieu car ceci est toujours sans ambiguïté et n'est pas
     affecté par l'associativité :
     <informalexample>
      <programlisting role="php">
@@ -47,7 +47,7 @@
    <title>Accès de position de tableau et de chaînes en utilisant les accolades</title>
 
    <para>
-    La syntaxe pour accéder à la position des &array;x et &string; avec les
+    La syntaxe pour accéder à la position des &array; et &string; avec les
     accolades est obsolète. Utiliser <literal>$var[$idx]</literal> au lieu de
     <literal>$var{$idx}</literal>.
    </para>

--- a/appendices/migration74/incompatible.xml
+++ b/appendices/migration74/incompatible.xml
@@ -88,17 +88,17 @@
     </listitem>
     <listitem>
      <simpara>
-      <constant>PASSWORD_BCRYPT</constant> était l'entier 1; maintenant est '2y'
+      <constant>PASSWORD_BCRYPT</constant> était l'entier 1; maintenant c'est '2y'
      </simpara>
     </listitem>
     <listitem>
      <simpara>
-      <constant>PASSWORD_ARGON2I</constant>  était l'entier 2; maintenant est 'argon2i'
+      <constant>PASSWORD_ARGON2I</constant>  était l'entier 2; maintenant c'est 'argon2i'
      </simpara>
     </listitem>
     <listitem>
      <simpara>
-      <constant>PASSWORD_ARGON2ID</constant>  était l'entier 3; maintenant est 'argon2id'
+      <constant>PASSWORD_ARGON2ID</constant>  était l'entier 3; maintenant c'est 'argon2id'
      </simpara>
     </listitem>
    </itemizedlist>
@@ -142,7 +142,7 @@
 
   <para>
    Les fonctions BCMath avertiront désormais si un nombre non bien formé est 
-   adopté, tel que <literal>"32foo"</literal>. L'argument sera interprété comme 
+   passé, tel que <literal>"32foo"</literal>. L'argument sera interprété comme 
    zéro, comme avant.
   </para>
  </sect2>
@@ -159,7 +159,7 @@
    prise en charge à partir de cURL 7.62.0.
   </para>
   <para>
-   Le paramètre <literal>$version</literal> de <function>curl_version </function> 
+   Le paramètre <literal>$version</literal> de <function>curl_version</function> 
    est déprécié. Si une valeur n'est pas égale à la valeur par défaut
    <constant>CURLVERSION_NOW</constant> est passé, un avertissement est levé et 
    le paramètre est ignoré.
@@ -252,7 +252,7 @@
   <para>
    La valeur des constantes de classe de <classname>ReflectionClassConstant</classname>,
    <classname>ReflectionMethod</classname> et <classname>ReflectionProperty</classname>
-   ont été changé.
+   ont été changées.
   </para>
  </sect2>
 

--- a/appendices/migration74/new-features.xml
+++ b/appendices/migration74/new-features.xml
@@ -365,7 +365,7 @@ public function __unserialize(array $data): void
      </programlisting>
     </informalexample>
     Le nouveau mécanisme de sérialisation succèdera à l'interface
-    <interfacename>Serializable</interfacename>, qui sera rendu
+    <interfacename>Serializable</interfacename>, qui sera rendue
     obsolète dans le futur.
    </para>
   </sect3>

--- a/appendices/migration74/other-changes.xml
+++ b/appendices/migration74/other-changes.xml
@@ -14,7 +14,7 @@
     Un opcode de VM spécialisé pour la fonction
     <function>array_key_exists</function> a été ajouté, ceci améliore les
     performances de cette fonction si elle peut être résolue statiquement.
-    Dans du code sous un espace de nom, ceci peut nécessiter d'écrire
+    Dans du code sous un espace de noms, ceci peut nécessiter d'écrire
     <literal>\array_key_exists()</literal> ou importer explicitement la fonction.
    </para>
   </sect3>

--- a/appendices/migration80/incompatible.xml
+++ b/appendices/migration80/incompatible.xml
@@ -318,7 +318,7 @@ function test(int $arg = null) {}
       </simplelist>
      </para>
      <para>
-      Un certain nombre de notices ont été convertis en avertissements :
+      Un certain nombre de notices ont été converties en avertissements :
      </para>
      <para>
       <simplelist>
@@ -349,7 +349,7 @@ function test(int $arg = null) {}
     </listitem>
     <listitem>
      <para>
-      Les exceptions non capturée passent maintenant par un "arrêt propre", ce qui signifie que les destructeurs seront appelés
+      Les exceptions non capturées passent maintenant par un "arrêt propre", ce qui signifie que les destructeurs seront appelés
       après une exception non capturée.
      </para>
     </listitem>
@@ -361,7 +361,7 @@ function test(int $arg = null) {}
     </listitem>
     <listitem>
      <para>
-      Certaines notices "Only variables should be passed by reference" ont été convertis en exception "Argument
+      Certaines notices "Only variables should be passed by reference" ont été converties en exception "Argument
       cannot be passed by reference".
      </para>
     </listitem>
@@ -551,7 +551,7 @@ $array["key"];
      <para>
       <simplelist>
        <member>La fonction <function>is_numeric</function></member>
-       <member>Les comparaisons entre deux chaîne de caractères</member>
+       <member>Les comparaisons entre deux chaînes de caractères</member>
        <member>Les déclarations de type</member>
        <member>Les opérations d'incrémentation et de décrémentation</member>
       </simplelist>

--- a/appendices/migration80/new-features.xml
+++ b/appendices/migration80/new-features.xml
@@ -32,7 +32,7 @@
    <title>Promotion du Constructeur</title>
 
    <para>
-    Le support pour la <link linkend="language.oop5.decon.constructor.promotion">promotion de propriété de constructeur</link> (déclarer les propriété dans la signature du constructeur)
+    Le support pour la <link linkend="language.oop5.decon.constructor.promotion">promotion de propriété de constructeur</link> (déclarer les propriétés dans la signature du constructeur)
     a été ajouté.
     <!-- RFC: https://wiki.php.net/rfc/constructor_promotion -->
    </para>
@@ -66,7 +66,7 @@
   </sect3>
 
   <sect3 xml:id="migration80.new-features.core.others">
-   <title>Autre nouvelles fonctionnalités</title>
+   <title>Autres nouvelles fonctionnalités</title>
 
    <itemizedlist>
     <listitem>
@@ -143,7 +143,7 @@ class Test {
     <listitem>
      <para>
       Ajout de l'interface <interfacename>Stringable</interfacename>, qui est automatiquement implémentée si
-      une classe définie une méthode <link linkend="object.tostring">__toString()</link>.
+      une classe définit une méthode <link linkend="object.tostring">__toString()</link>.
       <!-- RFC: https://wiki.php.net/rfc/stringable -->
      </para>
     </listitem>
@@ -200,7 +200,7 @@ function functionWithLongSignature(
     <listitem>
      <para>
       Les méthodes privées déclarées dans une classe parente n'imposent plus de règles d'héritage sur les méthodes
-      de la classe enfante (à l'exception des constructeurs privés finaux).
+      de la classe enfant (à l'exception des constructeurs privés finaux).
       L'exemple suivant illustre les restrictions qui ont été supprimées :
       <programlisting role="php">
 <![CDATA[
@@ -214,7 +214,7 @@ class ParentClass {
 }
 class ChildClass extends ParentClass {
     // Tous les exemples suivants sont maintenant autorisés, même si les modificateurs ne sont pas
-    // les même que pour les méthods privés dans la classe parente.
+    // les mêmes que pour les méthodes privées dans la classe parente.
     public abstract function method1() {}
     public static function method2() {}
     public function method3() {}
@@ -253,7 +253,7 @@ class ChildClass extends ParentClass {
    </listitem>
    <listitem>
     <para>
-     Le formatteur de date et heure <literal>p</literal> a été ajouté, qui est le même que
+     Le formateur de date et heure <literal>p</literal> a été ajouté, qui est le même que
      <literal>P</literal> mais retourne <literal>Z</literal> plutôt que <literal>+00:00</literal>
      pour UTC.
     </para>
@@ -428,7 +428,7 @@ class ChildClass extends ParentClass {
    </listitem>
    <listitem>
     <para>
-     <function>fdiv</function> a été ajouté, qui éffectue une division en virgule flottante sous les sémantiques IEEE 754.
+     <function>fdiv</function> a été ajouté, qui effectue une division en virgule flottante sous les sémantiques IEEE 754.
      La division par zéro est considérée comme bien définie et retournera l'une des valeurs <literal>Inf</literal>,
      <literal>-Inf</literal> ou <literal>NaN</literal>.
     </para>
@@ -470,7 +470,7 @@ printf("%.*H", (int) ini_get("serialize_precision"), $float);
    </listitem>
    <listitem>
     <para>
-     <function>proc_open</function> support maintent les descripteurs de pseudo-terminal (PTY). Le code suivant
+     <function>proc_open</function> supporte maintenant les descripteurs de pseudo-terminal (PTY). Le code suivant
      attache <literal>stdin</literal>, <literal>stdout</literal> et <literal>stderr</literal> au
      même PTY:
     </para>
@@ -487,7 +487,7 @@ $proc = proc_open($command, [['pty'], ['pty'], ['pty']], $pipes);
    <listitem>
     <para>
      <function>proc_open</function> supportent maintenant les descripteurs de paire de socket. Le code suivant attache
-     distinct socket paire to <literal>stdin</literal>, <literal>stdout</literal> and
+     une paire de socket distincte à <literal>stdin</literal>, <literal>stdout</literal> et
      <literal>stderr</literal> :
     </para>
     <para>
@@ -544,7 +544,7 @@ array_intersect(...$arrays);
 
   <para>
    <classname>PhpToken</classname> ajoute une interface basée sur les objets au tokenizer. Il fournit une
-   repésentation plus uniforme et ergonomique, tout en étant plus efficace en mémoire et plus rapide.
+   représentation plus uniforme et ergonomique, tout en étant plus efficace en mémoire et plus rapide.
    <!--  RFC: https://wiki.php.net/rfc/token_as_object -->
   </para>
  </sect2>
@@ -555,7 +555,7 @@ array_intersect(...$arrays);
   <itemizedlist>
    <listitem>
     <para>
-     L'extension Zip a été mis à jour en version 1.19.1.
+     L'extension Zip a été mise à jour en version 1.19.1.
     </para>
    </listitem>
    <listitem>
@@ -594,7 +594,7 @@ array_intersect(...$arrays);
    </listitem>
    <listitem>
     <para>
-     La propriété <varname>ZipArchive::lastId</varname> pour avoir la valuer de l'index de la 
+     La propriété <varname>ZipArchive::lastId</varname> pour avoir la valeur de l'index de la 
      dernière entrée ajoutée a été ajoutée.
     </para>
    </listitem>

--- a/appendices/migration80/other-changes.xml
+++ b/appendices/migration80/other-changes.xml
@@ -88,7 +88,7 @@
  </sect2>
 
  <sect2 xml:id="migration80.other-changes.extensions">
-  <title>Autre changements aux extensions</title>
+  <title>Autres changements aux extensions</title>
 
   <sect3 xml:id="migration80.other-changes.extensions.curl">
    <title>CURL</title>
@@ -153,8 +153,8 @@
      <para>
       Le paramètre <parameter>num_points</parameter> de <function>imagepolygon</function>,
       <function>imageopenpolygon</function> et <function>imagefilledpolygon</function> est maintenant
-      optionnel, par exemple ces fonctions peuvent être appélées avec soit 3 ou 4 arguments. Si l'argument est
-      omit il est calculé comme <code>count($points)/2</code>.
+      optionnel, par exemple ces fonctions peuvent être appelées avec soit 3 ou 4 arguments. Si l'argument est
+      omis, il est calculé comme <code>count($points)/2</code>.
      </para>
     </listitem>
     <listitem>
@@ -209,13 +209,13 @@
    <itemizedlist>
     <listitem>
      <para>
-      Lorsque mysqlnd n'est pas utilisé (ce qui est l'option recommandé par défaut), la version minimum supportée
+      Lorsque mysqlnd n'est pas utilisé (ce qui est l'option recommandée par défaut), la version minimum supportée
       de libmysqlclient est maintenant 5.5.
      </para>
     </listitem>
     <listitem>
      <para>
-      <classname>mysqli_result</classname> implemente maintenant
+      <classname>mysqli_result</classname> implémente maintenant
       <interfacename>IteratorAggregate</interfacename> (à la place de
       <interfacename>Traversable</interfacename>).
      </para>
@@ -247,7 +247,7 @@
    <title>SimpleXML</title>
 
    <para>
-    <classname>SimpleXMLElement</classname> maintenant implémente 
+    <classname>SimpleXMLElement</classname> implémente maintenant 
     <interfacename>RecursiveIterator</interfacename> et a absorbé la fonctionnalité de
     <classname>SimpleXMLIterator</classname>. <classname>SimpleXMLIterator</classname> est une extension 
     vide de <classname>SimpleXMLElement</classname>.
@@ -291,13 +291,13 @@
   <itemizedlist>
    <listitem>
     <para>
-     Un compilateur à la volé (Just-In-Time ou JIT) a été ajouté à l'extension opcache.
+     Un compilateur à la volée (Just-In-Time ou JIT) a été ajouté à l'extension opcache.
      <!-- https://wiki.php.net/rfc/jit -->
     </para>
    </listitem>
    <listitem>
     <para>
-     <function>array_slice</function> sur un tableau sans trou ne scan plus l'entièreté du tableau
+     <function>array_slice</function> sur un tableau sans trou ne scanne plus l'entièreté du tableau
      pour trouver l'écart de départ. Cela peut réduire significativement le temps d'exécution de la fonction avec de grands
      écarts et de petites longueurs.
     </para>

--- a/appendices/migration81/deprecated.xml
+++ b/appendices/migration81/deprecated.xml
@@ -64,7 +64,7 @@ $a[15.0]; // ok, car 15.0 == 15
   </sect3>
 
   <sect3 xml:id="migration81.deprecated.core.static-trait">
-   <title>Appeller un element <modifier>static</modifier> sur un trait</title>
+   <title>Appeler un élément <modifier>static</modifier> sur un trait</title>
 
    <para>
     Appeler une méthode <modifier>static</modifier>, ou accéder à une
@@ -212,7 +212,7 @@ $arr[] = 2;
    <function>mhash_keygen_s2k</function>,
    <function>mhash_count</function>,
    <function>mhash_get_block_size</function>,
-   et <function>mhash_get_hash_name</function> ont été dépréciés.
+   et <function>mhash_get_hash_name</function> ont été dépréciées.
    Utiliser les fonctions <literal>hash_*()</literal> à la place.
   </para>
  </sect2>
@@ -230,7 +230,7 @@ $arr[] = 2;
   <title>Intl</title>
 
   <para>
-   Appeller <methodname>IntlCalendar::roll</methodname> avec un argument
+   Appeler <methodname>IntlCalendar::roll</methodname> avec un argument
    &boolean; est déprécié.
    Utiliser <literal>1</literal> et <literal>-1</literal> à la place de
    &true; et &false; respectivement.
@@ -241,7 +241,7 @@ $arr[] = 2;
   <title>Chaîne de caractères multibytes</title>
 
   <para>
-   Appeller <function>mb_check_encoding</function> avec aucun argument
+   Appeler <function>mb_check_encoding</function> avec aucun argument
    est déprécié.
   </para>
  </sect2>
@@ -250,14 +250,14 @@ $arr[] = 2;
   <title>MySQLi</title>
 
   <para>
-   La propriété <property>mysqli_driver::$report_mode</property>
+   La propriété <property>mysqli_driver::$driver_version</property>
    a été dépréciée.
    C'était dénué de sens et obsolète, utilisez <constant>PHP_VERSION_ID</constant>
    à la place.
   </para>
 
   <para>
-   Appeller <methodname>mysqli::get_client_info</methodname> ou
+   Appeler <methodname>mysqli::get_client_info</methodname> ou
    <function>mysqli_get_client_info</function> avec l'argument
    <parameter>mysqli</parameter> a été déprécié.
    Appeler <function>mysqli_get_client_info</function> sans argument
@@ -322,7 +322,7 @@ $arr[] = 2;
   <title>Standard</title>
 
   <para>
-   Appeller <function>key</function>, <function>current</function>,
+   Appeler <function>key</function>, <function>current</function>,
    <function>next</function>, <function>prev</function>,
    <function>reset</function>, ou <function>end</function>
    sur les &object;s est déprécié.

--- a/appendices/migration81/incompatible.xml
+++ b/appendices/migration81/incompatible.xml
@@ -8,7 +8,7 @@
   <title>PHP Core</title>
 
   <sect3 xml:id="migration81.incompatible.core.globals-access">
-   <title>Restrictions d'acceès $GLOBALS</title>
+   <title>Restrictions d'accès $GLOBALS</title>
 
    <para>
     L'accès au tableau <varname>$GLOBALS</varname> est maintenant soumis à
@@ -25,7 +25,7 @@
 
   <sect3 xml:id="migration81.incompatible.core.static-variable-inheritance">
    <title>
-    L'utilisation de variables <modifier>static</modifier> dans les méthods héritées.
+    L'utilisation de variables <modifier>static</modifier> dans les méthodes héritées.
    </title>
 
    <para>
@@ -57,7 +57,7 @@ var_dump(B::counter()); // int(4), précédemment int(2)
   </sect3>
 
   <sect3 xml:id="migration81.incompatible.core.optional-before-required">
-   <title>Les paramètres optionnels spécifié avant les paramètres requis</title>
+   <title>Les paramètres optionnels spécifiés avant les paramètres requis</title>
 
    <para>
     Un <link linkend="functions.arguments.default">paramètre optionnel</link>
@@ -126,7 +126,7 @@ ArgumentCountError - makeyogurt(): Argument #1 ($container) not passed
   </sect3>
 
   <sect3 xml:id="migration81.incompatible.core.new-keywords">
-   <title>Nouveau mots-clés</title>
+   <title>Nouveaux mots-clés</title>
    <para>
     <literal>readonly</literal> est désormais un mot-clé. Cependant, il peut toujours être utilisé
     comme nom de fonction.
@@ -274,7 +274,7 @@ ArgumentCountError - makeyogurt(): Argument #1 ($container) not passed
 
   <para>
    La directive INIT <link linkend="ini.mysqlnd.fetch_data_copy">mysqlnd.fetch_data_copy</link>
-   a été enlèvée.
+   a été enlevée.
    Cela ne devrait pas entraîner de changements de comportement visibles pour l'utilisateur.
   </para>
  </sect2>
@@ -298,12 +298,12 @@ ArgumentCountError - makeyogurt(): Argument #1 ($container) not passed
   <title>Les objets de données PHP</title>
 
   <para>
-   <constant>PDO::ATTR_STRINGIFY_FETCHES</constant> tranforme désormais les valeurs
+   <constant>PDO::ATTR_STRINGIFY_FETCHES</constant> transforme désormais les valeurs
    de type &boolean; en <literal>"0"</literal> ou
    <literal>"1"</literal>. Précédemment, les &boolean; n'étaient pas transformés en chaînes.
   </para>
   <para>
-   Appeller <methodname>PDOStatement::bindColumn</methodname> avec
+   Appeler <methodname>PDOStatement::bindColumn</methodname> avec
    <constant>PDO::PARAM_LOB</constant> liera désormais constamment un stream
    de résultat lorsqu'<constant>PDO::ATTR_STRINGIFY_FETCHES</constant> n'est pas activé.
    Précédemment, le résultat était soit un stream, soit une chaîne en fonction du

--- a/appendices/migration81/new-features.xml
+++ b/appendices/migration81/new-features.xml
@@ -30,10 +30,10 @@
   </sect3>
 
   <sect3 xml:id="migration81.new-features.core.unpacking-string-keys">
-   <title>La décompression de tableau avec des clés chaines de caractères</title>
+   <title>La décompression de tableau avec des clés chaînes de caractères</title>
 
    <para>
-    Ajout du support pour <link linkend="language.types.array.unpacking">La décompression de tableau avec des clés chaines de caractères</link>.
+    Ajout du support pour <link linkend="language.types.array.unpacking">La décompression de tableau avec des clés chaînes de caractères</link>.
     <informalexample>
      <programlisting role="php">
 <![CDATA[
@@ -49,7 +49,7 @@ $arr2 = [...$arr1, 'c' => 'd']; //[1, 'a' => 'b', 'c' => 'd']
   </sect3>
 
   <sect3 xml:id="migration81.new-features.core.named-arg-after-unpack">
-   <title>Argument nommé apres une décompression d'argument</title>
+   <title>Argument nommé après une décompression d'argument</title>
 
    <para>
     Il est désormais possible de spécifier des arguments nommés après une décompression d'argument.
@@ -248,7 +248,7 @@ curl_setopt($curl, CURLOPT_POSTFIELDS, ['file' => $file]);
   <para>
    Les fonctions suivantes <function>hash</function>,
    <function>hash_file</function>, et <function>hash_init</function>
-   supportent maintenant un nouveau argument optionel <parameter>options</parameter>, 
+   supportent maintenant un nouvel argument optionnel <parameter>options</parameter>, 
    qui peut être utilisé pour passer des données spécifiques à l'algorithme.
   </para>
 
@@ -352,7 +352,7 @@ echo $h, "\n";
   <title>MySQLi</title>
 
   <sect3 xml:id="migration81.new-features.mysqli.local_infile_directory">
-   <title>Nouvelle directive INI<literal>mysqli.local_infile_directory</literal></title>
+   <title>Nouvelle directive INI <literal>mysqli.local_infile_directory</literal></title>
 
    <para>
     La directive INI <link linkend="ini.mysqli.local-infile-directory">mysqli.local_infile_directory</link>

--- a/appendices/migration81/other-changes.xml
+++ b/appendices/migration81/other-changes.xml
@@ -156,7 +156,7 @@
     </listitem>
     <listitem>
      <para>
-      Ajout du suuport pour les signatures OpenSSL_SHA256 and OpenSSL_SHA512.
+      Ajout du support pour les signatures OpenSSL_SHA256 and OpenSSL_SHA512.
      </para>
     </listitem>
    </itemizedlist>
@@ -206,7 +206,7 @@
     <para>
      Les antislashes dans les chaînes doublement citées sont maintenant traités de manière plus cohérente comme
      des caractères d'échappement. Auparavant, <literal>"foo\\"</literal> suivi de
-     quelque chose d'autrequ'une nouvelle ligne n'était pas considéré comme une chaîne terminée.
+     quelque chose d'autre qu'une nouvelle ligne n'était pas considéré comme une chaîne terminée.
      Il est maintenant interprété comme une chaîne avec le contenu <literal>foo\</literal>.
      Cependant, en tant qu'exception, la chaîne <literal>"foo\"</literal>
      suivie d'une nouvelle ligne continuera d'être traitée comme une chaîne valide avec

--- a/appendices/migration82/incompatible.xml
+++ b/appendices/migration82/incompatible.xml
@@ -59,7 +59,7 @@
 
   <para>
    <methodname>FilesystemIterator::__construct</methodname>: antérieur à PHP 8.2.0,
-   le constante <constant>FilesystemIterator::SKIP_DOTS</constant> était toujours définie
+   la constante <constant>FilesystemIterator::SKIP_DOTS</constant> était toujours définie
    et ne pouvait pas être désactivée. Afin de conserver le comportement précédent, la constante
    doit être explicitement définie lors de l'utilisation du paramètre <parameter>flags</parameter>.
    La valeur par défaut du paramètre <parameter>flags</parameter>
@@ -104,7 +104,7 @@
   <title>Bibliothèque standard de PHP (SPL)</title>
 
   <para>
-   Les méthodes suivantes enforcent désormais leur signature :
+   Les méthodes suivantes appliquent désormais leur signature :
    <simplelist>
     <member><methodname>SplFileInfo::_bad_state_ex</methodname></member>
     <member><methodname>SplFileObject::getCsvControl</methodname></member>

--- a/appendices/migration83/constants.xml
+++ b/appendices/migration83/constants.xml
@@ -2,7 +2,7 @@
 <!-- EN-Revision: f037a94fd276a36a5061b0160fd3c2eafb20d980 Maintainer: Fan2Shrek Status: ready -->
 <!-- Reviewed: yes -->
 <sect1 xml:id="migration83.constants" xmlns:xlink="http://www.w3.org/1999/xlink">
-    <title>Nouvelle constantes globales</title>
+    <title>Nouvelles constantes globales</title>
 
     <sect2 xml:id="migration83.constants.curl">
         <title>cURL</title>
@@ -322,8 +322,8 @@
             </listitem>
             <listitem>
                 <simpara>
-                    <constant>ZipArchive::LENGTH_TO_END</constant> as default value for <function>
-                    ZipArchive::addFile</function> and <function>ZipArchive::replaceFile</function>
+                    <constant>ZipArchive::LENGTH_TO_END</constant> en tant que valeur par défaut pour <function>
+                    ZipArchive::addFile</function> et <function>ZipArchive::replaceFile</function>
                 </simpara>
             </listitem>
             <listitem>

--- a/appendices/migration83/deprecated.xml
+++ b/appendices/migration83/deprecated.xml
@@ -126,7 +126,7 @@
    La fonction <function>assert_options</function> est désormais dépréciée.
   </para>
   <para>
-   les constantes <constant>ASSERT_ACTIVE</constant>, <constant>ASSERT_BAIL</constant>,
+   Les constantes <constant>ASSERT_ACTIVE</constant>, <constant>ASSERT_BAIL</constant>,
     <constant>ASSERT_CALLBACK</constant>, <constant>ASSERT_EXCEPTION</constant>,
     et <constant>ASSERT_WARNING</constant> sont désormais dépréciées.
   </para>

--- a/appendices/migration83/incompatible.xml
+++ b/appendices/migration83/incompatible.xml
@@ -12,14 +12,14 @@
    <title>Programmes très proches de déborder la pile d'appels</title>
    <para>
     Les programmes très proches de déborder la pile d'appels peuvent maintenant
-    <classname>Error</classname> lorsqu'ils utilisent plus de
+    lancer une <classname>Error</classname> lorsqu'ils utilisent plus de
     <!-- link linkend="zend.max_allowed_stack_size-zend.reserved_stack_size" -->zend.max_allowed_stack_size-zend.reserved_stack_size<!-- </link>--> octets de pile
     (<!-- link linkend="fiber.stack_size-zend.reserved_stack_size" -->fiber.stack_size-zend.reserved_stack_size<!-- </link>--> pour les fibres).
    </para>
   </sect3>
 
   <sect3 xml:id="migration83.incompatible.core.proc-get-status-multiple-times">
-   <title>Executer proc_get_status() plusieurs fois</title>
+   <title>Exécuter proc_get_status() plusieurs fois</title>
    <para>
     Exécuter <function>proc_get_status</function> plusieurs fois retournera désormais
     toujours la bonne valeur sur les systèmes POSIX. Précédemment, seul le premier appel
@@ -53,7 +53,7 @@
   </sect3>
 
   <sect3 xml:id="migration83.incompatible.core.negative-index-to-empty-array">
-   <title>Assigné un index négatif à un tableau vide</title>
+   <title>Assigner un index négatif à un tableau vide</title>
    <para>
     Assigner un index négatif <varname>$n</varname> à un tableau vide fera en sorte que
     le prochain index soit <code>$n+1</code> au lieu de <literal>0</literal>.
@@ -73,8 +73,8 @@
    <para>
     Les entrées <classname>WeakMap</classname> dont la clé est mappée sur elle-même (éventuellement
     de manière transitive) peuvent maintenant être supprimées lors de la collecte des cycles si la clé n'est pas
-    atteignable sauf en itérant sur le WeakMap (l'atteignabilité via l'itération est 
-    onsidérée comme faible).
+    atteignable sauf en itérant sur le WeakMap (l'atteignabilité via l'itération est
+    considérée comme faible).
     Auparavant, de telles entrées ne seraient jamais automatiquement supprimées.
    </para>
   </sect3>
@@ -225,7 +225,7 @@ range('9', 'A');  // [9, 8, 7, 6, 5, 4, 3, 2, 1, 0], avant PHP 8.3.0
   </para>
 
   <para>
-   Le drapeau d'erreur de <function>file</function> vérifie maintenant toutes les drapeaux invalides.
+   Le drapeau d'erreur de <function>file</function> vérifie maintenant tous les drapeaux invalides.
    Notamment <constant>FILE_APPEND</constant> était précédemment accepté silencieusement.
   </para>
  </sect2>

--- a/appendices/migration83/new-features.xml
+++ b/appendices/migration83/new-features.xml
@@ -46,7 +46,7 @@
   </sect3>
 
   <sect3 xml:id="migration83.new-features.core.override-attribute">
-   <title>L'attribute Override</title>
+   <title>L'attribut Override</title>
 
    <para>
     Ajout de l'attribut #[\Override] pour vérifier qu'une méthode existe dans une classe

--- a/appendices/migration83/new-functions.xml
+++ b/appendices/migration83/new-functions.xml
@@ -2,7 +2,7 @@
 <!-- EN-Revision: 8598998a73bc4a6709d27f9eb4373ddcb2d65354 Maintainer: Fan2Shrek Status: ready -->
 <!-- Reviewed: yes -->
 <sect1 xml:id="migration83.new-functions">
- <title>Nouvelles fonction</title>
+ <title>Nouvelles fonctions</title>
 
  <sect2 xml:id="migration83.new-functions.date">
   <title>Date</title>

--- a/appendices/migration83/other-changes.xml
+++ b/appendices/migration83/other-changes.xml
@@ -25,7 +25,7 @@
    <title>FPM</title>
 
    <para>
-    Les test FPM CLI échouent désormais si le chemin du socket est plus long que ce que l'OS supporte.
+    Les tests FPM CLI échouent désormais si le chemin du socket est plus long que ce que l'OS supporte.
    </para>
   </sect3>
 
@@ -51,7 +51,7 @@
 
    <para>
     Un stream de mémoire ne retourne plus d'erreur si le décalage de recherche est au-delà de la fin.
-    A la place, la mémoire sera augmentée à la prochaîne écriture et les données entre
+    A la place, la mémoire sera augmentée à la prochaine écriture et les données entre
     l'ancienne fin et le décalage sont remplies de zéros, similaire à la façon dont les fichiers fonctionnent.
    </para>
 
@@ -87,7 +87,7 @@
    <title>Core</title>
 
    <para>
-    <function>gc_status</function> a ajouté les 8 champs suivantes:
+    <function>gc_status</function> a ajouté les 8 champs suivants:
 
     <simplelist>
      <member><literal>"running"</literal> => bool</member>
@@ -191,7 +191,7 @@
    <para>
     <function>datefmt_set_timezone</function> (et ses alias
     <methodname>IntlDateformatter::setTimeZone</methodname>)
-    retourn désormais &true; en cas de succès, avant &null; étais retourné.
+    retourne désormais &true; en cas de succès, avant &null; était retourné.
    </para>
 
    <para>
@@ -217,7 +217,7 @@
    <para>
     <function>mb_strtolower</function> et <function>mb_convert_case</function>
     implémentent des règles de casse conditionnelles pour la lettre grecque sigma.
-    Pour <function>mb_strtolower</function>,
+    Pour <function>mb_convert_case</function>,
     la casse conditionnelle s'applique uniquement aux modes <constant>MB_CASE_LOWER</constant>,
     et <constant>MB_CASE_TITLE</constant>, pas aux modes
     <constant>MB_CASE_LOWER_SIMPLE</constant> et
@@ -301,7 +301,7 @@
    <para>
     <function>pg_fetch_object</function> lance désormais une
     <classname>ValueError</classname> à la place d'une <classname>Exception</classname>
-    lorsque l'argument<parameter>$constructor_args</parameter> n'est pas vide
+    lorsque l'argument <parameter>$constructor_args</parameter> n'est pas vide
     avec la classe n'ayant pas de constructeur.
    </para>
 
@@ -442,7 +442,6 @@
     <type>bool</type> émet désormais des avertissements.
     Cela est dû au fait que cela n'a actuellement aucun effet, mais se comportera comme
     <code>$bool += 1</code> à l'avenir.
-    Using the <link linkend="language.operators.increment">increment/decrement</link>
    </para>
 
    <para>

--- a/appendices/migration84/constants.xml
+++ b/appendices/migration84/constants.xml
@@ -2,7 +2,7 @@
 <!-- EN-Revision: 8a6397d39aefd23c61d64aa4e9af919772541e2a Maintainer: Fan2Shrek Status: ready -->
 <!-- Reviewed: yes -->
 <sect1 xml:id="migration84.constants">
- <title>Nouvelle constantes globales</title>
+ <title>Nouvelles constantes globales</title>
 
  <sect2 xml:id="migration84.constants.core">
   <title>Core</title>
@@ -115,7 +115,7 @@
    <member>
     <constant>LIBXML_NO_XXE</constant>.
      Ceci est utilisé en conjonction avec <constant>LIBXML_NOENT</constant>
-     lorsque que la substitution d'entité doit être effectuée,
+     lorsque la substitution d'entité doit être effectuée,
      tout en interdisant le chargement d'entité externe.
      Cette constante est disponible à partir de libxml2 2.13.
    </member>

--- a/appendices/migration84/deprecated.xml
+++ b/appendices/migration84/deprecated.xml
@@ -351,7 +351,7 @@ class _MyClass {}
   <title>Reflection</title>
 
   <simpara>
-   Appeler <methodname>ReflectionProperty::setValue</methodname>
+   Appeler <methodname>ReflectionMethod::__construct</methodname>
    avec un seul paramètre est désormais déprécié.
    Utiliser plutôt <methodname>ReflectionMethod::createFromMethodName</methodname>
   </simpara>
@@ -378,7 +378,7 @@ class _MyClass {}
 
   <!-- RFC: https://wiki.php.net/rfc/deprecate-get-post-sessions -->
   <simpara>
-   Changer la valuer des paramètres INI
+   Changer la valeur des paramètres INI
    <link linkend="ini.session.use-only-cookies"><literal>session.use_only_cookies</literal></link>,
    <link linkend="ini.session.use-trans-sid"><literal>session.use_trans_sid</literal></link>,
    <link linkend="ini.session.trans-sid-tags"><literal>session.trans_sid_tags</literal></link>,

--- a/appendices/migration84/incompatible.xml
+++ b/appendices/migration84/incompatible.xml
@@ -85,7 +85,7 @@
    <simpara>
     Le niveau d'erreur <constant>E_STRICT</constant> a été supprimé,
     car il n'était plus utilisé dans le moteur PHP.
-    La constante <constant>E_STRICT</constant> a également été déprécié.
+    La constante <constant>E_STRICT</constant> a également été dépréciée.
    </simpara>
   </sect3>
  </sect2>
@@ -237,7 +237,7 @@
      <member><function>d<replaceable>*</replaceable>gettext</function></member>
     </simplelist>
     lance désormais une <exceptionname>ValueError</exceptionname> si un
-    <parameter>domain</parameter> invalide est passé.
+    <parameter>domain</parameter> est la chaîne vide.
    </para>
   </sect3>
 
@@ -282,7 +282,7 @@
     <function>mb_encode_numericentity</function> et
     <function>mb_decode_numericentity</function> vérifient désormais que
     <parameter>map</parameter> est uniquement composé de &integer;s,
-    si ce n'est pas le cas, une <exceptionname>ValueError</exceptionname> est
+    si ce n'est pas le cas, une <exceptionname>ValueError</exceptionname> est lancée.
    </simpara>
 
    <simpara>
@@ -428,7 +428,7 @@
    </simpara>
 
    <simpara>
-    Passer une &string; contenant des octets émettait précédemment une alerte
+    Passer une &string; contenant des octets nuls émettait précédemment une alerte
     et lance désormais une <exceptionname>ValueError</exceptionname>.
    </simpara>
   </sect3>
@@ -437,7 +437,7 @@
    <title>XMLWriter</title>
 
    <simpara>
-    Passer une &string; contenant des octets émettait précédemment une alerte
+    Passer une &string; contenant des octets nuls émettait précédemment une alerte
     et lance désormais une <exceptionname>ValueError</exceptionname>.
    </simpara>
   </sect3>
@@ -472,7 +472,6 @@
   <para>
    Le symbole <literal>number</literal> dans les <link linkend="datetime.formats.relative">formats relatifs</link>
    accepte à nouveau plusieurs signes, par exemple <literal>+-2</literal>.
-   <literal>number</literal> symbols in <link linkend="datetime.formats.relative">relative formats</link>
   </para>
  </sect2>
 
@@ -481,10 +480,10 @@
 
   <simpara>
    Quelques méthodes DOM retournaient précédemment &false; ou une
-   <exceptionname>DOMException</exceptionname> <constant>PHP_ERR</constant>
+   <exceptionname>DOMException</exceptionname> <constant>DOM_PHP_ERR</constant>
    si un nouveau nœud ne pouvait pas être alloué.
    Elles lancent désormais systématiquement une <exceptionname>DOMException</exceptionname>
-   <constant>INVALID_STATE_ERR</constant>.
+   <constant>DOM_INVALID_STATE_ERR</constant>.
    Cette situation est extrêmement improbable et la probabilité d'être affecté
    est faible.
    En conséquence, <methodname>DOMImplementation::createDocument</methodname>
@@ -545,13 +544,13 @@
   </simpara>
 
   <simpara>
-   La constante <constant>MYSQLI_STMT_ATTR_UPDATE_MAX_LENGTH</constant> a été
+   La constante <constant>MYSQLI_STMT_ATTR_PREFETCH_ROWS</constant> a été
    supprimée. Cette fonctionnalité n'est pas disponible avec mysqlnd.
   </simpara>
 
   <simpara>
-   Les constantes <constant>MYSQLI_STMT_ATTR_CURSOR_TYPE</constant> et
-   <constant>MYSQLI_STMT_ATTR_PREFETCH_ROWS</constant> ont été supprimées.
+   Les constantes <constant>MYSQLI_CURSOR_TYPE_FOR_UPDATE</constant> et
+   <constant>MYSQLI_CURSOR_TYPE_SCROLLABLE</constant> ont été supprimées.
    Ces fonctionnalités n'ont jamais été implémentées,
    ni avec mysqlnd ni avec libmysql.
   </simpara>
@@ -570,7 +569,7 @@
   <title>MySQLnd</title>
 
   <simpara>
-   Le code d'erreur signalé pour les délais d'attente du serveur MySQL a été de
+   Le code d'erreur signalé pour les délais d'attente du serveur MySQL a été changé de
    <literal>2006</literal> à <literal>4031</literal> pour les versions du serveur
    Mysql 8.0.24 et supérieures.
   </simpara>
@@ -602,7 +601,7 @@
     car le JIT est toujours désactivé par défaut.
     Cependant, il est désormais désactivé via la configuration
     <link linkend="ini.opcache.jit">opcache.jit</link>,
-    plut$ot que 
+    plutôt que
     <link linkend="ini.opcache.jit-buffer-size">opcache.jit_buffer_size</link>.
     Cela peut affecter les utilisateurs qui ont précédemment activé le JIT via
     <link linkend="ini.opcache.jit-buffer-size">opcache.jit_buffer_size</link>
@@ -627,7 +626,7 @@
    <function>pcntl_sigwaitinfo</function>, et
    <function>pcntl_sigtimedwait</function> retournent désormais systématiquement
    &false; en cas d'échec.
-   Dans certains cas précédemment, elles pouvaient retourné la valeur <literal>-1</literal>.
+   Dans certains cas précédemment, elles pouvaient retourner la valeur <literal>-1</literal>.
   </simpara>
  </sect2>
 
@@ -669,7 +668,7 @@
   </simpara>
 
   <simpara>
-   L'exntension expose désormais certaines API C++ Firebird,
+   L'extension expose désormais certaines API C++ Firebird,
    donc la construction de cette extension nécessite désormais un compilateur C++.
    De plus, l'extension doit désormais être compilée contre fbclient 3.0 ou supérieur.
   </simpara>
@@ -679,7 +678,7 @@
   <title>PDO_MYSQL</title>
 
   <simpara>
-   Les attributs <constant>PDO::ATTR_AUTOCOMMIT</constant>
+   Les attributs <constant>PDO::ATTR_AUTOCOMMIT</constant>,
    <constant>PDO::ATTR_EMULATE_PREPARES</constant>, et
    <constant>PDO::MYSQL_ATTR_DIRECT_QUERY</constant> agissent désormais comme des
    attributs booléens au lieu d'attributs entiers.

--- a/appendices/migration84/new-features.xml
+++ b/appendices/migration84/new-features.xml
@@ -386,7 +386,7 @@ $object = $reflector->newLazyGhost($initializer);
    Ajout d'un analyseur personnalisé prenant en charge :
    <simplelist>
     <member>
-     les littéraux simples et doubles, avec le doublement comme mécanisme d'échappement
+     les littéraux simples et doubles, avec le doublement et l'antislash comme mécanisme d'échappement
     </member>
     <member>
      les identifiants littéraux avec un accent grave et le doublement comme mécanisme d'échappement
@@ -535,7 +535,7 @@ $object = $reflector->newLazyGhost($initializer);
   </simpara>
 
   <simpara>
-   Les intances de <interfacename>DateTimeInterface</interfacename> qui sont
+   Les instances de <interfacename>DateTimeInterface</interfacename> qui sont
    passées à <literal>xsd:datetime</literal> ou des éléments similaires sont maintenant
    sérialisées en tant que telles au lieu d'être sérialisées en tant que chaîne vide.
   </simpara>

--- a/appendices/migration84/other-changes.xml
+++ b/appendices/migration84/other-changes.xml
@@ -124,7 +124,7 @@
     <methodname>DOMDocument::registerNodeClass</methodname>
     a désormais un type de retour de <type>true</type> au lieu de
     <type>bool</type>.
-    Il pouvait retourner que &true; en pratique.
+    Il ne pouvait retourner que &true; en pratique.
    </simpara>
   </sect3>
 
@@ -135,7 +135,7 @@
     <function>hash_update</function>
     a désormais un type de retour de <type>true</type> au lieu de
     <type>bool</type>.
-    Il pouvait retourner que &true; en pratique.
+    Il ne pouvait retourner que &true; en pratique.
    </simpara>
   </sect3>
 
@@ -330,7 +330,7 @@
    </simpara>
 
    <simpara>
-    Si la colone est de type <literal>FLOAT4OID</literal> ou
+    Si la colonne est de type <literal>FLOAT4OID</literal> ou
     <literal>FLOAT8OID</literal> la valeur sera maintenant retournée en tant que
     <type>float</type> au lieu d'une <type>string</type>.
    </simpara>
@@ -476,7 +476,7 @@
     </para>
 
     <simpara>
-     L'implementation interne de l'arrondi aux entiers a été réécrite pour être plus facile à vérifier
+     L'implémentation interne de l'arrondi aux entiers a été réécrite pour être plus facile à vérifier
      pour la correction et plus facile à maintenir.
      Quelques bugs d'arrondi ont été corrigés à la suite de la réécriture.
      Par exemple, auparavant, l'arrondi de <literal>0.49999999999999994</literal> à l'entier le plus proche
@@ -743,7 +743,7 @@
    <title>SimpleXML</title>
 
    <simpara>
-    Augmentation de la performance et reduction de la consommation de mémoire de la sérialisation XML.
+    Augmentation de la performance et réduction de la consommation de mémoire de la sérialisation XML.
    </simpara>
   </sect3>
 

--- a/appendices/migration85/incompatible.xml
+++ b/appendices/migration85/incompatible.xml
@@ -23,7 +23,7 @@
 
    <simpara>
     Comparer approximativement des objets non comparables (par exemple des enums,
-    <classname>CurlHandle</classname> et d'autre classes internes) à des booléens
+    <classname>CurlHandle</classname> et d'autres classes internes) à des booléens
     était auparavant incohérent. Si comparé à un littéral booléen
     <code>$object == true</code>, il se comportait de la même manière que
     <code>(bool)$object</code>. Si comparé à une valeur statiquement inconnue
@@ -473,7 +473,7 @@
    <function>snmp2_set</function>,
    <function>snmp3_get</function>,
    <function>snmp3_set</function>
-   et <methodname>SNMP::__construct</methodname> lève désormais une
+   et <methodname>SNMP::__construct</methodname> lèvent désormais une
    <exceptionname>ValueError</exceptionname> lorsque le nom d'hôte
    est trop grand, contient un octet nul ou si le port est donné
    lorsqu'il est négatif ou supérieur à 65535, les valeurs de délai d'attente et de tentatives
@@ -534,7 +534,7 @@
 
   <simpara>
    <classname>ArrayObject</classname> n'accepte plus les enums, car la modification des
-   <property>$name</property> ou <property>$value</property> peut casser
+   propriétés <property>$name</property> ou <property>$value</property> peut casser
    les hypothèses du moteur.
   </simpara>
 
@@ -551,7 +551,7 @@
   <title>Standard</title>
 
   <simpara>
-   L'utilisation d'une fonction de la famille printf avec un formatteur qui ne spécifiait pas la
+   L'utilisation d'une fonction de la famille printf avec un formateur qui ne spécifiait pas la
    précision réinitialisait incorrectement la précision au lieu de la traiter
    comme une précision de 0.
   </simpara>

--- a/appendices/migration85/new-features.xml
+++ b/appendices/migration85/new-features.xml
@@ -32,7 +32,7 @@ print $result . PHP_EOL;  // Affiche "11"
 
    <para>
     Ajout du support pour <link linkend="class.closure">Closures</link> et
-    <link linkend="functions.first_class_callable_syntax">callable de première classes</link>
+    <link linkend="functions.first_class_callable_syntax">callables de première classe</link>
     dans les expressions constantes. Cela inclut :
 
     <simplelist>
@@ -307,7 +307,7 @@ print T1 . PHP_EOL;   // Affiche "0"
    lorsque la validation échoue.
    Le nouveau drapeau ne peut pas être combiné avec
    <constant>FILTER_NULL_ON_FAILURE</constant>; essayer de le faire entraînera
-   en une <exceptionname>ValueError</exceptionname> levée.
+   une <exceptionname>ValueError</exceptionname> levée.
    <!-- RFC: https://wiki.php.net/rfc/filter_throw_on_failure -->
   </simpara>
 
@@ -348,7 +348,7 @@ print T1 . PHP_EOL;   // Affiche "0"
   <title>PDO_Sqlite</title>
 
   <simpara>
-   Ajout des constantes de classes <constant>Pdo\Sqlite::ATTR_BUSY_STATEMENT</constant>
+   Ajout de la constante de classe <constant>Pdo\Sqlite::ATTR_BUSY_STATEMENT</constant>.
   </simpara>
 
   <simpara>

--- a/appendices/migration85/other-changes.xml
+++ b/appendices/migration85/other-changes.xml
@@ -5,7 +5,7 @@
  <title>Autres changements</title>
 
  <sect2 xml:id="migration85.other-changes.core">
-  <title>Core changes</title>
+  <title>Changements du cœur</title>
 
   <sect3 xml:id="migration85.other-changes.core.core">
    <title>Core</title>
@@ -246,7 +246,7 @@
    <simpara>
     La sortie de <methodname>ReflectionProperty::__toString</methodname> pour
     les propriétés avec hooks a changé pour indiquer quels hooks la propriété possède,
-    que ces hooks soit finals, et si la propriété est virtuelle.
+    que ces hooks soient finals, et si la propriété est virtuelle.
     Cela affecte également la sortie de <methodname>ReflectionClass::__toString</methodname>
     lorsqu'une classe contient des propriétés avec hooks.
    </simpara>
@@ -507,7 +507,7 @@
    <title>Intl</title>
 
    <simpara>
-    Désormais ne créer plus de copies de chaînes supplémentaires lors de la conversion
+    Évite désormais de créer des copies de chaînes supplémentaires lors de la conversion
     des chaînes pour une utilisation dans le collateur.
    </simpara>
 

--- a/appendices/tokens.xml
+++ b/appendices/tokens.xml
@@ -601,14 +601,14 @@ defined('T_FN') || define('T_FN', 10001);
      <entry><constant>T_NAME_QUALIFIED</constant></entry>
      <entry>App\Namespace</entry>
      <entry>
-      <link linkend="language.namespaces">namespaces</link> (disponible à partir de PHP 8.0.0)
+      <link linkend="language.namespaces">espaces de noms</link> (disponible à partir de PHP 8.0.0)
      </entry>
     </row>
     <row xml:id="constant.t-name-relative">
      <entry><constant>T_NAME_RELATIVE</constant></entry>
      <entry>namespace\Namespace</entry>
      <entry>
-      <link linkend="language.namespaces">namespaces</link> (disponible à partir de PHP 8.0.0)
+      <link linkend="language.namespaces">espaces de noms</link> (disponible à partir de PHP 8.0.0)
      </entry>
     </row>
     <row xml:id="constant.t-new">
@@ -852,7 +852,7 @@ defined('T_FN') || define('T_FN', 10001);
     <row xml:id="constant.t-unset-cast">
      <entry><constant>T_UNSET_CAST</constant></entry>
      <entry>(unset)</entry>
-     <entry><link linkend="language.types.typecasting">type-casting</link></entry>
+     <entry><link linkend="language.types.typecasting">transtypage</link></entry>
     </row>
     <row xml:id="constant.t-use">
      <entry><constant>T_USE</constant></entry>

--- a/appendices/transports.xml
+++ b/appendices/transports.xml
@@ -10,8 +10,8 @@
   PHP dispose en interne pour les flux qui exploitent les sockets, tels
   que <function>fsockopen</function> et
   <function>stream_socket_client</function>. Ces modes de transport
-  <emphasis>ne s'appliquent pas</emphasis> à l'extension
-  <link linkend="ref.sockets">Fonctions de socket</link> de l'extension Sockets
+  <emphasis>ne s'appliquent pas</emphasis> aux
+  <link linkend="ref.sockets">fonctions de socket</link> de l'extension Sockets.
  </para>
 
  <para>
@@ -77,7 +77,7 @@
 
   <simpara>
    Les modes <literal>ssl://</literal> et <literal>tls://</literal>
-   (disponibles uniquement lorsque le support OpenSSl est compilé avec PHP) sont
+   (disponibles uniquement lorsque le support OpenSSL est compilé avec PHP) sont
    des extensions de <literal>tcp://</literal> qui incluent le chiffrement SSL.
   </simpara>
 

--- a/appendices/userlandnaming.xml
+++ b/appendices/userlandnaming.xml
@@ -34,8 +34,8 @@
  <section xml:id="userlandnaming.rules">
   <title>Règles</title>
   <para>
-   La liste suivante fournit un aperçu global des règles réservées
-   au projet PHP lors du choix des noms pour les nouveaux identifiants
+   La liste suivante fournit un aperçu global des droits que le projet PHP
+   se réserve lors du choix des noms pour les nouveaux identifiants
    internes. Le guide définitif est l'officiel
    <link xlink:href="&url.userlandnaming.cs;">CODING STANDARDS</link> :
   </para>

--- a/chmonly/usingchm.xml
+++ b/chmonly/usingchm.xml
@@ -127,7 +127,7 @@
        la liste, ajouter le sujet actuel, en retirer un, ou
        afficher un élément sélectionné. Vous pouvez également spécifier votre propre
        titre pour le favori, en le tapant dans la zone 'Current
-       topics :'. Les titres des pages de notes d'utilisateurs sont précédés
+       topic :'. Les titres des pages de notes d'utilisateurs sont précédés
        d'une chaîne 'N:' pour que vous puissiez les distinguer
        des pages de manuel normales dans la liste des favoris.
       </simpara>

--- a/faq/general.xml
+++ b/faq/general.xml
@@ -55,7 +55,7 @@
      <para>
       PHP/FI 2.0 est une des premières versions de PHP et elle n'est plus
       supportée.
-      PHP 3 en est son successeur et est beaucoup plus convivial.
+      PHP 3 en est le successeur et est beaucoup plus convivial.
       PHP 8 est la génération actuelle de PHP, qui utilise le
       moteur Zend 4 qui apporte, entre autres,
       beaucoup de nouveautés dans le <link linkend="language.oop5">modèle objet</link>.

--- a/faq/using.xml
+++ b/faq/using.xml
@@ -354,7 +354,7 @@ foreach ($headers as $nom => $contenu) {
       <literal>1M</literal> équivaut à un mégaoctet ou <literal>1048576</literal>
       octets. <literal>1K</literal> équivaut à un kilooctet ou 
       <literal>1024</literal> octets. Ces notations abrégées peuvent être utilisées dans le fichier &php.ini; et dans la fonction <function>ini_set</function>.
-      Notez que la valeur numérique est transtypé en &integer; ;
+      Notez que la valeur numérique est transtypée en &integer; ;
       par exemple, <literal>0.5M</literal> est interprété comme <literal>0</literal>.
      </para>
      <note>

--- a/features/commandline.xml
+++ b/features/commandline.xml
@@ -14,7 +14,7 @@
    Le but premier de &cli.sapi; est le développement
    d'applications shell avec PHP. Les différences entre le &cli.sapi;
    et les autres <acronym>SAPI</acronym> sont
-   expliqués dans ce chapitre. Il est important de mentionner que &cli;
+   expliquées dans ce chapitre. Il est important de mentionner que &cli;
    et <acronym>CGI</acronym> sont des <acronym>SAPI</acronym> différents malgré
    le fait qu'ils puissent partager la majeure partie de leurs comportements.
   </para>
@@ -277,7 +277,7 @@ if (php_sapi_name() === 'cli') {
       <programlisting role="php">
 <![CDATA[
 <?php
-// Un test simple : affiche le dossier d'exécution */
+// Un test simple : affiche le dossier d'exécution
 echo getcwd(), "\n";
 ?>
 ]]>

--- a/features/file-upload.xml
+++ b/features/file-upload.xml
@@ -421,9 +421,9 @@ foreach ($_FILES["pictures"]["error"] as $key => $error) {
     <programlisting role="html">
 <![CDATA[
 <form action="file-upload.php" method="post" enctype="multipart/form-data">
-  Send this directory:<br />
+  Envoyez ce dossier :<br />
   <input name="userfile[]" type="file" webkitdirectory multiple />
-  <input type="submit" value="Send files" />
+  <input type="submit" value="Envoyer les fichiers" />
 </form>
 ]]>
     </programlisting>

--- a/install/fpm/install.xml
+++ b/install/fpm/install.xml
@@ -30,7 +30,7 @@
    </listitem>
    <listitem>
     <para>
-     <literal>--with-fpm-acl</literal> - Utiliser  POSIX Access Control Lists (par défaut - no).
+     <literal>--with-fpm-acl</literal> - Utiliser POSIX Access Control Lists (par défaut - no).
     </para>
    </listitem>
    <listitem>

--- a/install/ini.xml
+++ b/install/ini.xml
@@ -420,7 +420,7 @@ but needs all top-level xml:id's removed (see XInclude 1.1 set-xml-id).
      <varlistentry>
       <term>
        <systemitem role="directive">php_admin_flag</systemitem>
-       <parameter>name</parameter>
+       <parameter>nom</parameter>
        <parameter>on|off</parameter>
       </term>
       <listitem>

--- a/install/pecl.xml
+++ b/install/pecl.xml
@@ -80,7 +80,7 @@
      <acronym>git</acronym>
     </simpara>
     <simpara>
-     Beaucoup d'extension PECL demeurent sur GitHub.
+     Beaucoup d'extensions PECL demeurent sur GitHub.
      <!-- TODO Expand -->
     </simpara>
    </listitem>
@@ -106,7 +106,7 @@ $ svn checkout https://svn.php.net/repository/pecl/extname/trunk extname
     </simpara>
     <simpara>
      Le projet PHP compile et offre des DLLs Windows pour la plupart des 
-     extensions PECL disponible sur la page du package.
+     extensions PECL disponibles sur la page du package.
     </simpara>
    </listitem>
   </itemizedlist>

--- a/install/unix/apache2.xml
+++ b/install/unix/apache2.xml
@@ -273,7 +273,7 @@ LoadModule php7_module modules/libphp7.so
    <para>
     <literal>mod_rewrite</literal> peut être utilisé pour permettre à n'importe quel fichier <literal>.php</literal>
     d'être affiché comme code source avec coloration syntaxique, sans pour autant
-    avoir besoin de le renommer ou de le copier avec une extension <literal>.phps</literal>. :
+    avoir besoin de le renommer ou de le copier avec une extension <literal>.phps</literal> :
    </para>
    
    <informalexample>

--- a/install/unix/litespeed.xml
+++ b/install/unix/litespeed.xml
@@ -6,7 +6,7 @@
 
   <para>
    LiteSpeed PHP est une compilation optimisée de PHP construite pour fonctionner avec les produits LiteSpeed
-   à travers l'API LiteSpeed. LSPHP fonctionne comme son propre processus et a
+   à travers la SAPI LiteSpeed. LSPHP fonctionne comme son propre processus et a
    son propre binaire autonome, qui peut être utilisé comme un simple binaire en ligne de commande pour exécuter
    des scripts PHP à partir de la ligne de commande.
  </para>

--- a/language/constants.xml
+++ b/language/constants.xml
@@ -312,7 +312,7 @@ echo ANIMALS[1]; // affiche "chat"
        <entry><constant>__CLASS__</constant></entry>
        <entry>
         Le nom de la classe courante. Le nom de la
-        classe contient l'espace de nom dans lequel cette classe
+        classe contient l'espace de noms dans lequel cette classe
         a été déclarée (i.e. <literal>Foo\Bar</literal>).
         Lorsqu'elle est utilisée dans une méthode de trait,
         <constant>__CLASS__</constant> est le nom de la classe dans laquelle le trait est utilisé.
@@ -321,7 +321,7 @@ echo ANIMALS[1]; // affiche "chat"
       <row xml:id="constant.trait">
        <entry><constant>__TRAIT__</constant></entry>
        <entry>
-        Le nom du trait. Le nom du trait inclut l'espace de nom
+        Le nom du trait. Le nom du trait inclut l'espace de noms
         dans lequel il a été déclaré (par exemple <literal>Foo\Bar</literal>).
        </entry>
       </row>

--- a/language/context/ssl.xml
+++ b/language/context/ssl.xml
@@ -37,7 +37,7 @@
     <varlistentry xml:id="context.ssl.verify-peer">
      <term>
       <parameter>verify_peer</parameter>
-      <type>&boolean;</type>
+      <type>bool</type>
      </term>
      <listitem>
       <para>
@@ -65,7 +65,7 @@
     <varlistentry xml:id="context.ssl.allow-self-signed">
      <term>
       <parameter>allow_self_signed</parameter>
-      <type>&boolean;</type>
+      <type>bool</type>
      </term>
      <listitem>
       <para>

--- a/language/control-structures/else.xml
+++ b/language/control-structures/else.xml
@@ -15,7 +15,7 @@
   est &false;. Dans l'exemple suivant, ce bout de code
   affiche <computeroutput>a est plus grand que b</computeroutput> si la
   variable <varname>$a</varname> est plus grande que la variable
-  <varname>$b</varname>, et <computeroutput>a est plus petit que b</computeroutput>
+  <varname>$b</varname>, et <computeroutput>a n'est pas plus grand que b</computeroutput>
   sinon :
   <informalexample>
    <programlisting role="php">
@@ -24,7 +24,7 @@
 if ($a > $b) {
   echo "a est plus grand que b";
 } else {
-  echo "a est plus petit que b";
+  echo "a n'est pas plus grand que b";
 }
 ?>
 ]]>

--- a/language/control-structures/elseif.xml
+++ b/language/control-structures/elseif.xml
@@ -89,7 +89,7 @@ if ($a > $b):
 elseif ($a == $b): // Les deux mots sont collés
     echo $a." égal ".$b;
 else:
-    echo $a." est plus grand ou égal à ".$b;
+    echo $a." n'est ni plus grand ni égal à ".$b;
 endif;
 
 ?>

--- a/language/control-structures/include.xml
+++ b/language/control-structures/include.xml
@@ -187,7 +187,7 @@ include 'http://www.example.com/file.php?foo=1&bar=2';
  <simpara>
   Gestion du retour : <literal>include</literal> retourne &false; en cas
   d'erreur et émet un avertissement. Les inclusions avec succès, y compris si
-  elles sont écrasées par le fichier inclus, retourne
+  elles sont écrasées par le fichier inclus, retournent
   <literal>1</literal>. Il est possible d'exécuter la structure
   de langage <function>return</function> à l'intérieur d'un fichier
   inclus afin de déterminer le processus dans ce fichier, et retourner

--- a/language/control-structures/return.xml
+++ b/language/control-structures/return.xml
@@ -54,10 +54,10 @@
  </para>
 
  <para>
-  À partir de PHP 7.1.0, les déclarations de retour sans argument dans la
-  fonction déclenchent une <constant>E_COMPILE_ERROR</constant>, sauf si le
-  type de retour est <type>void</type>, auquel cas les déclarations retour
-  avec un argument déclenche cette erreur.
+  À partir de PHP 7.1.0, les déclarations de retour sans argument dans les
+  fonctions qui déclarent un type de retour déclenchent une <constant>E_COMPILE_ERROR</constant>,
+  sauf si le type de retour est <type>void</type>, auquel cas les déclarations de retour
+  avec un argument déclenchent cette erreur.
  </para>
 </sect1>
 

--- a/language/control-structures/switch.xml
+++ b/language/control-structures/switch.xml
@@ -79,7 +79,7 @@ if ($i == 0) {
   <literal>case</literal> est trouvée dont 
   l'expression est évaluée à une valeur qui correspond à la valeur de 
   l'expression <literal>switch</literal>, PHP exécute alors les instructions correspondantes.
-  PHP continu d'exécuter les instructions jusqu'à
+  PHP continue d'exécuter les instructions jusqu'à
   la fin du bloc d'instructions du <literal>switch</literal>,
   ou bien dès qu'il trouve l'instruction <literal>break</literal>.
   Si vous ne pouvez pas utiliser l'instruction

--- a/language/errors/basics.xml
+++ b/language/errors/basics.xml
@@ -35,7 +35,7 @@
    Dans un environnement de développement, la directive 
    <link linkend="ini.error-reporting"><parameter>error_reporting</parameter></link> 
    devrait toujours être configurée avec <constant>E_ALL</constant>, afin d'être
-   informé et de corriger les problèmes relevés par PHP. En production il est possible
+   informé et de corriger les problèmes relevés par PHP. En production il est possible de
    configurer la directive avec un niveau moins verbeux tel que 
    <code>E_ALL &amp; ~E_NOTICE &amp; ~E_DEPRECATED</code>,
    mais généralement <constant>E_ALL</constant> reste approprié car il peut fournir

--- a/language/expressions.xml
+++ b/language/expressions.xml
@@ -4,7 +4,7 @@
 <chapter xml:id="language.expressions" xmlns="http://docbook.org/ns/docbook">
  <title>Les expressions</title>
  <simpara>
-  Les expressions sont les pièces de construction les plus importants de PHP.
+  Les expressions sont les pièces de construction les plus importantes de PHP.
   En PHP, presque tout ce que vous écrivez est une expression. La manière la
   plus simple de définir une expression est : "tout ce qui a une valeur".
  </simpara>
@@ -106,7 +106,7 @@ function foo ()
  <simpara>
   Un type d'expression très commun est <link
   linkend="language.operators.comparison">l'expression de comparaison</link>. Ces
-  expressions sont évaluées à 0 ou 1, autrement dit &false; ou &true;,
+  expressions sont évaluées à &false; ou &true;,
   respectivement. PHP supporte les opérateurs de comparaison &gt; (plus
   grand que), &gt;= (plus grand ou égal), == (égal à),
   != (différent de), &lt; (plus petit que) et &lt;= (plus petit ou égal).

--- a/language/generators.xml
+++ b/language/generators.xml
@@ -106,7 +106,7 @@ Nombres impairs à un seul chiffre depuis xrange() : 1 3 5 7 9
    <para>
     Lorsqu'une fonction générateur est appelée,
     un objet de la classe interne <classname>Generator</classname> est
-    retournée. Cet objet implémente l'interface <classname>Iterator</classname>
+    retourné. Cet objet implémente l'interface <classname>Iterator</classname>
     de la même façon qu'un objet itérateur, qui avance uniquement, le ferait,
     et fournit les méthodes qui peuvent être appelées pour manipuler le statut
     du générateur, y compris l'envoi des valeurs et leurs retours.
@@ -120,7 +120,7 @@ Nombres impairs à un seul chiffre depuis xrange() : 1 3 5 7 9
   <para>
    Une fonction générateur ressemble à une fonction normale, sauf qu'au lieu de
    retourner une valeur, un générateur &yield; retourne autant de valeurs que nécessaire.
-   Toutes fonctions contenant &yield; est une fonction générateur.
+   Toute fonction contenant &yield; est une fonction générateur.
   </para>
 
   <para>

--- a/language/namespaces.xml
+++ b/language/namespaces.xml
@@ -80,7 +80,7 @@ echo constant($d); // Voyez "Espaces de noms et fonctionnalités dynamiques"
   </example>
    <note>
     <simpara>
-     Les noms d'espaces de noms ne sont pas sensible à la casse.
+     Les noms d'espaces de noms ne sont pas sensibles à la casse.
     </simpara>
    </note>
   <note>
@@ -126,7 +126,7 @@ function connecte() { /* ... */ }
     <simpara>
      Les noms complètement qualifiés (c.-à-d. les noms commençant avec un antislash)
      ne sont pas autorisés dans les déclarations d'espaces de noms, car de telles
-     constructions sont interprétées comme des expressions d'espace de nom
+     constructions sont interprétées comme des expressions d'espace de noms
      relatif.
     </simpara>
    </note>
@@ -534,7 +534,7 @@ echo constant('nomdelespacedenoms\constname'), "\n"; // affiche aussi namespaced
   <?phpdoc print-version-for="namespaces"?>
   <para>
    PHP supporte deux moyens pour accéder de manière abstraite aux éléments
-   dans l'espace de nom courant, à savoir la constante magique 
+   dans l'espace de noms courant, à savoir la constante magique 
    <constant>__NAMESPACE__</constant> et la commande <literal>namespace</literal>.
   </para>
   <para>
@@ -1379,7 +1379,7 @@ foo::nom(); // appelle la méthode statique "nom" dans la classe "blah\blah"
    </para>
    <para>
     Ensuite, si la constante ou la fonction <literal>nom</literal> n'existe pas
-    dans l'espace de nom courant, la version globale de la constante ou la 
+    dans l'espace de noms courant, la version globale de la constante ou la 
     fonction <literal>nom</literal> est utilisée.
    </para>
    <para>

--- a/language/oop5/abstract.xml
+++ b/language/oop5/abstract.xml
@@ -8,7 +8,7 @@
   PHP a des classes, méthodes et propriétés abstraites.
   Les classes définies comme abstraites ne peuvent pas être
   instanciées, et toute classe contenant au moins une
-  méthode abstraite doit elle-aussi être abstraite.
+  méthode abstraite ou propriété abstraite doit elle-aussi être abstraite.
   Les méthodes définies comme abstraites se contentent de déclarer la signature de la méthode et d'indiquer si elle est publique ou protégée ;  
   elles ne peuvent pas définir l'implémentation. Les propriétés définies comme abstraites  
   peuvent déclarer une exigence pour le comportement de <literal>get</literal> ou de <literal>set</literal>,  

--- a/language/oop5/autoload.xml
+++ b/language/oop5/autoload.xml
@@ -32,9 +32,9 @@
  <note>
   <para>
    <function>spl_autoload_register</function> peut être appelée plusieurs fois
-   pour enregistrer plusieurs autochargeur. Lancer une exception depuis une
+   pour enregistrer plusieurs autochargeurs. Lancer une exception depuis une
    fonction d'autochargement, interrompra ce processus et ne permet pas aux
-   fonctions d'autochargement suivantes à être exécutées. Pour cette raison,
+   fonctions d'autochargement suivantes d'être exécutées. Pour cette raison,
    lancer des exceptions depuis une fonction d'autochargement est fortement
    découragée.
   </para>

--- a/language/oop5/basic.xml
+++ b/language/oop5/basic.xml
@@ -186,7 +186,7 @@ readonly class Foo
       </informalexample>
       <para>
         Une classe <modifier>readonly</modifier> peut être
-        <link linkend="language.oop5.basic.extends">étendu</link> si,
+        <link linkend="language.oop5.basic.extends">étendue</link> si,
         et seulement si, la classe enfant est également
         une classe <modifier>readonly</modifier>.
       </para>
@@ -413,9 +413,9 @@ echo new DateTime()->format('Y'), PHP_EOL;
   <sect2 xml:id="language.oop5.basic.properties-methods">
    <title>Propriétés et méthodes</title>
    <para>
-    Les propriétés et méthodes de classe vivent dans des "espaces de noms" séparé,
+    Les propriétés et méthodes de classe vivent dans des "espaces de noms" séparés,
     donc il est possible d'avoir une propriété et une méthode avec le même nom.
-    Faire référence à la fois a une propriété ainsi qu'une méthode ont la même
+    Faire référence à la fois à une propriété ainsi qu'une méthode ont la même
     notation, et le fait qu'une propriété sera accédée ou qu'une méthode sera appelée,
     dépend seulement du contexte, c'est-à-dire si l'utilisation est un accès variable
     ou un appel de fonction.
@@ -448,7 +448,7 @@ method
    </example>
    <para>
     Ceci signifie qu'appeler une <link linkend="functions.anonymous">fonction
-    anonyme</link> qui a été assigné à une propriété n'est pas possible directement.
+    anonyme</link> qui a été assignée à une propriété n'est pas possible directement.
     Au lieu de cela, la propriété doit d'abord être affectée à une variable.
     Il est possible d'appeler ce genre de propriété directement
     en la mettant entre parenthèses.
@@ -501,7 +501,7 @@ echo ($obj->bar)(), PHP_EOL;
    </para>
    <note>
     <simpara>
-     À partir de PHP 8.1.0, les constantes peuvent être déclaré comme finale.
+     À partir de PHP 8.1.0, les constantes peuvent être déclarées comme finales.
     </simpara>
    </note>
    <example>
@@ -734,7 +734,7 @@ NS\ClassName
      La résolution du nom de classe en utilisant <literal>::class</literal> est une
      transformation lors de la compilation. C'est-à-dire à l'instant où la chaîne du
      nom de classe est créé aucun autochargement n'a encore eu lieu. Par conséquent,
-     les noms de classes sont étendues même si la classe n'existe pas. Aucune erreur
+     les noms de classes sont étendus même si la classe n'existe pas. Aucune erreur
      n'est émise dans ce cas là.
     </para>
     <example xml:id="language.oop5.basic.class.class.fail">
@@ -788,9 +788,9 @@ NS\ClassName
   <para>
    À partir de PHP 8.0.0, les méthodes et propriétés peuvent aussi être accédés
    avec l'opérateur "nullsafe": <literal>?-></literal>. L'opérateur nullsafe
-   fonctionne à l'identique que l'accès de propriétés ou méthodes comme si dessus,
+   fonctionne à l'identique que l'accès de propriétés ou méthodes comme ci-dessus,
    à l'exception que si l'objet qui est déréférencé est &null; alors &null; sera
-   retourné au lieu de lancer une exception. Si le déréférencement fait par d'une
+   retourné au lieu de lancer une exception. Si le déréférencement fait partie d'une
    chaîne, le reste de la chaîne est ignoré.
   </para>
   <para>

--- a/language/oop5/changelog.xml
+++ b/language/oop5/changelog.xml
@@ -56,7 +56,7 @@
        Ajout : Support limité pour la covariance du type de retour et
        contravariance pour le type d'argument. Support complet de variance est
        uniquement disponible si l'autochargement est utilisé. À l'intérieur
-       d'un fichier unique seul les références non-cyclique de type sont
+       d'un fichier unique seules les références non-cycliques de type sont
        possibles.
       </entry>
      </row>
@@ -117,20 +117,20 @@
       <entry>
        Changement : Élargissement du type des paramètres. Le type des
        paramètres des méthodes réécrite et d'implémentation d'interface
-       peuvent désormais être omit.
+       peuvent désormais être omis.
       </entry>
      </row>
      <row>
       <entry>7.2.0</entry>
       <entry>
-       Changement : Les méthodes abstraites peuvent désormais être réécrite
+       Changement : Les méthodes abstraites peuvent désormais être réécrites
        quand une classe abstraite étend une autre classe abstraite.
       </entry>
      </row>
      <row>
       <entry>7.1.0</entry>
       <entry>
-       Changement : Les noms suivant ne peuvent pas être utilisé pour nommer
+       Changement : Les noms suivants ne peuvent pas être utilisés pour nommer
        des classes, interfaces ou traits : <literal>void</literal> 
        et <literal>iterable</literal>.
       </entry>
@@ -162,7 +162,7 @@
       <entry>7.0.0</entry>
       <entry>
        Ajout : Déclaration <emphasis>use</emphasis> groupé : les classes,
-       fonctions et constantes qui sont importer depuis un même espace de nom
+       fonctions et constantes qui sont importées depuis un même espace de noms
        peuvent désormais être groupé ensemble en une seule déclaration use.
       </entry>
      </row>
@@ -231,7 +231,7 @@
        un <link linkend="language.namespaces">espace de noms</link>
        ne sont plus considérées comme un <link
        linkend="language.oop5.decon">constructeur</link>. Ce changement
-       n'affecte pas les classes sans espace de nom.
+       n'affecte pas les classes sans espace de noms.
       </entry>
      </row>
       <row>

--- a/language/oop5/constants.xml
+++ b/language/oop5/constants.xml
@@ -67,7 +67,7 @@ echo $class::CONSTANT."\n";
  <para>
   La constante spéciale <constant>::class</constant> permet
   une résolution de nom de classe pleinement qualifié au moment de la compilation,
-  cela est utile pour les classes dans un espace de nom :
+  cela est utile pour les classes dans un espace de noms :
  </para>
  <example>
   <title>Exemple d'utilisation de ::class</title>

--- a/language/oop5/decon.xml
+++ b/language/oop5/decon.xml
@@ -222,7 +222,7 @@ class Test {
     ) {}
 }
 
-// All not allowed (compile-time error):
+// Aucun n'est autorisé (erreur de compilation) :
 function test(
     $a = new (CLASS_NAME_CONSTANT)(), // nom de classe dynamique
     $b = new class {}, // classe anonyme

--- a/language/oop5/inheritance.xml
+++ b/language/oop5/inheritance.xml
@@ -21,23 +21,23 @@
   en leur sein toutes les fonctionnalités communes.
  </para>
  <para>
-  Les méthodes privées d'une classe parente ne sont pas accessible à la classe enfant.
-  Par conséquent, les classes enfant peuvent réimplémenter une méthode privée eux-mêmes
+  Les méthodes privées d'une classe parente ne sont pas accessibles à la classe enfant.
+  Par conséquent, les classes enfant peuvent réimplémenter une méthode privée elles-mêmes
   sans se soucier des règles d'héritage normales.
   Avant PHP 8.0.0, cependant, les restrictions <literal>final</literal>
   et <literal>static</literal> étaient appliquées aux méthodes privées.
-  À partir de PHP 8.0.0, l'unique restriction de méthode privée qui est imposé
+  À partir de PHP 8.0.0, l'unique restriction de méthode privée qui est imposée
   est <literal>private final</literal> sur les constructeurs, car c'est une
   manière courante pour "désactiver" le constructeur lors de l'utilisation
   de méthodes factory statique à la place.
  </para>
  <para>
   La <link linkend="language.oop5.visibility">visibilité</link>
-  des méthodes, propriétés et constantes peut être relaxé, c.-à-d. une
-  méthode <literal>protected</literal> peut être marqué comme
-  <literal>public</literal>, mais elles ne peuvent pas être restraint, e.g.
+  des méthodes, propriétés et constantes peut être relaxée, c.-à-d. une
+  méthode <literal>protected</literal> peut être marquée comme
+  <literal>public</literal>, mais elles ne peuvent pas être restreintes, e.g.
   marquer une propriété <literal>public</literal> comme <literal>private</literal>.
-  Une exception sont les constructeurs, pour lesquels la visibilité peut être restraintes,
+  Une exception sont les constructeurs, pour lesquels la visibilité peut être restreinte,
   par exemple un constructeur <literal>public</literal> peut être annoté
   en tant que <literal>private</literal> dans la classe enfant.
  </para>

--- a/language/oop5/overloading.xml
+++ b/language/oop5/overloading.xml
@@ -67,24 +67,24 @@
 
    <para>
     <link linkend="object.set">__set()</link> est sollicitée lors de l'écriture de données
-    vers des propriétés inaccessibles (protégées ou privées) ou non existante.
+    vers des propriétés inaccessibles (protégées ou privées) ou non existantes.
    </para>
 
    <para>
     <link linkend="object.get">__get()</link> est appelée pour lire des données depuis
-    des propriétés inaccessibles (protégées ou privées) ou non existante.
+    des propriétés inaccessibles (protégées ou privées) ou non existantes.
    </para>
 
    <para>
     <link linkend="object.isset">__isset()</link> est sollicitée lorsque
     <function>isset</function> ou <function>empty</function> sont appelées sur
-    des propriétés inaccessibles (protégées ou privées) ou non existante.
+    des propriétés inaccessibles (protégées ou privées) ou non existantes.
    </para>
 
    <para>
     <link linkend="object.unset">__unset()</link> est invoquée lorsque
     <function>unset</function> est appelée sur des propriétés inaccessibles
-    (protégées ou privées) ou non existante.
+    (protégées ou privées) ou non existantes.
    </para>
 
    <para>
@@ -98,7 +98,7 @@
     Ces méthodes magiques ne seront pas lancées en contexte statique.
     Par conséquent, ces méthodes ne devraient pas être déclarées comme
     <link linkend="language.oop5.static">statiques</link>.
-    Un avertissement est levée si une des méthodes magiques est déclarée comme statique.
+    Un avertissement est levé si une des méthodes magiques est déclarée comme statique.
    </para>
 
    <note>

--- a/language/oop5/paamayim-nekudotayim.xml
+++ b/language/oop5/paamayim-nekudotayim.xml
@@ -7,7 +7,7 @@
  <para>
   L'opérateur de résolution de portée (aussi appelé Paamayim Nekudotayim) ou,
   en termes plus simples, le symbole &quot;double deux-points&quot; (::),
-  fournit un moyen d'accéder aux membres
+  fournit un moyen d'accéder à
   une <link linkend="language.oop5.constants">constante</link>,
   une propriété <link linkend="language.oop5.static">statique</link>,
   ou une méthode <link linkend="language.oop5.static">statique</link>

--- a/language/oop5/properties.xml
+++ b/language/oop5/properties.xml
@@ -221,7 +221,7 @@ $test = new Test("foobar");
 // Lecture légale.
 var_dump($test->prop); // string(6) "foobar"
 
-// Réaffectation illégal. Ce n'importe pas que la valeur assigné soit identique.
+// Réaffectation illégale. Ce n'importe pas que la valeur assignée soit identique.
 $test->prop = "foobar";
 // Error: Cannot modify readonly property Test::$prop
 ?>
@@ -396,7 +396,7 @@ var_dump($test2->prop); // NULL
     Pour gérer des noms de propriétés arbitraires, la classe devrait implémenter
     les méthodes magiques <link linkend="object.get">__get()</link> et
     <link linkend="object.set">__set()</link>.
-    Comme dernier recours la classe peut être marqué avec l'attribut
+    Comme dernier recours la classe peut être marquée avec l'attribut
     <code>#[\AllowDynamicProperties]</code>.
    </simpara>
   </warning>

--- a/language/oop5/static.xml
+++ b/language/oop5/static.xml
@@ -69,7 +69,7 @@ $classname::aStaticMethod();
    <para>
     Les propriétés statiques sont accédées en utilisant l'
     <link linkend="language.oop5.paamayim-nekudotayim">opérateur de résolution de portée</link>
-    (<literal>::</literal>) et ne peuvent pas être accédé à travers l'opérateur
+    (<literal>::</literal>) et ne peuvent pas être accédées à travers l'opérateur
     objet (<literal>-&gt;</literal>).
    </para>
 

--- a/language/oop5/traits.xml
+++ b/language/oop5/traits.xml
@@ -344,7 +344,7 @@ Hello World!
    Les traits supportent l'utilisation de méthodes abstraites afin d'imposer
    des contraintes aux classes sous-jacentes. Les méthodes publiques, protégées,
    et privées sont supportées.
-   Avant PHP 8.0.0, seule les méthodes publiques et protégées abstraire
+   Avant PHP 8.0.0, seule les méthodes publiques et protégées abstraites
    étaient supportées.
   </para>
   <caution>

--- a/language/oop5/variance.xml
+++ b/language/oop5/variance.xml
@@ -179,7 +179,7 @@ abstract class Animal
   </informalexample>
 
   <para>
-   Afin de voir le comportement de la contravariance, la méthode
+   Afin de voir le comportement de la contravariance, la
    méthode <varname>eat</varname> est surchargée dans la classe <varname>Dog</varname> afin d'autoriser
    n'importe quel objet de type <varname>Food</varname>. La classe <varname>Cat</varname> reste inchangée.
   </para>

--- a/language/oop5/visibility.xml
+++ b/language/oop5/visibility.xml
@@ -55,7 +55,7 @@ $obj->printHello(); // Affiche Public, Protected et Private
  */
 class MyClass2 extends MyClass
 {
-    // On peut redéclarer les propriétés publics ou protégés, mais pas ceux privés
+    // On peut redéclarer les propriétés publiques ou protégées, mais pas celles privées
     public $public = 'Public2';
     protected $protected = 'Protected2';
 
@@ -347,7 +347,7 @@ $myFoo->test(); // Bar::testPrivate
    <title>Visibilité des constantes</title>
    <para>
     À partir de PHP 7.1.0, les constantes de classes peuvent être définies
-    comme public, privée ou protégée. Les constantes déclarées sans mot clé
+    comme publique, privée ou protégée. Les constantes déclarées sans mot clé
     de visibilité explicite sont définies en tant que public.
    </para>
    <example>

--- a/language/operators/comparison.xml
+++ b/language/operators/comparison.xml
@@ -234,7 +234,7 @@ echo $a <=> $b, ' '; // 1
     <row>
      <entry><type>bool</type> ou <type>null</type></entry>
      <entry>N'importe quoi</entry>
-     <entry>Convertit en <type>bool</type>, &false; &lt; &true;</entry>
+     <entry>Convertit les deux côtés en <type>bool</type>, &false; &lt; &true;</entry>
     </row>
     <row>
      <entry><type>object</type></entry>
@@ -529,7 +529,7 @@ if (isset($_POST['action'])) {
 // Émet un avertissement que $name est indéfinie.
 print 'Mr. ' . $name ?? 'Anonymous';
 
-// Prints "Mr. Anonymous"
+// Affiche "Mr. Anonymous"
 print 'Mr. ' . ($name ?? 'Anonymous');
 ?>
 ]]>

--- a/language/predefined/arrayaccess/offsetexists.xml
+++ b/language/predefined/arrayaccess/offsetexists.xml
@@ -68,7 +68,7 @@
     <programlisting role="php">
 <![CDATA[
 <?php
-class obj implements Arrayaccess {
+class obj implements ArrayAccess {
     public function offsetSet($offset, $value): void {
         var_dump(__METHOD__);
     }

--- a/language/predefined/arrayaccess/offsetget.xml
+++ b/language/predefined/arrayaccess/offsetget.xml
@@ -57,7 +57,7 @@
       Une modification directe remplace complètement la valeur dans la dimension du tableau
       comme dans <literal>$obj[6] = 7</literal>. Une modification indirecte, par contre, ne
       change qu'une partie de la dimension ou intervient lors de l'assignation par référence
-      vers une autres variable, comme dans <literal>$obj[6][7] = 7</literal> ou encore
+      vers une autre variable, comme dans <literal>$obj[6][7] = 7</literal> ou encore
       <literal>$var =&amp; $obj[6]</literal> suivi de l'incrémentation avec
       <literal>++</literal> et la décrémentation avec <literal>--</literal>.
     </para>

--- a/language/predefined/arrayaccess/offsetset.xml
+++ b/language/predefined/arrayaccess/offsetset.xml
@@ -86,7 +86,7 @@ Array
     lors de changements de dimensions indirects (indirects dans le sens
     d'un changement d'une sous-dimension ou lors de l'assignation par
     référence à une autre variable).
-    A la place, <function>ArrayAccess::offsetGet</function> est appelée. Cette
+    À la place, <function>ArrayAccess::offsetGet</function> est appelée. Cette
     opération ne fonctionnera que si cette méthode retourne une référence.
    </para>
   </note>

--- a/language/predefined/attributes/deprecated.xml
+++ b/language/predefined/attributes/deprecated.xml
@@ -68,7 +68,7 @@
         Sera inclus dans le message d'obsolescence émis.
        </para>
        <para>
-        Fonctionnalité qui fait partie de PHP utilisera Major.Minor comme valeur de <varname>since</varname>,
+        Une fonctionnalité qui fait partie de PHP utilisera Major.Minor comme valeur de <varname>since</varname>,
         par exemple <literal>'8.4'</literal>.
        </para>
      </listitem>

--- a/language/predefined/closure/bindto.xml
+++ b/language/predefined/closure/bindto.xml
@@ -18,7 +18,7 @@
   </methodsynopsis>
   <para>
    Crée et retourne une nouvelle <link linkend="functions.anonymous">fonction anonyme
-   </link> avec le même corps et les même variables liées que l'originale, mais avec un objet lié
+   </link> avec le même corps et les mêmes variables liées que l'originale, mais avec un objet lié
    qui peut être différent, et un nouveau contexte de classe.
   </para>
 

--- a/language/predefined/php-incomplete-class.xml
+++ b/language/predefined/php-incomplete-class.xml
@@ -11,7 +11,7 @@
   <section xml:id="php-incomplete-class.intro">
    &reftitle.intro;
    <para>
-    Créer par <function>unserialize</function>,
+    Créée par <function>unserialize</function>,
     lorsque l'on essaie de désérialiser une classe non définie
     ou une classe non listée dans les <literal>allowed_classes</literal>
     du tableau <parameter>options</parameter> de <function>unserialize</function>.
@@ -69,7 +69,7 @@
   <section xml:id="php-incomplete-class.examples" role="examples">
    &reftitle.examples;
    <example xml:id="php-incomplete-class.basic-example">
-    <title>Created by <function>unserialize</function></title>
+    <title>Créée par <function>unserialize</function></title>
     <programlisting role="php">
 <![CDATA[
 <?php
@@ -83,7 +83,7 @@ $myObject = new MyClass;
 
 $foo = serialize($myObject);
 
-// désérialise tous les objet en objet __PHP_Incomplete_Class
+// désérialise tous les objets en objets __PHP_Incomplete_Class
 $disallowed = unserialize($foo, ["allowed_classes" => false]);
 
 var_dump($disallowed);

--- a/language/predefined/variables/env.xml
+++ b/language/predefined/variables/env.xml
@@ -17,7 +17,7 @@
   </para>
 
   <simpara>
-   Cette variable est importée dans l'espace de nom global de PHP,
+   Cette variable est importée dans l'espace de noms global de PHP,
    depuis l'environnement dans lequel l'exécutable PHP fonctionne.
    De nombreuses valeurs sont fournies par le shell qui exécute PHP,
    et différents systèmes pouvant disposer de différents shell, même

--- a/language/predefined/variables/globals.xml
+++ b/language/predefined/variables/globals.xml
@@ -101,19 +101,19 @@ array_pop($GLOBALS);
 <![CDATA[
 <?php
 
-// Before PHP 8.1.0
+// Avant PHP 8.1.0
 $a = 1;
 
-$globals = $GLOBALS; // Ostensibly by-value copy
+$globals = $GLOBALS; // Copie par valeur en apparence
 $globals['a'] = 2;
 var_dump($a); // int(2)
 
-// As of PHP 8.1.0
-// this no longer modifies $a. The previous behavior violated by-value semantics.
+// À partir de PHP 8.1.0
+// ceci ne modifie plus $a. Le comportement précédent violait la sémantique par valeur.
 $globals = $GLOBALS;
 $globals['a'] = 1;
 
-// To restore the previous behavior, iterate its copy and assign each property back to $GLOBALS.
+// Pour restaurer le comportement précédent, itérer sa copie et réassigner chaque propriété à $GLOBALS.
 foreach ($globals as $key => $value) {
     $GLOBALS[$key] = $value;
 }

--- a/language/predefined/variables/httpresponseheader.xml
+++ b/language/predefined/variables/httpresponseheader.xml
@@ -23,7 +23,7 @@
    <link linkend="wrappers.http">gestionnaire HTTP</link>,
    <varname>$http_response_header</varname> sera rempli avec les en-têtes
    de réponses HTTP.
-   <varname>$http_response_header</varname> sera crée avec une <link linkend="language.variables.scope">
+   <varname>$http_response_header</varname> sera créé avec une <link linkend="language.variables.scope">
    portée locale</link>.
   </para>
  </refsect1>

--- a/language/predefined/variables/server.xml
+++ b/language/predefined/variables/server.xml
@@ -22,7 +22,7 @@
   </para>
   <note>
     <simpara>
-     Lorsque PHP est exécuté en ligne de commande <link linkend="features.commandline">command line</link>
+     Lorsque PHP est exécuté en <link linkend="features.commandline">ligne de commande</link>
      , la plupart de ces entrées ne seront pas disponibles ou n'auront aucun sens.
     </simpara>
   </note>
@@ -349,7 +349,7 @@
        Contient le nom du script courant. Cela sert lorsque
        les pages doivent s'appeler elles-mêmes.
        La constante <link linkend="language.constants.magic">__FILE__</link>
-       contient le chemin complet ainsi que le nom du fichier (i.e. inclut) courant.
+       contient le chemin complet ainsi que le nom du fichier (i.e. inclus) courant.
       </simpara>
      </listitem>
     </varlistentry>

--- a/language/references.xml
+++ b/language/references.xml
@@ -112,9 +112,9 @@ $foo =& find_var($bar);
    </para>
    <para>
     Utiliser la même syntaxe avec une fonction qui <emphasis>ne</emphasis>
-    retourne par référence génèrera une erreur, comme l'utiliser avec le
+    retourne pas par référence génèrera une erreur, comme l'utiliser avec le
     résultat de l'opérateur <link linkend="language.oop5.basic.new">new</link>.
-    Tant bien que les objets sont passés comme des pointeurs, ceci n'est pas
+    Bien que les objets soient passés comme des pointeurs, ceci n'est pas
     identique aux références comme expliqué dans la section les
     <link linkend="language.oop5.references">Objets et références</link>.
    </para>

--- a/language/types/callable.xml
+++ b/language/types/callable.xml
@@ -36,7 +36,7 @@ function foo(callable $callback) {
    Les callables peuvent être passés en tant qu'arguments aux fonctions ou méthodes qui
    attendent un paramètre callback ou ils peuvent être invoqués directement.
    Le type <type>callable</type> ne peut pas être utilisé comme déclaration de type pour les
-   propriétés. A la place, utilisez une déclaration de type <classname>Closure</classname>.
+   propriétés. À la place, utilisez une déclaration de type <classname>Closure</classname>.
   </simpara>
 
   <simpara>

--- a/language/types/declarations.xml
+++ b/language/types/declarations.xml
@@ -481,7 +481,7 @@ function foo(): X&Y {} // Autorisé (la redondance n'est connue qu'au moment de 
 class C {}
 class D extends C {}
 
-// This doesn't extend C.
+// Ceci n'étend pas C.
 class E {}
 
 function f(C $c) {
@@ -517,7 +517,7 @@ Stack trace:
 interface I { public function f(); }
 class C implements I { public function f() {} }
 
-// This doesn't implement I.
+// Ceci n'implémente pas I.
 class E {}
 
 function f(I $i) {
@@ -552,7 +552,7 @@ function sum($a, $b): float {
     return $a + $b;
 }
 
-// Note that a float will be returned.
+// Notez qu'un float sera retourné.
 var_dump(sum(1, 2));
 ?>
 ]]>
@@ -744,7 +744,7 @@ function sum(int $a, int $b) {
 
 var_dump(sum(1, 2));
 
-// These will be coerced to integers: note the output below!
+// Ceux-ci seront convertis en entiers : notez la sortie ci-dessous !
 var_dump(sum(1.5, 2.5));
 ?>
 ]]>

--- a/language/types/type-juggling.xml
+++ b/language/types/type-juggling.xml
@@ -6,7 +6,7 @@
 
  <simpara>
   PHP ne requiert pas une définition de type explicite dans les déclarations de variables.
-  Dans ce cas, le type d'une variable est déterminé en fonction de la valeur qu'elle a stocké.
+  Dans ce cas, le type d'une variable est déterminé en fonction de la valeur qu'elle stocke.
   C'est-à-dire, si une <type>string</type> est assignée à la variable
   <varname>$var</varname>, alors <varname>$var</varname> est de type
   <type>string</type>. Si après une valeur <type>int</type> est assignée à
@@ -115,7 +115,7 @@
    alors le résultat sera aussi une <type>string</type>.
    Sinon, les opérandes seront interprétés comme des <type>int</type>s,
    et le résultat sera aussi un <type>int</type>.
-   À partir de PHP 8.0.0, si un des opérandes ne peut être interprétés une
+   À partir de PHP 8.0.0, si un des opérandes ne peut être interprété, une
    <classname>TypeError</classname> est lancée.
   </simpara>
  </sect2>
@@ -158,7 +158,7 @@
   <warning>
    <simpara>
     <link linkend="functions.internal">Les fonctions internes</link>
-    contraigne automatiquement &null; aux types scalaires,
+    contraignent automatiquement &null; aux types scalaires,
     ce comportement est <emphasis>OBSOLÈTE</emphasis> à partir de PHP 8.1.0.
    </simpara>
   </warning>
@@ -286,7 +286,7 @@ true  --> 1           // bool compatible avec int
   <title>Cast de type</title>
 
   <simpara>
-   Le casting de type converti la valeur à un type donnée en écrivant le type
+   Le casting de type convertit la valeur en un type donné en écrivant le type
    entre parenthèse avant la valeur à convertir.
   </simpara>
 
@@ -356,8 +356,8 @@ var_dump($bar);
 
   <note>
    <para>
-    Les espaces blancs sont ignoré à l'intérieur des parenthèses d'un cast.
-    Ansi, les deux casts suivant sont équivalents :
+    Les espaces blancs sont ignorés à l'intérieur des parenthèses d'un cast.
+    Ainsi, les deux casts suivants sont équivalents :
     <informalexample>
      <programlisting role="php">
 <![CDATA[

--- a/language/variables.xml
+++ b/language/variables.xml
@@ -17,8 +17,7 @@
   <para>
    Un nom de variable valide commence par une lettre
    (<literal>A-Z</literal>, <literal>a-z</literal>, ou les octets de 128 à 255)
-   ou par un tiret bas, suivi par
-   une lettre ou un souligné (_), suivi de lettres, chiffres ou
+   ou par un souligné (_), suivi de lettres, chiffres ou
    soulignés. Exprimé sous la forme d'une expression
    régulière, cela donne :
    <code>^[a-zA-Z_\x80-\xff][a-zA-Z0-9_\x80-\xff]*$</code>
@@ -165,7 +164,7 @@ $bar = &test();    // invalide car test() ne retourne pas une variable par réf�
    bonne pratique. Accéder à une variable non définie entraînera un
    <constant>E_WARNING</constant> (avant PHP 8.0.0, <constant>E_NOTICE</constant>).
    Une variable non définie a une valeur par défaut de &null;.
-   Le langage <function>isset</function> peut être utilisé
+   La construction de langage <function>isset</function> peut être utilisée
    pour détecter si une variable a déjà été initialisée.
   </para>
   <para>
@@ -670,7 +669,7 @@ function &get_instance_ref() {
     var_dump($obj);
     if (!isset($obj)) {
         $new = new stdClass;
-        // Assign a reference to the static variable
+        // Assigne une référence à la variable statique
         $obj = &$new;
     }
     if (!isset($obj->property)) {
@@ -688,7 +687,7 @@ function &get_instance_noref() {
     var_dump($obj);
     if (!isset($obj)) {
         $new = new stdClass;
-        // Assign the object to the static variable
+        // Assigne l'objet à la variable statique
         $obj = $new;
     }
     if (!isset($obj->property)) {
@@ -996,7 +995,7 @@ if ($_POST) {
      <simpara>
       Si le nom d'une variable externe commence par une syntaxe valide pour un tableau, les caractères qui suivent
       sont silencieusement ignorés. Par exemple : <literal>&lt;input name="foo[bar]baz"&gt;</literal>
-      deviens <literal>$_REQUEST['foo']['bar']</literal>.
+      devient <literal>$_REQUEST['foo']['bar']</literal>.
      </simpara>
     </note>
    

--- a/language/wrappers/audio.xml
+++ b/language/wrappers/audio.xml
@@ -27,7 +27,7 @@
 
   <simpara><filename>ogg://</filename> (PECL)</simpara>
   <note>
-   <title>Cette enveloppe n'est pas activé par défaut</title>
+   <title>Cette enveloppe n'est pas activée par défaut</title>
    <simpara>
     Pour utiliser l'enveloppe <filename>ogg://</filename>,
     l'extension <link xlink:href="&url.pecl.package;oggvorbis">OGG/Vorbis</link>

--- a/language/wrappers/compression.xml
+++ b/language/wrappers/compression.xml
@@ -92,7 +92,7 @@
        <entry>Support de la fonction <function>unlink</function></entry>
        <entry>
         Non, utilisez le gestionnaire <literal>file://</literal>
-        pour obtenir des informations sur les fichiers compressés.
+        pour supprimer les fichiers compressés.
        </entry>
       </row>
       <row>

--- a/language/wrappers/http.xml
+++ b/language/wrappers/http.xml
@@ -13,7 +13,7 @@
   &reftitle.description;
   <para>
    Permet des accès, en lecture seule, à des fichiers accessibles via HTTP.
-   Par défaut, une requête HTTP 1.0 GET est utilisé.
+   Par défaut, une requête HTTP 1.0 GET est utilisée.
    Un en-tête <literal>Host:</literal> est envoyé avec la requête,
    pour gérer les hôtes virtuels basés sur des noms.
    Si vous avez configuré une version de navigateur avec

--- a/reference/array/functions/array-multisort.xml
+++ b/reference/array/functions/array-multisort.xml
@@ -48,8 +48,8 @@
       <para>
        L'ordre utilisé pour trier le précédent argument
        <type>array</type>. Soit la constante <constant>SORT_ASC</constant>
-       pour trier de façon croissant, soit la constante
-       <constant>SORT_DESC</constant> pour trier de façon décroissant.
+       pour trier de façon croissante, soit la constante
+       <constant>SORT_DESC</constant> pour trier de façon décroissante.
       </para>
       <para>
        Cet argument peut être associé avec le paramètre

--- a/reference/array/functions/array-udiff.xml
+++ b/reference/array/functions/array-udiff.xml
@@ -18,7 +18,7 @@
   </methodsynopsis>
   <para>
    Calcule la différence entre deux tableaux en utilisant une fonction rappel.
-   Cette fonctionne agit comme la fonction <function>array_diff</function>
+   Cette fonction agit comme la fonction <function>array_diff</function>
    qui utilise une fonction interne pour comparer les données.
   </para>
  </refsect1>

--- a/reference/array/functions/current.xml
+++ b/reference/array/functions/current.xml
@@ -72,6 +72,7 @@
     <programlisting role="php">
 <![CDATA[
 <?php
+$transport = array('foot', 'bike', 'car', 'plane');
 echo $mode = current($transport), PHP_EOL; // $mode = 'foot';
 echo $mode = next($transport), PHP_EOL;    // $mode = 'bike';
 echo $mode = current($transport), PHP_EOL; // $mode = 'bike';

--- a/reference/datetime/datetimeimmutable/createfromformat.xml
+++ b/reference/datetime/datetimeimmutable/createfromformat.xml
@@ -83,7 +83,7 @@
        <tgroup cols="3">
         <thead>
          <row>
-          <entry><parameter>format</parameter> character</entry>
+          <entry>Caractère de <parameter>format</parameter></entry>
           <entry>Description</entry>
           <entry>Exemple de valeurs analysées</entry>
          </row>
@@ -585,7 +585,7 @@ Format: i; 2022-06-02 00:15:00
   </example>
 
   <example>
-   <title>Texte de Format avec des caractères litéraux</title>
+   <title>Texte de Format avec des caractères littéraux</title>
    <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/datetime/datetimeimmutable/createfrommutable.xml
+++ b/reference/datetime/datetimeimmutable/createfrommutable.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="datetimeimmutable.createfrommutable" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>DateTimeImmutable::createFromMutable</refname>
-  <refpurpose>Retourne une nouvelle instance de DateTimeImmutable encapsulant l'objet DateTime fournit</refpurpose>
+  <refpurpose>Retourne une nouvelle instance de DateTimeImmutable encapsulant l'objet DateTime fourni</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/datetime/datetimeimmutable/getlasterrors.xml
+++ b/reference/datetime/datetimeimmutable/getlasterrors.xml
@@ -14,7 +14,7 @@
    <void/>
   </methodsynopsis>
   <para>
-   Retourne un tableau des alertes et erreur trouvés lors de l'analyse
+   Retourne un tableau des alertes et erreurs trouvées lors de l'analyse
    d'une chaîne date/heure.
   </para>
  </refsect1>
@@ -99,7 +99,7 @@ Failed to parse time string (asdfasdf) at position 0 (a): The timezone could not
    </screen>
    <para>
     Les index 6, et 0 dans la sortie de l'exemple réfère à l'index du
-    caractère dans la chaîne où l'erreur c'est produite.
+    caractère dans la chaîne où l'erreur s'est produite.
    </para>
   </example>
     <example>

--- a/reference/datetime/datetimeimmutable/setisodate.xml
+++ b/reference/datetime/datetimeimmutable/setisodate.xml
@@ -46,7 +46,7 @@
     <term><parameter>dayOfWeek</parameter></term>
     <listitem>
      <para>
-      Offset from the first day of the week.
+      Décalage par rapport au premier jour de la semaine.
      </para>
     </listitem>
    </varlistentry>

--- a/reference/datetime/datetimeinterface/gettimestamp.xml
+++ b/reference/datetime/datetimeinterface/gettimestamp.xml
@@ -53,7 +53,7 @@
    Si l'horodatage ne peut pas être représenté sous la forme d'un &integer;,
    une <exceptionname>DateRangeError</exceptionname> est lancée.
    Antérieur à PHP 8.3.0, une <exceptionname>ValueError</exceptionname>
-   était lancé.
+   était lancée.
    Et antérieur à PHP 8.0.0, &false; était retourné dans ce cas.
    Cependant, l'horodatage peut être récupéré en tant que &string; en utilisant
    <methodname>DateTimeInterface::format</methodname> avec le format <literal>U</literal>.
@@ -81,7 +81,7 @@
      <row>
       <entry>8.0.0</entry>
       <entry>
-       Ces fonctions ne retourne plus &false; en cas d'échec.
+       Ces fonctions ne retournent plus &false; en cas d'échec.
       </entry>
      </row>
     </tbody>

--- a/reference/datetime/datetimeinterface/serialize.xml
+++ b/reference/datetime/datetimeinterface/serialize.xml
@@ -6,7 +6,7 @@
   <refname>DateTime::__serialize</refname>
   <refname>DateTimeImmutable::__serialize</refname>
   <refname>DateTimeInterface::__serialize</refname>
-  <refpurpose>Désérialise un DateTime</refpurpose>
+  <refpurpose>Sérialise un DateTime</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/datetime/functions/date-parse-from-format.xml
+++ b/reference/datetime/functions/date-parse-from-format.xml
@@ -72,7 +72,7 @@
    sont ajoutés.
   </para>
   <para>
-   Le tableau inclus les champs <literal>warning_count</literal> et
+   Le tableau inclut les champs <literal>warning_count</literal> et
    <literal>warnings</literal>. Le premier indique le nombre 
    d'avertissements. Les clés du tableau <literal>warnings</literal> 
    indiquent la position dans le paramètre <parameter>datetime</parameter> 
@@ -81,8 +81,8 @@
    avertissement.
   </para>
   <para>
-   Le tableau inclus aussi les champs <literal>error_count</literal> et
-   <literal>errors</literal> fields. Le premier indique le nombre 
+   Le tableau inclut aussi les champs <literal>error_count</literal> et
+   <literal>errors</literal>. Le premier indique le nombre 
    d'erreurs. Les clés du tableau <literal>errors</literal> indiquent 
    la position dans le paramètre <parameter>datetime</parameter> où l'erreur
    s'est produite, avec la valeur de chaîne décrivant l'avertissement 

--- a/reference/datetime/functions/date-parse.xml
+++ b/reference/datetime/functions/date-parse.xml
@@ -73,7 +73,7 @@
    sont ajoutés.
   </para>
   <para>
-   Le tableau inclus les champs <literal>warning_count</literal> et
+   Le tableau inclut les champs <literal>warning_count</literal> et
    <literal>warnings</literal>. Le premier indique le nombre 
    d'avertissements. Les clés du tableau <literal>warnings</literal> 
    indiquent la position dans le paramètre <parameter>datetime</parameter> 
@@ -82,8 +82,8 @@
    avertissement.
   </para>
   <para>
-   Le tableau inclus aussi les champs <literal>error_count</literal> et
-   <literal>errors</literal> fields. Le premier indique le nombre 
+   Le tableau inclut aussi les champs <literal>error_count</literal> et
+   <literal>errors</literal>. Le premier indique le nombre 
    d'erreurs. Les clés du tableau <literal>errors</literal> indiquent 
    la position dans le paramètre <parameter>datetime</parameter> où l'erreur
    s'est produite, avec la valeur de chaîne décrivant l'avertissement 
@@ -184,7 +184,7 @@ array(12) {
    il y aura toujours un élément <literal>zone_type</literal> et 
    quelques autres en fonction de sa valeur.
    <example>
-    <title><function>date_parse</function> avec des informations abrégé sur le fuseau horaire</title>
+    <title><function>date_parse</function> avec des informations abrégées sur le fuseau horaire</title>
     <programlisting role="php">
 <![CDATA[
 <?php
@@ -234,7 +234,7 @@ array(16) {
     </screen>
    </example>
    <example>
-    <title><function>date_parse</function> avec des informations abrégé sur le fuseau horaire</title>
+    <title><function>date_parse</function> avec des informations abrégées sur le fuseau horaire</title>
     <programlisting role="php">
 <![CDATA[
 <?php
@@ -332,7 +332,7 @@ array(12) {
   </para>
   <para>
    <link linkend="datetime.formats.relative">Les formats relatifs</link>
-   n'influencent pas les valeurs analysées depuis des formats absoluts, mais
+   n'influencent pas les valeurs analysées depuis des formats absolus, mais
    sont analysées dans l'élément "relatif".
    <example>
     <title>Exemple avec <function>date_parse</function> et des formats relatifs</title>
@@ -395,7 +395,7 @@ array(13) {
   <para>
    Certaines strophes, telles que <literal>Thursday</literal> (jeudi) définiront 
    la partie heure de la chaîne sur <literal>0</literal>. Si <literal>Thursday</literal> 
-   (jeudi) is est passé à<function>DateTimeImmutable::__construct</function> l'heure, 
+   (jeudi) est passé à<function>DateTimeImmutable::__construct</function> l'heure, 
    la minute, la seconde et la fraction seront également définies sur
    <literal>0</literal>. Dans l'exemple ci-dessous, l'élément année 
    est cependant laissé à &false;.
@@ -466,7 +466,7 @@ array(13) {
   <para>
    <simplelist>
     <member><function>date_parse_from_format</function> pour analyser 
-     le parameters <parameter>datetime</parameter> avec un format spécifique</member>
+     le paramètre <parameter>datetime</parameter> avec un format spécifique</member>
     <member><function>checkdate</function> pour une validation de date Grégorienne</member>
     <member><function>getdate</function></member>
    </simplelist>

--- a/reference/datetime/functions/date-sunrise.xml
+++ b/reference/datetime/functions/date-sunrise.xml
@@ -13,7 +13,7 @@
    <para>
     Cette fonction est <emphasis>OBSOLÈTE</emphasis> à partir de PHP 8.1.0.
     Dépendre de cette fonction est fortement déconseillé. L'utilisation
-    de <function>date_sun_info</function> est encouragé à la place.
+    de <function>date_sun_info</function> est encouragée à la place.
    </para>
   </warning>
  </refsynopsisdiv>

--- a/reference/datetime/functions/date-sunset.xml
+++ b/reference/datetime/functions/date-sunset.xml
@@ -14,7 +14,7 @@
    <para>
     Cette fonction est <emphasis>OBSOLÈTE</emphasis> à partir de PHP 8.1.0.
     Dépendre de cette fonction est fortement déconseillé. L'utilisation
-    de <function>date_sun_info</function> est encouragé à la place.
+    de <function>date_sun_info</function> est encouragée à la place.
    </para>
   </warning>
  </refsynopsisdiv>

--- a/reference/dom/dom/attr/rename.xml
+++ b/reference/dom/dom/attr/rename.xml
@@ -75,7 +75,7 @@
  <refsect1 role="examples">
   &reftitle.examples;
   <example xml:id="dom-attr.rename.example.basic">
-   <title>Exemple de <methodname>Dom\Attr::rename</methodname> pour changer l'espace de nom et le nom qualifié</title>
+   <title>Exemple de <methodname>Dom\Attr::rename</methodname> pour changer l'espace de noms et le nom qualifié</title>
    <simpara>
     Cela change le nom qualifié de <literal>my-attr</literal> en
     <literal>my-new-attr</literal> et change également son espace de noms en

--- a/reference/dom/domelement/construct.xml
+++ b/reference/dom/domelement/construct.xml
@@ -33,7 +33,7 @@
      <term><parameter>qualifiedName</parameter></term>
      <listitem>
       <para>
-       Le nom de l'élément. Lorsqu'il est passé dans l'URI de l'espace de nom,
+       Le nom de l'élément. Lorsqu'il est passé dans l'URI de l'espace de noms,
        le nom de l'élément doit comporter un préfixe pour être associé à l'URI.
       </para>
      </listitem>
@@ -50,7 +50,7 @@
      <term><parameter>namespace</parameter></term>
      <listitem>
       <para>
-       Un espace de nom de l'URI pour créer l'élément dans un espace de nom spécifique.
+       Un espace de noms de l'URI pour créer l'élément dans un espace de noms spécifique.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/dom/domelement/setidattributens.xml
+++ b/reference/dom/domelement/setidattributens.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="domelement.setidattributens" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>DOMElement::setIdAttributeNS</refname>
-  <refpurpose>Déclare l'attribut spécifié par son nom local et son espace de nom URI à être de type ID</refpurpose>
+  <refpurpose>Déclare l'attribut spécifié par son nom local et son espace de noms URI à être de type ID</refpurpose>
  </refnamediv>
  <refsect1 role="description">
   &reftitle.description;
@@ -27,7 +27,7 @@
      <term><parameter>namespace</parameter></term>
      <listitem>
       <para>
-       L'URI de l'espace de nom de l'attribut.
+       L'URI de l'espace de noms de l'attribut.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/dom/domnode/isdefaultnamespace.xml
+++ b/reference/dom/domnode/isdefaultnamespace.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="domnode.isdefaultnamespace" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>DOMNode::isDefaultNamespace</refname>
-  <refpurpose>Vérifie si l'espace de nom spécifié est l'espace de noms par défaut ou non</refpurpose>
+  <refpurpose>Vérifie si l'espace de noms spécifié est l'espace de noms par défaut ou non</refpurpose>
  </refnamediv>
  <refsect1 role="description">
   &reftitle.description;

--- a/reference/exec/functions/escapeshellarg.xml
+++ b/reference/exec/functions/escapeshellarg.xml
@@ -83,7 +83,7 @@ system('ls '.escapeshellarg($dir));
     <member><function>exec</function></member>
     <member><function>popen</function></member>
     <member><function>system</function></member>
-    <member><link linkend="language.operators.execution">backtick operator</link></member>
+    <member><link linkend="language.operators.execution">les guillemets obliques</link></member>
    </simplelist>
   </para>
  </refsect1>

--- a/reference/exec/functions/system.xml
+++ b/reference/exec/functions/system.xml
@@ -79,7 +79,7 @@
 echo '<pre>';
 
  // Affiche le résultat de la commande "ls" et retourne
- // la dernière lignes dans $last_line. Stocke la valeur retournée
+ // la dernière ligne dans $last_line. Stocke la valeur retournée
  // par la commande shell dans $retval.
  $last_line = system('ls', $retval);
 

--- a/reference/filesystem/functions/file-get-contents.xml
+++ b/reference/filesystem/functions/file-get-contents.xml
@@ -154,7 +154,7 @@
       <row>
        <entry>7.1.0</entry>
        <entry>
-        Ajout du support pour des positions <parameter>offset</parameter> négative.
+        Ajout du support pour des positions <parameter>offset</parameter> négatives.
        </entry>
       </row>
      </tbody>

--- a/reference/filesystem/functions/fread.xml
+++ b/reference/filesystem/functions/fread.xml
@@ -178,7 +178,7 @@ fclose($handle);
     Noter que la fonction <function>fread</function> lit la position
     courante du pointeur de fichier. Utilisez la fonction
     <function>ftell</function> pour trouver la position courante du pointeur
-    et la fonction <function>rewind</function> pour réinitiliaser la position du
+    et la fonction <function>rewind</function> pour réinitialiser la position du
     pointeur.
    </para>
   </note>

--- a/reference/filesystem/functions/fseek.xml
+++ b/reference/filesystem/functions/fseek.xml
@@ -26,7 +26,7 @@
    En général, il est possible de se déplacer au-delà de la fin du flux (eof); si des
    données sont écrites dans ce cas, l'espace entre la fin du flux et
    la position courante sera rempli d'octets nuls. Cependant, certains flux ne supportent
-   pas ce comportement, en particulier lorsque l'espace de stockage sous-jascent est de
+   pas ce comportement, en particulier lorsque l'espace de stockage sous-jacent est de
    taille fixe.
   </para>
  </refsect1>

--- a/reference/filesystem/functions/glob.xml
+++ b/reference/filesystem/functions/glob.xml
@@ -58,7 +58,7 @@
          <simpara>
           <literal>[...]</literal> - Associe un caractère d'un ensemble de
           caractères. Si le premier caractère est <literal>!</literal>,
-          associe n'importe quel caractères pas dans cet ensemble.
+          associe n'importe quels caractères pas dans cet ensemble.
          </simpara>
         </listitem>
         <listitem>

--- a/reference/filesystem/functions/lstat.xml
+++ b/reference/filesystem/functions/lstat.xml
@@ -45,7 +45,7 @@
    informations seront alors basées sur le lien symbolique.
   </para>
   <para>
-   On failure, &false; is returned.
+   En cas d'échec, &false; est retourné.
   </para>
  </refsect1>
 

--- a/reference/filesystem/functions/mkdir.xml
+++ b/reference/filesystem/functions/mkdir.xml
@@ -18,7 +18,7 @@
    <methodparam choice="opt"><type class="union"><type>resource</type><type>null</type></type><parameter>context</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
   <para>
-   Tente de créer le dossier spécifier par <parameter>directory</parameter>.
+   Tente de créer le dossier spécifié par <parameter>directory</parameter>.
   </para>
  </refsect1>
  
@@ -39,7 +39,7 @@
      <term><parameter>permissions</parameter></term>
      <listitem>
       <para>
-       Les permissions par défaut est 0777, ce qui correspond au maximum de
+       Les permissions par défaut sont 0777, ce qui correspond au maximum de
        droits possible. Pour plus d'informations sur les permissions, lisez en
        détail la documentation de la fonction <function>chmod</function>.
       </para>
@@ -49,9 +49,9 @@
        </para>
       </note>
       <para>
-       Notez que vous aurez à préciser les<parameter>permissions</parameter> en base octale,
+       Notez que vous aurez à préciser les <parameter>permissions</parameter> en base octale,
        ce qui signifie que vous aurez probablement un 0 comme premier chiffre.
-       Les <parameter>permissions</parameter> sera aussi modifié par le umask courant, que vous pouvez
+       Les <parameter>permissions</parameter> seront aussi modifiées par le umask courant, que vous pouvez
        modifier avec la fonction <function>umask</function>.
       </para>
      </listitem>
@@ -84,7 +84,7 @@
    <para>
     Si le répertoire à créer existe déjà, cela est considéré
     comme une erreur et &false; sera toujours retourné.
-    Les fonctions <function>is_dir</function> ou <function>file_exists</function> peuvent être utilisée
+    Les fonctions <function>is_dir</function> ou <function>file_exists</function> peuvent être utilisées
     pour vérifier si le répertoire existe déjà avant d'essayer de le créer.
    </para>
   </note>

--- a/reference/filesystem/functions/parse-ini-file.xml
+++ b/reference/filesystem/functions/parse-ini-file.xml
@@ -117,7 +117,7 @@ urls[git] = "http://git.php.net"
     <title>Exemple avec <function>parse_ini_file</function></title>
     <para>
      Les <link linkend="language.constants">constantes</link> (mais pas les
-     "constantes magiques" tel que <constant>__FILE__</constant>) peuvent aussi
+     "constantes magiques" telles que <constant>__FILE__</constant>) peuvent aussi
      être utilisées dans le fichier .ini, ce qui fait que si vous définissez
      une constante avant d'exécuter <function>parse_ini_file</function>, elle
      sera intégrée dans les résultats. Seules les valeurs de configuration
@@ -242,7 +242,7 @@ echo '(chargé ) magic_quotes_gpc = ' . yesno(get_cfg_var('magic_quotes_gpc')) .
      particulière dans une valeur ini.
      Additionnellement, les variables d'environment et options de configuration
      définies précédemment (voir <function>get_cfg_var</function>) peuvent être
-     lu en utilisant la syntaxe <code>${}</code>.
+     lues en utilisant la syntaxe <code>${}</code>.
     </para>
     <programlisting>
 <![CDATA[
@@ -332,7 +332,7 @@ code = "\${test}"
   &reftitle.notes;
   <note>
    <para>
-    Cette fonction n'a rien a voir avec le fichier
+    Cette fonction n'a rien à voir avec le fichier
     &php.ini;. Ce dernier a déjà été traité lorsque
     vous commencez à exécuter votre script. Cette fonction
     peut vous permettre de lire vos propres fichiers de

--- a/reference/filesystem/functions/pathinfo.xml
+++ b/reference/filesystem/functions/pathinfo.xml
@@ -29,9 +29,9 @@
   </note>
   <note>
    <para>
-    <function>pathinfo</function> opère naivement sur la chaîne d'entrée,
+    <function>pathinfo</function> opère naïvement sur la chaîne d'entrée,
     et n'est pas conscient des systèmes de fichiers actuel, ou des composants
-    de chemins tel que "<literal>..</literal>".
+    de chemins tels que "<literal>..</literal>".
    </para>
   </note>
   <note>

--- a/reference/filesystem/functions/realpath.xml
+++ b/reference/filesystem/functions/realpath.xml
@@ -79,8 +79,8 @@
   </note>
   <note>
    <para>
-    Sur Windows, les jonctions et les liens symbolics aux dossiers sont
-    uniquement étendu d'un niveau.
+    Sur Windows, les jonctions et les liens symboliques aux dossiers sont
+    uniquement étendus d'un niveau.
    </para>
   </note>
   &fs.file.32bit;

--- a/reference/ftp/functions/ftp-alloc.xml
+++ b/reference/ftp/functions/ftp-alloc.xml
@@ -16,7 +16,7 @@
   </methodsynopsis>
   <para>
    <function>ftp_alloc</function> envoie la commande FTP <literal>ALLO</literal>
-   pour allouer un espace sur le serveur FTP de <parameter>filesize</parameter>
+   pour allouer un espace sur le serveur FTP de <parameter>size</parameter>
    octets.
   </para>
   <note>

--- a/reference/ftp/functions/ftp-fget.xml
+++ b/reference/ftp/functions/ftp-fget.xml
@@ -90,7 +90,7 @@
      <row>
       <entry>7.3.0</entry>
       <entry>
-       Le paramètre <parameter>mode</parameter> est maintenant optionel. Précédemment il
+       Le paramètre <parameter>mode</parameter> est maintenant optionnel. Précédemment il
        était obligatoire.
       </entry>
      </row>

--- a/reference/ftp/functions/ftp-mkdir.xml
+++ b/reference/ftp/functions/ftp-mkdir.xml
@@ -85,7 +85,7 @@ $dir = 'www';
 // Mise en place d'une connexion basique
 $ftp = ftp_connect($ftp_server);
 
-// Identication avec un nom d'utilisateur et un mot de passe
+// Identification avec un nom d'utilisateur et un mot de passe
 $login_result = ftp_login($ftp, $ftp_user_name, $ftp_user_pass);
 
 // Tentative de création du dossier $dir

--- a/reference/ftp/functions/ftp-mlsd.xml
+++ b/reference/ftp/functions/ftp-mlsd.xml
@@ -75,7 +75,7 @@ $ftp = ftp_connect($ftp_server);
 // connexion avec un nom d'utilisateur et un mot de passe
 $login_result = ftp_login($ftp, $ftp_user_name, $ftp_user_pass);
 
-// récupère le contenue du dossier courant
+// récupère le contenu du dossier courant
 $contents = ftp_mlsd($ftp, ".");
 
 // affiche $contents

--- a/reference/ftp/functions/ftp-nb-fput.xml
+++ b/reference/ftp/functions/ftp-nb-fput.xml
@@ -98,7 +98,7 @@
      <row>
       <entry>7.3.0</entry>
       <entry>
-       Le paramètre <parameter>mode</parameter> est maintenant optionel. Précédemment il
+       Le paramètre <parameter>mode</parameter> est maintenant optionnel. Précédemment il
        était obligatoire.
       </entry>
      </row>

--- a/reference/ftp/functions/ftp-nb-put.xml
+++ b/reference/ftp/functions/ftp-nb-put.xml
@@ -97,7 +97,7 @@
      <row>
       <entry>7.3.0</entry>
       <entry>
-       Le paramètre <parameter>mode</parameter> est maintenant optionel. Précédemment il
+       Le paramètre <parameter>mode</parameter> est maintenant optionnel. Précédemment il
        était obligatoire.
       </entry>
      </row>

--- a/reference/funchand/functions/call-user-func-array.xml
+++ b/reference/funchand/functions/call-user-func-array.xml
@@ -132,7 +132,7 @@ foo::bar got three and four
     </screen>
    </example>
    <example>
-    <title>Exemple avec <function>call_user_func_array</function> en utilisant un espace de nom</title>
+    <title>Exemple avec <function>call_user_func_array</function> en utilisant un espace de noms</title>
     <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/gmp/functions/gmp-neg.xml
+++ b/reference/gmp/functions/gmp-neg.xml
@@ -15,7 +15,7 @@
    <methodparam><type class="union"><type>GMP</type><type>int</type><type>string</type></type><parameter>num</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Retourne l'opposé de <parameter>a</parameter> (-1 * <parameter>a</parameter>).
+   Retourne l'opposé d'un nombre.
   </para>
  </refsect1>
 

--- a/reference/gmp/functions/gmp-or.xml
+++ b/reference/gmp/functions/gmp-or.xml
@@ -16,7 +16,7 @@
    <methodparam><type class="union"><type>GMP</type><type>int</type><type>string</type></type><parameter>num2</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Calcule le OU logique de <parameter>a</parameter> et <parameter>b</parameter>.
+   Calcule le OU logique de deux nombres GMP.
   </para>
  </refsect1>
 

--- a/reference/gmp/functions/gmp-random-seed.xml
+++ b/reference/gmp/functions/gmp-random-seed.xml
@@ -65,7 +65,7 @@
      <row>
       <entry>8.0.0</entry>
       <entry>
-       Si le paramètre <parameter>seed</parameter> est invalide, <function>gmd_random_seed</function>
+       Si le paramètre <parameter>seed</parameter> est invalide, <function>gmp_random_seed</function>
        lève une exception <classname>ValueError</classname> dorénavant.
        Précédemment une alerte <constant>E_WARNING</constant> était émise.
       </entry>

--- a/reference/gmp/functions/gmp-xor.xml
+++ b/reference/gmp/functions/gmp-xor.xml
@@ -16,8 +16,7 @@
    <methodparam><type class="union"><type>GMP</type><type>int</type><type>string</type></type><parameter>num2</parameter></methodparam>
   </methodsynopsis>
   <para>
-   calcule le OU exclusif logique de <parameter>a</parameter>
-   et <parameter>b</parameter>.
+   Calcule le OU exclusif logique (XOR) de deux nombres GMP.
   </para>
  </refsect1>
 

--- a/reference/hash/functions/hash-hmac-file.xml
+++ b/reference/hash/functions/hash-hmac-file.xml
@@ -100,19 +100,19 @@
      </thead>
      <tbody>
       <row>
-       <entry>7.2.0</entry>
-       <entry>
-        L'utilisation de fonctions de hachage non cryptographiques (adler32, 
-        crc32, crc32b, fnv132, fnv1a32, fnv164, fnv1a64, joaat) a été désactivée.
-       </entry>
-      </row>
-      <row>
        <entry>8.0.0</entry>
        <entry>
         Lève une exception <classname>ValueError</classname> dorénavant si
         le paramètre <parameter>algo</parameter> est inconnu ou n'est pas
         une fonction de hachage cryptographique; précédemment, &false;
         était retourné à la place.
+       </entry>
+      </row>
+      <row>
+       <entry>7.2.0</entry>
+       <entry>
+        L'utilisation de fonctions de hachage non cryptographiques (adler32,
+        crc32, crc32b, fnv132, fnv1a32, fnv164, fnv1a64, joaat) a été désactivée.
        </entry>
       </row>
      </tbody>

--- a/reference/hash/functions/hash-pbkdf2.xml
+++ b/reference/hash/functions/hash-pbkdf2.xml
@@ -123,7 +123,7 @@
    Une exception <classname>ValueError</classname> si 
    l'algorithme n'est pas connu, si le paramètre <parameter>iterations</parameter>
    est inférieur ou égal à <literal>0</literal>, si la longueur
-   <parameter>length</parameter> est inférieure ou égale à <literal>0</literal>
+   <parameter>length</parameter> est inférieure à <literal>0</literal>
    ou si le <parameter>salt</parameter> est trop long
    (plus grand que <constant>INT_MAX</constant><literal> - 4</literal>).
   </para>
@@ -142,19 +142,19 @@
      </thead>
      <tbody>
       <row>
-       <entry>7.2.0</entry>
-       <entry>
-        L'utilisation de fonctions de hachage non cryptographiques (adler32, 
-        crc32, crc32b, fnv132, fnv1a32, fnv164, fnv1a64, joaat) a été désactivée.
-       </entry>
-      </row>
-      <row>
-      <entry>8.0.0</entry>
+       <entry>8.0.0</entry>
        <entry>
         Lève une exception <classname>ValueError</classname> dorénavant en
         cas d'erreur.
         Précédemment, &false; était retourné et un message
         <constant>E_WARNING</constant> était émis.
+       </entry>
+      </row>
+      <row>
+       <entry>7.2.0</entry>
+       <entry>
+        L'utilisation de fonctions de hachage non cryptographiques (adler32,
+        crc32, crc32b, fnv132, fnv1a32, fnv164, fnv1a64, joaat) a été désactivée.
        </entry>
       </row>
      </tbody>

--- a/reference/image/functions/imagecopyresampled.xml
+++ b/reference/image/functions/imagecopyresampled.xml
@@ -222,7 +222,7 @@ $height = 200;
 // Content type
 header('Content-Type: image/jpeg');
 
-// Cacul des nouvelles dimensions
+// Calcul des nouvelles dimensions
 list($width_orig, $height_orig) = getimagesize($filename);
 
 $ratio_orig = $width_orig/$height_orig;
@@ -245,7 +245,7 @@ imagejpeg($image_p, null, 100);
     </programlisting>
     &example.outputs.similar;
     <mediaobject>
-     <alt>Affichage de l'exemple : Réchantillone une image proportionnellement</alt>
+     <alt>Affichage de l'exemple : Rééchantillonne une image proportionnellement</alt>
      <imageobject>
       <imagedata fileref="en/reference/image/figures/imagecopyresampled_2.jpg"/>
      </imageobject>

--- a/reference/image/functions/imagecreatetruecolor.xml
+++ b/reference/image/functions/imagecreatetruecolor.xml
@@ -92,7 +92,7 @@ imagepng($im);
     </programlisting>
     &example.outputs.similar;
     <mediaobject>
-     <alt>Affichage de l'exemple : Creating a new GD image stream and outputting an image.</alt>
+     <alt>Affichage de l'exemple : Création d'un flux d'image GD et affichage d'une image.</alt>
      <imageobject>
       <imagedata fileref="en/reference/image/figures/imagecreatetruecolor.png"/>
      </imageobject>

--- a/reference/image/setup.xml
+++ b/reference/image/setup.xml
@@ -21,7 +21,7 @@
    <note>
     <simpara>
      libgd-2.1.0 ou supérieur est requis. Alternativement, 
-     utilisez la bibliothèque <acronym>GD</acronym> fourni avec PHP.
+     utilisez la bibliothèque <acronym>GD</acronym> fournie avec PHP.
     </simpara>
    </note>
    <note>
@@ -111,7 +111,7 @@
   <para>
    Cette extension définit les types de ressources suivantes :
    <table>
-   <title>Liste des ressource dans GD</title>
+   <title>Liste des ressources dans GD</title>
     <tgroup cols="3">
      <thead>
       <row>

--- a/reference/imap/setup.xml
+++ b/reference/imap/setup.xml
@@ -24,8 +24,8 @@
    <filename>*.h</filename> dans le dossier <filename>include/</filename>
    et tous les fichiers <filename>*.c</filename> dans le dossier
    <filename>lib/</filename>. Additionnellement, lorsque vous compilez IMAP, un
-   fichier nommé <filename>c-client.a</filename> est crée. Mettez le également
-   dans le dossier <filename>lib/</filename> mais renommez le en
+   fichier nommé <filename>c-client.a</filename> est créé. Mettez-le également
+   dans le dossier <filename>lib/</filename> mais renommez-le en
    <filename>libc-client.a</filename>.
   </para>
   <note>

--- a/reference/info/functions/assert.xml
+++ b/reference/info/functions/assert.xml
@@ -291,7 +291,7 @@
        <entry>8.0.0</entry>
        <entry>
         Déclarer une fonction qui s'appelle <literal>assert()</literal> à
-        l'intérieur d'un espace de nom n'est plus autorisé, et génère
+        l'intérieur d'un espace de noms n'est plus autorisé, et génère
         une <constant>E_COMPILE_ERROR</constant>.
        </entry>
       </row>
@@ -299,7 +299,7 @@
        <entry>7.3.0</entry>
        <entry>
         Déclarer une fonction qui s'appelle <literal>assert()</literal> à
-        l'intérieur d'un espace de nom est devenue obsolète. De telles
+        l'intérieur d'un espace de noms est devenue obsolète. De telles
         déclarations génèrent désormais une <constant>E_DEPRECATED</constant>.
        </entry>
       </row>

--- a/reference/info/functions/getopt.xml
+++ b/reference/info/functions/getopt.xml
@@ -87,8 +87,8 @@
    Le tableau de valeurs <parameter>long_options</parameter> peut contenir :
    <simplelist>
     <member>String (paramètre n'accepte aucune valeur)</member>
-    <member>String suivit d'un deux-point (paramètre nécessite une valeur)</member>
-    <member>String suivit de deux deux-points (valeur optionnel)</member>
+    <member>String suivi d'un deux-point (paramètre nécessite une valeur)</member>
+    <member>String suivi de deux deux-points (valeur optionnel)</member>
    </simplelist>
   </para>
   <note>

--- a/reference/info/functions/version-compare.xml
+++ b/reference/info/functions/version-compare.xml
@@ -148,7 +148,7 @@ if (version_compare(PHP_VERSION, '5.0.0', '<')) {
    <para>
     Les chaînes spéciales de version comme <literal>alpha</literal> et
     <literal>beta</literal> sont sensibles à la casse. Les chaînes de version
-    issues de sources arbitraires qui n'adhère pas au standard PHP
+    issues de sources arbitraires qui n'adhèrent pas au standard PHP
     doivent être mises en minuscule en utilisant la fonction
     <function>strtolower</function> avant d'appeler la fonction
     <function>version_compare</function>.

--- a/reference/intl/book.xml
+++ b/reference/intl/book.xml
@@ -46,8 +46,7 @@
     <simpara>
      Number Formatter : permet d'afficher des nombres en fonction des conventions
      locales, ou de modèles particuliers, ou encore de règles d'affichages.
-     Il peut gérer les pluriels,
-      nombres, devises, conditions et bien plus encore.
+     et d'analyser des chaînes pour en extraire des nombres.
     </simpara>
    </listitem>
    <listitem>
@@ -55,7 +54,8 @@
      Message Formatter : permet de créer des messages en incorporant des
      données (comme des dates ou des nombres) formatées en fonction des conventions
      locale ou particulières; permet aussi d'analyser des textes pour extraire
-     ces informations.
+     ces informations. Il peut gérer les pluriels, les nombres, les devises,
+     les conditions et bien plus encore.
     </simpara>
    </listitem>
    <listitem>
@@ -75,9 +75,9 @@
     <simpara>
      Calendar: fournit une classe qui peut être utilisée pour
      les opérations de régionalisation du calendrier, et
-     obtenir des informations variées tel que le fuseau horaire pour
+     obtenir des informations variées telles que le fuseau horaire pour
      la locale choisie, le premier jour de la semaine, ou si le
-     changement d'heure (été/hiver) est activée.
+     changement d'heure (été/hiver) est actif.
     </simpara>
    </listitem>
    <listitem>

--- a/reference/json/functions/json-decode.xml
+++ b/reference/json/functions/json-decode.xml
@@ -132,7 +132,7 @@
        <entry>
         Les <parameter>flags</parameter>
         <constant>JSON_INVALID_UTF8_IGNORE</constant>, et
-        <constant>JSON_INVALID_UTF8_SUBSTITUTE</constant> ont été ajouté.
+        <constant>JSON_INVALID_UTF8_SUBSTITUTE</constant> ont été ajoutés.
        </entry>
       </row>
       <row>

--- a/reference/json/functions/json-last-error.xml
+++ b/reference/json/functions/json-last-error.xml
@@ -84,7 +84,7 @@
        Une ou plusieurs valeurs
        <link linkend="language.types.float.nan"><constant>NAN</constant></link>
        ou <link linkend="function.is-infinite"><constant>INF</constant></link>
-       sont présentes dans la valeurs à encoder.
+       sont présentes dans la valeur à encoder.
       </entry>
       <entry></entry>
      </row>

--- a/reference/libxml/constants.xml
+++ b/reference/libxml/constants.xml
@@ -87,7 +87,7 @@
     <caution>
      <simpara>
       Activer la validation du DTD peut faciliter les attaques par entités externes XML (XXE).
-      La constante <constant>LIBXML_NO_XXE</constant> peut être utilisée pour empêcher cela (disponible uniquement dans Libxml >= 2.13.0, à partir de PHP 8.4.0).
+      La constante <constant>LIBXML_NO_XXE</constant> peut être utilisée pour empêcher cela (disponible uniquement dans Libxml &gt;= 2.13.0, à partir de PHP 8.4.0).
      </simpara>
     </caution>
    </listitem>

--- a/reference/libxml/setup.xml
+++ b/reference/libxml/setup.xml
@@ -11,7 +11,7 @@
   &reftitle.required;
   <para>
    Cette extension requiert <link xlink:href="&url.libxml;">libxml</link> &gt;=
-   2.9.4 à partir de PHP 8.4.0, libxml &gt;= 2.9.0 à partir de PHP 8.0.0. Avant PHP 8.0, libxml doit être &gt;= 2.6.0.
+   2.9.4 à partir de PHP 8.4.0, libxml &gt;= 2.9.0 avant PHP 8.4.0, et libxml &gt;= 2.6.0 avant PHP 8.0.0.
   </para>
  </section>
  <!-- }}} -->

--- a/reference/mbstring/constants.xml
+++ b/reference/mbstring/constants.xml
@@ -48,7 +48,7 @@
    <listitem>
     <simpara>
      Convertit tous les caractères en majuscule.
-     Ceci modifie la longueur de la chaîne.
+     Ceci peut modifier la longueur de la chaîne.
      C'est le mode utilisé par la fonction mb_strtoupper().     
     </simpara>
    </listitem>
@@ -61,7 +61,7 @@
    <listitem>
     <simpara>
      Convertit tous les caractères en minuscule.
-     Ceci modifie la longueur de la chaîne.
+     Ceci peut modifier la longueur de la chaîne.
      C'est le mode utilisé par la fonction mb_strtolower().   
     </simpara>
    </listitem>
@@ -76,7 +76,7 @@
      Réalise une conversion de la casse du titre, basé sur les propriétés
      unicode Cased et CaseIgnorable.
      En particulier, ceci améliore la gestion des guillemets et des apostrophes.
-     Ceci peut modifier la longueur de la chaînes.
+     Ceci peut modifier la longueur de la chaîne.
      
     </simpara>
    </listitem>

--- a/reference/mbstring/functions/mb-detect-encoding.xml
+++ b/reference/mbstring/functions/mb-detect-encoding.xml
@@ -151,7 +151,7 @@ var_dump(mb_detect_encoding($str, "auto"));
 // Spécifie le paramètre "encodings" avec une liste à virgules
 var_dump(mb_detect_encoding($str, "JIS, eucjp-win, sjis-win"));
 
-// Utilisation d'un tableau pour spécifie le paramètre "encodings"
+// Utilisation d'un tableau pour spécifier le paramètre "encodings"
 $encodings = [
   "ASCII",
   "JIS",
@@ -178,7 +178,7 @@ string(5) "ASCII"
     <programlisting role="php">
 <![CDATA[
 <?php
-// 'áéóú' encodées in ISO-8859-1
+// 'áéóú' encodées en ISO-8859-1
 $str = "\xE1\xE9\xF3\xFA";
 
 // La chaîne n'est pas valide en ASCII ou UTF-8, mais l'UTF-8 est considéré comme une correspondance plus proche

--- a/reference/mbstring/functions/mb-ereg-replace-callback.xml
+++ b/reference/mbstring/functions/mb-ereg-replace-callback.xml
@@ -62,7 +62,7 @@
         déclarer une fonction de rappel lors de l'appel de la fonction
         <function>mb_ereg_replace_callback</function>. En faisait cela de cette manière
         vous avez toutes les informations nécessaires à l'appel de la fonction
-        en un seul endroit, ce qui permet d'éviter d'encombrer l'espace de nom
+        en un seul endroit, ce qui permet d'éviter d'encombrer l'espace de noms
         des fonctions avec un callback de fonction qui n'est pas utilisé ailleur.
       </para>
      </listitem>

--- a/reference/mbstring/functions/mb-strpos.xml
+++ b/reference/mbstring/functions/mb-strpos.xml
@@ -37,7 +37,7 @@
      <term><parameter>haystack</parameter></term>
      <listitem>
       <para>
-       La chaîne sur laquelle récupéré la position de la première occurrence
+       La chaîne dans laquelle récupérer la position de la première occurrence
        de <parameter>needle</parameter>
       </para>
      </listitem>

--- a/reference/mcrypt/setup.xml
+++ b/reference/mcrypt/setup.xml
@@ -16,11 +16,11 @@
    et suivez les instructions d'installation fournies.
   </simpara>
   <simpara>
-   La version 2.5.6 ou suivant de la bibliothèque libmcrypt est requise.
+   La version 2.5.6 ou suivante de la bibliothèque libmcrypt est requise.
   </simpara>
   <simpara>
    Les utilisateurs de Windows trouveront la bibliothèque dans la version Windows
-   de PHP 5.3. La version binaire Windows de PHP 5.3 utilise la version statique
+   de PHP 5.2. La version binaire Windows de PHP 5.3 utilise la version statique
    de la bibliothèque MCrypt, aucune DLL n'est nécessaire.
   </simpara>
   <simpara>

--- a/reference/memcached/constants.xml
+++ b/reference/memcached/constants.xml
@@ -488,7 +488,7 @@
      où vous utilisez un socket non bloquant, cela vous permettra d'avoir
      des délais d'expiration en réception de données, malgré tout.
     </simpara>
-    <para>Type : &integer;, par défaut : <literal>0</literal>.</para>
+    <para>Type : <type>int</type>, par défaut : <literal>0</literal>.</para>
    </listitem>
   </varlistentry>
 
@@ -498,7 +498,7 @@
     <simpara>
      Délai d'expiration pour le polling de connexions, en millisecondes.
     </simpara>
-    <para>Type : &integer;, par défaut : <literal>1000</literal>.</para>
+    <para>Type : <type>int</type>, par défaut : <literal>1000</literal>.</para>
    </listitem>
   </varlistentry>
 
@@ -508,7 +508,7 @@
     <simpara>
      Active ou non le cache de DNS.
     </simpara>
-    <para>Type : &boolean;, par défaut : &false;.</para>
+    <para>Type : <type>bool</type>, par défaut : &false;.</para>
    </listitem>
   </varlistentry>
 
@@ -519,7 +519,7 @@
      Spécifie la limite du nombre d'échec de connexions. Le serveur sera
      alors retiré de la liste après autant d'échec de connexions en succession.
     </simpara>
-    <para>Type : &integer;, par défaut : <literal>5</literal>.</para>
+    <para>Type : <type>int</type>, par défaut : <literal>5</literal>.</para>
    </listitem>
   </varlistentry>
   <varlistentry xml:id="memcached.constants.opt-server-timeout-limit">

--- a/reference/misc/functions/ignore-user-abort.xml
+++ b/reference/misc/functions/ignore-user-abort.xml
@@ -35,7 +35,7 @@
      <term><parameter>enable</parameter></term>
      <listitem>
       <para>
-       Si définis et non &null;, la fonction va attribuer à la directive
+       Si défini et non &null;, la fonction va attribuer à la directive
        <link linkend="ini.ignore-user-abort">ignore_user_abort</link> la 
        valeur de <parameter>enable</parameter>. Si omis, cette
        fonction ne fait que retourner la valeur de la configuration
@@ -93,7 +93,7 @@ echo 'Test du gestionnaire de connexion de PHP';
 
 // Exécution d'une boucle infinie surveillant
 // l'activité de l'utilisateur. Soit il clique en dehors
-// de la page, soit il clique sur le boutton "Stop".
+// de la page, soit il clique sur le bouton "Stop".
 while(1)
 {
     // La connexion a-t-elle échoué ?
@@ -110,7 +110,7 @@ while(1)
 // sera lancée depuis la boucle infinie
 
 // Aussi, nous pouvons à ce niveau entrer des informations dans l'historique,
-// ou exécuter d'autres taches nécessaires, sans pour autant être dépendant
+// ou exécuter d'autres tâches nécessaires, sans pour autant être dépendant
 // du navigateur.
 ?>
 ]]>

--- a/reference/misc/functions/pack.xml
+++ b/reference/misc/functions/pack.xml
@@ -142,11 +142,11 @@
           </row>
           <row>
            <entry>g</entry>
-           <entry>nombre à virgule flottante (taille dépendantes de la machine, ordre des octets little endian)</entry>
+           <entry>nombre à virgule flottante (taille dépendante de la machine, ordre des octets little endian)</entry>
           </row>
           <row>
            <entry>G</entry>
-           <entry>nombre à virgule flottante (taille dépendantes de la machine, ordre des octets big endian)</entry>
+           <entry>nombre à virgule flottante (taille dépendante de la machine, ordre des octets big endian)</entry>
           </row>
           <row>
            <entry>d</entry>
@@ -154,11 +154,11 @@
           </row>
           <row>
            <entry>e</entry>
-           <entry>nombre à virgule flottante double (taille dépendantes de la machine, ordre des octets little endian)</entry>
+           <entry>nombre à virgule flottante double (taille dépendante de la machine, ordre des octets little endian)</entry>
           </row>
           <row>
            <entry>E</entry>
-           <entry>nombre à virgule flottante double (taille dépendantes de la machine, ordre des octets big endian)</entry>
+           <entry>nombre à virgule flottante double (taille dépendante de la machine, ordre des octets big endian)</entry>
           </row>
           <row>
            <entry>x</entry>
@@ -170,7 +170,7 @@
           </row>
           <row>
            <entry>Z</entry>
-           <entry>La chaîne terminée par NUL (ASCIIZ) sera complétée la valeur NULL</entry>
+           <entry>La chaîne terminée par NUL (ASCIIZ) sera complétée par la valeur NULL</entry>
           </row>
           <row>
            <entry>@</entry>
@@ -227,7 +227,7 @@
       <row>
        <entry>7.0.15, 7.1.1</entry>
        <entry>
-        Les codes "e", "E", "g" and "G" ont été ajoutés pour activer la prise en 
+        Les codes "e", "E", "g" et "G" ont été ajoutés pour activer la prise en 
         charge de l'ordre des octets pour les nombres à virgule flottante simple 
         et double précision.
        </entry>

--- a/reference/misc/functions/sapi-windows-cp-conv.xml
+++ b/reference/misc/functions/sapi-windows-cp-conv.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="function.sapi-windows-cp-conv" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>sapi_windows_cp_conv</refname>
-  <refpurpose>Convertit une chaîne d'une page de code à un autre</refpurpose>
+  <refpurpose>Convertit une chaîne d'une page de code à une autre</refpurpose>
  </refnamediv>
 
  <refsect1 role="description"><!-- {{{ -->
@@ -16,7 +16,7 @@
    <methodparam><type>string</type><parameter>subject</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Convertit une chaîne d'une page de code à un autre.
+   Convertit une chaîne d'une page de code à une autre.
   </para>
  </refsect1><!-- }}} -->
 
@@ -36,7 +36,7 @@
     <term><parameter>out_codepage</parameter></term>
     <listitem>
      <para>
-      La page de code dans lequel convertir la chaîne <parameter>subject</parameter>.
+      La page de code dans laquelle convertir la chaîne <parameter>subject</parameter>.
       Soit le nom, soit l'identifiant de la page de code.
      </para>
     </listitem>

--- a/reference/misc/functions/sapi-windows-set-ctrl-handler.xml
+++ b/reference/misc/functions/sapi-windows-set-ctrl-handler.xml
@@ -95,7 +95,7 @@
   <example xml:id="sapi-windows-set-ctrl-handler.example.basic">
    <title>Utilisation basique de <function>sapi_windows_set_ctrl_handler</function></title>
    <para>
-     Cette exemple montre comment intercepter les événements <literal>CTRL</literal>.
+     Cet exemple montre comment intercepter les événements <literal>CTRL</literal>.
    </para>
    <programlisting role="php">
 <![CDATA[

--- a/reference/misc/functions/sapi-windows-vt100-support.xml
+++ b/reference/misc/functions/sapi-windows-vt100-support.xml
@@ -81,7 +81,7 @@
      <row>
       <entry>8.0.0</entry>
       <entry>
-       <parameter>enable</parameter> est déormais nullable.
+       <parameter>enable</parameter> est désormais nullable.
       </entry>
      </row>
     </tbody>

--- a/reference/mongodb/mongodb/driver/exception/bulkwritecommandexception.xml
+++ b/reference/mongodb/mongodb/driver/exception/bulkwritecommandexception.xml
@@ -93,7 +93,7 @@
      <term><varname>errorReply</varname></term>
      <listitem>
       <para>
-       Chacune des erreurs du plus haut niveau qui ont eu lieu lors de l'essaie de la communication
+       Chacune des erreurs du plus haut niveau qui ont eu lieu lors de l'essai de la communication
        avec le serveur ou de l'exécution de l'écriture en masse. Cette valeur peut être &null; si
        l'exception a été lancée à cause d'erreurs survenant lors d'écritures individuelles.
       </para>
@@ -117,7 +117,7 @@
       <para>
        Un tableau de chacun des <classname>MongoDB\Driver\WriteConcernError</classname>s
        qui se sont produits lors de l'exécution de l'écriture en masse. Cette liste peut avoir
-       plusieurs entréss si plus d'une commande serveur a été requise pour exécuter
+       plusieurs entrées si plus d'une commande serveur a été requise pour exécuter
        l'écriture en masse.
       </para>
      </listitem>

--- a/reference/mongodb/mongodb/driver/exception/bulkwritecommandexception/geterrorreply.xml
+++ b/reference/mongodb/mongodb/driver/exception/bulkwritecommandexception/geterrorreply.xml
@@ -26,7 +26,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Renvoie une erreur de commande de niveau supérieur qui s'est produite lors de l'essaie de communication
+   Renvoie une erreur de commande de niveau supérieur qui s'est produite lors de l'essai de communication
    avec le serveur ou d'exécution de l'écriture en masse. Cette valeur peut être &null; si l'exception
    a été lancée en raison d'erreurs survenant sur des écritures individuelles.
   </para>

--- a/reference/mongodb/mongodb/driver/exception/bulkwritecommandexception/getwriteconcernerrors.xml
+++ b/reference/mongodb/mongodb/driver/exception/bulkwritecommandexception/getwriteconcernerrors.xml
@@ -27,8 +27,8 @@
   &reftitle.returnvalues;
   <para>
    Un tableau de chacun des <classname>MongoDB\Driver\WriteConcernError</classname>s
-   qui se sont produite lors de l'exécution de l'écriture en masse. Cette liste peut avoir
-   plusieurs entrés si plus d'une commande de serveur était nécessaire pour exécuter l'écriture
+   qui se sont produits lors de l'exécution de l'écriture en masse. Cette liste peut avoir
+   plusieurs entrées si plus d'une commande de serveur était nécessaire pour exécuter l'écriture
    en masse.
   </para>
  </refsect1>

--- a/reference/mongodb/mongodb/driver/exception/bulkwritecommandexception/getwriteerrors.xml
+++ b/reference/mongodb/mongodb/driver/exception/bulkwritecommandexception/getwriteerrors.xml
@@ -27,9 +27,8 @@
   &reftitle.returnvalues;
   <para>
    Un tableau de <classname>MongoDB\Driver\WriteError</classname>s qui se
-   sont produite lors de l'exécution de l'écriture individuelle. Les clés de tableau
+   sont produits lors de l'exécution de l'écriture individuelle. Les clés de tableau
    correspondent à l'index de l'opération d'écriture dans
-   will correspond to the index of the write operation from
    <classname>MongoDB\Driver\BulkWriteCommand</classname>. Cette liste
    contiendra au plus une entrée si l'écriture en masse était ordonnée.
   </para>

--- a/reference/mongodb/mongodb/driver/manager/executereadwritecommand.xml
+++ b/reference/mongodb/mongodb/driver/manager/executereadwritecommand.xml
@@ -22,7 +22,7 @@
    Cette méthode appliquera une logique spécifique aux commandes qui lisent et écrivent
    (par exemple <link xlink:href="&url.mongodb.docs;reference/command/aggregate/">aggregate</link>).
    Les valeurs par défaut des options <literal>"readConcern"</literal> et
-   <literal>"writeConcern"</literal> seront déduites à à partir d'une transaction active
+   <literal>"writeConcern"</literal> seront déduites à partir d'une transaction active
    (indiquée par l'option <literal>"session"</literal>), suivie de l'
    <link linkend="mongodb-driver-manager.construct-uri">URI de connexion</link>.
   </para>

--- a/reference/mysqli/configure.xml
+++ b/reference/mysqli/configure.xml
@@ -26,7 +26,7 @@ xmlns:xlink="http://www.w3.org/1999/xlink">
   
   <para>
    Par exemple, sur Ubuntu le package <literal>php5-mysql</literal> installe les
-   extensions PHP ext/mysql, ext/mysqli, et pdo_mysqls. Sur CentOS, le package 
+   extensions PHP ext/mysql, ext/mysqli, et pdo_mysql. Sur CentOS, le package 
    <literal>php-mysql</literal> installe aussi ces trois extensions PHP.
   </para>
   
@@ -37,7 +37,7 @@ xmlns:xlink="http://www.w3.org/1999/xlink">
   </para>
   
   <para>
-   Le driver natif MySQL est la bibliothèque client recommandé, vu qu'il apporte
+   Le driver natif MySQL est la bibliothèque cliente recommandée, vu qu'il apporte
    un gain de performance et donne l'accès à des fonctionnalités
    qui ne sont pas disponibles lors de l'utilisation de la bibliothèque
    cliente MySQL. Reportez-vous à la section

--- a/reference/mysqli/constants.xml
+++ b/reference/mysqli/constants.xml
@@ -72,7 +72,7 @@
     </term>
     <listitem>
      <para>
-      Résultat d'exécution durée d'expiration d'une commande en secondes.
+      Durée d'expiration du résultat d'exécution d'une commande en secondes.
       Disponible à partir de PHP 7.2.0.
      </para>
     </listitem>
@@ -95,7 +95,7 @@
     </term>
     <listitem>
      <para>
-      Convertie les colonnes de type entier et nombre à virgule flottante en
+      Convertit les colonnes de type entier et nombre à virgule flottante en
       nombres PHP. Seulement valide pour mysqlnd.
      </para>
     </listitem>
@@ -119,7 +119,7 @@
     <listitem>
      <para>
       Taille en octets de la portion maximale à lire, lors de la lecture
-      du corps d'un packet de commande MySQL. Seulement valide pour mysqlnd.
+      du corps d'un paquet de commande MySQL. Seulement valide pour mysqlnd.
      </para>
     </listitem>
    </varlistentry>
@@ -773,7 +773,7 @@
    </term>
    <listitem>
     <para>
-     Le champ est de type <literal>STRING</literal> ou <literal>BINARY</literal>.
+     Le champ est de type <literal>CHAR</literal> ou <literal>BINARY</literal>.
     </para>
    </listitem>
   </varlistentry>
@@ -1001,7 +1001,7 @@
    <listitem>
     <para>
      Définit à 1 si la fonctionnalité <function>mysqli_debug</function>
-     est désactivée.
+     est activée.
     </para>
    </listitem>
   </varlistentry>
@@ -1022,7 +1022,7 @@
    </term>
    <listitem>
     <para>
-     Rafraîchie les tables GRANT.
+     Rafraîchit les tables GRANT.
      Obsolète à partir de PHP 8.4.0.
     </para>
    </listitem>

--- a/reference/mysqli/persistconns.xml
+++ b/reference/mysqli/persistconns.xml
@@ -90,7 +90,7 @@
  </para>
 
  <para>
-  L'extension <literal>mysqli</literal> effectue ce nettoyage e
+  L'extension <literal>mysqli</literal> effectue ce nettoyage en
   appelant automatiquement la fonction C <literal>mysql_change_user()</literal>.
  </para>
 

--- a/reference/mysqlnd/book.xml
+++ b/reference/mysqlnd/book.xml
@@ -24,7 +24,7 @@
    PDO MYSQL, communiquent avec le serveur MySQL. Dans le passé, ces
    actions étaient réalisées par l'extension, en utilisant les services
    fournis par la bibliothèque cliente MySQL. Les extensions étaient ainsi
-   compilées avec la bibliothèque cliente MySQL afin de pouvoir utilisées
+   compilées avec la bibliothèque cliente MySQL afin de pouvoir utiliser
    son protocole client-serveur.
   </simpara>
   <simpara>

--- a/reference/network/functions/dns-get-record.xml
+++ b/reference/network/functions/dns-get-record.xml
@@ -114,7 +114,7 @@
       <row>
        <entry>host</entry>
        <entry>
-        L'enregistrement de l'espace de nom DNS qui est décrit par les autres
+        L'enregistrement de l'espace de noms DNS qui est décrit par les autres
         données.
        </entry>
       </row>

--- a/reference/network/functions/headers-sent.xml
+++ b/reference/network/functions/headers-sent.xml
@@ -43,7 +43,7 @@
       <note>
        <para>
         Si l'affichage a commencé avant l'exécution du fichier source PHP (par exemple en raison d'une erreur de démarrage),
-        le paramètre <parameter>nom du fichier</parameter> sera défini comme une chaîne vide.
+        le paramètre <parameter>filename</parameter> sera défini comme une chaîne vide.
        </para>
       </note>
      </listitem>

--- a/reference/network/functions/inet-pton.xml
+++ b/reference/network/functions/inet-pton.xml
@@ -42,9 +42,9 @@
   <para>
    Retourne la représentation <literal>in_addr</literal> de l'adresse
    fournie par le paramètre <parameter>ip</parameter> ou &false;
-   si le paramètre <parameter>ip</parameter> fourni a une synthaxe
+   si le paramètre <parameter>ip</parameter> fourni a une syntaxe
    invalide (par exemple, une adresse IPv4 sans point, ou une adresse
-   IPv6 sans virgule).
+   IPv6 sans deux-points).
   </para>
  </refsect1>
 

--- a/reference/network/functions/setrawcookie.xml
+++ b/reference/network/functions/setrawcookie.xml
@@ -64,7 +64,7 @@
        <entry>7.3.0</entry>
        <entry>
         Une signature alternative supportant un tableau 
-        d'<parameter>options</parameter> a été ajouté. Cette signature supporte
+        d'<parameter>options</parameter> a été ajoutée. Cette signature supporte
         la définition de l'attribut SameSite du cookie.
        </entry>
       </row>

--- a/reference/oci8/functions/oci-connect.xml
+++ b/reference/oci8/functions/oci-connect.xml
@@ -23,7 +23,7 @@
   </para>
   <para>
    Pour les performances, la plupart des applications devraient utiliser les
-   connexions persistentes avec <function>oci_pconnect</function> au lieu de
+   connexions persistantes avec <function>oci_pconnect</function> au lieu de
    <function>oci_connect</function>.
    Voir la section sur <link linkend="oci8.connection">la gestion des connexions</link>
    pour des informations générales sur la gestion des connexions et le
@@ -152,7 +152,7 @@ echo "</table>\n";
 <?php
 
 // Connexion à la base de données MYDB décrite dans le fichier tnsnames.ora,
-// Un exemple d'entrée tnsnames.ora pour MYDB pourraît être :
+// Un exemple d'entrée tnsnames.ora pour MYDB pourrait être :
 //   MYDB =
 //     (DESCRIPTION =
 //       (ADDRESS = (PROTOCOL = TCP)(HOST = mymachine.oracle.com)(PORT = 1521))

--- a/reference/openssl/constants.xml
+++ b/reference/openssl/constants.xml
@@ -90,7 +90,7 @@
  </section>
  
  <section xml:id="openssl.padding">
-  <title>Options de remplissage (<literal>Padding</literal>) pour le cryptage asymétrique</title>
+  <title>Options de remplissage (<literal>Padding</literal>) pour le chiffrement asymétrique</title>
   <variablelist>
    <varlistentry xml:id="constant.openssl-pkcs1-padding">
     <term>
@@ -391,9 +391,9 @@
   <title>Drapeaux/Constantes <acronym>CMS</acronym></title>
   <para>
    Les fonctions CMS utilisent des drapeaux qui sont spécifiés en utilisant
-   un masque de bit qui inclus une ou plusieurs des valeurs suivantes :
+   un masque de bit qui inclut une ou plusieurs des valeurs suivantes :
    <table>
-    <title><acronym>CMS</acronym> CONSTANTS</title>
+    <title>Constantes <acronym>CMS</acronym></title>
     <tgroup cols="2">
      <thead>
       <row>
@@ -824,13 +824,13 @@
       </term>
       <listitem>
         <simpara>
-         Par défaut, les opérations de cryptage sont complétées en utilisant
+         Par défaut, les opérations de chiffrement sont complétées en utilisant
          des blocs standards et la complétion est vérifiée et supprimée
-         lors du décryptage. Si la constante <constant>OPENSSL_ZERO_PADDING</constant>
+         lors du déchiffrement. Si la constante <constant>OPENSSL_ZERO_PADDING</constant>
          est définie dans le paramètre <parameter>options</parameter> de la fonction
          <function>openssl_encrypt</function> ou <function>openssl_decrypt</function>
          alors aucune complétion ne sera réalisée, la quantité totale
-         de données cryptées devra alors être un multiple de la taille du bloc
+         de données chiffrées devra alors être un multiple de la taille du bloc
          ou bien une erreur surviendra.
         </simpara>
       </listitem>

--- a/reference/openssl/functions/openssl-decrypt.xml
+++ b/reference/openssl/functions/openssl-decrypt.xml
@@ -81,8 +81,8 @@
      <listitem>
       <para>
        Un vecteur d'initialisation non-&null;. Si le VI est plus court que prévu, il est complété avec
-       des caractères <literal>NUL</literal> et un avertissement est émis ; si la phrase de passe est plus longue
-       que prévu, elle est tronquée et un avertissement est émis.
+       des caractères <literal>NUL</literal> et un avertissement est émis ; si le VI est plus long
+       que prévu, il est tronqué et un avertissement est émis.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/openssl/functions/openssl-encrypt.xml
+++ b/reference/openssl/functions/openssl-encrypt.xml
@@ -52,7 +52,7 @@
      <listitem>
       <para>
        La passphrase. Si la passphrase est plus courte qu'attendu, elle est silencieusement
-       capitonnée avec des caractères <literal>NUL</literal> ; si la passphrase est plus longue
+       complétée avec des caractères <literal>NUL</literal> ; si la passphrase est plus longue
        qu'attendu, elle est silencieusement tronquée.
       </para>
       <caution>
@@ -80,8 +80,8 @@
      <listitem>
       <para>
        Un vecteur d'initialisation non-&null;. Si le VI est plus court que prévu, il est complété par des
-       caractères <literal>NUL</literal> et un avertissement est émis ; si la phrase secrète est plus longue
-       que prévu, elle est tronquée et un avertissement est émis.
+       caractères <literal>NUL</literal> et un avertissement est émis ; si le VI est plus long
+       que prévu, il est tronqué et un avertissement est émis.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/password/functions/password-hash.xml
+++ b/reference/password/functions/password-hash.xml
@@ -99,7 +99,7 @@
     <listitem>
      <para>
       <literal>memory_cost</literal> (<type>int</type>) - Mémoire maximale 
-      (en kilo octets binaire) pouvant être utilisée pour calculer le hachage Argon2. Par 
+      (en kibioctets) pouvant être utilisée pour calculer le hachage Argon2. Par
       défaut à <constant>PASSWORD_ARGON2_DEFAULT_MEMORY_COST</constant>.
      </para>
     </listitem>

--- a/reference/password/setup.xml
+++ b/reference/password/setup.xml
@@ -25,7 +25,7 @@
    le support libargon2 en utilisant l'option de configuration
    <option role="configure">--with-password-argon2</option>
    ou, à partir de PHP 8.4.0, avec OpenSSL en utilisant
-    <option role="configure">--with-openssl</option> and
+    <option role="configure">--with-openssl</option> et
    <option role="configure">--with-openssl-argon2</option>.
   </para> 
   <para>

--- a/reference/pcntl/book.xml
+++ b/reference/pcntl/book.xml
@@ -12,7 +12,8 @@
   &reftitle.intro;
   <para>
    Le système de contrôle des processus de PHP implémente un système
-   de création, gestion et terminaison des processus comme sous Unix.
+   de création de processus, d'exécution de programmes, de gestion des signaux
+   et de terminaison des processus comme sous Unix.
    Cette extension ne doit pas être activée pour une utilisation
    en serveur web, car les résultats pourraient être inattendus.
   </para>

--- a/reference/pcre/constants.xml
+++ b/reference/pcre/constants.xml
@@ -78,7 +78,8 @@
      </entry>
      <entry>
       <para>
-       Voir la description de <constant>PREG_OFFSET_CAPTURE</constant>.
+       Si cette option est activée, les expressions entre parenthèses du
+       masque délimiteur seront aussi capturées et retournées.
        Ce drapeau est uniquement utilisé avec <function>preg_split</function>.
       </para>
      </entry>
@@ -154,7 +155,7 @@
      <entry>
       Retourné par la fonction <function>preg_last_error</function> si
       <link linkend="ini.pcre.recursion-limit">la limite de récurrence</link>
-      a été atteint.
+      a été atteinte.
      </entry>
      <entry>5.2.0</entry>
     </row>

--- a/reference/pcre/functions/preg-filter.xml
+++ b/reference/pcre/functions/preg-filter.xml
@@ -109,7 +109,7 @@ Array
   &reftitle.seealso;
   <para>
    <simplelist>
-    <member>Les <link linkend="pcre.pattern">Patterns PCRE</link></member>
+    <member>Les <link linkend="pcre.pattern">Masques PCRE</link></member>
     <member><function>preg_quote</function></member>
     <member><function>preg_replace</function></member>
     <member><function>preg_replace_callback</function></member>

--- a/reference/pcre/functions/preg-grep.xml
+++ b/reference/pcre/functions/preg-grep.xml
@@ -97,7 +97,7 @@ var_dump($fl_array);
   &reftitle.seealso;
   <para>
    <simplelist>
-    <member>Les <link linkend="pcre.pattern">Patterns PCRE</link></member>
+    <member>Les <link linkend="pcre.pattern">Masques PCRE</link></member>
     <member><function>preg_quote</function></member>
     <member><function>preg_match_all</function></member>
     <member><function>preg_filter</function></member>

--- a/reference/pcre/functions/preg-match-all.xml
+++ b/reference/pcre/functions/preg-match-all.xml
@@ -369,6 +369,7 @@ foreach ($matches as $val) {
     <screen role="html">
 <![CDATA[
 matched: <b>texte en gras</b>
+part 1: <b>
 part 2: b
 part 3: texte en gras
 part 4: </b>

--- a/reference/pcre/functions/preg-match.xml
+++ b/reference/pcre/functions/preg-match.xml
@@ -325,7 +325,7 @@ if (preg_match("/\bweb\b/i", "PHP est le meilleur langage de script du web.")) {
 
 echo "\n";
 
-if (preg_match("/\bweb\b/i", "PHP est le meilleur langage de script du web.")) {
+if (preg_match("/\bweb\b/i", "PHP est le meilleur langage de script du website.")) {
     echo "Le mot a été trouvé.";
 } else {
     echo "Le mot n'a pas été trouvé.";

--- a/reference/pcre/functions/preg-replace-callback-array.xml
+++ b/reference/pcre/functions/preg-replace-callback-array.xml
@@ -5,7 +5,7 @@
 <refentry xml:id="function.preg-replace-callback-array" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>preg_replace_callback_array</refname>
-  <refpurpose>Éffectue une recherche de correspondance avec une expression régulière et remplace grâce à une fonction de rappel</refpurpose>
+  <refpurpose>Effectue une recherche de correspondance avec une expression régulière et remplace grâce à une fonction de rappel</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/pcre/functions/preg-replace.xml
+++ b/reference/pcre/functions/preg-replace.xml
@@ -57,7 +57,7 @@
        <parameter>replacement</parameter> sont des tableaux, chaque
        <parameter>pattern</parameter> sera remplacé par son
        <parameter>replacement</parameter> associé.
-       Si <parameter>replacement</parameter> à moins d'éléments
+       Si <parameter>replacement</parameter> a moins d'éléments
        que <parameter>pattern</parameter>, alors une chaîne vide est
        utilisée pour le reste des valeurs.
       </para>

--- a/reference/pdo/book.xml
+++ b/reference/pdo/book.xml
@@ -13,7 +13,7 @@
   &reftitle.intro;
   <para>
    L'extension <literal>PHP Data Objects</literal> (<acronym>PDO</acronym>) définit
-   une excellente interface pour accéder à une base de données depuis PHP.
+   une interface légère et cohérente pour accéder à une base de données depuis PHP.
    Chaque pilote de base de données implémenté dans l'interface PDO peut utiliser
    des fonctionnalités spécifiques de chacune des bases de données
    en utilisant des extensions de fonctions. Notez que vous ne pouvez

--- a/reference/pdo/configure.xml
+++ b/reference/pdo/configure.xml
@@ -65,7 +65,7 @@ extension=pdo_sqlite
     </screen>
    </para>
    <para>
-    Ces bibliothèques DDLs doivent exister dans le dossier système
+    Ces bibliothèques DLL doivent exister dans le dossier système
     <link linkend="ini.extension-dir">extension_dir</link>.
    </para>
   </step>

--- a/reference/pdo_sqlite/configure.xml
+++ b/reference/pdo_sqlite/configure.xml
@@ -12,10 +12,10 @@
   <literal>[=DIR]</literal> (optionnel) représente le chemin vers le
   dossier d'installation de base de sqlite.
   À partir de PHP 7.4.0 <link xlink:href="&url.sqlite;">libsqlite</link> ≥ 3.5.0 est requis.
-  Aupravant, la libsqlite intégré pouvait être utilisé à la place, et était par défaut, si <literal>[=DIR]</literal> était omis.
+  Auparavant, la libsqlite intégrée pouvait être utilisée à la place, et était par défaut, si <literal>[=DIR]</literal> était omis.
  </para>
  <note>
-  <title>Installation supplméntaire sur Windows à partir de PHP 7.4.0</title>
+  <title>Installation supplémentaire sur Windows à partir de PHP 7.4.0</title>
   <para>
    &ext.windows.path.dll; <filename>libsqlite3.dll</filename>.
   </para>

--- a/reference/pgsql/book.xml
+++ b/reference/pgsql/book.xml
@@ -15,7 +15,7 @@
    Science informatique, à UC Berkeley, a été le pionnier de nombreux
    concepts objet-relationnels actuellement disponibles sur le
    marché. PostgreSQL accepte le langage SQL92/SQL99, assure
-   l'intégrité transactionnelle et l'extension de type.
+   l'intégrité transactionnelle, l'intégrité référentielle, les procédures stockées et l'extension de type.
    PostgreSQL est une évolution du code original de Berkeley.
   </para>
  </preface>

--- a/reference/pgsql/setup.xml
+++ b/reference/pgsql/setup.xml
@@ -31,7 +31,7 @@
  <section xml:id="pgsql.resources">
   &reftitle.resources;
   <para>
-   Antérieur à PHP 8.1.0, il y avait deux types de ressource utilisés dans le module PostgreSQL.
+   Antérieur à PHP 8.1.0, il y avait deux types de ressources utilisés dans le module PostgreSQL.
    La première est l'identifiant pour la connexion à la base de données
    et le second est une ressource qui contient le résultat d'une requête.
   </para>

--- a/reference/random/functions/mt-srand.xml
+++ b/reference/random/functions/mt-srand.xml
@@ -103,7 +103,7 @@
       <row>
        <entry>7.1.0</entry>
        <entry>
-        <function>mt_rand</function> <link linkend="migration71.incompatible.fixes-to-mt_rand-algorithm">a été mis à jour</link> pour utiliser la version corrigé, correcte 
+        <function>mt_rand</function> <link linkend="migration71.incompatible.fixes-to-mt_rand-algorithm">a été mis à jour</link> pour utiliser la version corrigée, correcte 
         de l'algorithme de Mersenne Twister. Pour retourner à l'ancien comportement,
         utilisez <function>mt_srand</function> avec <constant>MT_RAND_PHP</constant> comme deuxième paramètre.
        </entry>

--- a/reference/random/functions/rand.xml
+++ b/reference/random/functions/rand.xml
@@ -100,7 +100,7 @@
       <row>
        <entry>7.1.0</entry>
        <entry>
-        <function>rand</function> <link linkend="migration71.incompatible.rand-srand-aliases">a été fait</link> un alias de <function>mt_rand</function>.
+        <function>rand</function> <link linkend="migration71.incompatible.rand-srand-aliases">est devenu</link> un alias de <function>mt_rand</function>.
        </entry>
       </row>
      </tbody>

--- a/reference/reflection/reflectionfunction/construct.xml
+++ b/reference/reflection/reflectionfunction/construct.xml
@@ -63,7 +63,7 @@ function counter1()
 }
 
 /**
- * Une autre simple compteur
+ * Un autre simple compteur
  *
  * @return    int
  */
@@ -112,7 +112,7 @@ dumpReflectionFunction(new ReflectionFunction($counter2));
      lines 7 to 11
 ---> Documentation:
  '/**
- * A simple counter
+ * Un simple compteur
  *
  * @return    int
  */'
@@ -126,7 +126,7 @@ dumpReflectionFunction(new ReflectionFunction($counter2));
      lines 18 to 23
 ---> Documentation:
  '/**
- * Another simple counter
+ * Un autre simple compteur
  *
  * @return    int
  */'

--- a/reference/session/functions/session-cache-expire.xml
+++ b/reference/session/functions/session-cache-expire.xml
@@ -5,7 +5,7 @@
 <refentry xml:id="function.session-cache-expire" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>session_cache_expire</refname>
-  <refpurpose>Récupère et/ou définie le délai d'expiration du cache</refpurpose>
+  <refpurpose>Récupère et/ou définit le délai d'expiration du cache</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/session/functions/session-destroy.xml
+++ b/reference/session/functions/session-destroy.xml
@@ -41,7 +41,7 @@
    Quand <link linkend="ini.session.use-strict-mode">session.use_strict_mode</link>
    est activé. Vous n'avez pas besoin d'effacer le cookies d'ID de session
    obsolète car le module de session n'accepte pas les cookies d'ID de sessions
-   quand il n'y a pas données associer avec ces ID de sessions et définira un
+   quand il n'y a pas de données associées à cet ID de session et définira un
    nouvel cookie d'ID de session.
    Activer <link linkend="ini.session.use-strict-mode">session.use_strict_mode</link>
    est recommandé pour tous les sites.

--- a/reference/session/functions/session-encode.xml
+++ b/reference/session/functions/session-encode.xml
@@ -20,7 +20,7 @@
    stockées dans la variable superglobale $_SESSION.
   </para>
   <para>
-   Par défaut, la méthode de sérialisation utilisé est interne à PHP, et n'est pas la même que <function>serialize</function>.
+   Par défaut, la méthode de sérialisation utilisée est interne à PHP, et n'est pas la même que <function>serialize</function>.
    La méthode de sérialisation peut être définie en utilisant l'option de configuration
    <link linkend="ini.session.serialize-handler">session.serialize_handler</link>.
   </para>

--- a/reference/session/functions/session-gc.xml
+++ b/reference/session/functions/session-gc.xml
@@ -83,7 +83,7 @@ session_destroy();
    </programlisting>
   </example>
   <example>
-   <title>Exemple de <function>session_gc</function> pour des scripts accessible par l'utilisateur</title>
+   <title>Exemple de <function>session_gc</function> pour des scripts accessibles par l'utilisateur</title>
    <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/session/functions/session-get-cookie-params.xml
+++ b/reference/session/functions/session-get-cookie-params.xml
@@ -85,7 +85,7 @@
       <row>
        <entry>7.3.0</entry>
        <entry>
-        L'entrée "<literal>samesite</literal>" a été ajouté dans le tableau retourné.
+        L'entrée "<literal>samesite</literal>" a été ajoutée dans le tableau retourné.
        </entry>
       </row>
      </tbody>

--- a/reference/session/functions/session-name.xml
+++ b/reference/session/functions/session-name.xml
@@ -23,7 +23,7 @@
   <para>
    Si un nouveau nom de session <parameter>name</parameter> est
    fourni, <function>session_name</function> modifie le cookie HTTP
-   (et le contenue de sortie quand <link linkend="ini.session.use-trans-sid">session.use_trans_sid</link> est
+   (et le contenu de sortie quand <link linkend="ini.session.use-trans-sid">session.use_trans_sid</link> est
    activé). Une fois le cookie HTTP envoyé,
    appeler <function>session_name</function> déclenche un <constant>E_WARNING</constant>.
    <function>session_name</function> doit être appelé
@@ -98,7 +98,7 @@
        <entry>
         <function>session_name</function> vérifie l'état de la session,
         auparavant elle vérifiait uniquement l'état du cookie. Par conséquent,
-        les versions plus anciennes de <function>session_name</function> autorise
+        les versions plus anciennes de <function>session_name</function> autorisent
         l'appel de <function>session_name</function>
         après <function>session_start</function> ce qui peut causer le plantage de PHP
         et peut donner lieu à des comportements étranges.

--- a/reference/session/functions/session-regenerate-id.xml
+++ b/reference/session/functions/session-regenerate-id.xml
@@ -97,7 +97,7 @@ if (isset($_SESSION['destroyed'])
 
 $old_sessionid = session_id();
 
-// Définir l'horodatage de déstruction
+// Définir l'horodatage de destruction
 $_SESSION['destroyed'] = time(); // session_regenerate_id () enregistre les anciennes données de session
 
 // Il suffit d'appeler session_regenerate_id() peut entraîner la perte de session, etc.
@@ -165,7 +165,7 @@ function my_session_regenerate_id() {
     $new_session_id = session_create_id();
     $_SESSION['new_session_id'] = $new_session_id;
     
-    // Définie le timestamp de destruction
+    // Définit le timestamp de destruction
     $_SESSION['destroyed'] = time();
     
     // Ecrit et ferme la session courante

--- a/reference/session/functions/session-set-save-handler.xml
+++ b/reference/session/functions/session-set-save-handler.xml
@@ -141,7 +141,7 @@
        de rappel <parameter>write</parameter>. La valeur retournée sera désérialisée
        automatiquement par PHP et utilisée pour peupler la variable superglobale
        <varname>$_SESSION</varname>. Malgré le fait que les données ressemblent fortement
-       aux données issuées de la fonction <function>serialize</function>, notez que c'est bien
+       aux données issues de la fonction <function>serialize</function>, notez que c'est bien
        un format différent, qui est spécifié via l'option de configuration
        <link linkend="ini.session.serialize-handler">session.serialize_handler</link>.
       </para>
@@ -221,7 +221,7 @@
       <para>
        La fonction de rappel de ramasse miettes (garbage collector) est invoquée en interne par PHP
        périodiquement afin de purger les anciennes données de session. La fréquence
-       est contrôlé par les options de configuration
+       est contrôlée par les options de configuration
        <link linkend="ini.session.gc-probability">session.gc_probability</link> et
        <link linkend="ini.session.gc-divisor">session.gc_divisor</link>.
        La valeur de la durée de vie passée à cette fonction de rappel peut être
@@ -347,7 +347,7 @@ session_start();
     <parameter>close</parameter> sont appelés après la destruction des objets,
     et donc, ne peuvent pas utiliser les objets ou lancer des exceptions.
     Les exceptions ne peuvent donc pas être attrapées ni affichées,
-    et l'exécution ne fera que s'arrêter de façon innatendue.
+    et l'exécution ne fera que s'arrêter de façon inattendue.
    </para>
    <para>
     Il est possible d'appeler <function>session_write_close</function> depuis

--- a/reference/session/functions/session-start.xml
+++ b/reference/session/functions/session-start.xml
@@ -127,7 +127,7 @@ $_SESSION['time']     = time();
 // Fonctionne si le cookie a été accepté
 echo '<br /><a href="page2.php">page 2</a>';
 
-// Ou bien, en indiquant explicitement l'identfiant de session
+// Ou bien, en indiquant explicitement l'identifiant de session
 echo '<br /><a href="page2.php?' . SID . '">page 2</a>';
 ?>
 ]]>

--- a/reference/shmop/functions/shmop-open.xml
+++ b/reference/shmop/functions/shmop-open.xml
@@ -138,8 +138,8 @@
      <row>
       <entry>8.0.0</entry>
       <entry>
-       <parameter>shmop</parameter> attend une instance de <classname>Shmop</classname>
-       désormais; auparavant une <type>resource</type> était attendue.
+       En cas de succès, cette fonction retourne désormais une instance de <classname>Shmop</classname> ;
+       auparavant, une <type>resource</type> était retournée.
       </entry>
      </row>
      <row>

--- a/reference/simplexml/functions/simplexml-import-dom.xml
+++ b/reference/simplexml/functions/simplexml-import-dom.xml
@@ -124,7 +124,7 @@ blah
     </screen>
    </example>
    <example>
-    <title>Importing a <classname>Dom\Document</classname></title>
+    <title>Import d'un <classname>Dom\Document</classname></title>
     <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/simplexml/simplexmlelement/addAttribute.xml
+++ b/reference/simplexml/simplexmlelement/addAttribute.xml
@@ -45,7 +45,7 @@
      <term><parameter>namespace</parameter></term>
      <listitem>
       <para>
-       Si spécifié, l'espace de nom auquel l'attribut appartient.
+       Si spécifié, l'espace de noms auquel l'attribut appartient.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/simplexml/simplexmlelement/addChild.xml
+++ b/reference/simplexml/simplexmlelement/addChild.xml
@@ -45,7 +45,7 @@
      <term><parameter>namespace</parameter></term>
      <listitem>
       <para>
-       Si spécifié, l'espace de nom auquel l'élément enfant appartient.
+       Si spécifié, l'espace de noms auquel l'élément enfant appartient.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/simplexml/simplexmlelement/registerXPathNamespace.xml
+++ b/reference/simplexml/simplexmlelement/registerXPathNamespace.xml
@@ -18,9 +18,9 @@
   <para>
    Crée un contexte préfixe/ns pour la prochaine requête XPath. En
    particulier, ceci est utile si le fournisseur du document XML donné modifie
-   les préfixes d'espace de nom. <literal>registerXPathNamespace</literal>
-   créera un préfixe pour l'espace de nom associé, autorisant l'accès aux
-   nœuds dans cet espace de nom sans avoir besoin de changer le code pour
+   les préfixes d'espace de noms. <literal>registerXPathNamespace</literal>
+   créera un préfixe pour l'espace de noms associé, autorisant l'accès aux
+   nœuds dans cet espace de noms sans avoir besoin de changer le code pour
    autoriser les nouveaux préfixes dictés par le fournisseur.
   </para>
  </refsect1>
@@ -33,8 +33,8 @@
      <term><parameter>prefix</parameter></term>
      <listitem>
       <para>
-       Le préfixe d'espace de nom à utiliser dans la requête XPath pour
-       l'espace de nom donnée dans <parameter>namespace</parameter>.
+       Le préfixe d'espace de noms à utiliser dans la requête XPath pour
+       l'espace de noms donnée dans <parameter>namespace</parameter>.
       </para>
      </listitem>
     </varlistentry>
@@ -42,8 +42,8 @@
      <term><parameter>namespace</parameter></term>
      <listitem>
       <para>
-       L'espace de nom à utiliser pour la requête XPath. Ceci doit concorder
-       avec un espace de nom qui est utilisé par le document XML, sinon la requête
+       L'espace de noms à utiliser pour la requête XPath. Ceci doit concorder
+       avec un espace de noms qui est utilisé par le document XML, sinon la requête
        XPath qui utilise <parameter>prefix</parameter> ne retournera aucun
        résultat.
       </para>
@@ -64,7 +64,7 @@
   &reftitle.examples;
   <para>
    <example>
-    <title>Fixe un préfixe d'espace de nom pour utiliser dans une requête XPath</title>
+    <title>Fixe un préfixe d'espace de noms pour utiliser dans une requête XPath</title>
     <programlisting role="php">
 <![CDATA[
 <?php
@@ -112,11 +112,11 @@ Chapter 2
      Notez comment le document XML montré dans cet exemple fixe un espace de
      nom avec le préfixe <literal>chap</literal>. Imaginez que ce document (ou
      un autre similaire) puisse avoir utilisé un préfixe <literal>c</literal>
-     dans le passé pour le même espace de nom. Puisqu'il a changé, la requête
+     dans le passé pour le même espace de noms. Puisqu'il a changé, la requête
      XPath ne retournerait plus les résultats appropriés et la requête devrait
      être modifiée. L'utilisation de <literal>registerXPathNamespace</literal>
      évite les modifications futures de la requête même si le fournisseur
-     change le préfixe d'espace de nom.
+     change le préfixe d'espace de noms.
     </para>
    </example>
   </para>

--- a/reference/snmp/book.xml
+++ b/reference/snmp/book.xml
@@ -11,8 +11,8 @@
   &reftitle.intro;
   <simpara>
    L'extension SNMP fournit un jeu de fonctionnalités simple et fonctionnel
-   pour gérer les périphériques distantes via le protocole
-   Simple Network Management.
+   pour gérer les périphériques distants via le protocole
+   Simple Network Management Protocol.
   </simpara>
   <simpara>
    Vu qu'il agit comme une enveloppe de la bibliothèque Net-SNMP,

--- a/reference/soap/constants.xml
+++ b/reference/soap/constants.xml
@@ -45,10 +45,7 @@
       (<type>int</type>)
      </entry>
      <entry>1</entry>
-     <entry>
-      Spécifie l'utilisation de l'encodage SOAP lorsqu'elle est passée en tant qu'option
-      <literal>use</literal> à la méthode <methodname>SoapClient::__construct</methodname>.
-     </entry>
+     <entry/>
     </row>
     <row xml:id="constant.soap-persistence-request">
      <entry>
@@ -56,10 +53,7 @@
       (<type>int</type>)
      </entry>
      <entry>2</entry>
-     <entry>
-      Spécifie l'utilisation d'un encodage spécifique au service lorsqu'elle est passée en tant
-      qu'option <literal>use</literal> à <methodname>SoapClient::__construct</methodname>.
-     </entry>
+     <entry/>
     </row>
     <row xml:id="constant.soap-functions-all">
      <entry>
@@ -76,8 +70,8 @@
      </entry>
      <entry>1</entry>
      <entry>
-      Spécifie l'utilisation d'une liaison de style RPC lorsqu'elle est passée en tant qu'option
-      <literal>style</literal> à <methodname>SoapClient::__construct</methodname>.
+      Spécifie l'utilisation de l'encodage SOAP lorsqu'elle est passée en tant qu'option
+      <literal>use</literal> à <methodname>SoapClient::__construct</methodname>.
      </entry>
     </row>
     <row xml:id="constant.soap-literal">
@@ -87,8 +81,8 @@
      </entry>
      <entry>2</entry>
      <entry>
-      Spécifie l'utilisation d'une liaison de type document lorsque passée en tant que valeur <literal>style</literal>
-      de l'option à <methodname>SoapClient::__construct</methodname>.
+      Spécifie l'utilisation d'un encodage spécifique au service lorsqu'elle est passée en tant qu'option
+      <literal>use</literal> à <methodname>SoapClient::__construct</methodname>.
      </entry>
     </row>
     <row xml:id="constant.soap-rpc">
@@ -97,7 +91,10 @@
       (<type>int</type>)
      </entry>
      <entry>1</entry>
-     <entry/>
+     <entry>
+      Spécifie l'utilisation d'une liaison de style RPC lorsqu'elle est passée en tant qu'option
+      <literal>style</literal> à <methodname>SoapClient::__construct</methodname>.
+     </entry>
     </row>
     <row xml:id="constant.soap-document">
      <entry>
@@ -105,7 +102,10 @@
       (<type>int</type>)
      </entry>
      <entry>2</entry>
-     <entry/>
+     <entry>
+      Spécifie l'utilisation d'une liaison de type document lorsqu'elle est passée en tant qu'option
+      <literal>style</literal> à <methodname>SoapClient::__construct</methodname>.
+     </entry>
     </row>
     <row xml:id="constant.soap-actor-next">
      <entry>
@@ -741,7 +741,7 @@
      </entry>
      <entry>1</entry>
      <entry>
-      Indique l'utilisation du cache WSDL en mémoire uniquement lorsqu'il est utilisé dans l'option de configuration
+      Indique l'utilisation du cache WSDL sur disque uniquement lorsqu'il est utilisé dans l'option de configuration
       <link linkend="ini.soap.wsdl-cache">soap.wsdl_cache</link> ou l'option <literal>wsdl_cache</literal> de
       <methodname>SoapClient::__construct</methodname> et <methodname>SoapServer::__construct</methodname>.
      </entry>

--- a/reference/soap/soapclient/construct.xml
+++ b/reference/soap/soapclient/construct.xml
@@ -591,7 +591,7 @@
           </para>
           <para>
            Cette option est <emphasis role="strong">obsolète</emphasis> à partir de PHP 8.1.0.
-           Une alternative plus flexible, qui permet de spécifier des versions individuelles de TLS, consiste à utiliser l'option <link linkend="soapclient.construct.options.stream-context"><parameter>contexte_de_flux</parameter></link> avec le paramètre de contexte 'crypto_method'.
+           Une alternative plus flexible, qui permet de spécifier des versions individuelles de TLS, consiste à utiliser l'option <link linkend="soapclient.construct.options.stream-context"><parameter>stream_context</parameter></link> avec le paramètre de contexte 'crypto_method'.
            <informalexample>
             <programlisting role="php">
 <![CDATA[
@@ -635,7 +635,7 @@ $client = new SoapClient("some.wsdl", ['context' => $context]);
   <para>
    <example>
     <title>
-     Example <methodname>SoapClient::__construct</methodname>
+     Exemple avec <methodname>SoapClient::__construct</methodname>
     </title>
     <programlisting role="php">
 <![CDATA[

--- a/reference/stream/functions/stream-filter-append.xml
+++ b/reference/stream/functions/stream-filter-append.xml
@@ -139,7 +139,7 @@ Guvf vf n grfg
   <note>
    <title>Quand vous utilisez des filtres personnalisés</title>
    <simpara>
-    <function>stream_register_filter</function> doit être appelée avant
+    <function>stream_filter_register</function> doit être appelée avant
     <function>stream_filter_append</function> pour enregistrer le filtre
     sous le nom de <parameter>filtername</parameter>.
    </simpara>

--- a/reference/stream/functions/stream-get-contents.xml
+++ b/reference/stream/functions/stream-get-contents.xml
@@ -105,7 +105,7 @@ if ($stream = fopen('http://www.example.com', 'r')) {
 }
 
 
-if ($stream = fopen('http://www.exemple.net', 'r')) {
+if ($stream = fopen('http://www.example.net', 'r')) {
     // Affichage des 5 premiers octets
     echo stream_get_contents($stream, 5);
 

--- a/reference/stream/functions/stream-socket-client.xml
+++ b/reference/stream/functions/stream-socket-client.xml
@@ -24,7 +24,7 @@
    par le transport spécifié avec le formatage URL suivant :
    <literal>transport://target</literal>. Pour un socket Internet,
    (AF_INET) comme TCP et UDP, la <literal>cible</literal>
-   de <parameter>address</parameter> sera une adresse IP ou un nom d'hôte.
+   de <parameter>address</parameter> doit être constituée d'un nom d'hôte ou d'une adresse IP suivie de deux-points et d'un numéro de port.
    Pour un socket Unix, la <literal>cible</literal> doit être un fichier de
    socket du système.
   </para>

--- a/reference/strings/functions/get-html-translation-table.xml
+++ b/reference/strings/functions/get-html-translation-table.xml
@@ -127,7 +127,7 @@
   &reftitle.returnvalues;
   <para>
    Retourne la table de traduction, sous la forme d'un tableau,
-   avec comme clés, les caractères orignaux, et comme valeurs, les entités
+   avec comme clés, les caractères originaux, et comme valeurs, les entités
    correspondantes.
   </para>
  </refsect1>
@@ -146,7 +146,7 @@
      <row>
       <entry>8.1.0</entry>
       <entry>
-       <parameter>flags</parameter> à changé de <constant>ENT_COMPAT</constant> à
+       <parameter>flags</parameter> a changé de <constant>ENT_COMPAT</constant> à
        <constant>ENT_QUOTES</constant> | <constant>ENT_SUBSTITUTE</constant> | <constant>ENT_HTML401</constant>.
       </entry>
      </row>

--- a/reference/strings/functions/levenshtein.xml
+++ b/reference/strings/functions/levenshtein.xml
@@ -31,7 +31,7 @@
   </para>
   <para>
    Si <parameter>insertion_cost</parameter>, <parameter>replacement_cost</parameter>
-   et/oru <parameter>deletion_cost</parameter> sont différent de <literal>1</literal>,
+   et/ou <parameter>deletion_cost</parameter> sont différent de <literal>1</literal>,
    l'algorithme s'adapte pour choisir la transformation la moins coûteuse.
    E.g. si <code>$insertion_cost + $deletion_cost &lt; $replacement_cost</code>,
    Aucun remplacement ne sera effectué, mais plutôt des insertions et suppressions.

--- a/reference/strings/functions/metaphone.xml
+++ b/reference/strings/functions/metaphone.xml
@@ -138,8 +138,8 @@ string(5) "PRKRM"
    <example xml:id="metaphone.example.phonemes-overlong">
     <title>Utilisant le paramètre de <parameter>max_phonemes</parameter></title>
     <simpara>
-     Dans cette exemple, <function>metaphone</function> est avisé de produire
-     une chaîne de cinq caractères, mais ceci nécessiterai de séparer le
+     Dans cet exemple, <function>metaphone</function> est avisé de produire
+     une chaîne de cinq caractères, mais ceci nécessiterait de séparer le
      phonème final (<literal>'x'</literal> est supposé d'être transcrit en
      <literal>'KS'</literal>), donc la fonction retourne une chaîne de six
      caractères.

--- a/reference/strings/functions/print.xml
+++ b/reference/strings/functions/print.xml
@@ -152,7 +152,7 @@ else {
 
    <para>
     Quand <literal>print</literal> est utilisé dans une expression plus large,
-    placer tout deux le mot clé et son argument dans les parenthèses peut être
+    placer tous deux le mot clé et son argument dans les parenthèses peut être
     nécessaire pour obtenir le résultat attendu :
    <informalexample>
      <programlisting role="php">
@@ -193,7 +193,7 @@ print "hello " && print "world";
     <member><function>echo</function></member>
     <member><function>printf</function></member>
     <member><function>flush</function></member>
-    <member><link linkend="language.types.string">Manière de spécifié des chaînes littérales</link></member>
+    <member><link linkend="language.types.string">Manière de spécifier des chaînes littérales</link></member>
    </simplelist>
   </para>
  </refsect1>

--- a/reference/strings/functions/setlocale.xml
+++ b/reference/strings/functions/setlocale.xml
@@ -15,7 +15,7 @@
    <methodparam><type class="union"><type>string</type><type>null</type></type><parameter>locales</parameter></methodparam>
    <methodparam rep="repeat"><type>string</type><parameter>rest</parameter></methodparam>
   </methodsynopsis>
-  <simpara>Signature alternative (non supporté avec les arguments nommés) :</simpara>
+  <simpara>Signature alternative (non supportée avec les arguments nommés) :</simpara>
   <methodsynopsis>
    <type class="union"><type>string</type><type>false</type></type><methodname>setlocale</methodname>
    <methodparam><type>int</type><parameter>category</parameter></methodparam>

--- a/reference/strings/functions/similar-text.xml
+++ b/reference/strings/functions/similar-text.xml
@@ -76,7 +76,7 @@
   </para>
   <para>
    Le nombre de caractères correspondant est calculés en trouvant la première plus
-   longue sous-chaîne commune, et puis faire ceci pour les préfixes et les sufixes,
+   longue sous-chaîne commune, et puis faire ceci pour les préfixes et les suffixes,
    de façon récursive. La longueur de toutes les sous-chaînes communes sont ajoutées.
   </para>
  </refsect1>

--- a/reference/strings/functions/str-ireplace.xml
+++ b/reference/strings/functions/str-ireplace.xml
@@ -148,7 +148,7 @@ echo $bodytag; // <body text=black>
    <para>
     Vu le fait que la fonction <function>str_ireplace</function> effectue
     les remplacements de la gauche vers la droite, elle peut remplacer
-    une valeur précédemment insérée lors de remplacement multpiple.
+    une valeur précédemment insérée lors de remplacement multiple.
     L'exemple #2 de la documentation de la fonction
     <function>str_replace</function> sur la façon de traiter cette problématique.
    </para>

--- a/reference/strings/functions/str-pad.xml
+++ b/reference/strings/functions/str-pad.xml
@@ -43,8 +43,7 @@
        La longueur souhaitée de la chaîne finale complétée.
        Si la valeur de <parameter>length</parameter> est négative, plus petite
        que, ou égale à la taille courante de la chaîne <parameter>string</parameter>,
-       <parameter>string</parameter> est retournée inchangée et
-       <parameter>string</parameter> sera retourné.
+       <parameter>string</parameter> est retournée inchangée.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/strings/functions/str-replace.xml
+++ b/reference/strings/functions/str-replace.xml
@@ -34,7 +34,7 @@
    Si les paramètres <parameter>search</parameter> et <parameter>replace</parameter>
    sont des tableaux, alors la fonction <function>str_replace</function>
    prendra une valeur de chaque tableau et les utilisera pour la recherche et
-   le remplacement sur <parameter>subject</parameter>. Si les paramètres
+   le remplacement sur <parameter>subject</parameter>. Si le paramètre
    <parameter>replace</parameter> a moins de valeurs que le paramètre
    <parameter>search</parameter>, alors une &string; vide sera utilisée
    comme valeur pour le reste des valeurs de remplacement. Si le paramètre
@@ -128,7 +128,7 @@ $yummy   = array("pizza", "beer", "ice cream");
 $newphrase = str_replace($healthy, $yummy, $phrase);
 echo $newphrase, PHP_EOL;
 
-// Génère : good goy miss moy
+// Génère : 2
 $str = str_replace("ll", "", "good golly miss molly!", $count);
 echo $count, PHP_EOL;
 

--- a/reference/strings/functions/stripos.xml
+++ b/reference/strings/functions/stripos.xml
@@ -110,7 +110,7 @@
      <row>
       <entry>7.3.0</entry>
       <entry>
-       Passer un &integer; comme <parameter>before_needle</parameter> a été
+       Passer un &integer; comme <parameter>needle</parameter> a été
        rendu obsolète.
       </entry>
      </row>

--- a/reference/strings/functions/strpos.xml
+++ b/reference/strings/functions/strpos.xml
@@ -107,7 +107,7 @@
      <row>
       <entry>7.3.0</entry>
       <entry>
-       Passer un &integer; comme <parameter>before_needle</parameter> a été
+       Passer un &integer; comme <parameter>needle</parameter> a été
        rendu obsolète.
       </entry>
      </row>

--- a/reference/strings/functions/strrchr.xml
+++ b/reference/strings/functions/strrchr.xml
@@ -54,7 +54,7 @@
       <para>
        Si &true;, <function>strrchr</function>
        renvoie la partie du <parameter>haystack</parameter> avant la
-       dernière occurrence de <parameter>needdle</parameter> (à l'exclusion de cette dernière).
+       dernière occurrence de <parameter>needle</parameter> (à l'exclusion de cette dernière).
       </para>
      </listitem>
     </varlistentry>

--- a/reference/strings/functions/strripos.xml
+++ b/reference/strings/functions/strripos.xml
@@ -128,7 +128,7 @@
      <row>
       <entry>7.3.0</entry>
       <entry>
-       Passer un &integer; comme <parameter>before_needle</parameter> a été
+       Passer un &integer; comme <parameter>needle</parameter> a été
        rendu obsolète.
       </entry>
      </row>

--- a/reference/strings/functions/strrpos.xml
+++ b/reference/strings/functions/strrpos.xml
@@ -121,7 +121,7 @@
      <row>
       <entry>7.3.0</entry>
       <entry>
-       Passer un &integer; comme <parameter>before_needle</parameter> a été
+       Passer un &integer; comme <parameter>needle</parameter> a été
        rendu obsolète.
       </entry>
      </row>

--- a/reference/strings/functions/strtok.xml
+++ b/reference/strings/functions/strtok.xml
@@ -14,7 +14,7 @@
    <methodparam><type>string</type><parameter>string</parameter></methodparam>
    <methodparam><type>string</type><parameter>token</parameter></methodparam>
   </methodsynopsis>
-  <simpara>Signature alternative (non supporté avec les arguments nommés) :</simpara>
+  <simpara>Signature alternative (non supportée avec les arguments nommés) :</simpara>
   <methodsynopsis>
    <type class="union"><type>string</type><type>false</type></type><methodname>strtok</methodname>
    <methodparam><type>string</type><parameter>token</parameter></methodparam>

--- a/reference/strings/functions/strtr.xml
+++ b/reference/strings/functions/strtr.xml
@@ -15,7 +15,7 @@
    <methodparam><type>string</type><parameter>from</parameter></methodparam>
    <methodparam><type>string</type><parameter>to</parameter></methodparam>
   </methodsynopsis>
-  <simpara>Signature alternative (non supporté avec les arguments nommés) :</simpara>
+  <simpara>Signature alternative (non supportée avec les arguments nommés) :</simpara>
   <methodsynopsis>
    <type>string</type><methodname>strtr</methodname>
    <methodparam><type>string</type><parameter>string</parameter></methodparam>
@@ -90,7 +90,7 @@
       <para>
        Si <parameter>replace_pairs</parameter> contient une clé qui est une
        <type>string</type> vide (<literal>""</literal>), l'élément est ignoré ;
-       à partir de PHP 8.0.0 une <constant>E_WARNING</constant> est levé dans ce cas.
+       à partir de PHP 8.0.0 une <constant>E_WARNING</constant> est levée dans ce cas.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/strings/functions/substr-compare.xml
+++ b/reference/strings/functions/substr-compare.xml
@@ -133,7 +133,7 @@ echo substr_compare("abcde", "bcg", 1, 2), PHP_EOL; // 0
 echo substr_compare("abcde", "BC", 1, 2, true), PHP_EOL; // 0
 echo substr_compare("abcde", "bc", 1, 3), PHP_EOL; // 1
 echo substr_compare("abcde", "cd", 1, 2), PHP_EOL; // -1
-echo substr_compare("abcde", "abc", 5, 1), PHP_EOL; // -1g
+echo substr_compare("abcde", "abc", 5, 1), PHP_EOL; // -1
 ?>
 ]]>
     </programlisting>

--- a/reference/strings/functions/substr.xml
+++ b/reference/strings/functions/substr.xml
@@ -60,9 +60,9 @@
         <programlisting role="php">
 <![CDATA[
 <?php
-$rest = substr("abcdef", -1), PHP_EOL;    // retourne "f"
-$rest = substr("abcdef", -2), PHP_EOL;    // retourne "ef"
-$rest = substr("abcdef", -3, 1), PHP_EOL; // retourne "d"
+echo substr("abcdef", -1), PHP_EOL;    // retourne "f"
+echo substr("abcdef", -2), PHP_EOL;    // retourne "ef"
+echo substr("abcdef", -3, 1), PHP_EOL; // retourne "d"
 ?>
 ]]>
         </programlisting>
@@ -99,10 +99,10 @@ $rest = substr("abcdef", -3, 1), PHP_EOL; // retourne "d"
        <programlisting role="php">
 <![CDATA[
 <?php
-$rest = substr("abcdef", 0, -1), PHP_EOL;  // retourne "abcde"
-$rest = substr("abcdef", 2, -1), PHP_EOL;  // retourne "cde"
-$rest = substr("abcdef", 4, -4), PHP_EOL;  // retourne ""; antérieur à PHP 8.0.0, false était retourné
-$rest = substr("abcdef", -3, -1), PHP_EOL; // retourne "de"
+echo substr("abcdef", 0, -1), PHP_EOL;  // retourne "abcde"
+echo substr("abcdef", 2, -1), PHP_EOL;  // retourne "cde"
+echo substr("abcdef", 4, -4), PHP_EOL;  // retourne ""; antérieur à PHP 8.0.0, false était retourné
+echo substr("abcdef", -3, -1), PHP_EOL; // retourne "de"
 ?>
 ]]>
        </programlisting>

--- a/reference/strings/functions/ucfirst.xml
+++ b/reference/strings/functions/ucfirst.xml
@@ -72,8 +72,8 @@ $foo = 'bonjour tout le monde!';
 echo ucfirst($foo), PHP_EOL;             // Bonjour tout le monde!
 
 $bar = 'BONJOUR TOUT LE MONDE!';
-$bar = ucfirst($bar), PHP_EOL;             // BONJOUR TOUT LE MONDE!
-$bar = ucfirst(strtolower($bar)), PHP_EOL; // Bonjour tout le monde!
+echo ucfirst($bar), PHP_EOL;             // BONJOUR TOUT LE MONDE!
+echo ucfirst(strtolower($bar)), PHP_EOL; // Bonjour tout le monde!
 ?>
 ]]>
     </programlisting>

--- a/reference/strings/functions/ucwords.xml
+++ b/reference/strings/functions/ucwords.xml
@@ -94,7 +94,7 @@ $foo = 'bonjour tout le monde!';
 echo ucwords($foo), PHP_EOL;             // Bonjour Tout Le Monde!
 
 $bar = 'BONJOUR TOUT LE MONDE!';
-echo ucwords($bar);, PHP_EOL             // BONJOUR TOUT LE MONDE!
+echo ucwords($bar), PHP_EOL;             // BONJOUR TOUT LE MONDE!
 echo ucwords(strtolower($bar)), PHP_EOL; // Bonjour Tout Le Monde!
 ?>
 ]]>
@@ -104,7 +104,7 @@ echo ucwords(strtolower($bar)), PHP_EOL; // Bonjour Tout Le Monde!
 
   <para>
    <example>
-    <title>Exemple avec <function>ucwords</function> et un séparation personnalisé</title>
+    <title>Exemple avec <function>ucwords</function> et un séparateur personnalisé</title>
     <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/strings/functions/vprintf.xml
+++ b/reference/strings/functions/vprintf.xml
@@ -16,7 +16,7 @@
    <methodparam><type>array</type><parameter>values</parameter></methodparam>
   </methodsynopsis>
   <para>
-   <function>vprintf</function> affiche le tableau <parameter>args</parameter>, 
+   <function>vprintf</function> affiche le tableau <parameter>values</parameter>, 
    sous forme de chaîne formatée grâce à <parameter>format</parameter>. 
    Le format est le même que celui utilisé par <function>sprintf</function>.
   </para>

--- a/reference/tidy/constants.xml
+++ b/reference/tidy/constants.xml
@@ -7,7 +7,7 @@
  &reftitle.constants;
  &extension.constants;
  <para>
-  Chaque <literal>TIDY_TAG_<replaceable>*</replaceable></literal> représente une balise HTML. Par exemple, 
+  Chaque <constant>TIDY_TAG_<replaceable>*</replaceable></constant> représente une balise HTML. Par exemple, 
   <constant>TIDY_TAG_A</constant> représente une balise
   <literal>"&lt;a href="XX"&gt;link&lt;/a&gt;"</literal>.
  </para>

--- a/reference/url/functions/urlencode.xml
+++ b/reference/url/functions/urlencode.xml
@@ -88,6 +88,7 @@ UserInput: Data123!@-_ +
 $foo = 'Data123!@-_ +';
 $bar = "Not the same content as $foo";
 echo "foo: $foo\n";
+echo "bar: $bar\n";
 $query_string = 'foo=' . urlencode($foo) . '&bar=' . urlencode($bar);
 echo '<a href="mycgi?' . htmlentities($query_string) . '">';
 ?>

--- a/reference/var/functions/is-numeric.xml
+++ b/reference/var/functions/is-numeric.xml
@@ -177,7 +177,7 @@ foreach ($tests as $element) {
   &reftitle.seealso;
   <para>
    <simplelist>
-    <member><link linkend="language.types.numeric-strings">Les chaînes numérique</link></member>
+    <member><link linkend="language.types.numeric-strings">Les chaînes numériques</link></member>
     <member><function>ctype_digit</function></member>
     <member><function>is_bool</function></member>
     <member><function>is_null</function></member>

--- a/reference/var/functions/serialize.xml
+++ b/reference/var/functions/serialize.xml
@@ -132,7 +132,7 @@ if (!odbc_execute($stmt, $sqldata)) {
   <warning>
    <para>
     Lorsque la fonction <function>serialize</function> sérialise des objets,
-    l'antislash de fin n'est pas inclus dans l'espace de nom du nom de la classe
+    l'antislash de fin n'est pas inclus dans l'espace de noms du nom de la classe
     et ce, pour un maximum de compatibilité.
    </para>
   </warning>

--- a/reference/var/functions/strval.xml
+++ b/reference/var/functions/strval.xml
@@ -22,7 +22,7 @@
   </simpara>
   <simpara>
    Cette fonction n'effectue aucun formatage sur la valeur retournée.
-   Si vous cherchez un moyen de formatter une valeur numérique en chaîne de
+   Si vous cherchez un moyen de formater une valeur numérique en chaîne de
    caractères, reportez-vous à la fonction
    <function>sprintf</function> ou la fonction <function>number_format</function>.
   </simpara>

--- a/reference/var/functions/var-export.xml
+++ b/reference/var/functions/var-export.xml
@@ -256,7 +256,7 @@ object(A)#2 (2) {
   <warning>
    <para>
     Antérieur à PHP 8.2.0, lorsque <function>var_export</function> exporte des objets, 
-    l'antislash initial n'est pas inclus dans l'espace de nom de la classe
+    l'antislash initial n'est pas inclus dans l'espace de noms de la classe
     et ce, pour un maximum de compatibilité.
    </para>
   </warning>

--- a/reference/win32service/constants.xml
+++ b/reference/win32service/constants.xml
@@ -398,7 +398,7 @@
       <entry><literal>0x00000004</literal></entry>
       <entry>
        Un service qui ne peut pas être démarré. Les tentatives pour démarrer
-       retourne un code d'erreur <constant>WIN32_ERROR_SERVICE_DISABLED </constant>.
+       retourne un code d'erreur <constant>WIN32_ERROR_SERVICE_DISABLED</constant>.
       </entry>
      </row>
     </tbody>

--- a/reference/win32service/functions/win32-create-service.xml
+++ b/reference/win32service/functions/win32-create-service.xml
@@ -127,7 +127,7 @@
          <listitem>
           <para>
            Spécifie comment le service devrait être démarré. La valeur par
-           défaut est <constant>WIN32_SERVIDE_AUTO_START</constant> qui
+           défaut est <constant>WIN32_SERVICE_AUTO_START</constant> qui
            signifie que le service sera démarré lorsque la machine démarrera.
           </para>
          </listitem>

--- a/reference/win32service/win32serviceexception.xml
+++ b/reference/win32service/win32serviceexception.xml
@@ -8,7 +8,7 @@
  xmlns:xlink="http://www.w3.org/1999/xlink"
  xmlns:xi="http://www.w3.org/2001/XInclude"
  xmlns="http://docbook.org/ns/docbook">
- <title>La class Win32ServiceException</title>
+ <title>La classe Win32ServiceException</title>
  <titleabbrev>Win32ServiceException</titleabbrev>
 
  <partintro>

--- a/reference/xattr/functions/xattr-get.xml
+++ b/reference/xattr/functions/xattr-get.xml
@@ -20,7 +20,7 @@
   </methodsynopsis>
   <para>
    <function>xattr_get</function> récupère la valeur de l'attribut étendu nommé
-   <parameter>name</parameter> du fichier <parameter>path</parameter>.
+   <parameter>name</parameter> du fichier <parameter>filename</parameter>.
   </para>
   &xattr.namespace;
  </refsect1>

--- a/reference/xattr/functions/xattr-list.xml
+++ b/reference/xattr/functions/xattr-list.xml
@@ -19,7 +19,7 @@
   </methodsynopsis>
   <para>
    <function>xattr_list</function> récupère une liste de noms d'attributs étendus
-   d'un fichier désigné par le paramètre <parameter>path</parameter>.
+   d'un fichier désigné par le paramètre <parameter>filename</parameter>.
   </para>
   &xattr.namespace;
  </refsect1>
@@ -80,7 +80,7 @@ $file = 'un_fichier';
 $root_attributes = xattr_list($file, XATTR_ROOT);
 $user_attributes = xattr_list($file);
 
-echo "Root attributes: \n";
+echo "Attributs racine :\n";
 foreach ($root_attributes as $attr_name) {
     printf("%s\n", $attr_name);
 }

--- a/reference/xattr/functions/xattr-remove.xml
+++ b/reference/xattr/functions/xattr-remove.xml
@@ -20,7 +20,7 @@
   <para>
    <function>xattr_remove</function> efface un attribut étendu nommé
    <parameter>name</parameter> d'un fichier désigné par le paramètre
-   <parameter>path</parameter>.
+   <parameter>filename</parameter>.
   </para>
   &xattr.namespace;
  </refsect1>

--- a/reference/xattr/functions/xattr-set.xml
+++ b/reference/xattr/functions/xattr-set.xml
@@ -20,9 +20,9 @@
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
   <para>
-   <function>xattr_set</function> définie la valeur d'un attribut étendu nommé
+   <function>xattr_set</function> définit la valeur d'un attribut étendu nommé
    <parameter>name</parameter> à la valeur <parameter>value</parameter>
-   d'un fichier désigné par le paramètre <parameter>path</parameter>.
+   d'un fichier désigné par le paramètre <parameter>filename</parameter>.
   </para>
   &xattr.namespace;
  </refsect1>

--- a/reference/xattr/functions/xattr-supported.xml
+++ b/reference/xattr/functions/xattr-supported.xml
@@ -19,8 +19,8 @@
   </methodsynopsis>
   <para>
    <function>xattr_supported</function> vérifie si le système de fichiers contenant
-   le fichier <parameter>path</parameter> supporte les attributs étendus.
-   Un accès en lecture au fichier <parameter>path</parameter> est nécessaire.
+   le fichier <parameter>filename</parameter> supporte les attributs étendus.
+   Un accès en lecture au fichier <parameter>filename</parameter> est nécessaire.
   </para>
  </refsect1>
  <refsect1 role="parameters">

--- a/reference/xdiff/functions/xdiff-file-diff-binary.xml
+++ b/reference/xdiff/functions/xdiff-file-diff-binary.xml
@@ -18,7 +18,7 @@
    <methodparam><type>string</type><parameter>dest</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Créé un diff binaire entre les deux fichiers et stocke le résultat dans
+   Crée un diff binaire entre les deux fichiers et stocke le résultat dans
    <parameter>dest</parameter>. Cette fonction fonctionne avec les fichiers
    texte, mais aussi avec les fichiers binaires. Le patch résultant
    peut être appliqué à l'aide de la fonction <function>xdiff_file_bpatch</function>.

--- a/reference/xdiff/functions/xdiff-file-diff.xml
+++ b/reference/xdiff/functions/xdiff-file-diff.xml
@@ -6,7 +6,7 @@
 <refentry xml:id="function.xdiff-file-diff" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>xdiff_file_diff</refname>
-  <refpurpose>Créé un diff unifié entre deux fichiers</refpurpose>
+  <refpurpose>Crée un diff unifié entre deux fichiers</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/xdiff/functions/xdiff-string-diff.xml
+++ b/reference/xdiff/functions/xdiff-string-diff.xml
@@ -6,7 +6,7 @@
 <refentry xml:id="function.xdiff-string-diff" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>xdiff_string_diff</refname>
-  <refpurpose>Créé un diff unifié entre deux chaînes</refpurpose>
+  <refpurpose>Crée un diff unifié entre deux chaînes</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/xmlreader/xmlreader.xml
+++ b/reference/xmlreader/xmlreader.xml
@@ -314,7 +314,7 @@
     <varlistentry xml:id="xmlreader.props.namespaceuri">
      <term><varname>namespaceURI</varname></term>
      <listitem>
-      <para>L'URI de l'espace de nom associé avec le nœud</para>
+      <para>L'URI de l'espace de noms associé au nœud</para>
      </listitem>
     </varlistentry>
 
@@ -328,7 +328,7 @@
     <varlistentry xml:id="xmlreader.props.prefix">
      <term><varname>prefix</varname></term>
      <listitem>
-      <para>Le préfixe de l'espace de nom associé avec le nœud</para>
+      <para>Le préfixe de l'espace de noms associé au nœud</para>
      </listitem>
     </varlistentry>
 

--- a/reference/xmlreader/xmlreader/getattributens.xml
+++ b/reference/xmlreader/xmlreader/getattributens.xml
@@ -14,7 +14,7 @@
    <methodparam><type>string</type><parameter>namespace</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Retourne la valeur d'un attribut par nom et espace de nom URI ou une chaîne
+   Retourne la valeur d'un attribut par nom et URI d'espace de noms ou une chaîne
    de caractères vide si l'attribut n'existe pas ou n'est pas positionné sur
    le nœud.
   </para>
@@ -35,7 +35,7 @@
      <term><parameter>namespace</parameter></term>
      <listitem>
       <para>
-       L'espace de nom URI.
+       L'URI de l'espace de noms.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/xmlreader/xmlreader/lookupnamespace.xml
+++ b/reference/xmlreader/xmlreader/lookupnamespace.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="xmlreader.lookupnamespace" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>XMLReader::lookupNamespace</refname>
-  <refpurpose>Consulte l'espace de nom pour un préfixe</refpurpose>
+  <refpurpose>Consulte l'espace de noms pour un préfixe</refpurpose>
  </refnamediv>
  <refsect1 role="description">
   &reftitle.description;
@@ -13,7 +13,7 @@
    <methodparam><type>string</type><parameter>prefix</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Consulte dans la portée de l'espace de nom pour un préfixe donné.
+   Consulte dans la portée de l'espace de noms pour un préfixe donné.
   </para>
  </refsect1>
  <refsect1 role="parameters">
@@ -34,7 +34,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   La valeur de l'espace de nom, ou &null; si aucun espace de nom existe.
+   La valeur de l'espace de noms, ou &null; si aucun espace de noms existe.
   </para>
  </refsect1>
 

--- a/reference/xmlreader/xmlreader/movetoattributens.xml
+++ b/reference/xmlreader/xmlreader/movetoattributens.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="xmlreader.movetoattributens" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>XMLReader::moveToAttributeNs</refname>
-  <refpurpose>Déplace le curseur à un attribut d'espace de nom</refpurpose>
+  <refpurpose>Déplace le curseur à un attribut par espace de noms</refpurpose>
  </refnamediv>
  <refsect1 role="description">
   &reftitle.description;
@@ -14,7 +14,7 @@
    <methodparam><type>string</type><parameter>namespace</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Positionne le curseur sur le nom de l'attribut dans l'espace de nom
+   Positionne le curseur sur le nom de l'attribut dans l'espace de noms
    spécifié.
   </para>
  </refsect1>
@@ -34,7 +34,7 @@
      <term><parameter>namespace</parameter></term>
      <listitem>
       <para>
-       L'espace de nom URI.
+       L'URI de l'espace de noms.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/xmlwriter/examples.xml
+++ b/reference/xmlwriter/examples.xml
@@ -96,7 +96,7 @@ xmlwriter_set_indent($xw, 1);
 $res = xmlwriter_set_indent_string($xw, ' ');
 
 xmlwriter_start_document($xw, '1.0', 'UTF-8');
-// A first element
+// Un premier élément
 xmlwriter_start_element_ns($xw,'prefix', 'books', 'uri');
 xmlwriter_start_attribute($xw, 'isbn');
 

--- a/reference/xsl/xsltprocessor/getparameter.xml
+++ b/reference/xsl/xsltprocessor/getparameter.xml
@@ -26,7 +26,7 @@
      <term><parameter>namespace</parameter></term>
      <listitem>
       <para>
-       L'URI du namespace du paramètre XSLT.
+       L'URI de l'espace de noms du paramètre XSLT.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/xsl/xsltprocessor/registerphpfunctionns.xml
+++ b/reference/xsl/xsltprocessor/registerphpfunctionns.xml
@@ -26,7 +26,7 @@
     <term><parameter>namespaceURI</parameter></term>
     <listitem>
      <simpara>
-      L'URI du namespace.
+      L'URI de l'espace de noms.
      </simpara>
     </listitem>
    </varlistentry>
@@ -34,7 +34,7 @@
     <term><parameter>name</parameter></term>
     <listitem>
      <simpara>
-      La fonction locale à l'intérieur du namespace.
+      La fonction locale à l'intérieur de l'espace de noms.
      </simpara>
     </listitem>
    </varlistentry>

--- a/reference/xsl/xsltprocessor/removeparameter.xml
+++ b/reference/xsl/xsltprocessor/removeparameter.xml
@@ -26,7 +26,7 @@
      <term><parameter>namespace</parameter></term>
      <listitem>
       <para>
-       L'URI du namespace du paramètre XSLT.
+       L'URI de l'espace de noms du paramètre XSLT.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/xsl/xsltprocessor/setparameter.xml
+++ b/reference/xsl/xsltprocessor/setparameter.xml
@@ -33,7 +33,7 @@
      <term><parameter>namespace</parameter></term>
      <listitem>
       <para>
-       L'URI du namespace du paramètre XSLT.
+       L'URI de l'espace de noms du paramètre XSLT.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/zip/ziparchive/addfromstring.xml
+++ b/reference/zip/ziparchive/addfromstring.xml
@@ -77,7 +77,7 @@
      </thead>
      <tbody>
       <row>
-       <entry>8.0.0, PECL zip1.18.0</entry>
+       <entry>8.0.0, PECL zip 1.18.0</entry>
        <entry>
         <parameter>flags</parameter> a été ajouté.
        </entry>

--- a/reference/zlib/functions/gzencode.xml
+++ b/reference/zlib/functions/gzencode.xml
@@ -23,8 +23,8 @@
   </para>
   <para>
    Pour plus de détails sur l'algorithme, lisez le document
-   "<link xlink:href="&url.rfc;1952">ZLIB Compressed Data Format
-   Specification version 4.3</link>" (RFC 1952).
+   "<link xlink:href="&url.rfc;1952">GZIP file format specification
+   version 4.3</link>" (RFC 1952).
   </para>
  </refsect1>
 

--- a/reference/zlib/functions/gzread.xml
+++ b/reference/zlib/functions/gzread.xml
@@ -17,7 +17,7 @@
   <para>
    <function>gzread</function> lit jusqu'à <parameter>length</parameter>
    octets dans le fichier compressé gzip, représenté par
-   <parameter>zp</parameter>. La lecture s'arrête lorsque
+   <parameter>stream</parameter>. La lecture s'arrête lorsque
    <parameter>length</parameter> octets (décompressés) ont été lus,
    ou que la fin du fichier a été atteinte (position <acronym>EOF</acronym>).
   </para>

--- a/security/database.xml
+++ b/security/database.xml
@@ -201,8 +201,8 @@ insert into pg_shadow(usename,usesysid,usesuper,usecatupd,passwd)
      </programlisting>
     </informalexample>
     Si cela arrive, le script donnerait un accès super utilisateur à l'attaquant.
-    Notez que la valeur <literal>0;</literal> sert à terminer la requête
-    originale et la terminer correctement.
+    Notez que la valeur <literal>0;</literal> fournit un décalage valide à la requête
+    originale et la termine correctement.
    </para>
    <note>
     <para>


### PR DESCRIPTION
## Summary

Comprehensive review of the entire French documentation (doc-fr vs doc-en), fixing only real issues