### PR TITLE
reference/filesystem: fix code examples, translation error, and missing content

### DIFF
--- a/reference/filesystem/functions/file-get-contents.xml
+++ b/reference/filesystem/functions/file-get-contents.xml
@@ -215,10 +215,10 @@ string(14) "lle Bjori Ro"
 <?php
 // Création d'un flux
 $opts = [
-  'http'=> [
-    'method'=>"GET",
-    'header'=>"Accept-language: en\r\n" .
-              "Cookie: foo=bar\r\n",
+  'http' => [
+    'method' => "GET",
+    'header' => "Accept-language: en\r\n" .
+                "Cookie: foo=bar",
   ]
 ];
 

--- a/reference/filesystem/functions/fileatime.xml
+++ b/reference/filesystem/functions/fileatime.xml
@@ -77,7 +77,7 @@ if (file_exists($filename)) {
   &reftitle.notes;
   <note>
    <para>
-    La date de dernière modification d'un fichier est supposée changer
+    La date de dernier accès d'un fichier est supposée changer
     à chaque fois que les blocs de données du fichier ont commencé
     à être lus. Cela peut être très coûteux en termes de performance lorsqu'une
     application accède régulièrement à beaucoup de fichiers ou de répertoires.

--- a/reference/filesystem/functions/fwrite.xml
+++ b/reference/filesystem/functions/fwrite.xml
@@ -148,7 +148,7 @@ function fwrite_stream($fp, $string) {
     for ($written = 0; $written < strlen($string); $written += $fwrite) {
         $fwrite = fwrite($fp, substr($string, $written));
         if ($fwrite === false) {
-            return $fwrite;
+            return $written;
         }
     }
     return $written;

--- a/reference/filesystem/functions/parse-ini-file.xml
+++ b/reference/filesystem/functions/parse-ini-file.xml
@@ -195,6 +195,8 @@ Array
                     [git] => http://git.php.net
                 )
 
+        )
+
 )
 ]]>
     </screen>


### PR DESCRIPTION
- Fix code example spacing and extra \r\n in file-get-contents
- Fix wrong return variable in fwrite_stream helper
- Add missing closing parenthesis in parse-ini-file output
- Fix "modification" → "accès" for fileatime (access time, not mtime)