### PR TITLE
dio-tcsetattr: fix parameter name (ressource -> fd)

### DIFF
--- a/reference/dio/functions/dio-tcsetattr.xml
+++ b/reference/dio/functions/dio-tcsetattr.xml
@@ -20,7 +20,7 @@
   </methodsynopsis>
   <para>
    <function>dio_tcsetattr</function> modifie les attributs du terminal 
-   et le taux de baud du port série de <parameter>ressource</parameter>.
+   et le taux de baud du port série de <parameter>fd</parameter>.
   </para>
  </refsect1>
 


### PR DESCRIPTION
Correction nom de paramètre dans dio-tcsetattr.xml (ressource -> fd).