### PR TITLE
dbase: fix grammar, add missing array_values() in example

### DIFF
--- a/reference/dbase/functions/dbase-numrecords.xml
+++ b/reference/dbase/functions/dbase-numrecords.xml
@@ -19,7 +19,7 @@
   </para>
   <note>
    <para>
-    Les enregistrements marqués comme supprimé sont aussi compté.
+    Les enregistrements marqués comme supprimés sont aussi comptés.
    </para>
   </note>
   <note>
@@ -95,9 +95,9 @@ if ($db) {
     for ($i = 1; $i <= $record_numbers; $i++) {
         $record = dbase_get_record($db, $i);
         if (!$record['deleted']) {
-            // faire qqch avec l'enregistrement $record
+            // faire quelque chose avec l'enregistrement $record
         } else {
-            // faire qqch avec l'enregistrement supprimé $record ou l'ignorer
+            // faire quelque chose avec l'enregistrement supprimé $record ou l'ignorer
         }
     }
 }

--- a/reference/dbase/functions/dbase-replace-record.xml
+++ b/reference/dbase/functions/dbase-replace-record.xml
@@ -112,7 +112,10 @@ if ($db) {
                    
   // Supprime l'entrée effacée
   unset($row['deleted']);
-                   
+
+  // Convertir la ligne en un tableau indexé
+  $row = array_values($row);
+
   // Mise à jour de la date du champ avec le timestamp courant
   $row['date'] = date('Ymd');
                    


### PR DESCRIPTION
Accords grammaticaux dans dbase-numrecords.xml, ajout array_values() manquant dans dbase-replace-record.xml.