### PR TITLE
Style impersonnel dans security/

### DIFF
--- a/security/apache.xml
+++ b/security/apache.xml
@@ -10,15 +10,15 @@
   permissions accordées à l'utilisateur faisant tourner Apache (par défaut,
   l'utilisateur "nobody"). Ceci a plusieurs impacts sur la sécurité et
   les autorisations.
-  Par exemple, si vous utilisez <acronym>PHP</acronym> pour accéder à une base de données, à
-  moins que la base n'ait un système de droits d'accès interne, vous devrez
+  Par exemple, lors de l'utilisation de <acronym>PHP</acronym> pour accéder à une base de données, à
+  moins que la base n'ait un système de droits d'accès interne, il faudra
   la rendre accessible à l'utilisateur "nobody". Cela signifie qu'un
   script mal intentionné peut accéder à la base et la modifier, sans
   identification. Il est même possible qu'un robot accède à une page
-  d'administration, et détruise toutes les bases de données. Vous pouvez vous protéger
-  contre cela avec les autorisations Apache, ou définir votre
-  propre modèle d'accès en utilisant LDAP, des fichiers &htaccess;, etc. et inclure ce code
-  dans vos scripts <acronym>PHP</acronym>.
+  d'administration, et détruise toutes les bases de données. Il est possible de se protéger
+  contre cela avec les autorisations Apache, ou définir un
+  modèle d'accès propre en utilisant LDAP, des fichiers &htaccess;, etc. et inclure ce code
+  dans les scripts <acronym>PHP</acronym>.
  </simpara>
  <simpara>
   Souvent, lorsqu'on a établi les droits de l'utilisateur <acronym>PHP</acronym> (ici,
@@ -41,9 +41,9 @@
  </simpara>
  <simpara>
   Il existe des solutions plus simples. En utilisant
-  <link linkend="ini.open-basedir">open_basedir</link>, vous pouvez contrôler et restreindre
-  les dossiers qui seront accessibles par <acronym>PHP</acronym>. Vous pouvez
-  aussi créer des aires de restrictions Apache, pour limiter les activités
+  <link linkend="ini.open-basedir">open_basedir</link>, il est possible de contrôler et restreindre
+  les dossiers qui seront accessibles par <acronym>PHP</acronym>. Il est également possible de
+  créer des aires de restrictions Apache, pour limiter les activités
   en provenance du web à des fichiers qui ne soient en rapport ni avec des utilisateurs,
   ni avec le système.
  </simpara>

--- a/security/cgi-bin.xml
+++ b/security/cgi-bin.xml
@@ -15,8 +15,8 @@
      combinaison avec un gestionnaire <acronym>CGI</acronym> complémentaire, afin de
      créer un environnement de script sécurisé (en utilisant
      des techniques de <command>chroot</command> ou <command>setuid</command>).
-     Une telle décision signifie habituellement que vous installerez
-     l'exécutable <command>php</command> dans le répertoire du serveur web <filename class="directory">cgi-bin</filename>.
+     Une telle décision signifie habituellement que l'exécutable
+     <command>php</command> sera installé dans le répertoire du serveur web <filename class="directory">cgi-bin</filename>.
      Le conseil de sécurité CERT <link xlink:href="&url.cert;">CA-96.11</link> recommande
      de ne pas placer d'interpréteurs dans le répertoire <filename class="directory">cgi-bin</filename>.
      Même si le binaire <command>php</command> peut être utilisé comme interpréteur autonome,
@@ -83,14 +83,14 @@
     <title>Cas 1 : Seuls les fichiers publics sont servis</title>
 
     <simpara>
-     Si votre serveur n'a aucun document dont l'accès n'est pas restreint
+     Si le serveur n'a aucun document dont l'accès n'est pas restreint
      par un mot de passe ou un système de vérification de l'adresse
-     IP, vous n'avez aucun besoin de ce type de configuration. Si votre serveur web
-     ne permet pas les redirections, ou si votre serveur web n'a aucun besoin de
+     IP, ce type de configuration n'est pas nécessaire. Si le serveur web
+     ne permet pas les redirections, ou s'il n'a aucun besoin de
      communiquer avec le binaire PHP de manière sécurisée,
-     vous pouvez activer la directive INI
-     <link linkend="ini.cgi.force-redirect">cgi.force_redirect</link>
-     Vous devez tout de même vous assurer que vos scripts PHP ne dépendent pas d'un appel
+     il est possible d'activer la directive INI
+     <link linkend="ini.cgi.force-redirect">cgi.force_redirect</link>.
+     Il faut tout de même s'assurer que les scripts PHP ne dépendent pas d'un appel
      de manière directe comme <filename role="php">http://my.host/cgi-bin/php/dir/script.php</filename>,
      ou de manière indirecte, par redirection, <filename role="php">http://my.host/dir/script.php</filename>.
     </simpara>
@@ -126,9 +126,9 @@ AddHandler php-script .php
      Cette option a uniquement été testée avec Apache, et
      compte sur Apache pour affecter la variable d'environnement non-standard
      <envar>REDIRECT_STATUS</envar> pour les requêtes redirigées.
-     Dans le cas où votre serveur web ne supporte aucune manière d'indiquer si la requête a été
-     redirigée ou non, vous ne pourrez pas utiliser cette option de
-     compilation. Vous devrez alors utiliser une des autres méthodes
+     Dans le cas où le serveur web ne supporte aucune manière d'indiquer si la requête a été
+     redirigée ou non, cette option de
+     compilation ne pourra pas être utilisée. Il faudra alors utiliser une des autres méthodes
      d'exploitation de la version binaire CGI de PHP, comme exposé ci-dessous.
     </simpara>
    </sect1>
@@ -149,21 +149,21 @@ AddHandler php-script .php
      seront interprétés et jamais affichés tels quels.
     </simpara>
     <simpara>
-     De plus, si vous ne pouvez pas utiliser la méthode
+     De plus, s'il n'est pas possible d'utiliser la méthode
      qui permet de s'assurer que les requêtes ne sont pas redirigées,
      comme présentée ci-dessus, il est nécessaire de mettre
      en place un répertoire de scripts "doc_root" différent du
      répertoire "document root" de votre serveur web.
     </simpara>
     <simpara>
-     Pour indiquer la racine des scripts PHP, vous pouvez utiliser la directive
+     Pour indiquer la racine des scripts PHP, il est possible d'utiliser la directive
      <link linkend="ini.doc-root">doc_root</link> dans le
      <link linkend="configuration.file">fichier de configuration</link>,
-     ou vous pouvez affecter la variable d'environnement
+     ou il est possible d'affecter la variable d'environnement
      <envar>PHP_DOCUMENT_ROOT</envar>. Si cette information
      est renseignée, le binaire <acronym>CGI</acronym> de PHP construira
      toujours le nom de fichier à ouvrir avec <parameter>doc_root</parameter>
-     et le "path information" de la requête, et vous serez donc sûr
+     et le "path information" de la requête, ce qui garantit
      qu'aucun script ne sera exécuté en dehors du répertoire
      prédéfini (à l'exception du répertoire
      désigné par la directive <parameter>user_dir</parameter> -
@@ -195,7 +195,7 @@ AddHandler php-script .php
     </simpara>
     <simpara>
      <parameter>user_dir</parameter> et <parameter>doc_root</parameter> sont
-     deux directives totalement indépendantes, et vous pouvez donc
+     deux directives totalement indépendantes, et il est donc possible de
      contrôler l'accès au répertoire "document root"
      séparément des répertoires "user directory".
     </simpara>
@@ -210,7 +210,7 @@ AddHandler php-script .php
      mettre l'exécutable PHP à l'extérieur de l'arborescence
      du serveur web. Dans le répertoire
      <filename role="dir">/usr/local/bin</filename>, par exemple.
-     Le seul véritable inconvénient de cette méthode est que vous aurez à
+     Le seul véritable inconvénient de cette méthode est qu'il faudra
      rajouter une ligne comme celle-ci :
      <informalexample>
       <programlisting>
@@ -219,9 +219,9 @@ AddHandler php-script .php
 ]]>
       </programlisting>
      </informalexample>
