### PR TITLE
reference/stream: fix function names, typos, and grammar

### DIFF
--- a/reference/stream/contexts.xml
+++ b/reference/stream/contexts.xml
@@ -22,8 +22,8 @@
   dans le chapitre <xref linkend="context" />.
  </simpara>
  <simpara>
-  <literal>Parameters</literal> peut être spécifié pour
-  <literal>contexts</literal> en utilisant la fonction
+  Les <literal>paramètres</literal> peuvent être spécifiés pour les
+  <literal>contextes</literal> en utilisant la fonction
   <function>stream_context_set_params</function>.
  </simpara>
 </chapter>

--- a/reference/stream/filters.xml
+++ b/reference/stream/filters.xml
@@ -11,7 +11,7 @@
   filtres peuvent être ajoutés sur un flux. Des filtres personnalisés peuvent aussi
   être ajoutés avec la fonction <function>stream_register_filter</function>, ou bien
   dans une extension. Pour
-  connaître la liste des gestionnaires actuellement enregistrés, utilisez la fonction
+  connaître la liste des filtres actuellement enregistrés, utilisez la fonction
   <function>stream_get_filters</function>.
  </simpara>
 </chapter>

--- a/reference/stream/functions/stream-filter-prepend.xml
+++ b/reference/stream/functions/stream-filter-prepend.xml
@@ -98,7 +98,7 @@
   <note>
    <title>Quand vous utilisez des filtres personnalisés</title>
    <simpara>
-    <function>stream_register_filter</function> doit être appelée avant
+    <function>stream_filter_register</function> doit être appelée avant
     <function>stream_filter_prepend</function> pour enregistrer le filtre
     sous le nom de <parameter>filtername</parameter>.
    </simpara>

--- a/reference/stream/functions/stream-get-line.xml
+++ b/reference/stream/functions/stream-get-line.xml
@@ -17,7 +17,7 @@
   </methodsynopsis>
   <para>
    <function>stream_get_line</function> lit une ligne dans la ressource
-   <parameter>handle</parameter>.
+   <parameter>stream</parameter>.
   </para>
   <para>
    La lecture se termine quand <parameter>length</parameter> octets

--- a/reference/stream/functions/stream-set-write-buffer.xml
+++ b/reference/stream/functions/stream-set-write-buffer.xml
@@ -51,7 +51,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Retourne 0 en cas de succès, ou un autre valeur si la requête échoue.
+   Retourne 0 en cas de succès, ou une autre valeur si la requête échoue.
   </para>
  </refsect1>
 

--- a/reference/stream/php_user_filter/oncreate.xml
+++ b/reference/stream/php_user_filter/oncreate.xml
@@ -48,7 +48,7 @@
       <row>
        <entry><literal>FilterClass-&gt;params</literal></entry>
        <entry>
-        Le contenu du pramètre <parameter>params</parameter> passé
+        Le contenu du paramètre <parameter>params</parameter> passé
         à la fonction <function>stream_filter_append</function> ou
         la fonction <function>stream_filter_prepend</function>.
        </entry>

--- a/reference/stream/streamwrapper/dir-readdir.xml
+++ b/reference/stream/streamwrapper/dir-readdir.xml
@@ -29,7 +29,7 @@
   &reftitle.returnvalues;
   <para>
    Doit retourner une &string; représentant le prochain nom de fichier, 
-   ou &false; s'i n'y a pas d'autre fichier.
+   ou &false; s'il n'y a pas d'autre fichier.
   </para>
   <warning>
    <simpara>


### PR DESCRIPTION
- Fix stream_register_filter → stream_filter_register
- Fix parameter name handle → stream
- Fix untranslated English text in contexts
- Fix typo "pramètre" → "paramètre"
- Fix gender agreement and missing contraction