### PR TITLE
Style impersonnel dans install/

### DIFF
--- a/install/cloud/azure.xml
+++ b/install/cloud/azure.xml
@@ -11,13 +11,13 @@
  </para>
  <para>
   Azure App Services gère les pools de serveurs Web Windows pour héberger 
-  votre application Web, en tant qu'alternative à la gestion de votre propre 
-  serveur Web sur vos propres VM de calcul Azure ou d'autres serveurs.
+  l'application Web, en tant qu'alternative à la gestion de son propre
+  serveur Web sur ses propres VM de calcul Azure ou d'autres serveurs.
  </para>
  <para>
-  PHP est déjà activé automatiquement pour votre site web Azure App Services. Dans 
-  le portail Azure, sélectionnez votre site Web, et vous pouvez choisir la 
-  version de PHP à utiliser. Vous voudrez peut-être choisir une version plus 
+  PHP est déjà activé automatiquement pour le site web Azure App Services. Dans
+  le portail Azure, sélectionner le site Web pour choisir la
+  version de PHP à utiliser. Il peut être souhaitable de choisir une version plus
   récente que la valeur par défaut.
   </para>
 
@@ -48,14 +48,14 @@
      </listitem>
      <listitem>
       <para>
-       Vous ne pouvez pas utiliser le gestionnaire des services Internet, 
+       Il n'est pas possible d'utiliser le gestionnaire des services Internet,
        le gestionnaire de serveur ou RDP.
      </para>
     </listitem>
   </itemizedlist>
 
   <para>
-   Il existe également un SDK PHP, qui vous permettra d'utiliser les nombreux services d'Azure à partir de votre code PHP.
+   Il existe également un SDK PHP, qui permet d'utiliser les nombreux services d'Azure à partir du code PHP.
    Voir <link xlink:href="&url.azure.php.sdk;">Azure SDK pour PHP</link>.
   </para>
   
@@ -68,7 +68,7 @@
   <para>WinCache est activé par défaut sur Azure App Services et il est 
    recommandé de le laisser activé.
 
-  Si vous installez votre propre version de PHP, vous devez activer 
+  Lors de l'installation d'une version personnalisée de PHP, il faut activer
    WinCache.
   </para>
   </sect2>
@@ -76,10 +76,10 @@
   <sect2>
     <title>Build personnalisée de PHP</title>
   <para>