-     au début de chaque fichier contenant des balises PHP. Vous devrez aussi rendre les
-     scripts PHP exécutables. En somme, traitez le fichier
-     exactement comme si vous aviez un autre script écrit en Perl ou en
+     au début de chaque fichier contenant des balises PHP. Il faudra aussi rendre les
+     scripts PHP exécutables. En somme, le fichier doit être traité
+     exactement comme tout autre script écrit en Perl ou en
      sh ou en un autre langage de script qui utilise <literal>#!</literal> comme
      mécanisme pour lancer l'interpréteur lui-même.
     </para>

--- a/security/database.xml
+++ b/security/database.xml
@@ -12,7 +12,7 @@
   bases de données : il est donc important de les protéger efficacement.
  </simpara>
  <simpara>
-  Pour lire ou stocker des informations, vous devez vous connecter au serveur
+  Pour lire ou stocker des informations, il faut se connecter au serveur
   de bases de données, envoyer une requête valide, lire le résultat et
   refermer la connexion. De nos jours, le langage le plus courant pour ce
   type de communication est le langage SQL 
@@ -22,23 +22,23 @@
    requête SQL</link>.
  </simpara>
  <simpara>
-  Comme vous pouvez vous en douter, <acronym>PHP</acronym> ne peut pas protéger
-  vos bases de données pour vous. La section suivante vous introduira aux
-  notions de base pour protéger vos bases de données, lors de la programmation
-  de vos scripts <acronym>PHP</acronym>.
+  Comme on peut s'en douter, <acronym>PHP</acronym> ne peut pas protéger
+  les bases de données par lui-même. La section suivante présente les
+  notions de base pour protéger les bases de données, lors de la programmation
+  de scripts <acronym>PHP</acronym>.
  </simpara>
  <simpara>
   Gardez bien cette règle simple en tête : la défense se fait par couches.
