### PR TITLE
strings/functions: fix translations, typos, and untranslated comments

### DIFF
--- a/reference/strings/functions/echo.xml
+++ b/reference/strings/functions/echo.xml
@@ -202,17 +202,17 @@ echo("hello", " world"), PHP_EOL;
    <programlisting role="php">
 <![CDATA[
 <?php
-// Below, the expression 'Hello ' . isset($name) is evaluated first,
-// and is always true, so the argument to echo is always $name
+// Ci-dessous, l'expression 'Hello ' . isset($name) est évaluée en premier,
+// et est toujours true, donc l'argument de echo est toujours $name
 echo 'Hello ' . isset($name) ? $name : 'John Doe' . '!';
 
-// The intended behaviour requires additional parentheses
+// Le comportement souhaité nécessite des parenthèses supplémentaires
 echo 'Hello ' . (isset($name) ? $name : 'John Doe') . '!';
 
-// In PHP prior to 8.0.0, the below outputs "2", rather than "Sum: 3"
+// En PHP antérieur à 8.0.0, le code ci-dessous affiche "2", au lieu de "Sum: 3"
 echo 'Sum: ' . 1 + 2;
 
-// Again, adding parentheses ensures the intended order of evaluation
+// Encore une fois, l'ajout de parenthèses garantit l'ordre d'évaluation souhaité
 echo 'Sum: ' . (1 + 2);
 ]]>
    </programlisting>

--- a/reference/strings/functions/hebrev.xml
+++ b/reference/strings/functions/hebrev.xml
@@ -5,7 +5,7 @@
 <refentry xml:id="function.hebrev" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>hebrev</refname>
-  <refpurpose>Convertit un texte logique hébreux en texte visuel</refpurpose>
+  <refpurpose>Convertit un texte logique hébreu en texte visuel</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -16,7 +16,7 @@
    <methodparam choice="opt"><type>int</type><parameter>max_chars_per_line</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
   <para>
-   Convertit un texte logique hébreux en texte visuel.
+   Convertit un texte logique hébreu en texte visuel.
   </para>
   <para>
    La fonction tente d'éviter la césure des mots.
@@ -31,7 +31,7 @@
      <term><parameter>string</parameter></term>
      <listitem>
       <para>
-       Une chaîne d'entrée en hébreux.
+       Une chaîne d'entrée en hébreu.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/strings/functions/hebrevc.xml
+++ b/reference/strings/functions/hebrevc.xml
@@ -5,7 +5,7 @@
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.hebrevc">
  <refnamediv>
   <refname>hebrevc</refname>
-  <refpurpose>Convertit un texte logique hébreux en texte visuel, avec retours à la ligne</refpurpose>
+  <refpurpose>Convertit un texte logique hébreu en texte visuel, avec retours à la ligne</refpurpose>
  </refnamediv>
 
  <refsynopsisdiv>
@@ -37,7 +37,7 @@
      <term><parameter>hebrew_text</parameter></term>
      <listitem>
       <para>
-       Une chaîne d'entrée en hébreux.
+       Une chaîne d'entrée en hébreu.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/strings/functions/hex2bin.xml
+++ b/reference/strings/functions/hex2bin.xml
@@ -50,8 +50,8 @@
  <refsect1 role="errors">
   &reftitle.errors;
   <para>
-   Si la chaîne d'entrée en héxadécimale est d'une longueur impaire ou
-   si la chaîne en héxadécimale est invalide, une alerte de niveau
+   Si la chaîne d'entrée en hexadécimale est d'une longueur impaire ou
+   si la chaîne en hexadécimale est invalide, une alerte de niveau
    <constant>E_WARNING</constant> sera émise.
   </para>
  </refsect1>

--- a/reference/strings/functions/html-entity-decode.xml
+++ b/reference/strings/functions/html-entity-decode.xml
@@ -27,7 +27,7 @@
    entités nommées qui peuvent être définies dans une DTD - et 2) et dont le caractère
    ou les caractères sont dans le jeu de caractères codé avec l'encodage choisi et
    sont autorisés dans le type de document choisi. Toutes les autres entités
-   sont laissées telle que.
+   sont laissées telles quelles.
   </para>
  </refsect1>
 