-   Vous pouvez télécharger votre propre version de PHP dans votre D:\Home (C:\ 
-   n'est pas accessible en écriture). Ensuite, dans le portail Azure, 
-   définissez SCRIPT_PROCESSOR pour .php sur le chemin d'accès absolu au 
-   fichier php-cgi.exe dans votre build personnalisée.
+   Il est possible de télécharger sa propre version de PHP dans D:\Home (C:\
+   n'est pas accessible en écriture). Ensuite, dans le portail Azure,
+   définir SCRIPT_PROCESSOR pour .php sur le chemin d'accès absolu au
+   fichier php-cgi.exe dans la build personnalisée.
   </para>
   </sect2>
 

--- a/install/fpm/configuration.xml
+++ b/install/fpm/configuration.xml
@@ -94,8 +94,8 @@
     <listitem>
      <para>
       Ajoute au début de chaque message.
-      Si vous avez de multiples instances FPM s'exécutant sur le même serveur,
-      vous pouvez changer la valeur par défaut afin qu'elle convienne à vos besoins.
+      En cas de multiples instances FPM s'exécutant sur le même serveur,
+      il est possible de changer la valeur par défaut afin qu'elle convienne aux besoins.
       Valeur par défaut : php-fpm.
      </para> 
     </listitem>
@@ -238,8 +238,8 @@
  <sect2> 
   <title>Liste des directives de pool</title>
   <para>
-   Avec FPM vous pouvez exécuter plusieurs pools de processus avec des paramètres différents.
-   Voici les paramètres qui peuvent être ajustés par pool. 
+   Avec FPM il est possible d'exécuter plusieurs pools de processus avec des paramètres différents.
+   Voici les paramètres qui peuvent être ajustés par pool.
   </para>
   <variablelist>
    <varlistentry xml:id="listen">
@@ -328,7 +328,7 @@
     </term>
     <listitem>
      <para>
-      Quand les listes de contrôle d'accès POSIX sont supportées, vous pouvez les définir en utilisant cette option.
+      Quand les listes de contrôle d'accès POSIX sont supportées, il est possible de les définir en utilisant cette option.
       Quand défini, <literal>listen.owner</literal> et <literal>listen.group</literal>
       sont ignorés.
       La valeur est une liste de noms d'utilisateurs séparés par des virgules.
@@ -774,7 +774,7 @@
        <para>
         Limite les extensions que le script principal FPM va être autorisé à analyser.
         Ceci peut prévenir les erreurs de configuration côté serveur.
-        Vous devriez limiter FPM aux extensions .php uniquement pour empêcher des utilisateurs malveillants d'utiliser d'autres extensions pour exécuter du code PHP.
+        Il est recommandé de limiter FPM aux extensions .php uniquement pour empêcher des utilisateurs malveillants d'utiliser d'autres extensions pour exécuter du code PHP.
         Valeur par défaut : .php .phar
        </para> 
       </listitem>

--- a/install/fpm/install.xml
+++ b/install/fpm/install.xml
@@ -6,7 +6,7 @@
  <sect2 xml:id="install.fpm.install.compiling">
   <title>Compiler depuis les sources</title>
   <para>
-   Pour activer FPM dans votre construction de PHP vous devez ajouter la ligne <literal>--enable-fpm</literal> 
+   Pour activer FPM dans la construction de PHP, il faut ajouter la ligne <literal>--enable-fpm</literal>
    à votre ligne de configuration.
   </para>
   <para>

--- a/install/ini.xml
+++ b/install/ini.xml
@@ -9,8 +9,8 @@ xmlns:xi="http://www.w3.org/2001/XInclude">
   <title>Le fichier de configuration</title>
   
   <simpara>
-   Le fichier de configuration (&php.ini;) est lu par PHP au démarrage. Si vous
-   avez compilé PHP en module, le fichier n'est lu qu'une seule
+   Le fichier de configuration (&php.ini;) est lu par PHP au démarrage. Si PHP
+   a été compilé en module, le fichier n'est lu qu'une seule
    fois, au lancement du serveur web. Pour les versions
    <acronym>CGI</acronym> et <acronym>CLI</acronym> le fichier est lu à
    chaque invocation.
@@ -116,9 +116,9 @@ max_execution_time = ${PHP_MAX_EXECUTION_TIME:-30}
    sur les pages respectives du manuel de ces extensions. La
    <link linkend="ini">liste des directives internes</link> est disponible
    en annexe. Il est probable que toutes les directives PHP ne sont pas documentées
-   dans le manuel. Pour une liste complète des directives disponibles dans votre version de PHP,
-   veuillez lire les commentaires de votre propre fichier &php.ini;. 
-   Vous pouvez également trouver la 
+   dans le manuel. Pour une liste complète des directives disponibles dans la version de PHP utilisée,
+   il convient de lire les commentaires du fichier &php.ini;.
+   Il est également possible de trouver la
    <link xlink:href="&url.php.git.phpini;">dernière version du &php.ini;</link>
    sur Git.
   </para>
@@ -214,7 +214,7 @@ $ PHP_INI_SCAN_DIR=/usr/local/etc/php.d: php
    PHP inclut la prise en charge des fichiers INI de configuration
    par répertoire. Ces fichiers sont analysés <emphasis>uniquement</emphasis>
    par le SAPI CGI/FastCGI. Cette fonctionnalité rend obsolète l'extension PECL
-   <literal>htscanner</literal>. Si vous exécutez PHP en tant que module Apache,
+   <literal>htscanner</literal>. Lors de l'exécution de PHP en tant que module Apache,
    l'utilisation des fichiers &htaccess; produit le même effet.
   </simpara>
   
@@ -340,20 +340,20 @@ but needs all top-level xml:id's removed (see XInclude 1.1 set-xml-id).
   <sect2 xml:id="configuration.changes.apache">
    <title>Exécuter PHP comme module Apache</title>
    <simpara>
-    Lorsque vous utilisez le module Apache, vous pouvez aussi changer
+    Lors de l'utilisation du module Apache, il est aussi possible de changer
     les paramètres de configuration en utilisant les directives
     dans les fichiers de configuration d'Apache (&httpd.conf;) et dans
-    les fichiers &htaccess;. Vous aurez besoin des privilèges
-    "AllowOverride Options" ou "AllowOverride All".
+    les fichiers &htaccess;. Les privilèges
+    "AllowOverride Options" ou "AllowOverride All" sont nécessaires.
    </simpara>
    
    <para>
     Il y a de nombreuses directives
-    Apache qui vous permettent de modifier la configuration de PHP
+    Apache qui permettent de modifier la configuration de PHP
     à partir des fichiers de configuration Apache. Pour une liste des
     directives qui sont <constant>INI_ALL</constant>,
     <constant>INI_PERDIR</constant> ou <constant>INI_SYSTEM</constant>
-    reportez-vous à l'annexe <link linkend="ini.list">Liste des directives
+    se reporter à l'annexe <link linkend="ini.list">Liste des directives
     du php.ini</link>.
    </para>
    
@@ -371,11 +371,11 @@ but needs all top-level xml:id's removed (see XInclude 1.1 set-xml-id).
         Cette instruction n'est utilisable qu'avec les directives PHP de type
         <constant>INI_ALL</constant> et <constant>INI_PERDIR</constant>.
         Pour annuler une valeur qui aurait été modifiée au préalable,
-        utilisez la valeur <literal>none</literal>.
+        utiliser la valeur <literal>none</literal>.
        </para>
        <note>
         <simpara>
-         N'utilisez pas <systemitem role="directive">php_value</systemitem>
+         Ne pas utiliser <systemitem role="directive">php_value</systemitem>
          pour configurer des valeurs booléennes.
          <systemitem role="directive">php_flag</systemitem> (voir plus bas)
          doit être utilisée.
@@ -456,12 +456,12 @@ but needs all top-level xml:id's removed (see XInclude 1.1 set-xml-id).
     <para>
      Les constantes PHP n'existent pas en dehors de PHP. Par
      exemple, dans le fichier &httpd.conf;,
-     vous ne pouvez pas utiliser des constantes PHP telles que
+     il n'est pas possible d'utiliser des constantes PHP telles que
      <constant>E_ALL</constant> ou <constant>E_NOTICE</constant> pour spécifier
      le niveau de <link linkend="ini.error-reporting">rapport d'erreur</link>,
      car ces constantes n'ont pas de signification pour Apache,
      et seront remplacées par <emphasis>0</emphasis>.
-     Utilisez les valeurs numériques à la place.
+     Utiliser les valeurs numériques à la place.
      Les constantes peuvent être utilisées dans le &php.ini;
     </para>
    </caution>
@@ -470,7 +470,7 @@ but needs all top-level xml:id's removed (see XInclude 1.1 set-xml-id).
   <sect2 xml:id="configuration.changes.windows">
    <title>Modifier la configuration de PHP via la base de registre Windows</title>
    <simpara>
-    Lorsque vous utilisez PHP sur Windows, la configuration peut
+    Lors de l'utilisation de PHP sur Windows, la configuration peut
     être modifiée dossier par dossier en utilisant la base de registres
     de Windows. Les valeurs de configuration sont stockées
     avec la clé de registre
@@ -495,17 +495,17 @@ but needs all top-level xml:id's removed (see XInclude 1.1 set-xml-id).
   <sect2 xml:id="configuration.changes.other">
    <title>Autres interfaces de configuration de PHP</title>
    <para>
-    Suivant la façon dont vous exécutez PHP, vous pouvez changer certaines valeurs
-    durant l'exécution de vos scripts en utilisant <function>ini_set</function>.
+    Suivant la façon dont PHP est exécuté, il est possible de changer certaines valeurs
+    durant l'exécution des scripts en utilisant <function>ini_set</function>.
     Voir la documentation de la fonction <function>ini_set</function> pour plus
     d'informations.
    </para>
    <para>
-    Si vous êtes intéressé par une liste complète des options configurées
-    sur votre système avec leurs valeurs courantes, vous pouvez exécuter
-    la fonction <function>phpinfo</function> et consulter la page résultante.
-    Vous pouvez aussi accéder individuellement aux directives de configuration
-    pendant l'exécution de vos scripts en utilisant soit la fonction
+    Pour obtenir une liste complète des options configurées
+    sur le système avec leurs valeurs courantes, il est possible d'exécuter
+    la fonction <function>phpinfo</function> et de consulter la page résultante.
+    Il est aussi possible d'accéder individuellement aux directives de configuration
+    pendant l'exécution des scripts en utilisant soit la fonction
     <function>ini_get</function>, soit la fonction <function>get_cfg_var</function>.
    </para>
   </sect2>

--- a/install/intro.xml
+++ b/install/intro.xml
@@ -6,7 +6,7 @@
 <chapter xml:id="install.general" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Considérations générales sur l'installation</title>
  <para>
-  Avant d'installer PHP, vous devez savoir ce que vous voulez
+  Avant d'installer PHP, il faut savoir ce que l'on souhaite
   faire avec PHP. Il y a deux cas d'utilisation décrits dans
   la section <link linkend="intro-whatcando">Que peut faire PHP ?</link> :
   <itemizedlist>
@@ -15,39 +15,37 @@
   </itemizedlist>
  </para>
  <para>
-  Pour la première tâche, qui est de loin la plus répandue, vous
-  avez besoin de trois choses : PHP lui-même, un serveur Web et
-  un navigateur. Vous avez probablement un navigateur, et en
-  fonction de votre système d'exploitation, vous pouvez
-  aussi disposer d'un serveur Web (c.-à-d. Apache sous Linux et macOS
-  ou IIS sous Windows). Vous pouvez aussi louer un espace
-  à une société. De cette façon, vous n'aurez pas à mettre
-  en place PHP, mais uniquement à écrire vos scripts, les charger
-  sur le serveur et voir le résultat sur votre navigateur.
+  Pour la première tâche, qui est de loin la plus répandue, trois
+  choses sont nécessaires : PHP lui-même, un serveur Web et
+  un navigateur. En fonction du système d'exploitation, il est possible de
+  disposer d'un serveur Web (c.-à-d. Apache sous Linux et macOS
+  ou IIS sous Windows). Il est aussi possible de louer un espace
+  à une société. De cette façon, il n'est pas nécessaire de mettre
+  en place PHP, mais uniquement d'écrire les scripts, les charger
+  sur le serveur et voir le résultat dans le navigateur.
  </para>
  <para>
