### PR TITLE
Fix tokenizer/examples: remove outdated PHP 4/5 compat code

### DIFF
--- a/reference/tokenizer/examples.xml
+++ b/reference/tokenizer/examples.xml
@@ -15,20 +15,6 @@
   <programlisting role="php">
 <![CDATA[
 <?php
-/*
-* T_ML_COMMENT n'existe pas en PHP 5.
-* Les lignes suivantes le définisse afin de rendre
-* compatible notre code.
-*
-* Ensuite, les 2 lignes définissent T_DOC_COMMENT uniquement pour PHP 5,
-* que nous masquons en T_ML_COMMENT pour PHP 4.
-*/
-if (!defined('T_ML_COMMENT')) {
-   define('T_ML_COMMENT', T_COMMENT);
-} else {
-   define('T_DOC_COMMENT', T_ML_COMMENT);
-}
-
 $source = file_get_contents('example.php');
 $tokens = token_get_all($source);
 
@@ -40,15 +26,14 @@ foreach ($tokens as $token) {
        // tableau token
        list($id, $text) = $token;
 
-       switch ($id) { 
-           case T_COMMENT: 
-           case T_ML_COMMENT: // nous avons défini ceci
-           case T_DOC_COMMENT: // et ceci
+       switch ($id) {
+           case T_COMMENT:
+           case T_DOC_COMMENT:
                // Aucune action sur les commentaires
                break;
 
            default:
-               // rien d'autre -> affiche "as is"
+               // rien d'autre -> affiche "tel quel"
                echo $text;
                break;
        }


### PR DESCRIPTION
Supprime le code de compatibilité PHP 4/5 obsolète dans l'exemple.