-  Plus vous ajouterez de tests pour protéger votre base, plus faible sera la
-  probabilité de réussite d'un pirate. Ajoutez à cela un bon schéma de base
-  de données, et vous aurez une application réussie.
+  Plus il y a de tests pour protéger la base, plus faible sera la
+  probabilité de réussite d'un pirate. En ajoutant à cela un bon schéma de base
+  de données, on obtient une application réussie.
  </simpara>
  
  <sect1 xml:id="security.database.design">
   <title>Schéma de base de données</title>
   <simpara>
-   La première étape est de créer une base de données, à moins que vous ne
-   souhaitiez utiliser une base de données déjà créée. Lorsque la base
+   La première étape est de créer une base de données, à moins d'utiliser
+   une base de données déjà créée. Lorsque la base
    de données est créée, elle est assignée à un propriétaire, qui a
    exécuté l'instruction de création.
    Généralement, seul le propriétaire et le super utilisateur peuvent
@@ -55,8 +55,8 @@
    la destruction de la base.
   </simpara>
   <simpara>
-   Vous pouvez créer différents utilisateurs de bases de données pour
-   chaque aspect de votre application, avec des droits limités aux
+   Il est possible de créer différents utilisateurs de bases de données pour
+   chaque aspect de l'application, avec des droits limités aux
    seules actions planifiées. Il faut alors éviter que le même utilisateur
    dispose des droits de plusieurs cas d'utilisation. Cela permet que
    si des intrus obtiennent l'accès à la base avec l'un de ces jeux
@@ -69,10 +69,10 @@
   <simpara>
    Il est recommandé d'établir des connexions au serveur avec le
    protocole SSL, pour chiffrer les échanges clients/serveur, afin
-   d'améliorer la sécurité. Vous pouvez aussi utiliser un client
+   d'améliorer la sécurité. Il est aussi possible d'utiliser un client
    SSH pour chiffrer la connexion entre les clients et le serveur
    de bases de données. Si l'une de ces deux protections est
-   mise en place, il sera difficile de surveiller votre trafic et
+   mise en place, il sera difficile de surveiller le trafic et
    de comprendre les informations échangées.
   </simpara>
  </sect1>