-  Si vous installez PHP et le serveur par vous-même, vous avez
+  Lors de l'installation de PHP et du serveur soi-même, il y a
   deux choix. Soit sous la forme d'un module du serveur
   Web (via une interface directe appelée SAPI). Les
   serveurs qui supportent cette solution comptent notamment
   Apache, Microsoft Internet Information Server,
   Netscape et les serveurs iPlanet.
   Si PHP ne supporte pas
-  l'interface de module de votre serveur Web, vous pouvez
-  toujours l'utiliser comme processeur CGI ou FastCGI. Cela signifie
-  que vous devez configurer votre serveur pour qu'il
+  l'interface de module du serveur Web, il est toujours possible de
+  l'utiliser comme processeur CGI ou FastCGI. Cela signifie
+  qu'il faut configurer le serveur pour qu'il
   utilise l'exécutable CGI de PHP, pour qu'il traite les fichiers
   PHP sur le serveur.
  </para>
  <para>
-  Si vous souhaitez aussi utiliser PHP en ligne de commande
+  Pour utiliser PHP en ligne de commande
   (écrire des scripts de génération d'image hors ligne,
   par exemple, ou bien traiter des textes en fonction
-  d'informations que vous leur fourniriez), vous aurez
-  besoin d'un exécutable PHP. Pour plus de détails, lisez la
+  d'informations fournies), un exécutable PHP est nécessaire. Pour plus de détails, lisez la
   section <link linkend="features.commandline"> écrire des applications
-   PHP en ligne de commande</link>. Dans ce cas, vous
-  n'aurez pas besoin de serveur Web, ni de navigateur.
+   PHP en ligne de commande</link>. Dans ce cas, il
+  n'est pas nécessaire d'avoir un serveur Web, ni un navigateur.
  </para>
  <para>
   À partir de maintenant, cette section décrit l'installation de

--- a/install/macos/bundled.xml
+++ b/install/macos/bundled.xml
@@ -19,7 +19,7 @@
   <emphasis>vivement recommandé</emphasis> de toujours mettre à jour PHP
   à sa version la plus récente. Comme la plupart des programmes, les nouvelles
   versions sont créées pour corriger les bogues et ajouter des fonctionnalités
-  et c'est le cas de PHP. Reportez-vous à la documentation de l'installation
+  et c'est le cas de PHP. Se reporter à la documentation de l'installation
   de macOS pour plus de détails. Les instructions suivantes sont destinées
   au débutant, en fournissant juste assez de détails pour mettre en place
   une configuration par défaut pour travailler. Tous les utilisateurs sont
@@ -47,10 +47,10 @@
       Une façon de l'ouvrir est d'utiliser un éditeur de texte Unix dans
       un terminal, par exemple, <literal>nano</literal>, et sachant que le
       fichier est la propriété de l'utilisateur <literal>root</literal>,
-      vous devrez utiliser la commande <literal>sudo</literal> pour l'ouvrir
-      (en tant que <literal>root</literal>) ; aussi, vous devrez entrer
-      la commande suivante dans votre <literal>Terminal</literal> (votre mot
-      de passe vous sera demandé) :
+      il faut utiliser la commande <literal>sudo</literal> pour l'ouvrir
+      (en tant que <literal>root</literal>) ; aussi, il faut entrer
+      la commande suivante dans le <literal>Terminal</literal> (le mot
+      de passe sera demandé) :
       <literal>sudo nano /private/etc/apache2/httpd.conf</literal>
      </simpara>
      <simpara>
@@ -79,17 +79,17 @@
 # AddModule mod_php5.c
 ]]>
      </screen>
