### PR TITLE
Style impersonnel dans appendices/

### DIFF
--- a/appendices/about.xml
+++ b/appendices/about.xml
@@ -28,13 +28,13 @@
    Deux avantages du manuel en ligne sur la plupart des formats
    téléchargeables, sont l'intégration des <link
    linkend="about.notes">notes des utilisateurs</link> et les <link
-   xlink:href="&url.php.urlhowto;">URL de raccourci</link> que vous pouvez utiliser
-   pour accéder rapidement à une partie du manuel. Un inconvénient
-   évident est que vous devez être en ligne pour profiter de ce format.
+   xlink:href="&url.php.urlhowto;">URL de raccourci</link> qui permettent
+   d'accéder rapidement à une partie du manuel. Un inconvénient
+   évident est qu'il faut être en ligne pour profiter de ce format.
   </para>
   <para>
    Il y a de nombreux formats du manuel pour la consultation hors ligne, et
-   le format le plus approprié dépend de votre OS et de vos goûts personnels.
+   le format le plus approprié dépend du système d'exploitation et des goûts personnels.
    Pour savoir comment le manuel est généré, lisez la section
    <link linkend="about.generate">'Comment le manuel est généré'</link> de cet
    appendice.
@@ -43,7 +43,7 @@
    Le format le plus portable est le HTML. Le manuel est fourni
    dans un format en une seule page HTML, ou comme un ensemble de fichiers
    de tailles réduites (mais un bon millier de fichiers tout de même). Nous
-   fournissons ce format sous une forme compressée, vous aurez donc besoin
+   fournissons ce format sous une forme compressée, il est donc nécessaire de disposer
    d'un utilitaire de décompression pour extraire les fichiers de l'archive.
   </para>
   <para>
@@ -98,7 +98,7 @@
   <title>Comment lire la définition d'une fonction (prototype)</title>
   <para>
    Chaque fonction dans le manuel est documentée pour permettre une
-   compréhension rapide. Savoir décoder le texte rendra votre apprentissage plus
+   compréhension rapide. Savoir décoder le texte rend l'apprentissage plus
    facile. Plutôt que de dépendre d'exemples prêts à copier/coller, il est
    plus utile de savoir lire la définition d'une fonction (prototype).
    Voici comment :
@@ -115,7 +115,7 @@
    </para>
   </note>
   <para>
-   Les définitions de fonctions vous indiquent quel type de données est
+   Les définitions de fonctions indiquent quel type de données est
    <link linkend="functions.returning-values">retourné</link>. Examinons
    la fonction <function>strlen</function> comme exemple :
   </para>
@@ -228,7 +228,7 @@ Retourne la taille de la chaîne $string.
    est optionnel. Tous les paramètres optionnels ont une valeur par défaut ;
    si la valeur par défaut est inconnue, elle est affichée en tant que <literal>?</literal>.
    Le manuel indique que le paramètre <parameter>strict</parameter> vaut par
-   défaut &false;. Reportez-vous au manuel de chaque fonction pour savoir
+   défaut &false;. Se reporter au manuel de chaque fonction pour savoir
    comment elle fonctionne.
   </para>
   <para> 
@@ -292,7 +292,7 @@ Retourne la taille de la chaîne $string.
    cette convention n'est pas toujours vérifiée.
   </para>
   <para>
-   Notez aussi que le manuel concerne PHP présent et non futur, même pour les fonctionnalités
+   Il est à noter aussi que le manuel concerne PHP présent et non futur, même pour les fonctionnalités
    documentées et qui ne sont pas encore disponibles. Ainsi le manuel peut perdurer dans le
    temps et ne requiert pas de mises à jour importantes à chaque sortie de PHP.
   </para>
@@ -302,7 +302,7 @@ Retourne la taille de la chaîne $string.
    configuration &php.ini;, ainsi ceci peut changer des valeurs trouvées dans les fichiers
    distribués <filename>php.ini-development</filename> et <filename>php.ini-production</filename>
    . Les valeurs indiquées sont aussi celles de la dernière version de PHP, un changelog indique les
-   valeurs précédemment employées. Voyez <link linkend="ini.list">l'appendice sur les directives PHP
+   valeurs précédemment employées. Voir <link linkend="ini.list">l'appendice sur les directives PHP
    </link> pour plus de détails sur ces valeurs et leurs évolutions.
   </para>
  </sect1>
@@ -311,15 +311,15 @@ Retourne la taille de la chaîne $string.
   <title>Où trouver plus d'informations sur PHP ?</title>
   <para>
    Ce manuel n'a pas pour objectif de fournir des présentations sur les
-   pratiques de programmation. Si vous êtes un néophyte total, ou même
-   un programmeur débutant, vous pouvez trouver difficile d'apprendre
-   la programmation PHP avec uniquement ce manuel : il serait mieux de trouver
+   pratiques de programmation. Pour un néophyte total, ou même
+   un programmeur débutant, il peut être difficile d'apprendre
+   la programmation PHP avec uniquement ce manuel : il serait préférable de trouver
    des ressources plus orientées vers l'apprentissage.
   </para>
   <para>
    Il y a un bon nombre de listes de diffusion actives, traitant de tous les
-   aspects du langage et de la programmation PHP. Si vous êtes bloqué par un
-   problème, vous pourrez sûrement trouver de l'aide auprès de ces listes.
+   aspects du langage et de la programmation PHP. En cas de blocage,
+   il est possible de trouver de l'aide auprès de ces listes.
    Il existe un recensement des listes de diffusion sur
    <link xlink:href="&url.php.support;">la page de support de php.net</link>.
   </para>
@@ -341,15 +341,15 @@ Retourne la taille de la chaîne $string.
   </para>
   <note>
    <para>