@@ -85,17 +85,17 @@
    une fois dans la base. SSL est un protocole en ligne.
   </simpara>
   <simpara>
-   Une fois que le pirate a obtenu l'accès direct à votre base de données
-   (en contournant le serveur web), les données sensibles, stockées dans votre
+   Une fois que le pirate a obtenu l'accès direct à la base de données
+   (en contournant le serveur web), les données sensibles, stockées dans la
    base sont accessibles directement, à moins que les données de la base
    ne soient protégées par la base. Chiffrer les données est une bonne
    solution pour réduire cette menace, mais très peu de bases de données
    offrent ce type de chiffrement.
   </simpara>
   <simpara>
-   Le moyen le plus simple pour contourner ce problème est de créer votre
-   propre logiciel de chiffrement, et de l'utiliser dans vos scripts PHP.
-   <acronym>PHP</acronym> peut vous aider dans cette tâche grâce aux nombreuses extensions
+   Le moyen le plus simple pour contourner ce problème est de créer un
+   logiciel de chiffrement propre, et de l'utiliser dans les scripts PHP.
+   <acronym>PHP</acronym> peut aider dans cette tâche grâce aux nombreuses extensions
    dont il dispose, comme
    <link linkend="book.openssl">OpenSSL</link> et
    <link linkend="book.sodium">Sodium</link>, qui connaissent un large éventail
@@ -219,7 +219,7 @@ insert into pg_shadow(usename,usesysid,usesuper,usecatupd,passwd)
     si elle est mal gérée. Ces variables peuvent avoir été configurées
     dans une page précédente pour être utilisées dans les clauses
     <literal>WHERE, ORDER BY, LIMIT</literal> et <literal>OFFSET</literal> des
-    requêtes <literal>SELECT</literal>. Si votre base de données supporte
+    requêtes <literal>SELECT</literal>. Si la base de données supporte
     les commandes <literal>UNION</literal>, le pirate peut essayer d'ajouter
     une requête entière pour lister les mots de passe dans n'importe quelle
     table. Utiliser la technique de stocker uniquement des hachages sécurisés
@@ -293,7 +293,7 @@ $query = "UPDATE usertable SET pwd='hehehe', trusted=100, admin='yes' WHERE
     obtenir ces informations est souvent très simple. Par exemple,
     le code peut faire partie d'un logiciel open-source et être disponible publiquement.
     Ces informations peuvent également être divulguées par un code source fermé -
-    même s'il est codé, obscurci ou compilé - et même par votre propre code à travers l'affichage de messages d'erreur.
+    même s'il est codé, obscurci ou compilé - et même par le code de l'application à travers l'affichage de messages d'erreur.
     D'autres méthodes comprennent l'utilisation de noms de table et de colonne typiques.
     Par exemple, un formulaire de connexion qui utilise une table 'users' avec des noms de colonnes
     'id', 'username' et 'password'.
@@ -342,7 +342,7 @@ $result = mssql_query($query);
     <para>
      Certains exemples ci-dessus sont spécifiques à certains serveurs de
      bases de données, mais cela n'empêche pas des attaques similaires d'être
-     possibles sur d'autres produits. Votre base de données sera alors
+     possibles sur d'autres produits. La base de données sera alors
      vulnérable d'une autre manière.
     </para>
    </note>
@@ -411,13 +411,13 @@ La liaison de paramètres ne peut être utilisée que pour les données. Les aut
   <itemizedlist>
    <listitem>
     <simpara>
-     Ne vous connectez jamais à la base de données en tant que superutilisateur ou en tant que propriétaire de la base de données.
-     Utilisez toujours des utilisateurs personnalisés avec des privilèges minimaux.
+     Il ne faut jamais se connecter à la base de données en tant que superutilisateur ou en tant que propriétaire de la base de données.
+     Il convient de toujours utiliser des utilisateurs personnalisés avec des privilèges minimaux.
     </simpara>
    </listitem>
    <listitem>
     <simpara>