-     Notez le chemin. Dans le futur, lorsque vous compilerez PHP, les fichiers
+     Noter le chemin. Dans le futur, lors de la compilation de PHP, les fichiers
      ci-dessus doivent être remplacés ou commentés.
     </para>
    </listitem>
    <listitem>
     <para>
-     Assurez-vous que les extensions désirées soient analysées par PHP (exemples :
+     S'assurer que les extensions désirées soient analysées par PHP (exemples :
      <filename class="extension">.php</filename>, <filename class="extension">.html</filename> et <filename class="extension">.inc</filename>)
     </para>
     <para>
-     Sachant que ce comportement a déjà été activé dans votre fichier
+     Sachant que ce comportement a déjà été activé dans le fichier
      <filename>httpd.conf</filename> (depuis Mac Panther), une fois PHP activé,
      les fichiers <filename class="extension">.php</filename> seront automatiquement analysés par PHP.
      <screen>
@@ -117,14 +117,14 @@
    </listitem>
    <listitem>
     <simpara>
-     Assurez-vous que DirectoryIndex charge le fichier index par défaut.
+     S'assurer que DirectoryIndex charge le fichier index par défaut.
     </simpara>
     <simpara>
      Ceci est également défini dans le fichier <filename>httpd.conf</filename>.
      Normalement, les fichiers <filename>index.php</filename> et
      <filename>index.html</filename> sont utilisés. Par défaut,
      <filename>index.php</filename> est activé car il est également
-     dans la vérification de PHP ci-dessus. Ajustez-le suivant votre besoin.
+     dans la vérification de PHP ci-dessus. L'ajuster selon les besoins.
     </simpara>
    </listitem>
    <listitem>
@@ -137,7 +137,7 @@
      <filename>/usr/local/php/php.ini</filename> et un appel à la fonction
      <function>phpinfo</function> révèlera cette information.
      Si aucun fichier &php.ini; n'est utilisé, PHP utilisera toutes les valeurs
-     par défaut. Reportez-vous à la FAQ sur
+     par défaut. Se reporter à la FAQ sur
      "<link linkend="faq.installation.phpini">trouver le fichier php.ini</link>".
     </simpara>
    </listitem>
@@ -179,7 +179,7 @@
      dans un terminal ou arrêter/démarrer l'option "Personal Web Server" dans les
      préférences systèmes de macOS. Par défaut, le chargement de fichiers locaux dans
      le navigateur s'effectue via des <acronym>URL</acronym> comme ceci :
-     <filename>http://localhost/info.php</filename> ou, si vous utilisez le DocumentRoot
+     <filename>http://localhost/info.php</filename> ou, lors de l'utilisation du DocumentRoot
      d'un dossier utilisateur, l'URL ressemblera à :
      <filename>http://localhost/~yourusername/info.php</filename>
     </para>
@@ -192,7 +192,7 @@
   <filename>/usr/bin/php</filename>. Ouvrez un terminal, lisez la section sur
   <link linkend="features.commandline">la ligne de commande</link> du manuel PHP, et
   exécutez la commande <literal>php -v</literal> pour vérifier la version PHP de ce binaire.
-  Un appel à la fonction <function>phpinfo</function> pourra également vous révéler cette
+  Un appel à la fonction <function>phpinfo</function> pourra également révéler cette
   information.
  </simpara>
 </sect1>

--- a/install/macos/compile.xml
+++ b/install/macos/compile.xml
@@ -6,7 +6,7 @@
  <sect1 xml:id="install.macosx.compile" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
   <title>Compiler PHP sur macOS</title>
   <simpara>
-   Référez-vous au <link linkend="install.unix">guide d'installation sous Unix</link>
+   Se référer au <link linkend="install.unix">guide d'installation sous Unix</link>
    pour compiler PHP sur macOS.
   </simpara>
  </sect1>

--- a/install/macos/packages.xml
+++ b/install/macos/packages.xml
@@ -7,12 +7,12 @@
  <simpara>
   Il existe quelques versions pré-packagées et pré-compilées
   de PHP pour macOS. Cela peut être utile pour mettre en place une configuration
-  standard, mais si vous avez besoin d'accéder à des fonctionnalités
+  standard, mais en cas de besoin d'accéder à des fonctionnalités
   spécifiques (comme un serveur sécurisé, ou un pilote de bases de données
-  exotiques), vous aurez à compiler PHP et/ou votre serveur Web vous-même.
-  Si vous n'êtes pas familier avec la compilation et la mise en place
+  exotiques), il faudra compiler PHP et/ou le serveur Web soi-même.
+  Sans être familier avec la compilation et la mise en place
   d'applications, il est bon de vérifier si personne d'autre n'a pas déjà
-  réalisé un paquet contenant les fonctionnalités que vous désirez.
+  réalisé un paquet contenant les fonctionnalités souhaitées.
  </simpara>
  <simpara>
   Une manière simple d'installer PHP sur macOS est d'utiliser le gestionnaire de paquets

--- a/install/pie.xml
+++ b/install/pie.xml
@@ -17,7 +17,7 @@
   </simpara>
   <simpara>
    Après <link xlink:href="&url.pie;?tab=readme-ov-file#what-do-i-need-to-get-started">l'installation
-   des prérequis et de PIE lui-même</link>, vous pouvez ensuite installer
+   des prérequis et de PIE lui-même</link>, il est ensuite possible d'installer
    l'<link linkend="mongodb.mongodb">extension MongoDB</link> en exécutant
    la commande suivante en ligne de commande.
   </simpara>

--- a/install/problems.xml
+++ b/install/problems.xml
@@ -19,10 +19,10 @@
     <title>Autres problèmes</title>
 
     <simpara>
-     Si vous êtes complètement bloqué,
+     En cas de blocage complet,
      quelqu'un sur la liste de diffusion PHP pourra probablement
-     vous aider. Essayez de consulter les archives, au cas où
-     quelqu'un aurait déjà rencontré votre
+     aider. Il est recommandé de consulter les archives, au cas où
+     quelqu'un aurait déjà rencontré le même
      problème. Les archives sont toujours accessibles à :
      <link xlink:href="&url.php.support;">&url.php.support;</link>. Pour souscrire à
      la liste de diffusion, envoyez un mail vide à