@@ -76,7 +76,7 @@
            <entry><constant>ENT_SUBSTITUTE</constant></entry>
            <entry>
             Remplace les séquences de code invalide avec un caractère de remplacement
-            Unicode U+FFFD (UTF-8) ou &amp;#FFFD; (sinon) au lieu de retourner une
+            Unicode U+FFFD (UTF-8) ou &amp;#xFFFD; (sinon) au lieu de retourner une
             chaîne vide.
            </entry>
           </row>
@@ -142,7 +142,7 @@
      <row>
       <entry>8.1.0</entry>
       <entry>
-       <parameter>flags</parameter> à changé de <constant>ENT_COMPAT</constant> à
+       <parameter>flags</parameter> a changé de <constant>ENT_COMPAT</constant> à
        <constant>ENT_QUOTES</constant> | <constant>ENT_SUBSTITUTE</constant> | <constant>ENT_HTML401</constant>.
       </entry>
      </row>

--- a/reference/strings/functions/htmlentities.xml
+++ b/reference/strings/functions/htmlentities.xml
@@ -177,7 +177,7 @@
      <row>
       <entry>8.1.0</entry>
       <entry>
-       <parameter>flags</parameter> à changé de <constant>ENT_COMPAT</constant> à
+       <parameter>flags</parameter> a changé de <constant>ENT_COMPAT</constant> à
        <constant>ENT_QUOTES</constant> | <constant>ENT_SUBSTITUTE</constant> | <constant>ENT_HTML401</constant>.
       </entry>
      </row>

--- a/reference/strings/functions/htmlspecialchars-decode.xml
+++ b/reference/strings/functions/htmlspecialchars-decode.xml
@@ -74,7 +74,7 @@
            <entry><constant>ENT_SUBSTITUTE</constant></entry>
            <entry>
             Remplace les séquences de code invalide avec un caractère de remplacement
-            Unicode U+FFFD (UTF-8) ou &amp;#FFFD; (sinon) au lieu de retourner une
+            Unicode U+FFFD (UTF-8) ou &amp;#xFFFD; (sinon) au lieu de retourner une
             chaîne vide.
            </entry>
           </row>
@@ -133,7 +133,7 @@
      <row>
       <entry>8.1.0</entry>
       <entry>
-       <parameter>flags</parameter> à changé de <constant>ENT_COMPAT</constant> à
+       <parameter>flags</parameter> a changé de <constant>ENT_COMPAT</constant> à
        <constant>ENT_QUOTES</constant> | <constant>ENT_SUBSTITUTE</constant> | <constant>ENT_HTML401</constant>.
       </entry>
      </row>