-     Vérifiez si l'entrée donnée a le type de données attendu. <acronym>PHP</acronym> a
+     Il faut vérifier si l'entrée donnée a le type de données attendu. <acronym>PHP</acronym> a
      une large gamme de fonctions de validation d'entrée, des plus simples
      trouvées dans <link linkend="ref.var">Fonctions de variables</link> et
      dans <link linkend="ref.ctype">Fonctions de type de caractères</link>
@@ -448,7 +448,7 @@ La liaison de paramètres ne peut être utilisée que pour les données. Les aut
     <simpara>
      Il est particulièrement important de ne pas divulguer d'informations spécifiques à la base de données,
      en particulier sur le schéma, que ce soit de manière légale ou illégale.
-     Consultez également <link linkend="security.errors">Rapport d'erreurs</link> et
+     Se référer également à <link linkend="security.errors">Rapport d'erreurs</link> et
      <link linkend="ref.errorfunc">Fonctions de gestion et de journalisation des erreurs</link>.
      </simpara>
        </listitem>
@@ -456,12 +456,12 @@ La liaison de paramètres ne peut être utilisée que pour les données. Les aut
      </para>
 
    <simpara>
-    À côté de ces conseils, il est recommandé d'enregistrer vos requêtes, soit
-    dans vos scripts, soit dans la base elle-même, si elle le supporte.
+    À côté de ces conseils, il est recommandé d'enregistrer les requêtes, soit
+    dans les scripts, soit dans la base elle-même, si elle le supporte.
     Évidemment, cet enregistrement ne sera pas capable d'empêcher une attaque,
-    mais vous permettra de retrouver la requête qui a fauté. L'historique
+    mais permettra de retrouver la requête qui a fauté. L'historique
     n'est pas très utile par lui-même mais au niveau des informations qu'il
-    contient. Plus vous avez de détails, mieux c'est.
+    contient. Plus il y a de détails, mieux c'est.
    </simpara>
    </sect2>
  </sect1>

--- a/security/errors.xml
+++ b/security/errors.xml
@@ -43,7 +43,7 @@
   vérifiées, ou d'autres informations critiques. Il est particulièrement
   dangereux d'exécuter du code de sources connues avec des gestionnaires de
   débogage inclus, ou de travailler avec des techniques de débogage répandues.
-  Si l'attaquant peut déterminer quelle technique générale vous utilisez, il peut
+  Si l'attaquant peut déterminer quelle technique générale est utilisée, il peut
   tenter une attaque frontale sur une page, en envoyant des chaînes de débogage connues :
   <example>
    <title>Exploiter des variables classiques de débogage</title>
@@ -61,7 +61,7 @@
  <para>
   Indépendamment de la méthode de gestion des erreurs, la possibilité de tester
   un système pour identifier des erreurs revient à fournir à un attaquant
-  plus d'informations sur votre système.
+  plus d'informations sur le système.
  </para>
  <para>
   Par exemple, le style même d'une erreur PHP standard indique qu'un système fait
@@ -93,23 +93,23 @@
   est de scruter toutes les fonctions, et d'essayer de traiter toutes les
   erreurs. La seconde est de totalement désactiver le rapport d'erreur, dès
   que le script est en production. La troisième est d'utiliser les
-  fonctions de gestion des erreurs de PHP pour créer vos propres gestionnaires d'erreurs.
-  En fonction de votre politique de sécurité, il se peut que vous arriviez à la conclusion
-  que ces solutions sont toutes les trois applicables à votre situation.
+  fonctions de gestion des erreurs de PHP pour créer des gestionnaires d'erreurs personnalisés.
+  En fonction de la politique de sécurité en place, il se peut que
+  ces solutions soient toutes les trois applicables.
  </para>
  <para>
   Une méthode pour gagner du temps est d'utiliser la fonction