-    N'abusez pas du gestionnaire d'issues pour envoyer des demandes d'aide. Utilisez
-    plutôt une des options proposées par le <link xlink:href="&url.php.support;">support</link>.
+    Il ne faut pas abuser du gestionnaire d'issues pour envoyer des demandes d'aide. Il est préférable d'utiliser
+    une des options proposées par le <link xlink:href="&url.php.support;">support</link>.
    </para>
   </note>
   <para>
-   En contribuant aux notes, vous pouvez fournir de nouveaux exemples,
+   En contribuant aux notes, il est possible de fournir de nouveaux exemples,
    mettre en lumière des effets de bords et apporter des clarifications pour
    les autres lecteurs. Mais ne prenez pas le système d'annotation pour
-   un système de soumission de bogues. Vous pouvez en savoir plus sur les
+   un système de soumission de bogues. Il est possible d'en savoir plus sur les
    annotations dans la section
    <link linkend="about.notes">'À propos des notes utilisateurs'</link>
   </para>
@@ -359,16 +359,16 @@ Retourne la taille de la chaîne $string.
   </para>
   <para>
    Le manuel PHP est traduit en de nombreux langages. La connaissance
-   de l'anglais ainsi que d'une autre langue peut vous permettre d'aider
+   de l'anglais ainsi que d'une autre langue permet d'aider
    la documentation de PHP en travaillant avec une équipe de traduction.
    Pour plus d'informations sur la manière de démarrer une nouvelle traduction
    ou de contribuer à une version déjà traduite, commencez par lire
    <link xlink:href="&url.php.dochowto;">&url.php.dochowto;</link>.
   </para>
   <para>
-   Le projet de documentation de PHP a un canal IRC où vous pouvez venir
+   Le projet de documentation de PHP a un canal IRC où il est possible de venir
    et parler avec les auteurs du manuel ou trouver un certain aspect du manuel
-   avec lequel vous pourriez aider. Les coordonnées :
+   avec lequel il serait possible d'aider. Les coordonnées :
    <literal>#php.doc</literal> sur <literal>irc.efnet.org</literal>.
   </para>
  </sect1>
@@ -419,13 +419,13 @@ Retourne la taille de la chaîne $string.
   </para>
   <note>
    <para>
-    Si vous voulez aider à la traduction de la documentation, entrez en
-    contact avec l'équipe de documentation en vous inscrivant à la liste de
+    Pour aider à la traduction de la documentation, il convient d'entrer en
+    contact avec l'équipe de documentation en s'inscrivant à la liste de
     diffusion : <link
     xlink:href="mailto:&email.php.doc.subscribe;">&email.php.doc.subscribe;</link>.
     L'adresse de la liste de diffusion est <literal>&email.php.doc;</literal>.
-    Indiquez dans le message que vous êtes intéressé par la traduction de la
-    documentation dans une nouvelle langue, et quelqu'un viendra vous aider à
+    Indiquer dans le message l'intérêt pour la traduction de la
+    documentation dans une nouvelle langue, et quelqu'un viendra aider à
     démarrer une nouvelle traduction, ou rejoindre l'équipe qui a pris en
     charge cette traduction.
    </para>

--- a/appendices/aliases.xml
+++ b/appendices/aliases.xml
@@ -15,7 +15,7 @@
   conservés uniquement pour des raisons de compatibilité ascendante. C'est une
   très mauvaise habitude d'utiliser ces alias, car ils risquent à tout moment de
   disparaître, rendus obsolètes sans préavis, ou bien par un simple changement de
-  nom, ce qui rend votre script inutilisable avec des versions plus récentes de
+  nom, ce qui rend le script inutilisable avec des versions plus récentes de
   PHP. Préférez toujours les versions officielles. En fait, cette liste est
   surtout destinée à ceux qui doivent mettre à jour leurs scripts avec les
   syntaxes plus récentes.

--- a/appendices/comparisons.xml
+++ b/appendices/comparisons.xml
@@ -32,9 +32,9 @@
   <para>
    La ligne <literal>if ($x)</literal> génère une erreur de niveau
    <constant>E_NOTICE</constant> lorsque <varname>$x</varname> est
-   indéfini. Alternativement, utilisez plutôt les fonctions
+   indéfini. Alternativement, il est préférable d'utiliser les fonctions
    <function>empty</function> ou <function>isset</function>, ou encore,
-   initialisez toutes vos variables.
+   d'initialiser toutes les variables.
   </para>
  </note>
  <note>

