### PR TITLE
reference/datetime: fix grammar, spelling, and code examples

### DIFF
--- a/reference/datetime/dateperiod/construct.xml
+++ b/reference/datetime/dateperiod/construct.xml
@@ -33,7 +33,7 @@
     <methodparam choice="opt"><type>int</type><parameter>options</parameter><initializer>0</initializer></methodparam>
    </constructorsynopsis>
    <simpara>
-    A la place la méthode usine <methodname>DatePeriod::createFromISO8601String</methodname>
+    À la place la méthode usine <methodname>DatePeriod::createFromISO8601String</methodname>
     devrait être utilisée.
    </simpara>
   </warning>
@@ -306,7 +306,7 @@ Thursday 2022-12-29
    "Intervalle de temps récurrent" de la norme ISO 8601 ne sont pas 
    supportés, c'est-à-dire ni <literal>"R/..."</literal> comme 
    <parameter>isostr</parameter> ni &null; comme 
-   <parameter>end</parameter> ne fonctionnerait.
+   <parameter>end</parameter> ne fonctionneraient.
   </simpara>
  </refsect1>
 </refentry>

--- a/reference/datetime/datetime/createfromformat.xml
+++ b/reference/datetime/datetime/createfromformat.xml
@@ -32,8 +32,9 @@
    <parameter>format</parameter> donné.
   </para>
   <para>
-   Identique à <methodname>DateTimeImmutable::createFromFormat</methodname> 
-   mais crée une instance de l'objet <classname>DateTime</classname>.
+   Identique à <methodname>DateTimeImmutable::createFromFormat</methodname>
+   et <function>date_create_immutable_from_format</function>, respectivement, mais
+   crée un objet <classname>DateTime</classname>.
   </para>
   <para>
    Cette méthode, y compris les paramètres, les exemples et les considérations,

--- a/reference/datetime/datetime/modify.xml
+++ b/reference/datetime/datetime/modify.xml
@@ -76,6 +76,7 @@
        <exceptionname>DateMalformedStringException</exceptionname> si une
        chaîne invalide est passée. Auparavant, il retournait &false;,
        et un avertissement était émis.
+       <function>date_modify</function> n'a pas été modifiée.
       </entry>
      </row>
     </tbody>

--- a/reference/datetime/datetimeimmutable/createfromformat.xml
+++ b/reference/datetime/datetimeimmutable/createfromformat.xml
@@ -676,7 +676,7 @@ Mon, 10 Aug 2020 01:00:00 +0000
     <listitem>
      <simpara>
       <literal>Mon</literal> est appliqué, ce qui avance la date au
-      <literal>Mon, 10 Aug 2020 01:00:00</literal>.L'explication des 
+      <literal>Mon, 10 Aug 2020 01:00:00</literal>. L'explication des 
       mots-clés relatifs tels que <literal>Mon</literal> est expliquée 
       dans la section sur les <link linkend="datetime.formats.relative">
       formats relatifs</link>.
@@ -779,7 +779,7 @@ Array
    <para>
     De plus, une heure de <literal>60</literal> est en dehors de la plage 
     <literal>0</literal>-<literal>24</literal>, ce qui fait que le tableau 
-    <literal>warnings</literal> inclut un avertissant que l'heure n'est pas 
+    <literal>warnings</literal> inclut un avertissement indiquant que l'heure n'est pas
     valide.
    </para>
   </example>

--- a/reference/datetime/datetimeimmutable/getlasterrors.xml
+++ b/reference/datetime/datetimeimmutable/getlasterrors.xml
@@ -28,7 +28,7 @@
   &reftitle.returnvalues;
   <para>
    Retourne un tableau contenant les informations à propos des alertes et
-   erreurs, ou &false; s'il y a ni alertes ni erreurs.
+   erreurs, ou &false; s'il n'y a ni alertes ni erreurs.
   </para>
  </refsect1>
 
@@ -98,7 +98,7 @@ Failed to parse time string (asdfasdf) at position 0 (a): The timezone could not
 ]]>
    </screen>
    <para>
-    Les index 6, et 0 dans la sortie de l'exemple réfère à l'index du
+    Les index 6, et 0 dans la sortie de l'exemple réfèrent à l'index du
     caractère dans la chaîne où l'erreur s'est produite.
    </para>
   </example>

--- a/reference/datetime/datetimeimmutable/setisodate.xml
+++ b/reference/datetime/datetimeimmutable/setisodate.xml
@@ -17,7 +17,7 @@
    <methodparam choice="opt"><type>int</type><parameter>dayOfWeek</parameter><initializer>1</initializer></methodparam>
   </methodsynopsis>
   <para>