-  <function>error_reporting</function>, pour vous aider à
-  sécuriser votre code, et détecter certaines utilisations dangereuses de variables.
-  En testant votre code, avant le déploiement, avec <constant>E_ALL</constant>,
-  vous pouvez rapidement repérer les variables qui ne sont pas protégées.
-  Une fois que le code est prêt à être déployé, vous devriez soit désactiver complètement
+  <function>error_reporting</function>, pour aider à
+  sécuriser le code et détecter certaines utilisations dangereuses de variables.
+  En testant le code avant le déploiement avec <constant>E_ALL</constant>,
+  il est possible de rapidement repérer les variables qui ne sont pas protégées.
+  Une fois que le code est prêt à être déployé, il est recommandé soit de désactiver complètement
   le rapport d'erreur en passant 0 à la fonction <function>error_reporting</function>,
-  soit en désactivant l'affichage des erreurs en utilisant l'option de configuration
-  <literal>display_errors</literal> de &php.ini;. Si vous choisissez la
-  seconde solution, vous devriez également définir le chemin vers votre fichier
+  soit de désactiver l'affichage des erreurs en utilisant l'option de configuration
+  <literal>display_errors</literal> de &php.ini;. En choisissant la
+  seconde solution, il est également recommandé de définir le chemin vers le fichier
   de log en utilisant la directive de configuration <literal>error_log</literal>,
-  et en activant la directive <literal>log_errors</literal>.
+  et d'activer la directive <literal>log_errors</literal>.
   <example>
    <title>Détecter des variables non protégées avec E_ALL</title>
    <programlisting role="php">

--- a/security/filesystem.xml
+++ b/security/filesystem.xml
@@ -16,9 +16,9 @@
  <simpara>
   Puisque <acronym>PHP</acronym> a été fait pour permettre aux utilisateurs
   d'accéder aux fichiers, il est possible de créer un
-  script <acronym>PHP</acronym> qui vous permet de lire des fichiers tels que <filename>/etc/passwd</filename>,
+  script <acronym>PHP</acronym> qui permet de lire des fichiers tels que <filename>/etc/passwd</filename>,
   de modifier les connexions ethernet, lancer des impressions de documents,
-  etc. Cela implique notamment que vous devez vous assurer que les fichiers
+  etc. Cela implique notamment qu'il faut s'assurer que les fichiers
   manipulés par les scripts sont bien ceux qu'il faut.
  </simpara>
  <simpara>
@@ -52,7 +52,7 @@ echo "Ce fichier a été effacé !";
   Étant donné que le nom de l'utilisateur et le nom du fichier sont fournis, des intrus peuvent
   envoyer un nom d'utilisateur et un nom de fichier autres que les leurs, et effacer des
   documents dans les comptes des autres utilisateurs.
-  Dans ce cas, vous souhaiterez utiliser une autre forme d'identification.
+  Dans ce cas, il est préférable d'utiliser une autre forme d'identification.
   Considérez ce qui pourrait se passer si les utilisateurs passent
   <literal>../etc/</literal> et <literal>passwd</literal> comme arguments!
   Le code serait exécuté tel que :
@@ -121,10 +121,10 @@ echo htmlentities($logstring, ENT_QUOTES);
    </programlisting>
   </example>
   Cependant, même cette technique n'est pas sans faille.
-  Si votre système d'identification permet aux utilisateurs
+  Si le système d'identification permet aux utilisateurs
   de créer leur propre login, et qu'un utilisateur choisit
   le login <literal>../etc/</literal>, le système est de nouveau exposé. Pour
-  cette raison, vous pouvez essayer d'écrire un script renforcé :
+  cette raison, il est possible d'écrire un script renforcé :
   <example>
    <title>Vérification renforcée de noms de fichiers</title>
    <programlisting role="php">