@@ -31,25 +31,25 @@
      xlink:href="mailto:&email.php.install;">&email.php.install;</link>.
     </simpara>
     <simpara>
-     Si vous voulez obtenir de l'aide sur la liste
-     de diffusion PHP, essayez d'être concis et clair,
-     et pensez à donner tous les détails sur votre
-     environnement (OS, version de PHP, serveur Web, CGI ou module,
-     etc.), et n'hésitez pas à envoyer 
-     suffisamment de code pour que nous puissions reproduire et tester l'erreur.
+     Pour obtenir de l'aide sur la liste
+     de diffusion PHP, il est important d'être concis et clair,
+     et de penser à donner tous les détails sur l'environnement
+     (OS, version de PHP, serveur Web, CGI ou module,
+     etc.), en envoyant
+     suffisamment de code pour que l'erreur puisse être reproduite et testée.
     </simpara>
    </sect1>
 
    <sect1 xml:id="install.problems.bugs">
     <title>Rapports de Bogue</title>
     <simpara>
-     Si vous pensez avoir trouvé un bogue dans PHP, n'oubliez
-     pas de le signaler. L'équipe de développement
-     PHP ne le connaît peut-être pas et, si vous ne le signalez pas,
-     vos chances de voir le bogue corrigé sont nulles. Vous pouvez
+     En cas de découverte d'un bogue dans PHP, il ne faut pas oublier
+     de le signaler. L'équipe de développement
+     PHP ne le connaît peut-être pas et, s'il n'est pas signalé,
+     les chances de voir le bogue corrigé sont nulles. Il est possible de
      rapporter des bogues grâce au système de suivi, accessible
      à <link xlink:href="&url.php.bugs;">&url.php.bugs;</link>.
-     S'il vous plait, n'envoyez pas de rapports de bogue sur les 
+     Il est important de ne pas envoyer de rapports de bogue sur les
      listes de diffusion ou par courrier personnel. Le système de
      suivi est de plus prévu pour permettre la proposition
      de nouvelles fonctionnalités.

--- a/install/unix/apache2.xml
+++ b/install/unix/apache2.xml
@@ -34,7 +34,7 @@
   Il y a actuellement 2 versions d'Apache 2.x - 2.4 et 2.2.
   Il y a plusieurs raisons de choisir l'une plutôt que l'autre ; néanmoins, la version
   2.4 est actuellement la dernière version disponible et c'est aussi celle
-  que nous vous recommandons. Cependant, les instructions contenues
+  qui est recommandée. Cependant, les instructions contenues
   dans ce guide devraient fonctionner pour la version 2.4 comme pour la version 2.2. Note : Apache httpd 2.2 est officiellement en fin de vie, il n'y aura plus de développement ni de correctif pour cette version.
  </para>
  
@@ -87,9 +87,9 @@ make install
   
   <listitem>
    <para>
-    Maintenant que vous avez Apache 2.x.NN de disponible sous /usr/local/apache2,
-    configurez-le avec le support pour le chargement de modules, ainsi que le
-    MPM prefork standard. Pour tester votre installation, utilisez la procédure
+    Maintenant qu'Apache 2.x.NN est disponible sous /usr/local/apache2,
+    le configurer avec le support pour le chargement de modules, ainsi que le
+    MPM prefork standard. Pour tester l'installation, utiliser la procédure
     normale pour démarrer le serveur Apache, i.e. :
     
     <informalexample>
@@ -99,7 +99,7 @@ make install
 ]]>
      </screen>
     </informalexample>
-    et arrêtez-le pour continuer dans la configuration de PHP :
+    et l'arrêter pour continuer la configuration de PHP :
     
     <informalexample>
      <screen>
@@ -115,18 +115,18 @@ make install
    
    <para>
     Maintenant, configurez et compilez PHP. Ce sera à ce moment-là
-    où vous pourrez personnaliser PHP avec les diverses options disponibles,
-    comme la liste des extensions à activer. Exécutez
+    où il est possible de personnaliser PHP avec les diverses options disponibles,
+    comme la liste des extensions à activer. Exécuter
     <command>./configure --help</command> pour la liste des options disponibles. Dans notre exemple, nous effectuerons
     une configuration simple, avec Apache 2 et le support MySQL.
    </para>
    
    <para>
-    Si vous avez construit Apache depuis les sources, tel que décrit ci-dessus,
+    Si Apache a été construit depuis les sources, tel que décrit ci-dessus,
     l'exemple suivant devrait être correct concernant les chemins vers <command>apxs</command>, mais si
-    vous avez installé Apache d'une autre façon, vous devrez prendre en compte vos
+    Apache a été installé d'une autre façon, il faut prendre en compte les
     spécificités et ajuster les chemins <command>apxs</command> en conséquence. Notez que suivant
-    les distributions, vous pourriez être amené à renommer <command>apxs</command> en <command>apxs2</command>.
+    les distributions, il peut être nécessaire de renommer <command>apxs</command> en <command>apxs2</command>.
    </para>
    <informalexample>
     <screen>
@@ -140,9 +140,9 @@ make install
    </informalexample>
    
    <para>
-    Si vous décidez de modifier les options de configuration après l'installation,
-    vous devrez exécuter de nouveau les étapes <command>configure</command>, <command>make</command> et <command>make install</command>.
-    Vous n'aurez alors qu'à redémarrer Apache pour que le nouveau module prenne effet.
+    En cas de modification des options de configuration après l'installation,
+    il faut exécuter de nouveau les étapes <command>configure</command>, <command>make</command> et <command>make install</command>.
+    Il suffit alors de redémarrer Apache pour que le nouveau module prenne effet.
     Une re-compilation d'Apache n'est pas nécessaire.
    </para>
    
@@ -156,7 +156,7 @@ make install
   
   <listitem>
    <para>
-    Configurez votre <filename>php.ini</filename>.
+    Configurer le fichier <filename>php.ini</filename>.
    </para>
    
    <informalexample>
@@ -168,13 +168,13 @@ cp php.ini-development /usr/local/lib/php.ini
    </informalexample>
    
    <para>