-   Retourne un nouvel objet DateTimeImmutable avec la date défini en respectant
+   Retourne un nouvel objet DateTimeImmutable avec la date définie en respectant
    le standard ISO 8601, utilisant les semaines et écarts de jour plutôt que
    des dates spécifiques.
   </para>

--- a/reference/datetime/datetimeinterface.xml
+++ b/reference/datetime/datetimeinterface.xml
@@ -192,8 +192,9 @@
       <note>
        <simpara>
         Ce format n'est pas compatible avec ISO-8601, mais reste ainsi pour des 
-        raisons de compatibilité ascendante. Utilisez <constant>DateTime::ISO8601_EXPANDED</constant>
-        ou <constant>DateTimeInterface::ATOM</constant> pour assurer la compatibilité avec 
+        raisons de compatibilité ascendante. Utilisez
+        <constant>DateTimeInterface::ISO8601_EXPANDED</constant>,
+        <constant>DateTimeInterface::ATOM</constant> pour assurer la compatibilité avec
         ISO-8601. (ref ISO8601:2004 section 4.3.3 clause d)
        </simpara>
       </note>

--- a/reference/datetime/datetimeinterface/format.xml
+++ b/reference/datetime/datetimeinterface/format.xml
@@ -264,7 +264,7 @@
            <entry><literal>u</literal></entry>
            <entry>
             Microsecondes. Notez que la fonction
-            <function>date</function> génèrera toujours
+            <function>date</function> générera toujours
             <literal>000000</literal> vu qu'elle prend un paramètre de type
             entier, alors que la méthode <methodname>DateTimeInterface::format</methodname>
             supporte les microsecondes si un objet de type
@@ -339,7 +339,7 @@
           <row>
            <entry><literal>r</literal></entry>
            <entry>Format de date <link xlink:href="&url.rfc;2822">RFC 2822</link>/<link xlink:href="&url.rfc;5322">RFC 5322</link></entry>
-           <entry>Exemple : <literal>Thu, 21 Dec 2000 16:01:070200</literal></entry>
+           <entry>Exemple : <literal>Thu, 21 Dec 2000 16:01:07 +0200</literal></entry>
           </row>
           <row>
            <entry><literal>U</literal></entry>

--- a/reference/datetime/datetimeinterface/getoffset.xml
+++ b/reference/datetime/datetimeinterface/getoffset.xml
@@ -45,7 +45,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Retourne le décalage horaire en seconde, depuis UTC en cas de succès.
+   Retourne le décalage horaire en secondes, depuis UTC en cas de succès.
   </para>
  </refsect1>
 

--- a/reference/datetime/datetimezone/construct.xml
+++ b/reference/datetime/datetimezone/construct.xml
@@ -25,7 +25,7 @@
   </para>
   <para>
    Un objet DateTimeZone fournit l'accès à trois types différents de règles
-   de fuseau horaires : un décalage UTC (type <literal>1</literal>), une
+   de fuseaux horaires : un décalage UTC (type <literal>1</literal>), une
    abréviation de fuseau horaire (type <literal>2</literal>), et un
    <link linkend="timezones">identifiant de fuseau horaire</link> tel que
    publié dans la base de données de fuseau horaire IANA (type <literal>3</literal>).
@@ -143,7 +143,6 @@ foreach ($timezones as $tz) {
         $mars = new DateTimeZone($tz);
         echo $mars->getName() . "\n";
     } catch(Exception $e) {
-        echo $e->getMessage() . '<br />';
         echo $e->getMessage() . "\n";
     }
 }

--- a/reference/datetime/datetimezone/getlocation.xml
+++ b/reference/datetime/datetimezone/getlocation.xml
@@ -77,6 +77,14 @@ Array
     </screen>
    </example>
   </para>
+  <para>
+   L'élément <literal>country_code</literal> contient le code pays
+   ISO 3166-1 alpha-2 de chaque entrée. Les éléments <literal>latitude</literal> et
+   <literal>longitude</literal> contiennent les coordonnées de la ville nommée à
+   partir de l'identifiant de fuseau horaire, et <literal>comments</literal> contient
+   (lorsque non &false;) un indice de l'endroit où dans le pays donné ce fuseau horaire
+   est appliqué. Cette information est appropriée pour les utilisateurs finaux.
+  </para>
  </refsect1>
 
  <refsect1 role="seealso">
@@ -87,14 +95,6 @@ Array
     complète ou partielle de tous les identifiants de fuseaux horaires pris en charge
    </member>
   </simplelist>
