### PR TITLE
Fix ldap: voter→votre, fix variable name, remove duplicate English, t…

### DIFF
--- a/reference/ldap/functions/ldap-connect.xml
+++ b/reference/ldap/functions/ldap-connect.xml
@@ -137,11 +137,11 @@
 <?php
 
 // LDAP variables
-$ldapuri = "ldap://ldap.example.com:389";  // voter ldap-uri
+$ldapuri = "ldap://ldap.example.com:389";  // votre ldap-uri
 
 // Connexion LDAP
-$ldapconn = ldap_connect($ldaphost, $ldapport)
-          or die("Cette LDAP-URI n'a pas été analysable");
+$ldapconn = ldap_connect($ldapuri)
+          or die("Cette LDAP-URI n'a pas pu être analysée");
 
 ?>
 ]]>

--- a/reference/ldap/functions/ldap-search.xml
+++ b/reference/ldap/functions/ldap-search.xml
@@ -134,7 +134,6 @@
         <listitem>
          <simpara>
           <constant>LDAP_DEREF_NEVER</constant> - (défaut) les alias ne sont jamais déréférencés.
-          dereferenced.
          </simpara>
         </listitem>
         <listitem>
@@ -230,7 +229,7 @@ $sr=ldap_search($ds, $dn, $filter, $justthese);
 
 $info = ldap_get_entries($ds, $sr);
 
-echo $info["count"]." entries returned\n";
+echo $info["count"]." entrées retournées\n";
 ?>
 ]]>
     </programlisting>


### PR DESCRIPTION


Corrige voter→votre, variable \→, supprime le doublon anglais et traduit entries returned.