-    Vous devez éditer le fichier .ini pour définir les options PHP.
-    Si vous préférez placer ce fichier dans un autre répertoire, utilisez
+    Il faut éditer le fichier .ini pour définir les options PHP.
+    Pour placer ce fichier dans un autre répertoire, utiliser
     l'option <literal>--with-config-file-path=/some/path</literal> à l'étape 5.
    </para>
    
    <para>
-    Si vous choisissez le fichier php.ini-production, assurez-vous de lire la liste
+    En cas d'utilisation du fichier php.ini-production, il faut s'assurer de lire la liste
     des modifications correspondante car il peut affecter considérablement la façon
     dont PHP fonctionnera.
    </para>
@@ -184,10 +184,10 @@ cp php.ini-development /usr/local/lib/php.ini
   <listitem>
    
    <para>
-    Éditez le fichier <filename>httpd.conf</filename> pour charger le module PHP. Le chemin spécifié
+    Éditer le fichier <filename>httpd.conf</filename> pour charger le module PHP. Le chemin spécifié
     à droite de la chaîne LoadModule, doit correspondre au chemin système du module
     PHP. L'étape "make install" ci-dessus devrait avoir réalisé cette opération
-    à votre place, mais une simple vérification permettra de s'en assurer.
+    automatiquement, mais une simple vérification permettra de s'en assurer.
    </para>
 
    <informalexample>
@@ -217,13 +217,13 @@ LoadModule php7_module modules/libphp7.so
   <listitem>
    
    <para>
-    Dites à Apache d'analyser certaines extensions comme étant des scripts PHP.
+    Configurer Apache pour analyser certaines extensions comme étant des scripts PHP.
     Par exemple, laissez Apache passer à PHP les fichiers dont l'extension est
     <literal>.php</literal>.
     Au lieu d'utiliser seulement la directive <literal>AddType</literal> d'Apache,
     nous souhaitons éviter tout risque potentiellement dangereux, lors
     d'un téléchargement et de la création de fichier comme <filename>exploit.php.jpg</filename>,
-    d'être exécutés par PHP. En utilisant cet exemple, vous pouvez avoir n'importe
+    d'être exécutés par PHP. En utilisant cet exemple, il est possible d'avoir n'importe
     quelle extension analysée par PHP. Nous avons ajouté <literal>.php</literal> pour l'exemple.
    </para>
    
@@ -239,7 +239,7 @@ LoadModule php7_module modules/libphp7.so
    </informalexample>
    
    <para>
-    Ou, si vous voulez autoriser les fichiers <literal>.php</literal>, <literal>.php2</literal>, 
+    Ou, pour autoriser les fichiers <literal>.php</literal>, <literal>.php2</literal>,
     <literal>.php3</literal>, <literal>.php4</literal>, <literal>.php5</literal>,
     <literal>.php6</literal>, et <literal>.phtml</literal> à être
     analysés par PHP, mais rien d'autre, nous utiliserons ceci :
@@ -258,7 +258,7 @@ LoadModule php7_module modules/libphp7.so
    <para>
     Et pour autoriser les fichiers <literal>.phps</literal> à être gérés par le filtre du code
     source de PHP, et ainsi, être affichés comme code source avec la coloration
-    syntaxique, utilisez ceci :
+    syntaxique, utiliser ceci :
    </para>
    
    <informalexample>
@@ -296,7 +296,7 @@ RewriteRule (.*\.php)s$ $1 [H=application/x-httpd-php-source]
   
   <listitem>
    <para>
-    Utilisez la procédure normale pour démarrer le serveur Apache, i.e. :
+    Utiliser la procédure normale pour démarrer le serveur Apache, i.e. :
    </para>
    
    <informalexample>
@@ -321,7 +321,7 @@ service httpd restart
  </orderedlist>
  
  <para>
-  Si vous avez suivi les étapes précédentes, vous avez maintenant un serveur web
+  En ayant suivi les étapes précédentes, le serveur web est maintenant un
   Apache2 fonctionnel avec le support PHP comme module <literal>SAPI</literal>.
   Bien-sûr, il y a une multitude d'autres options de configuration de disponibles
   avec Apache et PHP. Pour plus d'informations, entrez la commande
@@ -345,8 +345,8 @@ service httpd restart
   et ayant au moins une juste compréhension de ce que cela implique.
   La documentation Apache concernant
   <link xlink:href="&url.apache2.mpm;">MPM-Modules</link>
-  vous apportera d'importantes informations qui vous permettra de prendre
-  votre décision.
+  apportera d'importantes informations qui permettront de prendre
+  une décision.
  </para>
  <note>
   <para>

--- a/install/unix/commandline.xml
+++ b/install/unix/commandline.xml
@@ -8,8 +8,8 @@
  <para>
    Par défaut, PHP est construit comme programme à la fois
    <acronym>CLI</acronym> et <acronym>CGI</acronym>, pouvant être utilisé comme
-   processeur CGI. Si vous utilisez un serveur qui supporte le module PHP,
-   vous devriez en général utiliser cette solution pour des raisons de
+   processeur CGI. Lors de l'utilisation d'un serveur qui supporte le module PHP,
+   il est en général recommandé d'utiliser cette solution pour des raisons de
    performances. Cependant, la version CGI permet aux utilisateurs de lancer
    des pages PHP sous différents identifiants utilisateurs (Unix).
  </para>
@@ -18,10 +18,10 @@
  <sect2 xml:id="install.unix.commandline.testing">
   <title>Tests</title>
   <simpara>
-   Si vous avez compilé PHP comme programme CGI, vous pouvez tester
-   votre produit en tapant : <command>make test</command>. C'est toujours
+   Si PHP a été compilé comme programme CGI, il est possible de tester
+   le produit en tapant : <command>make test</command>. C'est toujours
    une bonne chose de tester le résultat d'une compilation.
-   Cela vous permet de repérer des problèmes entre PHP et votre
+   Cela permet de repérer des problèmes entre PHP et la
    plate-forme, plutôt que d'attendre qu'ils surviennent.
   </simpara>
  </sect2>

--- a/install/unix/debian.xml
+++ b/install/unix/debian.xml
@@ -108,7 +108,7 @@
    <listitem>
     <simpara>
      Si une extension a apparemment été installée mais que ses fonctions ne sont pas définies,