--- a/appendices/configure/index.xml
+++ b/appendices/configure/index.xml
@@ -17,7 +17,7 @@
    <command>./configure --help</command> dans le répertoire contenant les sources de PHP
    après avoir exécuté la commande <command>autoconf</command>
    (voir aussi le chapitre sur <link linkend="install">l'installation de PHP</link>).
-   Vous pouvez également être intéressé par la lecture de la documentation sur
+   Il peut également être intéressant de lire la documentation sur
    la <link xlink:href="&url.gnu.configure;">configuration GNU</link> pour plus d'informations sur les
    options de la commande <command>configure</command> comme
    <literal>--prefix=PREFIX</literal>.
@@ -25,7 +25,7 @@
 
   <note>
    <para>
-    Elles sont également utilisées lors de la compilation. Si vous voulez modifier la configuration
+    Elles sont également utilisées lors de la compilation. Pour modifier la configuration
     de l'exécution de PHP, lisez le chapitre sur la <link
     linkend="configuration">configuration de l'exécution</link>.
    </para>

--- a/appendices/configure/misc.xml
+++ b/appendices/configure/misc.xml
@@ -23,7 +23,7 @@
     <listitem>
      <para>
       Spécifie la façon dont les fichiers installés seront présentés. <literal>TYPE</literal>
-      peut valoir PHP (valeur par défaut) ou GNU. Notez que si vous installez les pages de manuel sous PREFIX (par défaut), choisissez
+      peut valoir PHP (valeur par défaut) ou GNU. Il est à noter que lors de l'installation des pages de manuel sous PREFIX (par défaut), il faut choisir
       le style GNU afin qu'elles puissent être trouvées dans le chemin de recherche de l'utilitaire <filename>manpath</filename>.
      </para>
     </listitem>
@@ -86,7 +86,7 @@
     <listitem>
      <para>
       Inclut le support expérimental des flux PHP.
-      Utilisez-le seulement si vous testez le code !
+      À utiliser uniquement pour tester le code !
      </para>
     </listitem>
    </varlistentry>

--- a/appendices/configure/php.xml
+++ b/appendices/configure/php.xml
@@ -44,7 +44,7 @@
     <listitem>
      <para>
       Précise le chemin vers les bibliothèques de construction Unix pour
-      construire PHP. Pour les systèmes 64 bits, vous devez renseigner le dossier
+      construire PHP. Pour les systèmes 64 bits, il faut renseigner le dossier
       <literal>lib64</literal> comme cela: 
       <literal>--with-libdir=lib64</literal>.
      </para>

--- a/appendices/configure/servers.xml
+++ b/appendices/configure/servers.xml
@@ -16,8 +16,8 @@
     <listitem>
      <para>
       Compile un module Apache partagé. FILE est un chemin d'accès optionnel vers
-      les outils apxs d'Apache. Par défaut, c'est apxs. Assurez-vous de spécifier
-      la version d'apxs qui est réellement installée sur votre système, et NON pas
+      les outils apxs d'Apache. Par défaut, c'est apxs. Il faut s'assurer de spécifier
+      la version d'apxs qui est réellement installée sur le système, et NON pas
       celle qui se trouve dans l'archive des sources d'Apache.
      </para>
     </listitem>

--- a/appendices/debugger.xml
+++ b/appendices/debugger.xml
@@ -12,7 +12,7 @@
   </simpara>
   <simpara>
    La plupart des IDE ont une prise en charge de <link xlink:href="&url.xdebug;">Xdebug</link>,
-   un outil de débogage gratuit, qui permet de déboguer pas à pas votre
+   un outil de débogage gratuit, qui permet de déboguer pas à pas le
    code PHP.
   </simpara>
  </sect1>

--- a/appendices/filters.xml
+++ b/appendices/filters.xml
@@ -6,7 +6,7 @@
  <para>
   Cette section contient la liste des filtres de flux, à utiliser
   avec <function>stream_filter_append</function>.
-  Votre version de PHP peut avoir des filtres supplémentaires,
+  La version de PHP installée peut avoir des filtres supplémentaires,
   ou manquants par rapport à cette liste.
  </para>
 
@@ -24,15 +24,15 @@
   Si des données sont déjà en attente dans le buffer lorsqu'un
   filtre est ajouté au flux (<emphasis>appended</emphasis>), ces données
   seront immédiatement passées au filtre, pour que la modification soit
-  transparente. Mais si vous ajoutez un filtre avec
+  transparente. Mais si l'on ajoute un filtre avec
   <emphasis>prepended</emphasis>, les données
   <emphasis>NE seront PAS</emphasis> filtrées. Elles
   attendront que le prochain bloc arrive de la ressource.
  </para>
 
  <para>
-  Pour avoir la liste complète des filtres de votre version de
-  PHP, utilisez la fonction <function>stream_get_filters</function>.
+  Pour avoir la liste complète des filtres de la version de
+  PHP installée, utiliser la fonction <function>stream_get_filters</function>.
  </para>
 
  <section xml:id="filters.string">
@@ -41,7 +41,7 @@
   <simpara>
    Chaque filtre fait ce que son nom implique, et se réfère au
    comportement de la fonction PHP correspondante. Pour plus de
-   détails sur un filtre, reportez-vous au manuel de la fonction
+   détails sur un filtre, se reporter au manuel de la fonction
    de référence.
   </simpara>
 

--- a/appendices/history.xml
+++ b/appendices/history.xml
@@ -9,12 +9,12 @@
   PHP a suivi un long chemin depuis sa naissance au milieu des années 1990.
   Depuis ses débuts modestes, jusqu'à devenir l'un des plus éminents
   langages de programmation pour le web, l'évolution de PHP
-  est un véritable conte de fées technologique. Figurez-vous
-  qu'une telle croissance n'a pas été tâche facile. Ceux d'entre
-  vous qui sont intéressés par un bref récapitulatif de ce qu'a été
-  l'histoire de PHP jusqu'à aujourd'hui, poursuivez la lecture de
-  ce document. Si vous souhaitez récupérer des pièces uniques de l'histoire
-  d'Internet, vous pouvez trouver les anciennes versions de PHP
+  est un véritable conte de fées technologique. Il faut savoir
+  qu'une telle croissance n'a pas été tâche facile. Pour un bref
+  récapitulatif de ce qu'a été l'histoire de PHP jusqu'à aujourd'hui,
+  il suffit de poursuivre la lecture de ce document. Pour récupérer
+  des pièces uniques de l'histoire d'Internet, il est possible de
+  trouver les anciennes versions de PHP
   dans notre <link xlink:href="&url.php.museum;">musée</link>.
  </para>
  <sect1 xml:id="history.php">

--- a/appendices/ini.core.xml
+++ b/appendices/ini.core.xml
@@ -5,8 +5,8 @@
  <section xml:id="ini.core" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
   <title>Description des directives internes du &php.ini;</title>
   <para>
-   Cette liste inclut les directives internes du &php.ini; que vous pouvez
-   définir pour personnaliser votre configuration de PHP. Les directives
+   Cette liste inclut les directives internes du &php.ini; qu'il est possible de
+   définir pour personnaliser la configuration de PHP. Les directives
    gérées par les extensions sont listées et détaillées dans les pages de
    documentation respectives des extensions ; les informations concernant
    les directives sur les sessions, par exemple, peuvent être trouvées sur
@@ -145,12 +145,12 @@
        <para>
         Définit si les balises courtes d'ouverture de PHP
         (<userinput>&lt;? ?&gt;</userinput>) sont autorisées ou non.
-        Si vous voulez utiliser PHP avec XML, vous devez désactiver
+        Pour utiliser PHP avec XML, il faut désactiver
         cette option de configuration pour pouvoir utiliser
-        <userinput>&lt;?xml ?&gt;</userinput>. Sinon, vous pouvez l'écrire
+        <userinput>&lt;?xml ?&gt;</userinput>. Sinon, il est possible de l'écrire
         à l'aide de PHP, par exemple : <userinput>&lt;?php echo '&lt;?xml
-        version="1.0"&gt;'; ?&gt;</userinput>. Si cette option est désactivée, vous
-        devez utiliser la version longue d'ouverture de balises PHP
+        version="1.0"&gt;'; ?&gt;</userinput>. Si cette option est désactivée, il
+        faut utiliser la version longue d'ouverture de balises PHP
         (<userinput>&lt;?php ?&gt;</userinput>).
        </para>
        <note>
@@ -225,7 +225,7 @@
        </para>
        <para>
         Cette directive doit être définie dans le &php.ini;.
-        Par exemple, vous ne pouvez pas la définir dans le fichier &httpd.conf;.
+        Par exemple, il n'est pas possible de la définir dans le fichier &httpd.conf;.
        </para>
       </listitem>
      </varlistentry>
@@ -247,7 +247,7 @@
        </para>
        <simpara>
         Cette directive doit être définie dans le &php.ini;.
-        Par exemple, vous ne pouvez pas la définir dans le fichier &httpd.conf;.
+        Par exemple, il n'est pas possible de la définir dans le fichier &httpd.conf;.
        </simpara>
       </listitem>
      </varlistentry>
@@ -461,8 +461,8 @@ Fatal error: Maximum execution time of 30+2 seconds exceeded (terminated) in Unk
        <para>
         Cette option détermine la mémoire limite, en octets, qu'un script
         est autorisé à allouer. Cela permet de prévenir l'utilisation de toute
-        la mémoire par un script mal codé.  Notez que pour n'avoir aucune limite,
-        vous devez définir cette directive à <literal>-1</literal>.
+        la mémoire par un script mal codé.  Il est à noter que pour n'avoir aucune limite,
+        il faut définir cette directive à <literal>-1</literal>.
        </para>
        
        &ini.shorthandbytes;
@@ -760,7 +760,7 @@ Fatal error: Maximum execution time of 30+2 seconds exceeded (terminated) in Unk
         est utilisé pour le contenu de <varname>$_REQUEST</varname>.
        </para>
        <para>
-        Notez que les fichiers <filename>php.ini</filename> de la distribution
+        Il est à noter que les fichiers <filename>php.ini</filename> de la distribution
         par défaut ne contiennent pas <literal>'C'</literal> pour les cookies,
         ceci pour des raisons de sécurité.
        </para>
@@ -863,9 +863,9 @@ Fatal error: Maximum execution time of 30+2 seconds exceeded (terminated) in Unk
         <note>
          <para>
           PHP autorise des mots-clés pour les octets, incluant K (kilo), M (méga)
-          et G (giga). PHP effectue la conversion automatiquement si vous les utilisez.
-          Soyez attentif de ne pas dépasser la limite d'un entier signé sur 32 bits
-          (si vous utilisez les versions 32 bits), auquel cas votre script échouera.
+          et G (giga). PHP effectue la conversion automatiquement lors de leur utilisation.
+          Il faut être attentif à ne pas dépasser la limite d'un entier signé sur 32 bits
+          (avec les versions 32 bits), auquel cas le script échouera.
          </para>
         </note>
        </para>
@@ -1230,7 +1230,7 @@ include_path=".;c:\php\includes"
        </para>
        <para>
         L'utilisation d'un point (<literal>.</literal>) dans le chemin
-        d'inclusion vous permet de faire des inclusions relatives au
+        d'inclusion permet de faire des inclusions relatives au
         répertoire courant. Cependant, il est plus efficace d'inclure
         explicitement un fichier avec <literal>include './file'</literal>,
         que de demander à PHP de vérifier le dossier courant à chaque inclusion.
@@ -1322,7 +1322,7 @@ include_path = ".:${USER}/pear/php"
          un script peut affiner la configuration en <literal>/www/tmp/</literal>
          au moment de l'exécution en utilisant la fonction <function>ini_set</function>.
          Lors d'un parcours de plusieurs dossiers,
-         vous pouvez utiliser la constante
+         il est possible d'utiliser la constante
          <constant>PATH_SEPARATOR</constant>
          suivant le système d'exploitation.
         </simpara>
@@ -1357,10 +1357,10 @@ include_path = ".:${USER}/pear/php"
        <para>
         Le dossier racine de PHP sur le serveur. Uniquement utilisé si
         non vide.
-        Si PHP n'a pas été compilé avec FORCE_REDIRECT, vous
-        <emphasis>devez</emphasis> définir le doc_root si vous utilisez
+        Si PHP n'a pas été compilé avec FORCE_REDIRECT, il
+        <emphasis>faut</emphasis> définir le doc_root lors de l'utilisation de
         PHP en tant que CGI sous n'importe quel serveur web (autre que
-        IIS). Alternativement, vous pouvez utiliser la configuration
+        IIS). Alternativement, il est possible d'utiliser la configuration
         <link linkend="ini.cgi.force-redirect">cgi.force_redirect</link>.
        </para>
       </listitem>