@@ -149,14 +149,14 @@ if (!ctype_alnum($username) || !preg_match('/^(?:[a-z0-9_-]|\.(?!\.))+$/iD', $us
   </example>
  </para>
  <para>
-  Suivant votre système d'exploitation, vous devrez protéger
+  Suivant le système d'exploitation, il faudra protéger
   un grand nombre de fichiers, notamment les entrées de périphériques,
   (<filename>/dev/</filename> ou <filename>COM1</filename>), les fichiers de
   configuration (fichiers <filename>/etc/</filename> et
   <literal>.ini</literal>), les lieux de stockage d'informations
   (<filename>/home/</filename>, <filename>My Documents</filename>), etc.
   Pour cette raison, il est généralement plus sûr d'établir une
-  politique qui interdit TOUT sauf ce que vous autorisez.
+  politique qui interdit TOUT sauf ce qui est autorisé.
  </para>
  <sect1 xml:id="security.filesystem.nullbytes">
   <title>Problèmes liés aux octets nuls</title>

--- a/security/general.xml
+++ b/security/general.xml
@@ -34,9 +34,9 @@
   l'utilisateur et les logs de transactions est sévèrement réduite.
  </simpara>
  <simpara>
-  Lorsque vous testez votre site, gardez à l'esprit que vous ne pourrez
-  jamais tester toutes les situations, même pour les pages les plus
-  simples. Les valeurs auxquelles vous pouvez vous attendre seront toujours complètement
+  Lors des tests d'un site, il faut garder à l'esprit qu'il est impossible
+  de tester toutes les situations, même pour les pages les plus
+  simples. Les valeurs attendues seront toujours complètement
   différentes des valeurs entrées par un employé mécontent, un hacker qui a des
   mois devant lui, ou encore le chat de la maison qui marche sur le clavier.
   C'est pourquoi il est préférable de regarder le code d'un point de vue
@@ -45,11 +45,11 @@
  </simpara>
  <simpara>
   L'Internet est rempli d'individus qui tentent de se faire une renommée
-  en piratant vos programmes, en bloquant votre site, en envoyant des contenus
+  en piratant des programmes, en bloquant des sites, en envoyant des contenus
   inappropriés, ou en rendant vos journées « intéressantes » d'une manière ou d'une autre.
-  Peu importe que vous ayez un grand portail ou un petit site web, vous pouvez
-  être la cible de tout quidam avec une connexion. En fait, vous êtes une
-  cible potentielle dès que vous êtes connecté vous-même.
+  Peu importe qu'il s'agisse d'un grand portail ou d'un petit site web, tout site peut
+  être la cible de tout quidam avec une connexion. En fait, tout système est une
+  cible potentielle dès qu'il est connecté.
   Certains programmes de piratage ne font pas dans la demi-mesure, et
   testent systématiquement des millions d'IP, à la recherche
   de victimes ; essayez de ne pas en devenir une.

--- a/security/hiding.xml
+++ b/security/hiding.xml
@@ -12,15 +12,15 @@
  </para>
  <para>
   Quelques astuces permettent de masquer <acronym>PHP</acronym>, ce qui peut ralentir
-  un attaquant qui recherche des faiblesses dans votre système. En
-  règlant l'option expose_php à <literal>off</literal> dans votre fichier &php.ini;,
-  vous pouvez réduire la quantité d'informations disponible.
+  un attaquant qui recherche des faiblesses dans le système. En
+  réglant l'option expose_php à <literal>off</literal> dans le fichier &php.ini;,
+  il est possible de réduire la quantité d'informations disponible.
  </para>
  <para>
   Une autre astuce est de configurer le serveur web, comme Apache,
   pour qu'il utilise plusieurs types de fichiers différents avec <acronym>PHP</acronym>,
   soit localement avec un fichier &htaccess;, soit
-  dans le fichier de configuration du serveur lui-même. Vous pouvez ainsi utiliser des
+  dans le fichier de configuration du serveur lui-même. Il est ainsi possible d'utiliser des
   extensions de fichiers déroutantes comme ceci :
   <example>
    <title>Masquer PHP avec un autre langage</title>
@@ -31,7 +31,7 @@ AddType application/x-httpd-php .asp .py .pl
 ]]>
    </programlisting>
   </example>
-  Ou masquez-le complètement :
+  Ou le masquer complètement :
   <example>
    <title>Masquer PHP avec des types inconnus</title>
    <programlisting role="apache-conf">
@@ -41,7 +41,7 @@ AddType application/x-httpd-php .bop .foo .133t
 ]]>
    </programlisting>
   </example>