-     assurez-vous que les lignes adéquates ont été insérées dans les fichiers .ini et/ou que
+     il faut s'assurer que les lignes adéquates ont été insérées dans les fichiers .ini et/ou que
      le serveur web a été redémarré après l'installation.
     </simpara>
    </listitem>

--- a/install/unix/lighttpd-14.xml
+++ b/install/unix/lighttpd-14.xml
@@ -11,7 +11,7 @@
  </para>
 
  <para>
-  Reportez-vous à <link xlink:href="&url.lighttpd.doc;">Lighttpd</link>
+  Se reporter à <link xlink:href="&url.lighttpd.doc;">Lighttpd</link>
   pour une installation correcte de Lighttpd avant de continuer.
  </para>
  
@@ -25,7 +25,7 @@
 
   <para>
    Pour configurer Lighttpd afin qu'il se connecte à PHP et appelle le processus
-   FastCGI, vous devez éditer le fichier <filename>lighttpd.conf</filename>. Une connexion par sockets
+   FastCGI, il faut éditer le fichier <filename>lighttpd.conf</filename>. Une connexion par sockets
    est la solution préférée pour les systèmes locaux.
   </para>
 

--- a/install/unix/nginx.xml
+++ b/install/unix/nginx.xml
@@ -12,25 +12,25 @@
  </para>
 
  <para>
-  Ce guide suppose que vous avez compilé Nginx à partir des sources et donc 
-  tous les binaires et fichiers de configuration se trouvent dans 
-  <literal>/usr/local/nginx</literal>. Si ce n'est pas le cas et que vous avez 
-  obtenu Nginx par d'autres moyens, veuillez vous référer au 
-  <link xlink:href="&url.nginx;">Wiki d'Nginx</link> pour adapter ce manuel 
-  pour votre configuration.
+  Ce guide suppose que Nginx a été compilé à partir des sources et donc
+  tous les binaires et fichiers de configuration se trouvent dans
+  <literal>/usr/local/nginx</literal>. Si ce n'est pas le cas et que Nginx a été
+  obtenu par d'autres moyens, se référer au
+  <link xlink:href="&url.nginx;">Wiki d'Nginx</link> pour adapter ce manuel
+  à la configuration utilisée.
  </para>
 
  <para>
   Ce guide couvre les bases de la configuration du serveur Nginx afin de 
   parvenir à servir une application PHP sur le port 80. Il est recommandé 
-  d'étudier les documentations d'Nginx et de PHP-FPM afin d'optimiser votre 
-  installation.
+  d'étudier les documentations d'Nginx et de PHP-FPM afin d'optimiser
+  l'installation.
  </para>
 
  <para>
-  Veuillez noter que tout au long de cette documentation, les numéros de version
-  ont été remplacés par un "x" pour assurer que cette dernière reste correcte 
-  dans l'avenir. Pensez à les remplacer par votre numéro de version.
+  Il est à noter que tout au long de cette documentation, les numéros de version
+  ont été remplacés par un "x" pour assurer que cette dernière reste correcte
+  dans l'avenir. Penser à les remplacer par le numéro de version approprié.
  </para>
 
  <orderedlist>
@@ -38,7 +38,7 @@
    <para>
     Il est recommandé de consulter la 
     <link xlink:href="&url.nginx.wiki.install;">documentation de Nginx</link> 
-    afin de l'installer sur votre système.
+    afin de l'installer sur le système.
    </para>
   </listitem>
 
@@ -58,7 +58,7 @@ tar zxf php-x.x.x
 
   <listitem>
    <para>
-    Configurer et compiler PHP. Ce sera le moment où vous pourrez
+    Configurer et compiler PHP. Ce sera le moment où il sera possible de
     personnaliser PHP avec diverses options, comme les extensions
     à activer. Exécuter ./configure --help pour obtenir une liste
     des options disponibles. Dans notre exemple, nous effectuerons
@@ -96,14 +96,14 @@ cp sapi/fpm/php-fpm /usr/local/bin
 
   <listitem>
    <para>
-    Il est important que vous empêchiez Nginx de passer les requêtes
+    Il est important d'empêcher Nginx de passer les requêtes
     au backend PHP-FPM si le fichier n'existe pas, évitant ainsi
     les failles par injections arbitraires de scripts.
    </para>
    <para>
     Nous pouvons réaliser cela en définissant la directive
     de configuration <link linkend="ini.cgi.fix-pathinfo">cgi.fix_pathinfo</link>
-    à la valeur <literal>0</literal> dans votre php.ini.
+    à la valeur <literal>0</literal> dans le php.ini.
    </para>
    <para>
     Modifier php.ini :
@@ -175,9 +175,9 @@ group = www-data
    </informalexample>
 
    <para>
-    Ce guide ne va pas configurer php-fpm plus que cela ; si vous
-    êtes intéressé dans la configuration avancée de php-fpm, veuillez
-    consulter la documentation.
+    Ce guide ne va pas configurer php-fpm plus que cela ; pour
+    la configuration avancée de php-fpm, consulter
+    la documentation.
    </para>
   </listitem>
 
@@ -246,7 +246,7 @@ sudo /usr/local/nginx/sbin/nginx
 
   <listitem>
    <para>
-    Créez un fichier de test
+    Créer un fichier de test
    </para>
 
    <informalexample xml:id="install.unix.nginx.test.nginx.php">
@@ -266,7 +266,7 @@ echo "<?php phpinfo(); ?>" >> /usr/local/nginx/html/index.php
  </orderedlist>
 
  <para>
-  En suivant ces différentes étapes, vous devriez exécuter un serveur
+  En suivant ces différentes étapes, le résultat devrait être un serveur
   web Nginx avec le support de PHP comme module <literal>FPM</literal> <literal>SAPI</literal>.
   Bien entendu, il y a beaucoup plus d'options de configuration
   disponibles pour Nginx et PHP. Pour plus d'informations, tapez

--- a/install/unix/openbsd.xml
+++ b/install/unix/openbsd.xml
@@ -15,14 +15,14 @@
    Cette méthode est la méthode recommandée pour installer PHP sur OpenBSD.
    C'est aussi la méthode la plus simple. Le paquet core a été séparé des modules
    et chacun d'entre eux peut être installé et supprimé indépendamment des autres.