@@ -1487,8 +1487,8 @@ include_path = ".:${USER}/pear/php"
         sur <literal>PATH_INFO</literal>, lisez les spécificités <acronym>CGI</acronym>.
         Si définie à <literal>1</literal>, PHP <acronym>CGI</acronym> fixera ce
         chemin suivant les spécifications. Si définie à <literal>0</literal>, PHP
-        appliquera l'ancien comportement. Par défaut, cette directive est activée. Vous
-        devriez modifier vos scripts pour utiliser <literal>SCRIPT_FILENAME</literal>
+        appliquera l'ancien comportement. Par défaut, cette directive est activée. Il est
+        recommandé de modifier les scripts pour utiliser <literal>SCRIPT_FILENAME</literal>
         à la place de <literal>PATH_TRANSLATED</literal>.
        </para>
       </listitem>
@@ -1503,9 +1503,9 @@ include_path = ".:${USER}/pear/php"
        <para>
         cgi.force_redirect est nécessaire pour des raisons de sécurité
         lors de l'utilisation de PHP en mode <acronym>CGI</acronym> sous la plupart des
-        serveurs web. Si vous ne la définissez pas, PHP l'activera
-        automatiquement par défaut. Vous pouvez la désactiver
-        <emphasis>à vos risques et périls</emphasis>.
+        serveurs web. Sans définition explicite, PHP l'activera
+        automatiquement par défaut. Il est possible de la désactiver
+        <emphasis>à ses risques et périls</emphasis>.
        </para>
        <note>
         <para>
