### PR TITLE
Fix taint: inverted translations (taint=corrompre, not nettoyer)

### DIFF
--- a/reference/taint/functions/is-tainted.xml
+++ b/reference/taint/functions/is-tainted.xml
@@ -6,7 +6,7 @@
 <refentry xml:id="function.is-tainted" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>is_tainted</refname>
-  <refpurpose>Vérifie si une chaîne est nettoyée</refpurpose>
+  <refpurpose>Vérifie si une chaîne est corrompue</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -16,7 +16,7 @@
    <methodparam><type>string</type><parameter>string</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Vérifie si une chaîne est nettoyée.
+   Vérifie si une chaîne est corrompue.
   </para>
 
  </refsect1>
@@ -38,7 +38,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Retourne &true; si la chaîne est nettoyée, &false; sinon.
+   Retourne &true; si la chaîne est corrompue, &false; sinon.
   </para>
  </refsect1>
 

--- a/reference/taint/functions/taint.xml
+++ b/reference/taint/functions/taint.xml
@@ -6,7 +6,7 @@
 <refentry xml:id="function.taint" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>taint</refname>
-  <refpurpose>Nettoie une chaîne</refpurpose>
+  <refpurpose>Marque une chaîne comme corrompue</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -17,7 +17,7 @@
    <methodparam rep="repeat"><type>string</type><parameter>strings</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Rend une chaîne propre. Utilisé uniquement dans un but de test.
+   Marque une chaîne comme corrompue. Utilisé uniquement dans un but de test.
   </para>
  </refsect1>
 

--- a/reference/taint/functions/untaint.xml
+++ b/reference/taint/functions/untaint.xml
@@ -6,7 +6,7 @@
 <refentry xml:id="function.untaint" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>untaint</refname>
-  <refpurpose>Ne nettoie pas une chaîne</refpurpose>
+  <refpurpose>Retire la corruption d'une chaîne</refpurpose>
  </refnamediv>
  
  <refsect1 role="description">
@@ -17,7 +17,7 @@
    <methodparam rep="repeat"><type>string</type><parameter>strings</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Ne nettoie pas une chaîne.
+   Retire la corruption d'une chaîne.
   </para>
  </refsect1>
  


### PR DESCRIPTION
Corrige les traductions inversées : taint=corrompre (pas nettoyer), untaint=retirer la corruption.