-   Les fichiers dont vous avez besoin sont sur le CD OpenBSD ou sur le site FTP.
+   Les fichiers nécessaires sont sur le CD OpenBSD ou sur le site FTP.
   </simpara>
   <simpara>
-   Le paquet principal que vous devez installer est <filename>php</filename>,
+   Le paquet principal à installer est <filename>php</filename>,
    qui contient le moteur de base (en plus de fpm, gettext et iconv) et pourrait
    être disponible sous plusieurs versions au choix.
    Puis, jetez un oeil aux paquets de module, comme <filename>php-mysqli</filename>
-   ou <filename>php-imap</filename>. Vous devez utiliser la commande 
+   ou <filename>php-imap</filename>. Il faut utiliser la commande
    <command>phpxs</command> pour activer et désactiver ces modules dans votre 
    &php.ini;.
   </simpara>
@@ -54,14 +54,14 @@ Follow the instructions shown with each package!
  <sect2 xml:id="install.unix.openbsd.ports">
   <title>Utilisation des ports</title>
   <simpara>
-   Vous pouvez aussi compiler PHP en utilisant <link
+   Il est aussi possible de compiler PHP en utilisant <link
    xlink:href="&url.openbsd.ports;">l'arbre des ports</link>.
    Cette méthode est recommandée aux utilisateurs expérimentés de OpenBSD. Le port PHP
    est divisé en core et extensions. Les
-   extensions génèrent les sous-paquets de tous les modules PHP supportés. Si vous souhaitez
-   ne pas créer certains de ces modules, utilisez le FLAVOR
+   extensions génèrent les sous-paquets de tous les modules PHP supportés. Pour
+   ne pas créer certains de ces modules, utiliser le FLAVOR
    <command>no_*</command>. Par exemple, pour ne pas compiler le module
-   imap, définissez le FLAVOR à <command>no_imap</command>.
+   imap, définir le FLAVOR à <command>no_imap</command>.
   </simpara>
  </sect2>
  <sect2 xml:id="install.unix.openbsd.faq">
@@ -79,15 +79,15 @@ Follow the instructions shown with each package!
      L'installation par défaut de httpd fonctionne dans un
      <link xlink:href="&url.openbsd.chroot;">contexte chroot(2)</link>, 
      qui va limiter l'accès des scripts PHP au dossier
-     <filename>/var/www</filename>. Vous devez donc créer un dossier 
+     <filename>/var/www</filename>. Il faut donc créer un dossier
      <filename>/var/www/tmp</filename> pour que les sessions PHP soient
      stockées, ou bien utiliser une autre solution de sauvegarde.
      De plus, les sockets de bases de données doivent être placés
      dans ce dossier, ou bien utiliser l'interface 
-     <filename>localhost</filename>. Si vous utilisez des fonctions de
+     <filename>localhost</filename>. Lors de l'utilisation de fonctions de
      réseau avec des fichiers comme <filename>/etc</filename>, 
      par exemple <filename>/etc/resolv.conf</filename>, et
-     <filename>/etc/services</filename>, vous devrez les rendre accessibles
+     <filename>/etc/services</filename>, il faut les rendre accessibles
      aussi dans <filename>/var/www/etc</filename>.
      Le paquet OpenBSD PEAR installe automatiquement les bons dossiers.
     </simpara>

--- a/install/unix/solaris.xml
+++ b/install/unix/solaris.xml
@@ -17,7 +17,7 @@
    sont nécessaires.
   </para>
   <para>
-   Pour décompresser la distribution PHP, vous avez besoin de
+   Pour décompresser la distribution PHP, les outils suivants sont nécessaires :
    <itemizedlist>
     <listitem>
      <simpara>
@@ -37,7 +37,7 @@
    </itemizedlist>
   </para>
   <para>
-   Pour compiler PHP, vous avez besoin de
+   Pour compiler PHP, les outils suivants sont nécessaires :
    <itemizedlist> 
     <listitem>
      <simpara>
@@ -58,7 +58,7 @@
   </para>
   <para>
    Pour construire les extensions additionnelles ou modifier le code de PHP,
-   vous pouvez également avoir besoin de
+   il peut également être nécessaire d'avoir
    <itemizedlist>
     <listitem>
      <simpara>
@@ -86,14 +86,14 @@
      </simpara>
     </listitem>
    </itemizedlist>
-   De plus, vous devrez aussi installer (et peut-être aussi compiler)
+   De plus, il faut aussi installer (et peut-être aussi compiler)
    toutes les bibliothèques nécessaires aux extensions comme MySQL, Oracle, etc.
   </para>     
  </sect2>
  <sect2 xml:id="install.unix.solaris.packages">
   <title>Utilisation des paquets</title>
   <simpara>
-   Vous pouvez simplifier l'installation <productname>Solaris</productname> 
+   Il est possible de simplifier l'installation <productname>Solaris</productname>
    en utilisant pkgadd pour installer la plupart des composants. Le
    système Image Packaging System (IPS) pour <productname>Solaris 11 Express</productname>
    contient également la plupart des composants nécessaires pour l'installation

--- a/install/windows/apache2.xml
+++ b/install/windows/apache2.xml
@@ -68,8 +68,8 @@ PHPIniDir "C:/php"
    <simpara>
     Le chemin réel vers PHP doit être substitué à la place de
     <filename>C:/php/</filename> dans les exemples ci-dessus.
-    Assurez-vous que le fichier référencé dans la directive <literal>LoadModule</literal> est à
-    l'emplacement spécifié. Utilisez <filename>php7apache2_4.dll</filename>
+    Il faut s'assurer que le fichier référencé dans la directive <literal>LoadModule</literal> est à
+    l'emplacement spécifié. Utiliser <filename>php7apache2_4.dll</filename>
     pour PHP 7, ou <filename>php8apache2_4.dll</filename> pour PHP 8.
    </simpara>
   </note>


### PR DESCRIPTION
Remplacement des formulations directes (vous/votre/vos) par des tournures impersonnelles dans `install/`, conformément à TRADUCTIONS.txt.