### PR TITLE
Fix errorfunc: translate error type labels, fix screen output

### DIFF
--- a/reference/errorfunc/examples.xml
+++ b/reference/errorfunc/examples.xml
@@ -33,15 +33,15 @@ function userErrorHandler($errno, $errmsg, $filename, $linenum, $vars)
                 E_WARNING            => 'Alerte',
                 E_PARSE              => 'Erreur d\'analyse',
                 E_NOTICE             => 'Note',
-                E_CORE_ERROR         => 'Core Error',
-                E_CORE_WARNING       => 'Core Warning',
-                E_COMPILE_ERROR      => 'Compile Error',
-                E_COMPILE_WARNING    => 'Compile Warning',
+                E_CORE_ERROR         => 'Erreur du noyau',
+                E_CORE_WARNING       => 'Alerte du noyau',
+                E_COMPILE_ERROR      => 'Erreur de compilation',
+                E_COMPILE_WARNING    => 'Alerte de compilation',
                 E_USER_ERROR         => 'Erreur spécifique',
                 E_USER_WARNING       => 'Alerte spécifique',
                 E_USER_NOTICE        => 'Note spécifique',
-                E_STRICT             => 'Runtime Notice',
-                E_RECOVERABLE_ERROR => 'Catchable Fatal Error'
+                E_STRICT             => 'Note d\'exécution',
+                E_RECOVERABLE_ERROR  => 'Erreur fatale rattrapable'
                 );
     // Les niveaux qui seront enregistrés
     $user_errors = array(E_USER_ERROR, E_USER_WARNING, E_USER_NOTICE);
@@ -58,7 +58,10 @@ function userErrorHandler($errno, $errmsg, $filename, $linenum, $vars)
         $err .= "\t<vartrace>".wddx_serialize_value($vars,"Variables")."</vartrace>\n";
     }
     $err .= "</errorentry>\n\n";
-    
+
+    // pour tester
+    // echo $err;
+
     // sauvegarde de l'erreur, et mail si c'est critique
     error_log($err, 3, "/usr/local/php4/error.log");
     if ($errno == E_USER_ERROR) {

--- a/reference/errorfunc/functions/set-error-handler.xml
+++ b/reference/errorfunc/functions/set-error-handler.xml
@@ -255,7 +255,7 @@ function myErrorHandler($errno, $errstr, $errfile, $errline)
 function scale_by_log($vect, $scale)
 {
     if (!is_numeric($scale) || $scale <= 0) {
-        trigger_error("log(x) for x <= 0 is undefined, you used: scale = $scale", E_USER_ERROR);
+        trigger_error("log(x) pour x <= 0 est indéfini, vous utilisez : scale = $scale", E_USER_ERROR);
     }
 
     if (!is_array($vect)) {
@@ -328,14 +328,14 @@ Array
     [5] => 24.165247890281
 )
 ----
-vector c - un avertissement
-<b>Mon ALERTE</b> [512] Entrée incorrecte, tableau de valeurs attendu<br />
+vector c - a warning
+<b>Mon ALERTE</b> [512] Type d'entrée incorrect, tableau de valeurs attendu<br />
 NULL
 ----
 vector d - fatal error
-<b>Mon ERREUR</b> [256] log(x) for x <= 0 est indéfini, vous utilisez : scale = -2.5<br />
-Erreur fatale sur la ligne 36 dans le fichier trigger_error.php, PHP 4.0.2 (Linux)<br />
-Abandon...<br />
+<b>Mon ERREUR</b> [256] log(x) pour x <= 0 est indéfini, vous utilisez : scale = -2.5<br />
+  Erreur fatale sur la ligne 36 dans le fichier trigger_error.php, PHP 5.2.1 (Linux)<br />
+Arrêt...<br />
 ]]>
     </screen>
    </example>


### PR DESCRIPTION
- examples.xml: translate remaining English error type labels (Core Error, Compile Error, etc.) and add missing test comment
- set-error-handler.xml: translate trigger_error string, fix screen output to match code (Arrêt instead of Abandon, correct trigger_error text)