@@ -1537,9 +1537,9 @@ include_path = ".:${USER}/pear/php"
       </term>
       <listitem>
        <para>
-        Si cgi.force_redirect est activé et que vous ne tournez pas sous
-        un serveur web Apache ou Netscape (iPlanet), vous
-        <emphasis>devriez</emphasis> avoir besoin de définir un nom de
+        Si cgi.force_redirect est activé et que le serveur web n'est pas
+        Apache ou Netscape (iPlanet), il
+        <emphasis>est recommandé</emphasis> de définir un nom de
         variable d'environnement que PHP utilisera pour voir si tout
         est correct pour continuer l'exécution.
        </para>
@@ -1547,8 +1547,8 @@ include_path = ".:${USER}/pear/php"
         <para>
          La définition de cette variable <emphasis>peut</emphasis> avoir
          des conséquences sur la sécurité.
-         <emphasis>Sachez ce que vous faites avant de faire
-          cela</emphasis>.
+         <emphasis>Il faut savoir ce que l'on fait avant de procéder
+          ainsi</emphasis>.
         </para>
        </note>
       </listitem>
@@ -1570,13 +1570,13 @@ include_path = ".:${USER}/pear/php"
         <link xlink:href="&url.rfc;2616">RFC 2616</link>.
        </para>
        <para>
-        Si cette option est activée, et que vous exécutez PHP en environnement CGI (par exemple, PHP-FPM),
-        vous ne devriez pas utiliser les en-têtes de réponse HTTP "status" RFC 2616, mais plutôt
-        utiliser l'équivalent RFC 3875, c.-à-d. au lieu de l'en-tête ("HTTP/1.0 404 Not found"), utilisez
+        Si cette option est activée et que PHP est exécuté en environnement CGI (par exemple, PHP-FPM),
+        il ne faut pas utiliser les en-têtes de réponse HTTP "status" RFC 2616, mais plutôt
+        utiliser l'équivalent RFC 3875, c.-à-d. au lieu de l'en-tête ("HTTP/1.0 404 Not found"), utiliser
         ("Status: 404 Not Found").
        </para>
        <para>
-        Laissez ce paramètre désactivé à moins que vous sachiez parfaitement ce que vous faîtes.
+        Il est recommandé de laisser ce paramètre désactivé, sauf en cas de parfaite connaissance de ses implications.
        </para>
       </listitem>
      </varlistentry>
@@ -1787,7 +1787,7 @@ include_path = ".:${USER}/pear/php"
        <para>
         Si activé, les fonctions de connexion à la base de données qui spécifient
         des valeurs par défaut utiliseront ces valeurs au lieu des arguments fournis.
-        Pour les valeurs par défaut, reportez-vous à la documentation des fonctions
+        Pour les valeurs par défaut, se reporter à la documentation des fonctions
         de connexion pour la base de données concernée.
        </para>
        <warning>

--- a/appendices/ini.sections.xml
+++ b/appendices/ini.sections.xml
@@ -6,8 +6,8 @@
  <section xml:id="ini.sections" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
   <title>Liste des sections du fichier &php.ini;</title>
   <para>
-   Cette liste inclut les sections du &php.ini; que vous pouvez ajuster pour
-   configurer votre PHP selon l'hôte virtuel ou le chemin. Ces sections sont optionnelles.
+   Cette liste inclut les sections du &php.ini; qu'il est possible d'ajuster pour
+   configurer PHP selon l'hôte virtuel ou le chemin. Ces sections sont optionnelles.
   </para>
   <para>
    Ces sections n'affectent pas directement PHP. Elles sont utilisées pour grouper
@@ -56,7 +56,7 @@
      </term>
      <listitem>
       <para>
-       Cette section vous permet de définir un jeu de directives du &php.ini;
+       Cette section permet de définir un jeu de directives du &php.ini;
        qui prendront effet sur l'hôte spécifié.
       </para>
       <para>
@@ -80,7 +80,7 @@ display_errors = On
      </term>
      <listitem>
       <para>
-       Cette section vous permet de définir un jeu de directives du &php.ini;
+       Cette section permet de définir un jeu de directives du &php.ini;
        qui prendront effet quand un script sera lancé depuis le chemin spécifié.
       </para>
       <para>

--- a/appendices/migration56/deprecated.xml
+++ b/appendices/migration56/deprecated.xml
@@ -59,7 +59,7 @@ B
    Le nouveau code devrait utiliser 
    <link linkend="wrappers.php.input"><literal>php://input</literal></link>
    à la place de <varname>$HTTP_RAW_POST_DATA</varname>, qui sera supprimé dans 
-   une version future de PHP. Vous pouvez basculer vers le nouveau comportement 
+   une version future de PHP. Il est possible de basculer vers le nouveau comportement
    (dans lequel <varname>$HTTP_RAW_POST_DATA</varname> n'est jamais défini, et donc
    aucune alerte de niveau <constant>E_DEPRECATED</constant> ne sera générée) 
    en définissant <literal>always_populate_raw_post_data</literal>