- <para>
-   L'élément <literal>country_code</literal> contient le code pays
-   ISO 3166-1 de chaque pays. Les éléments <literal>latitude</literal> et
-   <literal>longitude</literal> les coordonnées de la ville nommée à
-   partir du fuseau horaire, et <literal>comments</literal> contient
-   (lorsque non &false;) un indice de l'endroit où dans le pays donné ce fuseau horaire
-   est appliqué. Cette information est appropriée pour les utilisateurs finaux.
-  </para>
  </refsect1>
 
 </refentry>

--- a/reference/datetime/datetimezone/getoffset.xml
+++ b/reference/datetime/datetimezone/getoffset.xml
@@ -24,7 +24,7 @@
    <function>timezone_offset_get</function> retourne le décalage horaire par
    rapport au GMT pour le paramètre <parameter>datetime</parameter>. Le 
    décalage GMT est calculé à partir des informations de fuseau horaire 
-   contenu dans l'objet <classname>DateTime</classname>.
+   contenues dans l'objet <classname>DateTime</classname>.
   </para>
  </refsect1>
 

--- a/reference/datetime/functions/date-sun-info.xml
+++ b/reference/datetime/functions/date-sun-info.xml
@@ -60,7 +60,7 @@
      <term><literal>sunrise</literal></term>
      <listitem>
       <simpara>
-       L'horodatage du levé du soleil (angle de zenith = 90°35').
+       L'horodatage du lever du soleil (angle de zenith = 90°35').
       </simpara>
      </listitem> 
     </varlistentry>
@@ -112,7 +112,7 @@
      <term><literal>nautical_twilight_end</literal></term>
      <listitem>
        <simpara>
-       La fin du crépuscule nautique (angle de zenith = 102°). Elle commence a
+       La fin du crépuscule nautique (angle de zenith = 102°). Elle commence au
        <literal>civil_twilight_end</literal>.
       </simpara>
      </listitem> 
@@ -130,7 +130,7 @@
      <term><literal>astronomical_twilight_end</literal></term>
      <listitem>
       <simpara>
-       La fin du crépuscule astronomique (angle de zenith = 108°). Elle commence a
+       La fin du crépuscule astronomique (angle de zenith = 108°). Elle commence au
        <literal>nautical_twilight_end</literal>.
       </simpara>
      </listitem> 

--- a/reference/datetime/functions/date.xml
+++ b/reference/datetime/functions/date.xml
@@ -215,7 +215,7 @@ echo date("Y-m-d H:i:s") . "\n";                   // 2001-03-10 17:16:18 (the M
     <member><function>mktime</function></member>
     <member><methodname>IntlDateFormatter::format</methodname></member>
     <member><function>time</function></member>
-    <member><link linkend="datetimeinterface.constants.types">Constantes DateTime Prédéfinie</link></member>
+    <member><link linkend="datetimeinterface.constants.types">Constantes DateTime prédéfinies</link></member>
    </simplelist>
   </para>
  </refsect1>

--- a/reference/datetime/functions/microtime.xml
+++ b/reference/datetime/functions/microtime.xml
@@ -20,7 +20,7 @@
   </para>
   <para>
    Pour mesurer les performances, l'utilisation de <function>hrtime</function>
-   est recommandé.
+   est recommandée.
   </para>
  </refsect1>
 

--- a/reference/datetime/functions/mktime.xml
+++ b/reference/datetime/functions/mktime.xml
@@ -279,7 +279,7 @@ print date('c', $nextyear) . "\n";
 $lastday = mktime(0, 0, 0, 3, 0, 2000);
 echo 'Last day in Feb 2000 is: ', date('d', $lastday) . "\n";
 $lastday = mktime(0, 0, 0, 4, -31, 2000);
-echo 'Le dernier jour de Fevrier 2000 est : ', date('d', $lastday)). "\n";
+echo 'Last day in Feb 2000 is: ', date('d', $lastday) . "\n";
 ]]>
     </programlisting>
     &example.outputs;

--- a/reference/datetime/functions/strftime.xml
+++ b/reference/datetime/functions/strftime.xml
@@ -673,7 +673,7 @@ Format inconnu : 'v'
   <note>
    <simpara>
     <literal>%G</literal> et <literal>%V</literal>, qui sont basées
-    sur la semaine <literal>ISO 8601:1988</literal>, peut conduire 
+    sur la semaine <literal>ISO 8601:1988</literal>, peuvent conduire 
     à des résultats inattendus (bien que corrects) si le
     système de numérotation n'est pas connu. Voir l'exemple
     <literal>%V</literal> de cette page.


### PR DESCRIPTION
- Fix plural agreements (fuseaux, secondes, contenues)
- Fix missing negation, verb, accents on capitals
- Fix code syntax error in mktime example
- Fix "levé" → "lever" du soleil
- Fix conjugations (réfèrent, fonctionneraient, peuvent)