--- a/reference/strings/functions/ltrim.xml
+++ b/reference/strings/functions/ltrim.xml
@@ -17,6 +17,11 @@
   <simpara>
    Supprime les espaces (ou d'autres caractères) de début de chaîne.
   </simpara>
+  <simpara>
+   Sans le second paramètre,
+   <function>mb_ltrim</function> supprimera ces caractères :
+  </simpara>
+  &strings.stripped.characters;
  </refsect1>
 
  <refsect1 role="parameters">

--- a/reference/strings/functions/number-format.xml
+++ b/reference/strings/functions/number-format.xml
@@ -131,9 +131,9 @@ var_dump(number_format($number, -3));
    &example.outputs;
    <screen>
 <![CDATA[
-string(5) "1 230"
-string(5) "1 200"
-string(5) "1 000"
+string(5) "1,230"
+string(5) "1,200"
+string(5) "1,000"
 ]]>
    </screen>
   </example>

--- a/reference/strings/functions/parse-str.xml
+++ b/reference/strings/functions/parse-str.xml
@@ -122,7 +122,7 @@ echo $output['arr'][1], PHP_EOL; // baz
    ou de points, mais cela s'applique même lorsque vous utilisez
    cette fonction avec le paramètre <parameter>result</parameter> .
    <example>
-    <title>Déformation des nom par <function>parse_str</function></title>
+    <title>Déformation des noms par <function>parse_str</function></title>
     <programlisting role="php">
 <![CDATA[
 <?php
@@ -150,7 +150,7 @@ echo $output['My_Value']; // Something
 
    <note>
    <para>
-    Toutes les valeurs ajoutée dans le tableau <parameter>result</parameter>
+    Toutes les valeurs ajoutées dans le tableau <parameter>result</parameter>
     (ou les variables créées si le second paramètre n'est pas défini)
     sont déjà décodées avec les mêmes règles que <function>urldecode</function>.
    </para>

--- a/reference/strings/functions/print.xml
+++ b/reference/strings/functions/print.xml
@@ -65,7 +65,7 @@
 print "print does not require parentheses.";
 print PHP_EOL;
 
-// No newline or space is added; the below outputs "helloworld" all on one line
+// Aucune nouvelle ligne ou espace n'est ajoutée ; ci-dessous affiche "helloworld", tout sur une ligne
 print "hello";
 print "world";
 print PHP_EOL;
@@ -78,7 +78,7 @@ print PHP_EOL;
 print "This string spans\nmultiple lines. The newlines will be\noutput as well.";
 print PHP_EOL;
 
-// The argument can be any expression which produces a string
+// L'argument peut être n'importe quelle expression qui produit une chaîne de caractères
 $foo = "example";
 print "foo is $foo"; // foo is example
 print PHP_EOL;
@@ -87,18 +87,18 @@ $fruits = ["lemon", "orange", "banana"];
 print implode(" and ", $fruits); // lemon and orange and banana
 print PHP_EOL;
 
-// Non-string expressions are coerced to string, even if declare(strict_types=1) is used
+// Les expressions qui ne sont pas des chaînes sont converties en chaînes, même si declare(strict_types=1) est utilisé
 print 6 * 7; // 42
 print PHP_EOL;
 
-// Because print has a return value, it can be used in expressions
-// The following outputs "hello world"
+// Parce que print a une valeur de retour, il peut être utilisé dans des expressions
+// Le code suivant affiche "hello world"
 if ( print "hello" ) {
     echo " world";
 }
 print PHP_EOL;
 
-// The following outputs "true"
+// Le code suivant affiche "true"
 ( 1 === 1 ) ? print 'true' : print 'false';
 print PHP_EOL;
 ?>
@@ -125,14 +125,14 @@ print PHP_EOL;
 <![CDATA[
 <?php
 print "hello";
-// outputs "hello"
+// affiche "hello"
 
 print("hello");
-// also outputs "hello", because ("hello") is a valid expression
+// affiche également "hello", car ("hello") est une expression valide
 
 print(1 + 2) * 3;
-// outputs "9"; the parentheses cause 1+2 to be evaluated first, then 3*3
-// the print statement sees the whole expression as one argument
+// affiche "9" ; les parenthèses permettent à 1+2 d'être évalué en premier, puis 3*3
+// l'instruction print voit l'expression entière comme un seul argument
 
 if ( print("hello") && false ) {
     print " - inside if";
@@ -140,10 +140,10 @@ if ( print("hello") && false ) {
 else {
     print " - inside else";
 }
-// outputs " - inside if"
-// the expression ("hello") && false is first evaluated, giving false
-// this is coerced to the empty string "" and printed
-// the print construct then returns 1, so code in the if block is run
+// affiche " - inside if"
+// l'expression ("hello") && false est d'abord évaluée, donnant false
+// celle-ci est convertie en chaîne vide "" et affichée
+// la construction print retourne alors 1, donc le code du bloc if est exécuté
 ?>
 ]]>
      </programlisting>
@@ -164,18 +164,18 @@ if ( (print "hello") && false ) {
 else {
     print " - inside else";
 }
-// outputs "hello - inside else"
-// unlike the previous example, the expression (print "hello") is evaluated first
-// after outputting "hello", print returns 1
-// since 1 && false is false, code in the else block is run
+// affiche "hello - inside else"
+// contrairement à l'exemple précédent, l'expression (print "hello") est évaluée en premier
+// après avoir affiché "hello", print retourne 1
+// puisque 1 && false vaut false, le code du bloc else est exécuté
 
 print "hello " && print "world";
-// outputs "world1"; print "world" is evaluated first,
-// then the expression "hello " && 1 is passed to the left-hand print
+// affiche "world1" ; print "world" est évalué en premier,
+// puis l'expression "hello " && 1 est passée au print de gauche
 
 (print "hello ") && (print "world");
-// outputs "hello world"; the parentheses force the print expressions
-// to be evaluated before the &&
+// affiche "hello world" ; les parenthèses forcent les expressions print
+// à être évaluées avant le &&
 ?>
 ]]>
      </programlisting>

--- a/reference/strings/functions/quoted-printable-decode.xml
+++ b/reference/strings/functions/quoted-printable-decode.xml
@@ -20,7 +20,7 @@
    <literal>quoted printable</literal> binaire 8 bits (en accord avec la
    <link xlink:href="&url.rfc;2045">RFC2045</link>, section 6.7, et non pas la
    <link xlink:href="&url.rfc;2821">RFC2821</link>, section 4.5.2, pour que les
-   virgules additionnelles ne soient pas effacée du début de la ligne).
+   points additionnels ne soient pas effacés du début de la ligne).
   </para>
   <para>
    Cette fonction est similaire à <function>imap_qprint</function>, hormis le fait

--- a/reference/strings/functions/sha1.xml
+++ b/reference/strings/functions/sha1.xml
@@ -84,6 +84,7 @@ if (sha1($str) === '752c14ea195c460bac3c3b7896975ee9fd15eeb7') {
   <para>
    <simplelist>
     <member><function>hash</function></member>
+    <member><function>password_hash</function></member>
    </simplelist>
   </para>
  </refsect1>

--- a/reference/strings/functions/stripslashes.xml
+++ b/reference/strings/functions/stripslashes.xml
@@ -44,7 +44,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Retourne une chaîne dont les antislashs on été supprimés.
+   Retourne une chaîne dont les antislashs ont été supprimés.
    <literal>\'</literal> devient <literal>'</literal>, etc.
    Les doubles antislashs (<literal>\\</literal>) sont réduits
    à un seul antislash (<literal>\</literal>).

--- a/reference/strings/functions/stristr.xml
+++ b/reference/strings/functions/stristr.xml
@@ -94,7 +94,7 @@
       <row>
        <entry>7.3.0</entry>
        <entry>
-        Passer un &integer; comme <parameter>before_needle</parameter> a été
+        Passer un &integer; comme <parameter>needle</parameter> a été
         rendu obsolète.
        </entry>
       </row>

--- a/reference/strings/functions/strstr.xml
+++ b/reference/strings/functions/strstr.xml
@@ -101,7 +101,7 @@
       <row>
        <entry>7.3.0</entry>
        <entry>
-        Passer un &integer; comme <parameter>before_needle</parameter> a été
+        Passer un &integer; comme <parameter>needle</parameter> a été
         rendu obsolète.
        </entry>
       </row>

--- a/reference/strings/functions/ucwords.xml
+++ b/reference/strings/functions/ucwords.xml
@@ -120,7 +120,7 @@ echo ucwords($foo, "|"), PHP_EOL;        // Hello|World!
 
   <para>
    <example>
-    <title>Exemple de <function>ucwords</function> des séparateurs supplémentaires</title>
+    <title>Exemple avec <function>ucwords</function> et des séparateurs supplémentaires</title>
     <programlisting role="php">
      <![CDATA[
 <?php

--- a/reference/strings/functions/utf8-decode.xml
+++ b/reference/strings/functions/utf8-decode.xml
@@ -155,15 +155,15 @@ string(1) "?"
         <programlisting role="php">
 <![CDATA[
 <?php
-$utf8_string = "\xC3\xAB"; // 'ë' (e with diaeresis) in UTF-8
+$utf8_string = "\xC3\xAB"; // 'ë' (e tréma) en UTF-8
 $iso8859_1_string = mb_convert_encoding($utf8_string, 'ISO-8859-1', 'UTF-8');
 echo bin2hex($iso8859_1_string), "\n";
 
-$utf8_string = "\xCE\xBB"; // 'λ' (Greek lower-case lambda) in UTF-8
+$utf8_string = "\xCE\xBB"; // 'λ' (lambda grec minuscule) en UTF-8
 $iso8859_7_string = mb_convert_encoding($utf8_string, 'ISO-8859-7', 'UTF-8');
 echo bin2hex($iso8859_7_string), "\n";
 
-$utf8_string = "\xE2\x82\xAC"; // '€' (Euro sign) in UTF-8 (not present in ISO-8859-1)
+$utf8_string = "\xE2\x82\xAC"; // '€' (signe euro) en UTF-8 (absent en ISO-8859-1)
 $windows_1252_string = mb_convert_encoding($utf8_string, 'Windows-1252', 'UTF-8');
 echo bin2hex($windows_1252_string), "\n";
 ?>
@@ -189,7 +189,7 @@ eb
         <programlisting role="php">
 <![CDATA[
 <?php
-$utf8_string = "\x5A\x6F\xC3\xAB"; // 'Zoë' in UTF-8
+$utf8_string = "\x5A\x6F\xC3\xAB"; // 'Zoë' en UTF-8
 $iso8859_1_string = utf8_decode($utf8_string);
 echo bin2hex($iso8859_1_string), "\n";
 
@@ -220,7 +220,7 @@ echo bin2hex($iso8859_1_string), "\n";
         <programlisting role="php">
 <![CDATA[
 <?php
-$utf8_string = "\xE2\x82\xAC"; // € (Euro Sign) does not exist in ISO 8859-1
+$utf8_string = "\xE2\x82\xAC"; // € (signe euro) n'existe pas en ISO 8859-1
 $iso8859_1_string = UConverter::transcode(
     $utf8_string, 'ISO-8859-1', 'UTF-8', ['to_subst' => '?']
 );

--- a/reference/strings/functions/utf8-encode.xml
+++ b/reference/strings/functions/utf8-encode.xml
@@ -143,15 +143,15 @@ echo bin2hex($utf8_string), "\n";
         <programlisting role="php">
 <![CDATA[
 <?php
-$iso8859_1_string = "\xEB"; // 'ë' (e with diaeresis) in ISO-8859-1
+$iso8859_1_string = "\xEB"; // 'ë' (e tréma) en ISO-8859-1
 $utf8_string = mb_convert_encoding($iso8859_1_string, 'UTF-8', 'ISO-8859-1');
 echo bin2hex($utf8_string), "\n";
 
-$iso8859_7_string = "\xEB"; // the same string in ISO-8859-7 represents 'λ' (Greek lower-case lambda)
+$iso8859_7_string = "\xEB"; // la même chaîne en ISO-8859-7 représente 'λ' (lambda grec minuscule)
 $utf8_string = mb_convert_encoding($iso8859_7_string, 'UTF-8', 'ISO-8859-7');
 echo bin2hex($utf8_string), "\n";
 
-$windows_1252_string = "\x80"; // '€' (Euro sign) in Windows-1252, but not in ISO-8859-1
+$windows_1252_string = "\x80"; // '€' (signe euro) en Windows-1252, mais pas en ISO-8859-1
 $utf8_string = mb_convert_encoding($windows_1252_string, 'UTF-8', 'Windows-1252');
 echo bin2hex($utf8_string), "\n";
 ?>
@@ -177,7 +177,7 @@ e282ac
         <programlisting role="php">
 <![CDATA[
 <?php
-$iso8859_1_string = "\x5A\x6F\xEB"; // 'Zoë' in ISO-8859-1
+$iso8859_1_string = "\x5A\x6F\xEB"; // 'Zoë' en ISO-8859-1
 
 $utf8_string = utf8_encode($iso8859_1_string);
 echo bin2hex($utf8_string), "\n";


### PR DESCRIPTION
- echo.xml: translate English code comments in tip section
- hebrev.xml, hebrevc.xml: fix "hébreux" → "hébreu"
- hex2bin.xml: fix "héxadécimale" → "hexadécimale"
- print.xml: translate all English code comments to French
- ucwords.xml: fix awkward example title grammar
- utf8-decode.xml, utf8-encode.xml: translate English code comments in notes section
- html-entity-decode.xml, htmlentities.xml, htmlspecialchars-decode.xml, ltrim.xml, number-format.xml, parse-str.xml, quoted-printable-decode.xml, sha1.xml, stripslashes.xml, stristr.xml, strstr.xml: fixes from prior review