-  Ou encore, cachez-le sous forme de <acronym>HTML</acronym>. Cela a un léger impact négatif
+  Il est aussi possible de le cacher sous forme de <acronym>HTML</acronym>. Cela a un léger impact négatif
   sur les performances générales, car tous les fichiers <acronym>HTML</acronym> seront aussi
   analysés et traités par le moteur <acronym>PHP</acronym> :
   <example>
@@ -53,7 +53,7 @@ AddType application/x-httpd-php .htm .html
 ]]>
    </programlisting>
   </example>
-  Pour que cela fonctionne efficacement, pensez à renommer tous vos
+  Pour que cela fonctionne efficacement, il convient de renommer tous les
   fichiers <acronym>PHP</acronym> avec les extensions ci-dessus. Même si c'est une forme
   de sécurité du non-dit, c'est une mesure de prévention mineure,
   avec peu d'inconvénients.

--- a/security/intro.xml
+++ b/security/intro.xml
@@ -14,12 +14,12 @@
   un langage beaucoup plus sécurisé pour écrire des programmes
   <acronym>CGI</acronym> que le Perl ou le langage C, et, avec une
   sélection rigoureuse des options de compilation et d'exécution
-  et de bonnes habitudes de programmation, il vous permettra d'obtenir un équilibre
+  et de bonnes habitudes de programmation, il permet d'obtenir un équilibre
   parfait entre liberté et sécurité.
  </simpara>
  <simpara>
   Étant donné qu'il existe de nombreux moyens d'utiliser le langage PHP,
-  vous trouverez de nombreuses directives de configuration permettant d'en contrôler
+  il existe de nombreuses directives de configuration permettant d'en contrôler
   le comportement. Un grand nombre d'options permet d'utiliser PHP
   dans de nombreuses situations, mais signifie aussi que
   certaines combinaisons d'options de compilation et d'exécution peuvent

--- a/security/variables.xml
+++ b/security/variables.xml
@@ -9,7 +9,7 @@
   La plus grande faiblesse de nombreux programmes <acronym>PHP</acronym> ne vient pas
   du langage en lui-même, mais de son utilisation en omettant les
   caractéristiques de sécurité. Pour cette raison,
-  vous devriez toujours prendre le temps de réfléchir aux implications
+  il est recommandé de toujours prendre le temps de réfléchir aux implications
   d'une portion de code donnée, pour mesurer les éventuels dommages
   qui pourraient être causés si une variable inattendue lui était passée.
   <example>
@@ -31,10 +31,10 @@ exec($evil_var);
   </example>
  </para>
  <para>
-  Il est vivement recommandé d'examiner minutieusement votre code
-  pour vous assurer qu'il n'y a pas de variable envoyée par le
+  Il est vivement recommandé d'examiner minutieusement le code
+  pour s'assurer qu'il n'y a pas de variable envoyée par le
   client web qui ne soit pas suffisamment vérifié avant utilisation,
-  en vous posant les questions suivantes :
+  en se posant les questions suivantes :
   <itemizedlist>
    <listitem>
     <simpara>
@@ -66,11 +66,11 @@ exec($evil_var);
  </para>
  <para>
   En répondant de manière adéquate à ces questions
-  lors de l'écriture de vos scripts (plutôt qu'après), vous
-  éviterez une réécriture inopportune lorsque vous aurez besoin d'améliorer leur
-  sécurité. En commençant vos projets avec ces recommandations
-  en tête, vous ne garantirez pas la sécurité de votre
-  système, mais vous contribuerez à l'améliorer.
+  lors de l'écriture des scripts (plutôt qu'après), cela
+  évitera une réécriture inopportune lorsqu'il faudra améliorer leur
+  sécurité. En commençant les projets avec ces recommandations
+  en tête, la sécurité du système ne sera pas garantie,
+  mais elle s'en trouvera améliorée.
  </para>
  <para>
   Améliorez la sécurité en désactivant les paramètres de commodité qui masquent


### PR DESCRIPTION
Remplacement des formulations directes (vous/votre/vos) par des tournures impersonnelles dans `security/`, conformément à TRADUCTIONS.txt.