### PR TITLE
bzip2/reference.xml: fix title order

### DIFF
--- a/reference/bzip2/reference.xml
+++ b/reference/bzip2/reference.xml
@@ -4,7 +4,7 @@
 <!-- Reviewed: yes -->
 
 <reference xml:id="ref.bzip2" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
- <title>&Functions; Bzip2</title>
+ <title>Bzip2 &Functions;</title>
 
  &reference.bzip2.entities.functions;
 


### PR DESCRIPTION
Correction de reference.xml : ordre du titre (Bzip2 &Functions;).