### PR TITLE
review: reference/com

### DIFF
--- a/reference/com/functions/com-create-guid.xml
+++ b/reference/com/functions/com-create-guid.xml
@@ -20,7 +20,7 @@
   <para>
    Un GUID est généré de la même façon que DCE UUID, excepté le
    fait que la convention Microsoft inclut le GUID dans
-   une parenthèse.
+   des accolades.
   </para>
  </refsect1>
 

--- a/reference/com/ini.xml
+++ b/reference/com/ini.xml
@@ -89,7 +89,7 @@
     </term>
     <listitem>
     <para>
-     Si cette directive est activée, PHP essayera de déclarer des constantes
+     Si cette directive est activée, PHP essayera d'enregistrer des constantes
      provenant de la bibliothèque typelibrary des objets <classname>COM</classname> qu'il instancie, si ces 
      objets implémentent l'interface demandée pour obtenir les données demandées.
      La sensibilité des constantes à la casse est contrôlée par la directive


### PR DESCRIPTION
Correction 'parenthèse' -> 'accolades' (curly braces) dans com-create-guid.xml, 'déclarer' -> 'enregistrer' (register) dans ini.xml.