--- a/appendices/migration56/incompatible.xml
+++ b/appendices/migration56/incompatible.xml
@@ -7,7 +7,7 @@
  <title>Modifications entraînant une incompatibilité ascendante</title>
  <simpara>
   Bien que la plupart du code PHP 5 existant devrait fonctionner sans aucune 
-  modification, vous devez prendre en considération quelques incompatibilités 
+  modification, il faut prendre en considération quelques incompatibilités
   ascendantes : 
  </simpara>
 

--- a/appendices/migration56/new-features.xml
+++ b/appendices/migration56/new-features.xml
@@ -236,7 +236,7 @@ Name\Space\f
    utilisé comme jeu de caractères par défaut pour les fonctions
    <function>htmlentities</function>, <function>html_entity_decode</function> et
    <function>htmlspecialchars</function>.
-   Notez que si les configurations d'encodage (maintenant obsolète) d'iconv
+   Il est à noter que si les configurations d'encodage (maintenant obsolète) d'iconv
    et mbstring sont définies, elles prendront le dessus par rapport à la
    configuration de default_charset pour les fonctions iconv et mbstring,
    respectivement.
@@ -311,8 +311,8 @@ if (version_compare(PHP_VERSION, '5.6', '<')) {
    La fonction <function>hash_equals</function> a été ajoutée pour comparer deux
    &string; en temps constant. Ceci devrait être utilisé pour éviter les attaques
    de type timing, par exemple, lors d'un test du hash d'un mot de passe
-   créé via la fonction <function>crypt</function> (en supposant que vous ne
-   pouvez pas utiliser les fonctions <function>password_hash</function> et
+   créé via la fonction <function>crypt</function> (en supposant que l'on ne
+   peut pas utiliser les fonctions <function>password_hash</function> et
    <function>password_verify</function>, qui ne sont pas sensibles aux attaques de type timing).
   </para>
 

--- a/appendices/migration70/incompatible/error-handling.xml
+++ b/appendices/migration70/incompatible/error-handling.xml
@@ -39,7 +39,7 @@
   </para>
 
   <para>
-   Si le gestionnaire doit fonctionner à la fois avec PHP 5 et 7, vous devriez 
+   Si le gestionnaire doit fonctionner à la fois avec PHP 5 et 7, il est recommandé de
    supprimer la déclaration de type du gestionnaire, tandis que le code qui est migré 
    pour travailler sur PHP 7 exclusivement peut simplement remplacer la déclaration 
    de type <classname>Exception</classname> par <classname>Throwable</classname>.

--- a/appendices/migration70/incompatible/removed-functions.xml
+++ b/appendices/migration70/incompatible/removed-functions.xml
@@ -15,7 +15,7 @@
   <para>
    Ces fonctions ont été dépréciées en PHP 4.1.0 en faveur de
    <function>call_user_func</function> et
-   <function>call_user_func_array</function>. Vous pourriez également utiliser les
+   <function>call_user_func_array</function>. Il est également possible d'utiliser les
    <link linkend="functions.variable-functions">fonctions variables</link>
    et/ou l'opérateur
    <link linkend="functions.variable-arg-list"><literal>...</literal></link>.

--- a/appendices/migration70/new-features.xml
+++ b/appendices/migration70/new-features.xml
@@ -388,7 +388,7 @@ bool(true)
   </informalexample>
 
   <para>
-   Pour utiliser cette classe, vous devez installer l'extension 
+   Pour utiliser cette classe, il est nécessaire d'installer l'extension
    <link linkend="book.intl">Intl</link>.
   </para>
  </sect2>

--- a/appendices/migration70/other-changes.xml
+++ b/appendices/migration70/other-changes.xml
@@ -18,7 +18,7 @@
   </para>
 
   <para>
-   Ceci est particulièrement utile lorsque vous créez des DSLs internes avec
+   Ceci est particulièrement utile lors de la création de DSLs internes avec
    des interfaces "fluent" :
   </para>
   <informalexample>

--- a/appendices/migration71/incompatible.xml
+++ b/appendices/migration71/incompatible.xml
@@ -593,7 +593,7 @@ object(stdClass)#1 (1) {
   </informalexample>
   </para>
   <para>
-   Lorsque vous fournissez l'indicateur <constant>JSON_UNESCAPED_UNICODE</constant> 
+   Lorsque l'indicateur <constant>JSON_UNESCAPED_UNICODE</constant> est fourni
    à <function>json_encode</function>, les séquences U+2028 et U+2029 sont 
    maintenant échappées.
   </para>

--- a/appendices/migration73/deprecated.xml
+++ b/appendices/migration73/deprecated.xml
@@ -40,7 +40,7 @@
     Passer une valeur recherchée qui n'est pas du texte dans les fonctions de
     recherche est déconseillé. Dans le futur la valeur recherchée sera interprétée
     comme une chaîne au lieu d'un point de code ASCII. Selon le comportement prévu,
-    vous devez soit explicitement caster la recherche en chaîne soit effectuer un
+    il faut soit explicitement caster la recherche en chaîne soit effectuer un
     appel explicite à <function>chr</function>. Les fonctions suivantes sont affectées :
     <itemizedlist>
      <listitem>
@@ -119,7 +119,7 @@
 
   <para>
    Les alias <literal>mbereg_*()</literal> non documentés suivants sont 
-   déconseillés. Utilisez plutôt les variantes <literal>mb_ereg_*()</literal> 
+   déconseillés. Il est recommandé d'utiliser plutôt les variantes <literal>mb_ereg_*()</literal>
    correspondantes.
    <itemizedlist>
     <listitem>

--- a/appendices/migration73/incompatible.xml
+++ b/appendices/migration73/incompatible.xml
@@ -237,9 +237,9 @@ foo(...gen());
 
   <para>
    Les authentifications <command>rsh</command>/<command>ssh</command> sont
-   désactivées par défaut. Utilisez <link
-   linkend="ini.imap.enable-insecure-rsh">imap.enable_insecure_rsh</link> si
-   vous voulez les activer. Il est à noter que la bibliothèque IMAP ne filtre
+   désactivées par défaut. Il convient d'utiliser <link
+   linkend="ini.imap.enable-insecure-rsh">imap.enable_insecure_rsh</link> pour
+   les activer. Il est à noter que la bibliothèque IMAP ne filtre
    pas les noms des boîtes aux lettres avant de les passer aux commandes
    <command>rsh</command>/<command>ssh</command>, ainsi passer des données non
    fiables à cette fonction avec <command>rsh</command>/<command>ssh</command>

--- a/appendices/migration74/incompatible.xml
+++ b/appendices/migration74/incompatible.xml
@@ -131,7 +131,7 @@
    </para>
    <para>
     Ces fonctions soulèvent également un avis sur l'échec, par exemple lorsque 
-    vous essayez d'écrire à une ressource de fichier en lecture uniquement.
+    l'on tente d'écrire dans une ressource de fichier en lecture seule.
    </para>
   </sect3>
 

--- a/appendices/migration74/windows-support.xml
+++ b/appendices/migration74/windows-support.xml
@@ -63,7 +63,7 @@
    </listitem>
   </itemizedlist>
   <para>
-   Notez que les deux valeurs sont dérivées du système et fournies tel qu'il est 
+   Il est à noter que les deux valeurs sont dérivées du système et fournies tel qu'il est
    sur les systèmes 64 bits. Sur les systèmes 32 bits, ces valeurs peuvent dépasser 
    l'entier 32 bits dans PHP, donc ils sont faux.
   </para>

--- a/appendices/migration80/deprecated.xml
+++ b/appendices/migration80/deprecated.xml
@@ -188,7 +188,7 @@ usort($array, fn($a, $b) => $a <=> $b);
    </listitem>
    <listitem>
     <para>
-     L'API procédurale de Zip est obsolète. Utilisez plutôt <classname>ZipArchive</classname>.
+     L'API procédurale de Zip est obsolète. Il est recommandé d'utiliser <classname>ZipArchive</classname> à la place.
      L'itération sur toutes les entrées peut être réalisée en utilisant <methodname>ZipArchive::statIndex</methodname>
      et une boucle <link linkend="control-structures.for">for</link>:
     </para>

--- a/appendices/migration80/incompatible.xml
+++ b/appendices/migration80/incompatible.xml
@@ -1555,8 +1555,8 @@ echo file_get_contents('http://example.org', false, $ctx);
    </listitem>
    <listitem>
     <para>
-     L'appel à <function>crypt</function> sans salt explicite n'est plus supporté. Si vous
-     souhaitez produire un hachage fort avec un salt auto-généré, utilisez plutôt
+     L'appel à <function>crypt</function> sans salt explicite n'est plus supporté. Pour
+     produire un hachage fort avec un salt auto-généré, il convient d'utiliser
      <function>password_hash</function> à la place.
     </para>
    </listitem>
@@ -1657,7 +1657,7 @@ echo file_get_contents('http://example.org', false, $ctx);
   <title>Zip</title>
 
   <para>
-   <constant>ZipArchive::OPSYS_Z_CPM</constant> a été supprimée (ce nom était une erreur de frappe). Utilisez plutôt
+   <constant>ZipArchive::OPSYS_Z_CPM</constant> a été supprimée (ce nom était une erreur de frappe). Il convient d'utiliser
    <constant>ZipArchive::OPSYS_CPM</constant> à la place.
   </para>
  </sect2>

--- a/appendices/migration81/incompatible.xml
+++ b/appendices/migration81/incompatible.xml
@@ -107,7 +107,7 @@ ArgumentCountError - makeyogurt(): Argument #1 ($container) not passed
     </informalexample>
    </para>
    <para>
-    Notez qu'une valeur par défaut de &null; peut être utilisée avant les paramètres requis pour
+    Il est à noter qu'une valeur par défaut de &null; peut être utilisée avant les paramètres requis pour
     spécifier un <link linkend="language.types.declarations.nullable">type nullable</link>,
     mais le paramètre sera toujours requis.
    </para>

--- a/appendices/migration82/deprecated.xml
+++ b/appendices/migration82/deprecated.xml
@@ -63,7 +63,7 @@
    <para>
     Les styles d'interpolation de chaîne <code>"${var}"</code> et <code>"${expr}"</code>
     sont obsolètes.
-    Utilisez respectivement <code>"$var"/"{$var}"</code> et <code>"{${expr}}"</code>.
+    Il convient d'utiliser respectivement <code>"$var"/"{$var}"</code> et <code>"{${expr}}"</code>.
     <!-- RFC: https://wiki.php.net/rfc/deprecate_dollar_brace_string_interpolation -->
    </para>
   </sect3>

--- a/appendices/migration85/deprecated.xml
+++ b/appendices/migration85/deprecated.xml
@@ -86,7 +86,7 @@
 
    <simpara>
     La redéclaration de constantes a été dépréciée.
-    Notez que cela générait déjà un avertissement et continuera à le faire.
+    Il est à noter que cela générait déjà un avertissement et continuera à le faire.
    </simpara>
 
   </sect3>
@@ -276,7 +276,7 @@
 
   <simpara>
    L'alias <function>mysqli_execute</function> a été déprécié.
-   Utilisez <function>mysqli_stmt_execute</function> à la place.
+   Il convient d'utiliser <function>mysqli_stmt_execute</function> à la place.
    <!-- RFC: https://wiki.php.net/rfc/deprecations_php_8_5#formally_deprecate_mysqli_execute -->
   </simpara>
 

--- a/appendices/migration85/other-changes.xml
+++ b/appendices/migration85/other-changes.xml
@@ -25,7 +25,7 @@
    <simpara>
     L'option <option>-z</option> ou <option>--zend-extension</option>
     a été supprimée car elle n'était pas fonctionnelle.
-    Utilisez plutôt <option>-d zend_extension=[chemin]</option>.
+    Il convient d'utiliser <option>-d zend_extension=[chemin]</option> à la place.
    </simpara>
 
   </sect3>

--- a/appendices/reserved.constants.core.xml
+++ b/appendices/reserved.constants.core.xml
@@ -313,7 +313,7 @@
    <listitem>
     <simpara>
      Le plus petit nombre à virgule flottante <emphasis>positif</emphasis> supporté.
-     Si vous avez besoin de la plus petite représentation
+     Pour obtenir la plus petite représentation
      <emphasis>négative</emphasis> de nombre flottant,
      utiliser <literal>- PHP_FLOAT_MAX</literal>.
      Disponible à partir de PHP 7.2.0.

--- a/appendices/reserved.xml
+++ b/appendices/reserved.xml
@@ -6,7 +6,7 @@
  <para>
   Cette annexe est une liste d'identifiants prédéfinis en PHP. Aucun
   des identifiants utilisés ici ne doit être repris comme nom de
-  variable ou de fonction dans vos scripts, sauf s'il est noté explicitement
+  variable ou de fonction dans les scripts, sauf s'il est noté explicitement
   le contraire. Ces identifiants incluent des mots-clés, des constantes,
   des classes et des variables prédéfinies. Ces listes ne sont pas complètes
   ni exhaustives.

--- a/appendices/resources.xml
+++ b/appendices/resources.xml
@@ -5,10 +5,10 @@
  <title>Types des ressources PHP</title>
  <para>
   Voici la liste des fonctions qui créent, utilisent
-  ou détruisent les ressources PHP. Vous pouvez
+  ou détruisent les ressources PHP. Il est possible de
   déterminer si une variable contient une
   ressource avec la fonction <function>is_resource</function>, et
-  le type d'une ressource que vous utilisez avec la fonction
+  le type d'une ressource utilisée avec la fonction
   <function>get_resource_type</function>.
   <table>
    <title>Types de ressource</title>

--- a/appendices/tokens.xml
+++ b/appendices/tokens.xml
@@ -25,7 +25,7 @@
    de l'infrastructure sous-jacente de l'analyseur PHP.
    Ceci signifie que la valeur concrète d'un jeton peut changer entre
    deux versions de PHP.
-   Ceci signifie que votre code ne doit jamais utiliser la valeur littérale
+   Ceci signifie que le code ne doit jamais utiliser la valeur littérale
    des constantes T_* d'une version PHP X.Y.Z, pour fournir une certaine
    compatibilité entre plusieurs versions de PHP.
   </para>
@@ -277,7 +277,7 @@ defined('T_FN') || define('T_FN', 10001);
     <row xml:id="constant.t-double-colon">
      <entry><constant>T_DOUBLE_COLON</constant></entry>
      <entry>::</entry>
-     <entry>Voyez <constant>T_PAAMAYIM_NEKUDOTAYIM</constant> plus bas</entry>
+     <entry>Voir <constant>T_PAAMAYIM_NEKUDOTAYIM</constant> plus bas</entry>
     </row>
     <row xml:id="constant.t-echo">
      <entry><constant>T_ECHO</constant></entry>

--- a/appendices/transports.xml
+++ b/appendices/transports.xml
@@ -15,8 +15,8 @@
  </para>
 
  <para>
-  Pour connaître la liste des modes de transport installés sur votre version
-  de PHP, utilisez <function>stream_get_transports</function>.
+  Pour connaître la liste des modes de transport installés sur la version
+  de PHP utilisée, se servir de <function>stream_get_transports</function>.
  </para>
 
  <section xml:id="transports.inet">

--- a/appendices/userlandnaming.xml
+++ b/appendices/userlandnaming.xml
@@ -11,7 +11,7 @@
   Lors du choix des noms pour n'importe quel code qui crée des symboles
   dans l'espace de noms global, il est important de prendre en compte ce guide
   afin d'éviter d'éventuels problèmes avec les futures versions de PHP et
-  vos symboles.
+  les symboles utilisés.
  </para>
 
  <section xml:id="userlandnaming.globalnamespace">
@@ -89,8 +89,8 @@
     <para>
      PHP réserve tous les symboles commençant par un <literal>__</literal>
      comme étant magique. Il est recommandé de ne pas créer de symboles
-     commençant par un <literal>__</literal> en PHP sauf si
-     vous voulez utiliser les fonctionnalités magiques documentées.
+     commençant par un <literal>__</literal> en PHP sauf pour
+     utiliser les fonctionnalités magiques documentées.
      Exemple :
     </para>
     <itemizedlist>
@@ -104,7 +104,7 @@
  <section xml:id="userlandnaming.tips">
   <title>Astuces</title>
   <para>
-   Si vous voulez écrire du code portable, il est recommandé de ne pas placer 
+   Pour écrire du code portable, il est recommandé de ne pas placer
    de nombreuses variables, fonctions ou classes dans l'espace de noms global. 
    Cela empêchera les conflits de nommage avec le code tiers ainsi que des 
    ajouts possibles au langage.
@@ -130,9 +130,9 @@ function my_function() {
    </programlisting>
   </informalexample>
   <para>
-   Vous devrez toujours garder une trace des namespaces déjà utilisés,
-   mais une fois que vous aurez choisi un namespace, vous pourrez y
-   ajouter toutes les fonctions et les classes sans avoir à vous soucier des
+   Il faut toujours garder une trace des namespaces déjà utilisés,
+   mais une fois un namespace choisi, il est possible d'y
+   ajouter toutes les fonctions et les classes sans se soucier des
    conflits.
   </para>
   <para>


### PR DESCRIPTION
Remplacement des formulations directes (vous/votre/vos) par des tournures impersonnelles conformément à TRADUCTIONS.txt.