### PR TITLE
Style impersonnel dans reference/ (t-z)

### DIFF
--- a/reference/taint/book.xml
+++ b/reference/taint/book.xml
@@ -17,8 +17,8 @@
    vulnérabilités concernant des injections SQL, des injections shell, etc.
   </para>
   <para>
-   Lorsque taint est actif, si vous passez une chaîne corrompue (provenant de <varname>$_GET</varname>,
-   <varname>$_POST</varname> ou <varname>$_COOKIE</varname>) à des fonctions, taint vous en alertera.
+   Lorsque taint est actif, si une chaîne corrompue (provenant de <varname>$_GET</varname>,
+   <varname>$_POST</varname> ou <varname>$_COOKIE</varname>) est passée à des fonctions, taint émettra une alerte.
   </para>
   <example>
    <title>Exemple avec <function>Taint</function></title>

--- a/reference/tcpwrap/functions/tcpwrap-check.xml
+++ b/reference/tcpwrap/functions/tcpwrap-check.xml
@@ -76,7 +76,7 @@
   <example>
    <title>Refuser toutes les connexions depuis localhost</title>
    <para>
-    Si votre fichier <filename>/etc/hosts.deny</filename> contient :
+    Si le fichier <filename>/etc/hosts.deny</filename> contient :
    </para>
    <screen>
 <![CDATA[
@@ -84,7 +84,7 @@ php: 127.0.0.1
 ]]>
    </screen>
    <para>
-    Et votre code ressemble à :
+    Et le code ressemble à :
    </para>
    <programlisting role="php">
 <![CDATA[

--- a/reference/tidy/functions/tidy-access-count.xml
+++ b/reference/tidy/functions/tidy-access-count.xml
@@ -79,10 +79,10 @@ echo tidy_access_count($tidy); //5
   &reftitle.notes;
   <note>
    <para>
-    Du fait du comportement de la TidyLib, vous devez appeler
+    Du fait du comportement de la TidyLib, il faut appeler
     <function>tidy_diagnose</function> avant
     <function>tidy_access_count</function> sinon la fonction retournera
-    toujours <literal>0</literal>. Vous devez également activer l'option
+    toujours <literal>0</literal>. Il faut également activer l'option
     <literal>accessibility-check</literal>.
    </para>
   </note>

--- a/reference/tidy/ini.xml
+++ b/reference/tidy/ini.xml
@@ -63,8 +63,8 @@
      </para>
      <warning>
       <para>
-       N'activez pas <literal>tidy.clean_output</literal> si vous générez autre
-       chose que du HTML, comme des images dynamiques.
+       Il ne faut pas activer <literal>tidy.clean_output</literal> lors de la génération
+       d'autre chose que du HTML, comme des images dynamiques.
       </para>
      </warning>
     </listitem>

--- a/reference/tidy/setup.xml
+++ b/reference/tidy/setup.xml
@@ -10,7 +10,7 @@
  <section xml:id="tidy.requirements">
   &reftitle.required;
   <para>
-   Pour utiliser Tidy, vous devez disposer de la bibliothèque libtidy,
+   Pour utiliser Tidy, il faut disposer de la bibliothèque libtidy,
    qui est disponible sur la <link xlink:href="&url.tidy;">page d'accueil de tidy</link>.
    À partir de PHP 7.1.0, le successeur compatible HTML5
    <link xlink:href="&url.tidy5;">libtidy5</link> peut être utilisé en alternative.

--- a/reference/tidy/tidy/getoptdoc.xml
+++ b/reference/tidy/tidy/getoptdoc.xml
@@ -28,7 +28,7 @@
   </para>
   <note>
    <para>
-    Vous devez posséder au moins libtidy datant du 25 avril 2005 pour que
+    Il faut posséder au moins libtidy datant du 25 avril 2005 pour que
     cette fonction soit disponible.
    </para>
   </note>

--- a/reference/tokenizer/book.xml
+++ b/reference/tokenizer/book.xml
@@ -13,8 +13,8 @@
   <para>
    Les fonctions tokenizer fournissent une interface au tokenizer PHP
    interne au moteur Zend. En utilisant ces fonctions,
-   vous pouvez écrire vos propres outils d'analyse ou de modification
-   de code source PHP, sans avoir à vous soucier de la spécification
+   il est possible d'écrire ses propres outils d'analyse ou de modification
+   de code source PHP, sans avoir à se soucier de la spécification
    du langage au niveau lexical.
   </para>
   <para>

--- a/reference/uodbc/book.xml
+++ b/reference/uodbc/book.xml
@@ -12,7 +12,7 @@
  <preface xml:id="intro.uodbc">
   &reftitle.intro;
   <para>
-   En plus du support de l'ODBC normal, l'ODBC unifié de PHP vous donne
+   En plus du support de l'ODBC normal, l'ODBC unifié de PHP donne
    accès à diverses bases de données qui ont emprunté
    la sémantique des API ODBC pour implémenter leur propre API.
    Au lieu de maintenir de multiples pilotes qui sont similaires, ces pilotes
@@ -30,9 +30,9 @@
   <note>
    <para>
     Mis à part pour IODBC, il n'y a pas d'ODBC utilisé lors des connexions
-    aux bases de données ci-dessus. Les fonctions que vous utiliserez partagent les mêmes noms et syntaxes que les fonctions ODBC. L'exception à ceci est iODBC. En compilant PHP avec le
-    support iODBC, vous pourrez utiliser n'importe quel pilote
-    compatible ODBC avec vos applications PHP. Plus d'informations
+    aux bases de données ci-dessus. Les fonctions utilisées partagent les mêmes noms et syntaxes que les fonctions ODBC. L'exception à ceci est iODBC. En compilant PHP avec le
+    support iODBC, il est possible d'utiliser n'importe quel pilote
+    compatible ODBC avec les applications PHP. Plus d'informations
     sur iODBC, ainsi qu'un HOWTO (en anglais), sont disponibles sur
     <link xlink:href="&url.iodbc;">www.iodbc.org</link>, ainsi que
     l'alternative unixODBC, disponible sur

--- a/reference/uodbc/configure.xml
+++ b/reference/uodbc/configure.xml
@@ -95,10 +95,10 @@
      <para>
       Inclut le support d'un ODBC défini par l'utilisateur. DIR est le dossier d'installation d'ODBC.
       Par défaut, c'est <filename>/usr/local</filename>.
-      Assurez-vous que la variable CUSTOM_ODBC_LIBS est
+      Il faut s'assurer que la variable CUSTOM_ODBC_LIBS est
       définie, et que le fichier <filename>odbc.h</filename> est dans
-      votre chemin d'inclusion, c'est-à-dire que
-      vous devriez définir les lignes suivantes pour 
+      le chemin d'inclusion, c'est-à-dire que
+      il est recommandé de définir les lignes suivantes pour 
       <literal>Sybase SQL Anywhere 5.5.00</literal> sous QNX,
       avant d'utiliser le script de configuration :
 <![CDATA[

--- a/reference/uodbc/functions/odbc-connect.xml
+++ b/reference/uodbc/functions/odbc-connect.xml
@@ -18,7 +18,7 @@
   </methodsynopsis>
   <simpara>
    L'identifiant de connexion retourné par cette fonction est
-   nécessaire pour toutes les autres fonctions ODBC. Vous pouvez
+   nécessaire pour toutes les autres fonctions ODBC. Il est possible de
    avoir de multiples connexions en même temps.
   </simpara>
   <simpara>

--- a/reference/uodbc/functions/odbc-connection-string-should-quote.xml
+++ b/reference/uodbc/functions/odbc-connection-string-should-quote.xml
@@ -20,7 +20,7 @@
   <para>
    Notez que cette fonction ne vérifie pas si la chaîne est déjà
    mise entre guillemets; une chaîne déjà mise entre guillemets
-   contiendra des caractères qui feront que cette fonction retourne vrai. Vous devriez appeler
+   contiendra des caractères qui feront que cette fonction retourne vrai. Il est recommandé de appeler
    <function>odbc_connection_string_is_quoted</function> pour vérifier.
   </para>
  </refsect1>

--- a/reference/uodbc/functions/odbc-execute.xml
+++ b/reference/uodbc/functions/odbc-execute.xml
@@ -49,11 +49,11 @@
        avec la variable de requête appropriée.
       </para>
       <simpara>
-       Si vous voulez stocker une chaîne de caractères qui commence et se finit
-       réellement par des guillemets, vous devez ajouter un espace au début
+       Pour stocker une chaîne de caractères qui commence et se finit
+       réellement par des guillemets, il faut ajouter un espace au début
        ou à la fin de la chaîne, pour éviter que ce paramètre soit confondu avec
-       un nom de fichier. Si ce n'est pas possible dans le cadre de votre application,
-       vous devrez passer par la fonction <function>odbc_exec</function>.
+       un nom de fichier. Si ce n'est pas possible dans le cadre de l'application,
+       il faudra passer par la fonction <function>odbc_exec</function>.
       </simpara>
      </listitem>
     </varlistentry>
@@ -118,8 +118,8 @@ $success = odbc_execute($stmt, array($a, $b, $c));
    </example>
   </para>
   <para>
-   Si vous devez appeler une procédure stockée en utilisant des paramètres 
-   INOUT ou OUT, la solution est d'utiliser une extension native de votre
+   Si il faut appeler une procédure stockée en utilisant des paramètres 
+   INOUT ou OUT, la solution est d'utiliser une extension native de le
    base de données
    (par exemple pour <link linkend="ref.oci8">oci8</link> pour Oracle).
   </para>

--- a/reference/uodbc/functions/odbc-fetch-row.xml
+++ b/reference/uodbc/functions/odbc-fetch-row.xml
@@ -47,7 +47,7 @@
       </para>
       <para>
        Pour passer en revue toutes les lignes d'un résultat plusieurs fois,
-       vous pouvez appeler <function>odbc_fetch_row</function> avec row_number = 1,
+       il est possible de appeler <function>odbc_fetch_row</function> avec row_number = 1,
        puis continuer à appeler <function>odbc_fetch_row</function> sans le
        paramètre <parameter>row</parameter> pour passer en revue
        tout le résultat. Si un pilote ne supporte pas la lecture des

--- a/reference/uodbc/functions/odbc-free-result.xml
+++ b/reference/uodbc/functions/odbc-free-result.xml
@@ -19,8 +19,8 @@
   </para>
   <para>
    <function>odbc_free_result</function> n'est nécessaire que
-   si vous craignez d'utiliser trop de mémoire lors de l'exécution
-   de votre script. Tous les résultats en mémoire seront libérés
+   lorsqu'il y a un risque d'utiliser trop de mémoire lors de l'exécution
+   du script. Tous les résultats en mémoire seront libérés
    dès la fin du script.
   </para>
  </refsect1>
@@ -68,8 +68,8 @@
   <note>
    <para>
     Si l'autovalidation est désactivée (voir
-    <function>odbc_autocommit</function>) et que vous appelez
-    <function>odbc_free_result</function> avant de valider vos requêtes,
+    <function>odbc_autocommit</function>) et que l'on appelle
+    <function>odbc_free_result</function> avant de valider les requêtes,
     toutes les transactions préparées seront annulées.
    </para>
   </note>

--- a/reference/uodbc/functions/odbc-prepare.xml
+++ b/reference/uodbc/functions/odbc-prepare.xml
@@ -101,8 +101,8 @@ $res  = odbc_execute($stmt, array($a, $b, $c));
    </example>
   </para>
   <para>
-   Si vous devez appeler une procédure stockée utilisant des paramètres
-   INOUT ou OUT, il est recommandé d'utiliser l'extension native de votre
+   Si il faut appeler une procédure stockée utilisant des paramètres
+   INOUT ou OUT, il est recommandé d'utiliser l'extension native de le
    base de données
    (par exemple <link linkend="ref.oci8">oci8</link> pour Oracle).
   </para>

--- a/reference/uodbc/functions/odbc-result.xml
+++ b/reference/uodbc/functions/odbc-result.xml
@@ -109,7 +109,7 @@ $item_val = odbc_result($Query_ID, "val");
   <para>
    Les index de champs commencent à 1. Pour plus d'informations
    sur la façon de lire des colonnes de type binaire ou long,
-   reportez-vous à <function>odbc_binmode</function> et
+   se reporter à <function>odbc_binmode</function> et
    <function>odbc_longreadlen</function>.
   </para>
  </refsect1>

--- a/reference/uodbc/functions/odbc-setoption.xml
+++ b/reference/uodbc/functions/odbc-setoption.xml
@@ -23,10 +23,10 @@
    ODBC pour une connexion particulière ou un résultat de
    requête. Elle a été écrite pour aider à
    la résolution de problèmes liés aux pilotes ODBC
-   récalcitrants. Vous aurez sûrement à utiliser
-   <function>odbc_setoption</function> si vous êtes un programmeur
-   ODBC et que vous comprenez les divers effets des options disponibles.
-   Vous aurez aussi besoin d'un bon manuel de référence pour
+   récalcitrants. Il sera sûrement à utiliser
+   <function>odbc_setoption</function> en tant que programmeur
+   ODBC comprenant les divers effets des options disponibles.
+   Il sera aussi besoin d'un bon manuel de référence pour
    comprendre les options et leur usage. Différentes versions de
    pilotes supportent différentes versions d'options.
   </para>
@@ -38,7 +38,7 @@
    options ODBC ne sont pas disponibles car elles doivent être
    fixées avant l'établissement de la connexion. Cependant,
    si dans un cas bien spécifique, <function>odbc_setoption</function>
-   vous permet d'utiliser PHP sans que votre patron ne vous pousse à
+   permet d'utiliser PHP sans qu'il soit nécessaire de recourir à
    utiliser un produit commercial, alors cela n'a pas d'importance.
   </para>
  </refsect1>
@@ -52,7 +52,7 @@
      <listitem>
       <para>
        Un identifiant de connexion, ou un identifiant
-       de résultat, pour lequel vous souhaitez modifier des options.
+       de résultat, pour lequel il faut modifier des options.
        Pour <literal>SQLSetConnectOption()</literal>, c'est un identifiant de connexion.
        Pour <literal>SQLSetStmtOption()</literal>, c'est un identifiant de résultat.
       </para>

--- a/reference/url/functions/get-meta-tags.xml
+++ b/reference/url/functions/get-meta-tags.xml
@@ -73,7 +73,7 @@
   </para>
   <para>
    La valeur de la propriété sera utilisée comme clé du tableau,
-   et sa valeur comme valeur correspondante de la clé. Vous pourrez
+   et sa valeur comme valeur correspondante de la clé. Il sera possible de
    ainsi passer en revue facilement ce tableau avec les fonctions
    de tableau standard. Les caractères spéciaux présents dans la
    valeur seront replacés par un souligné (<literal>"_"</literal>),

--- a/reference/url/functions/rawurlencode.xml
+++ b/reference/url/functions/rawurlencode.xml
@@ -73,7 +73,7 @@ echo '<a href="ftp://user:', rawurlencode('foo @+%/'),
    </example>
   </para>
   <para>
-   Ou, si vous transmettez un composant PATH_INFO d'une URL :
+   Ou, lors de la transmission d'un composant PATH_INFO d'une URL :
   </para>
   <para>
    <example>

--- a/reference/url/functions/urlencode.xml
+++ b/reference/url/functions/urlencode.xml
@@ -125,8 +125,8 @@ bar: Not the same content as Data123!@-_ +
     n'envoient pas leurs données de formulaire avec des points-virgules. Une
     solution plus portable est d'utiliser <literal>&amp;amp;</literal>
     à la place de <literal>&amp;</literal> comme
-    séparateur. Vous n'avez alors pas à changer la directive
-    <option>arg_separator</option>. Laissez-la à &amp;, mais encodez vos URL
+    séparateur. Il n'est alors pas à changer la directive
+    <option>arg_separator</option>. Laissez-la à &amp;, mais encodez les URL
     en utilisant <function>htmlentities</function> ou
     <function>htmlspecialchars</function>.
    </para>

--- a/reference/var/book.xml
+++ b/reference/var/book.xml
@@ -9,7 +9,7 @@
  <preface xml:id="intro.var">
   &reftitle.intro;
   <para>
-   Pour plus de détails sur le comportement des variables, reportez-vous
+   Pour plus de détails sur le comportement des variables, se reporter
    à la section <link linkend="language.variables">Variables</link>
    du chapitre <link linkend="langref">Référence du langage</link>.
   </para>

--- a/reference/var/functions/gettype.xml
+++ b/reference/var/functions/gettype.xml
@@ -16,7 +16,7 @@
   </methodsynopsis>
   <para>
    Retourne le type de la variable <parameter>value</parameter>.
-   Pour vérifier le type de la variable, vous pouvez
+   Pour vérifier le type de la variable, il est possible de
    utiliser les fonctions <literal>is_*</literal>.
   </para>
  </refsect1>

--- a/reference/var/functions/is-float.xml
+++ b/reference/var/functions/is-float.xml
@@ -20,7 +20,7 @@
    <para>
     Pour tester si une variable est un nombre ou une chaîne numérique
     (comme les entrées de formulaire, qui sont toujours des chaînes), 
-    vous devez utiliser la fonction <function>is_numeric</function>.
+    il faut utiliser la fonction <function>is_numeric</function>.
    </para>
   </note>
  </refsect1>

--- a/reference/var/functions/is-int.xml
+++ b/reference/var/functions/is-int.xml
@@ -21,7 +21,7 @@
    <para>
     Pour tester si une variable est un nombre ou une chaîne numérique
     (comme les entrées de formulaire, qui sont toujours des chaînes), 
-    vous devez utiliser la fonction <function>is_numeric</function>.
+    il faut utiliser la fonction <function>is_numeric</function>.
    </para>
   </note>
  </refsect1>

--- a/reference/var/functions/print-r.xml
+++ b/reference/var/functions/print-r.xml
@@ -43,7 +43,7 @@
      <term><parameter>return</parameter></term>
      <listitem>
       <para>
-       Si vous voulez obtenir le résultat de <function>print_r</function> dans une chaîne,
+       Pour obtenir le résultat de <function>print_r</function> dans une chaîne,
        utilisez le paramètre <parameter>return</parameter>. Lorsque ce paramètre vaut
        &true;, <function>print_r</function> retournera l'information plutôt que de l'afficher.
       </para>

--- a/reference/var/functions/serialize.xml
+++ b/reference/var/functions/serialize.xml
@@ -37,7 +37,7 @@
       <para>
        La valeur à sérialiser. <function>serialize</function> accepte
        tous les types sauf les ressources &resource; et certains &object;s (voir note ci-dessous).
-       Vous pouvez même sérialiser un tableau
+       Il est possible de même sérialiser un tableau
        qui contient des références sur lui-même. Les références cycliques dans des
        tableaux/objets seront également stockées. Toutes les autres
        références seront perdues.

--- a/reference/var/functions/strval.xml
+++ b/reference/var/functions/strval.xml
@@ -22,8 +22,8 @@
   </simpara>
   <simpara>
    Cette fonction n'effectue aucun formatage sur la valeur retournée.
-   Si vous cherchez un moyen de formater une valeur numérique en chaîne de
-   caractères, reportez-vous à la fonction
+   Pour formater une valeur numérique en chaîne de
+   caractères, se reporter à la fonction
    <function>sprintf</function> ou la fonction <function>number_format</function>.
   </simpara>
  </refsect1>
@@ -41,7 +41,7 @@
       <para>
        <parameter>value</parameter> peut être un scalaire, <type>null</type>,
        ou un <type>object</type> implémentant la méthode magique <link linkend="object.tostring">__toString()</link>.
-       Vous ne pouvez pas utiliser la fonction <function>strval</function> avec des tableaux
+       Il n'est pas possible d'utiliser la fonction <function>strval</function> avec des tableaux
        ou des objets qui n'implémentent pas la méthode magique
        <link linkend="object.tostring">__toString()</link>.
       </para>

--- a/reference/var/functions/unserialize.xml
+++ b/reference/var/functions/unserialize.xml
@@ -28,14 +28,14 @@
     et l'autochargement d'objet, et ainsi, un utilisateur mal intentionné
     peut être capable d'exploiter ce comportement. Utilisez un standard d'échange
     sûr, comme JSON (via les fonctions <function>json_decode</function> 
-    et <function>json_encode</function>) si vous devez passer des données sérialisées
+    et <function>json_encode</function>) si il faut passer des données sérialisées
     à l'utilisateur.
    </para>
    <para>
-    Si vous avez besoin de désérialiser des données sérialisées enregistrées à l'extérieur,
+    Si l'on a besoin de désérialiser des données sérialisées enregistrées à l'extérieur,
     considérez l'utilisation de <function>hash_hmac</function> pour valider les
-    données. Assurez-vous que les données n'ont été modifiées par personne d'autre
-    que vous.
+    données. Il faut s'assurer que les données n'ont été modifiées par personne
+    d'autre.
    </para>
   </warning>
  </refsect1>
@@ -270,8 +270,8 @@ unserialize($serialized_object);
   &reftitle.notes;
   <warning>
    <para>
-    &false; est retourné dans les cas où une erreur survient et si vous
-    tentez de désérialiser une valeur sérialisée égale à &false;. Il est
+    &false; est retourné dans les cas où une erreur survient et lors de la
+    tentative de désérialiser une valeur sérialisée égale à &false;. Il est
     possible d'intercepter ce cas spécial en comparant
     <parameter>data</parameter> avec <literal>serialize(false)</literal>
     ou en attrapant l'erreur <constant>E_WARNING</constant> émise.

--- a/reference/var/functions/unset.xml
+++ b/reference/var/functions/unset.xml
@@ -21,7 +21,7 @@
   </para>
   <para>
    Le comportement de <function>unset</function> à l'intérieur d'une
-   fonction peut varier suivant le type de variable que vous voulez
+   fonction peut varier suivant le type de variable que on souhaite
    détruire.
   </para>
   <para>
@@ -50,7 +50,7 @@ echo $foo;
   </para>
   <para>
    Pour utiliser <function>unset</function> sur une variable globale à l'intérieur d'une
-   fonction, vous pouvez utiliser le tableau
+   fonction, il est possible de utiliser le tableau
    <varname>$GLOBALS</varname> :
    <example>
     <title><function>unset</function> une variable globale</title>

--- a/reference/var/functions/var-export.xml
+++ b/reference/var/functions/var-export.xml
@@ -31,7 +31,7 @@
      <term><parameter>value</parameter></term>
      <listitem>
       <para>
-       La variable que vous voulez exporter.
+       La variable que on souhaite exporter.
       </para>
      </listitem>
     </varlistentry>
@@ -249,7 +249,7 @@ object(A)#2 (2) {
    <para>
     <function>var_export</function> ne gère pas les références circulaires car il
     serait impossible de générer un code PHP analysable pour ce type de données.
-    Si vous voulez faire quelque chose avec la représentation complète d'un tableau
+    Pour faire quelque chose avec la représentation complète d'un tableau
     ou d'un objet, utilisez la fonction <function>serialize</function>.
    </para>
   </note>

--- a/reference/wddx/book.xml
+++ b/reference/wddx/book.xml
@@ -29,7 +29,7 @@
     aussi, un utilisateur malicieux peut être capable d'exploiter ce comportement.
     Utilisez donc un format sécurisé et standardisé d'échange de données tel que JSON
     (via la fonction <function>json_decode</function> et la fonction
-    <function>json_encode</function>) si vous devez passer les données sérialisées à l'utilisateur.
+    <function>json_encode</function>) si il faut passer les données sérialisées à l'utilisateur.
    </para>
   </warning>
  </preface>

--- a/reference/wddx/functions/wddx-deserialize.xml
+++ b/reference/wddx/functions/wddx-deserialize.xml
@@ -29,7 +29,7 @@
     de l'instanciation et l'autochargement de l'objet, et un utilisateur mal
     intentionné peut être capable d'y loger un exploit.
     Utilisez un format, sûr, d'échange de données standardisé comme JSON (à l'aide de
-    <function>json_decode</function> et <function>json_encode</function>) si vous devez
+    <function>json_decode</function> et <function>json_encode</function>) si il faut
     passer des données sérialisées à l'utilisateur.
    </para>
   </warning>

--- a/reference/wddx/setup.xml
+++ b/reference/wddx/setup.xml
@@ -11,7 +11,7 @@
   &reftitle.required;
   &libxml.required;
   <para>
-   Afin d'utiliser WDDX, vous devez installer la bibliothèque expat
+   Afin d'utiliser WDDX, il faut installer la bibliothèque expat
    (qui est fournie avec Apache 1.3.7 ou supérieur).
   </para>
  </section>

--- a/reference/win32service/book.xml
+++ b/reference/win32service/book.xml
@@ -14,7 +14,7 @@
    L'extension win32service est une extension spécifique à Windows qui
    autorise PHP à communiquer avec la Gestion de Contrôle de Service pour
    démarrer, arrêter, enregistrer ou effacer des services, et autorise
-   aussi vos scripts PHP à s'exécuter en tant que service.
+   aussi les scripts PHP à s'exécuter en tant que service.
   </para>
  </preface>
  <!-- }}} -->

--- a/reference/win32service/constants.xml
+++ b/reference/win32service/constants.xml
@@ -767,7 +767,7 @@
        threads de priorité normale ou au repos. Un exemple est la liste des
        tâches, qui doit répondre rapidement quand elle est appelée par
        l'utilisateur quel que sois la charge du système. Soyez extrêmement
-       prudent lorsque vous utilisez la classe de haute priorité, car une
+       prudent lorsque on utilise la classe de haute priorité, car une
        application de classe de haute priorité peut utiliser presque tout
        le temps CPU disponible.
       </entry>

--- a/reference/win32service/functions/win32-add-right-access-service.xml
+++ b/reference/win32service/functions/win32-add-right-access-service.xml
@@ -55,7 +55,7 @@
      <term><parameter>machine</parameter></term>
      <listitem>
       <para>
-       Le nom de la machine optionnel sur laquelle vous voulez créer un service.
+       Le nom de la machine optionnel sur laquelle on souhaite créer un service.
        Si omis, il utilisera la machine locale.
       </para>
      </listitem>

--- a/reference/win32service/functions/win32-create-service.xml
+++ b/reference/win32service/functions/win32-create-service.xml
@@ -35,8 +35,8 @@
          <term><parameter>service</parameter></term>
          <listitem>
           <para>
-           Le nom court du service. C'est le nom que vous utiliserez pour
-           contrôler le service en utilisant la commande
+           Le nom court du service. C'est le nom utilisé pour
+           contrôler le service avec la commande
            <literal>net</literal>. Le service doit être unique (deux services
            ne peuvent partager le même nom), et idéalement, devrait éviter
            d'avoir des espaces dans son nom.
@@ -46,7 +46,7 @@
         <varlistentry>
          <term><parameter>display</parameter></term>
          <listitem>
-          <para>Le nom d'affichage du service. C'est le nom que vous verrez
+          <para>Le nom d'affichage du service. C'est le nom visible
            dans l'Applet Services.
           </para>
          </listitem>
@@ -56,7 +56,7 @@
          <listitem>
           <para>
            La description longue du service.
-           C'est la description que vous verrez dans l'Applet des
+           C'est la description visible dans l'Applet des
            services.
           </para>
          </listitem>
@@ -65,9 +65,9 @@
          <term><parameter>user</parameter></term>
          <listitem>
           <para>
-           Le nom de l'utilisateur sous lequel vous voulez que le service
+           Le nom de l'utilisateur sous lequel on souhaite que le service
            s'exécute. Si oublié, le service fonctionnera en tant que
-           LocalSystem. Si le nom de l'utilisateur est spécifié, vous devez
+           LocalSystem. Si le nom de l'utilisateur est spécifié, il faut
            aussi fournir un mot de passe.
           </para>
          </listitem>
@@ -95,9 +95,9 @@
          <listitem>
           <para>
            Paramètres de commande à passer au service lorsqu'il démarre.
-           Si vous voulez exécuter un script PHP en tant que service, alors
+           Pour exécuter un script PHP en tant que service, alors
            le premier paramètre devrait être le chemin complet au script PHP
-           que vous prévoyez exécuter. Si le nom du script ou le chemin 
+           prévu pour l'exécution. Si le nom du script ou le chemin
            contiennent des espaces, alors, entourez le chemin complet du script
            PHP par des <literal>"</literal>
           </para>
@@ -118,7 +118,7 @@
           <para>
            Fixe le type de service. Si oublié, la valeur par défaut est
            <constant>WIN32_SERVICE_WIN32_OWN_PROCESS</constant>. Ne changez
-           pas ceci à moins que vous sachiez vraiment ce que vous faites.
+           pas ceci à moins de savoir vraiment ce que l'on fait.
           </para>
          </listitem>
         </varlistentry>
@@ -181,7 +181,7 @@
          <term><parameter>dependencies</parameter></term>
          <listitem>
           <para>
-           Pour définir les dépendances de votre service, il est nécessaire de 
+           Pour définir les dépendances de le service, il est nécessaire de 
            définir ce paramètre avec la liste des noms des services dans un tableau.
           </para>
          </listitem>
@@ -293,7 +293,7 @@
      <term><parameter>machine</parameter></term>
      <listitem>
       <para>
-       Le nom optionnel de la machine sur laquelle vous voulez créer le service.
+       Le nom optionnel de la machine sur laquelle on souhaite créer le service.
        Si oublié, cela utilisera la machine locale.
       </para>
      </listitem>

--- a/reference/win32service/functions/win32-get-last-control-message.xml
+++ b/reference/win32service/functions/win32-get-last-control-message.xml
@@ -15,7 +15,7 @@
   </methodsynopsis>
   <para>
    Retourne le code de contrôle qui a été envoyé en dernier à ce processus de
-   service. Lorsqu'il fonctionne en tant que service, vous devriez vérifier
+   service. Lorsqu'il fonctionne en tant que service, il est recommandé de vérifier
    périodiquement pour déterminer si le service doit être arrêté.
   </para>
   

--- a/reference/win32service/functions/win32-read-all-rights-access-service.xml
+++ b/reference/win32service/functions/win32-read-all-rights-access-service.xml
@@ -36,7 +36,7 @@
      <term><parameter>machine</parameter></term>
      <listitem>
       <para>
-       Le nom de la machine optionnel sur laquelle vous voulez créer un service.
+       Le nom de la machine optionnel sur laquelle on souhaite créer un service.
        Si omis, il utilisera la machine locale.
       </para>
      </listitem>

--- a/reference/win32service/functions/win32-read-right-access-service.xml
+++ b/reference/win32service/functions/win32-read-right-access-service.xml
@@ -45,7 +45,7 @@
      <term><parameter>machine</parameter></term>
      <listitem>
       <para>
-       Le nom de la machine optionnel sur laquelle vous voulez créer un service.
+       Le nom de la machine optionnel sur laquelle on souhaite créer un service.
        Si omis, il utilisera la machine locale.
       </para>
      </listitem>

--- a/reference/win32service/functions/win32-remove-right-access-service.xml
+++ b/reference/win32service/functions/win32-remove-right-access-service.xml
@@ -45,7 +45,7 @@
      <term><parameter>machine</parameter></term>
      <listitem>
       <para>
-       Le nom de la machine optionnel sur laquelle vous voulez créer un service.
+       Le nom de la machine optionnel sur laquelle on souhaite créer un service.
        Si omis, il utilisera la machine locale.
       </para>
      </listitem>

--- a/reference/win32service/functions/win32-start-service-ctrl-dispatcher.xml
+++ b/reference/win32service/functions/win32-start-service-ctrl-dispatcher.xml
@@ -27,9 +27,9 @@
    est d'indiquer au Service Control Manager que le service est en cours
    d'exécution. La seconde est d'appeler la fonction
    <function>win32_set_service_status</function> avec la constante
-   <constant>WIN32_SERVICE_RUNNING</constant>. Si vous avez besoin de
+   <constant>WIN32_SERVICE_RUNNING</constant>. Si l'on a besoin de
    lancer des processus longs avant que le service ne soit lancé, alors
-   vous pouvez utiliser la constante <constant>WIN32_SERVICE_START_PENDING</constant>.
+   il est possible de utiliser la constante <constant>WIN32_SERVICE_START_PENDING</constant>.
    La seconde est de continuer à vérifier en utilisant le Service Control Manager
    sachant qu'il peut déterminer si le service se termine ou non. Ceci consiste
    à appeler, périodiquement, la fonction <function>win32_get_last_control_message</function>

--- a/reference/wincache/functions/wincache-lock.xml
+++ b/reference/wincache/functions/wincache-lock.xml
@@ -26,7 +26,7 @@
     L'utilisation de la fonction <function>wincache_lock</function> et de la fonction
     <function>wincache_unlock</function> peut conduire à des verrous morts lors de l'exécution
     de scripts PHP sur des environnements multiprocessus, comme FastCGI. N'utilisez pas ces fonctions
-    tant que vous n'êtes pas absolument certain d'en avoir besoin. Pour la majorité des opérations sur
+    à moins d'être absolument certain d'en avoir besoin. Pour la majorité des opérations sur
     le cache utilisateur, il n'est pas nécessaire de les utiliser.
    </simpara>
   </warning>

--- a/reference/wincache/functions/wincache-ucache-add.xml
+++ b/reference/wincache/functions/wincache-ucache-add.xml
@@ -59,7 +59,7 @@
        Ce paramètre sera ignoré si le premier argument est un tableau. De façon général, il convient
        de passer la valeur &null; au paramètre <parameter>value</parameter> lors de l'utilisation
        d'un tableau pour le paramètre <parameter>key</parameter>. Si le paramètre <parameter>value</parameter>
-       est un objet, ou un tableau contenant des objets, alors les objets seront sérialisés. Reportez-vous
+       est un objet, ou un tableau contenant des objets, alors les objets seront sérialisés. Se reporter
        à la fonction <link linkend="object.sleep">__sleep()</link> pour plus de détails
        sur la sérialisation d'objets.
       </para>

--- a/reference/wincache/functions/wincache-ucache-get.xml
+++ b/reference/wincache/functions/wincache-ucache-get.xml
@@ -32,7 +32,7 @@
        <parameter>key</parameter> peut être un tableau de clés. Dans ce cas, la valeur
        retournée sera un tableau de valeurs de chaque éléments du tableau <parameter>key</parameter>.
        Si un objet ou un tableau contenant des objets est retourné, alors les objets
-       seront désérialisés. Reportez-vous à la fonction
+       seront désérialisés. Se reporter à la fonction
        <link linkend="object.wakeup">__wakeup()</link> pour plus
        de détails sur les désérialisation des objets.
       </para>

--- a/reference/wincache/functions/wincache-ucache-set.xml
+++ b/reference/wincache/functions/wincache-ucache-set.xml
@@ -59,7 +59,7 @@
        <parameter>value</parameter> lors de l'utilisation d'un tableau dans le paramètre
        <parameter>key</parameter>. Si le paramètre <parameter>value</parameter> est un objet,
        ou un tableau contenant des objets, alors tous les objets seront sérialisés.
-       Reportez-vous à la fonction <link linkend="object.sleep">__sleep()</link>
+       Se reporter à la fonction <link linkend="object.sleep">__sleep()</link>
        pour plus de détails sur la sérialisation d'objets.
       </para>
      </listitem>

--- a/reference/wincache/functions/wincache-unlock.xml
+++ b/reference/wincache/functions/wincache-unlock.xml
@@ -24,7 +24,7 @@
     L'utilisation des fonctions <function>wincache_lock</function> et
     <function>wincache_unlock</function> peut provoquer des verrous morts lors
     de l'exécution de scripts PHP dans un environnement multiprocessus comme FastCGI.
-    N'utilisez pas ces fonctions tant que vous n'êtes pas sûr d'en avoir besoin.
+    Il ne faut pas utiliser ces fonctions à moins d'être sûr d'en avoir besoin.
     Pour la majorité des opérations sur le cache utilisateur, il n'est pas nécessaire
     de les utiliser.
    </simpara>

--- a/reference/wincache/setup.xml
+++ b/reference/wincache/setup.xml
@@ -185,7 +185,7 @@ $user_allowed = array('DOMAIN\user1', 'DOMAIN\user2', 'DOMAIN\user3');
     <simpara>
      Protégez toujours le script <filename>wincache.php</filename> en utilisant soit 
      le mécanisme d'authentification intégré ou le mécanisme d'authentification du serveur. 
-     Laisser ce script non protégé peut compromettre la sécurité de votre application web 
+     Laisser ce script non protégé peut compromettre la sécurité de l'application web 
      et du serveur.
     </simpara>
    </note>

--- a/reference/wkhtmltox/configure.xml
+++ b/reference/wkhtmltox/configure.xml
@@ -7,8 +7,8 @@
  &reftitle.install;
 
  <para>
-  Utilisez l'option <option role="configure">--with-wkhtmltox[=DIR]</option>
-  lorsque vous compilez PHP.
+  Il faut utiliser l'option <option role="configure">--with-wkhtmltox[=DIR]</option>
+  lors de la compilation de PHP.
  </para>
 
  <!--

--- a/reference/xattr/functions/xattr-set.xml
+++ b/reference/xattr/functions/xattr-set.xml
@@ -43,7 +43,7 @@
      <listitem>
       <para>
        Le nom de l'attribut étendu. Cet attribut sera créé s'il n'existe pas encore ou
-       remplacé sinon. Vous pouvez modifier ce comportement en utilisant
+       remplacé sinon. Il est possible de modifier ce comportement en utilisant
        le paramètre <parameter>flags</parameter>.
       </para>
      </listitem>

--- a/reference/xattr/setup.xml
+++ b/reference/xattr/setup.xml
@@ -10,7 +10,7 @@
  <section xml:id="xattr.requirements">
   &reftitle.required;
   <para>
-   Pour utiliser xattr, vous devez installer la bibliothèque libattr.
+   Pour utiliser xattr, il faut installer la bibliothèque libattr.
    Elle est disponible sur
    <link xlink:href="&url.xattr;">&url.xattr;</link>.
   </para>

--- a/reference/xdiff/book.xml
+++ b/reference/xdiff/book.xml
@@ -31,7 +31,7 @@
    <link xlink:href="&url.xdiff;">libxdiff</link>.
   </para>
   <para>
-   Cette extension utilise la bibliothèque libxdiff pour implémenter ces fonctions. Reportez-vous à
+   Cette extension utilise la bibliothèque libxdiff pour implémenter ces fonctions. Se reporter à
    <link xlink:href="&url.xdiff;">&url.xdiff;</link> pour plus d'informations.  
   </para>
  </preface>

--- a/reference/xdiff/functions/xdiff-file-bdiff.xml
+++ b/reference/xdiff/functions/xdiff-file-bdiff.xml
@@ -92,8 +92,8 @@ xdiff_file_bdiff($old_version, $new_version, 'my_script.bdiff');
   &reftitle.notes;
   <note>
    <para>
-    Les 2 fichiers seront chargés en mémoire ; aussi, assurez-vous que votre
-    paramètre memory_limit est défini à valeur assez élevée.
+    Les 2 fichiers seront chargés en mémoire ; aussi, il faut s'assurer que le
+    paramètre memory_limit est défini à une valeur assez élevée.
    </para>
   </note>
  </refsect1>

--- a/reference/xdiff/functions/xdiff-file-bpatch.xml
+++ b/reference/xdiff/functions/xdiff-file-bpatch.xml
@@ -98,7 +98,7 @@ if ($result) {
   <note>
    <para>
     Les 2 fichiers (<parameter>file</parameter> et <parameter>patch</parameter>)
-    seront chargés en mémoire ; aussi, assurez-vous que votre paramétrage
+    seront chargés en mémoire ; aussi, il faut s'assurer que le paramétrage
     de memory_limit est suffisamment élevé.
    </para>
   </note>

--- a/reference/xdiff/functions/xdiff-file-diff-binary.xml
+++ b/reference/xdiff/functions/xdiff-file-diff-binary.xml
@@ -96,7 +96,7 @@ xdiff_file_diff_binary($old_version, $new_version, 'my_script.bdiff');
   &reftitle.notes;
   <note>
    <para>
-    Les deux fichiers seront chargés en mémoire ; assurez-vous d'avoir défini
+    Les deux fichiers seront chargés en mémoire ; il faut s'assurer d'avoir défini
     <literal>memory_limit</literal> à une valeur assez grande.
    </para>
   </note>

--- a/reference/xdiff/functions/xdiff-file-diff.xml
+++ b/reference/xdiff/functions/xdiff-file-diff.xml
@@ -63,7 +63,7 @@
      <term><parameter>context</parameter></term>
      <listitem>
       <para>
-       Indique le nombre de lignes de contexte que vous voulez inclure dans
+       Indique le nombre de lignes de contexte que on souhaite inclure dans
        le résultat de diff.
       </para>
      </listitem>
@@ -72,7 +72,7 @@
      <term><parameter>minimal</parameter></term>
      <listitem>
       <para>
-       Configurez <parameter>minimal</parameter> à &true; si vous voulez
+       Configurez <parameter>minimal</parameter> à &true; pour
        minimaliser la taille du fichier des différences (peut prendre beaucoup
        de temps).
       </para>

--- a/reference/xdiff/functions/xdiff-file-patch-binary.xml
+++ b/reference/xdiff/functions/xdiff-file-patch-binary.xml
@@ -101,7 +101,7 @@ if ($result) {
   &reftitle.notes;
   <note>
    <para>
-    Les deux fichiers (le fichier et le patch) seront chargés en mémoire ; assurez-vous d'avoir
+    Les deux fichiers (le fichier et le patch) seront chargés en mémoire ; il faut s'assurer d'avoir
     défini <literal>memory_limit</literal> à une valeur assez élevée.
    </para>
   </note>

--- a/reference/xdiff/functions/xdiff-file-patch.xml
+++ b/reference/xdiff/functions/xdiff-file-patch.xml
@@ -67,7 +67,7 @@
        (patch inversé).
       </para>
       <para>
-       Depuis la version 1.5.0, vous pouvez également utiliser l'opérateur
+       Depuis la version 1.5.0, il est possible de également utiliser l'opérateur
        binaire OR pour activer le drapeau
        <constant>XDIFF_PATCH_IGNORESPACE</constant>.
       </para>

--- a/reference/xdiff/functions/xdiff-file-rabdiff.xml
+++ b/reference/xdiff/functions/xdiff-file-rabdiff.xml
@@ -27,7 +27,7 @@
    <function>xdiff_string_bpatch</function>.
   </para>
   <para>
-   Pour plus de détails concernant les différences d'algorithme, reportez-vous
+   Pour plus de détails concernant les différences d'algorithme, se reporter
    au site web de la bibliothèque <link xlink:href="&url.xdiff;">libxdiff</link>.
   </para>
  </refsect1>
@@ -99,7 +99,7 @@ xdiff_file_rabdiff($old_version, $new_version, 'my_script.bdiff');
   &reftitle.notes;
   <note>
    <para>
-    Les 2 fichiers seront chargés en mémoire ; aussi, assurez-vous que votre
+    Les 2 fichiers seront chargés en mémoire ; aussi, il faut s'assurer que le
     paramétrage de memory_limit est suffisamment élevé.
    </para>
   </note>

--- a/reference/xdiff/functions/xdiff-string-diff.xml
+++ b/reference/xdiff/functions/xdiff-string-diff.xml
@@ -53,7 +53,7 @@
      <term><parameter>context</parameter></term>
      <listitem>
       <para>
-       Indique le nombre de lignes de contexte que vous voulez inclure
+       Indique le nombre de lignes de contexte que on souhaite inclure
        dans le diff résultant.
       </para>
      </listitem>
@@ -62,7 +62,7 @@
      <term><parameter>minimal</parameter></term>
      <listitem>
       <para>
-       Configurez <parameter>minimal</parameter> à &true; si vous voulez
+       Configurez <parameter>minimal</parameter> à &true; pour
        minimaliser la taille du diff (peut prendre beaucoup de temps).
       </para>
      </listitem>

--- a/reference/xdiff/functions/xdiff-string-patch.xml
+++ b/reference/xdiff/functions/xdiff-string-patch.xml
@@ -60,7 +60,7 @@
        soit <constant>XDIFF_PATCH_REVERSE</constant> (patch inversé).
       </para>
       <para>
-       Depuis la version 1.5.0, vous pouvez également utiliser l'opérateur binaire
+       Depuis la version 1.5.0, il est possible de également utiliser l'opérateur binaire
        OR pour activer le drapeau <constant>XDIFF_PATCH_IGNORESPACE</constant>.
       </para>
      </listitem>

--- a/reference/xdiff/setup.xml
+++ b/reference/xdiff/setup.xml
@@ -10,13 +10,13 @@
  <section xml:id="xdiff.requirements">
   &reftitle.required;
   <para>
-   Pour utiliser xdiff, vous devez avoir installé libxdiff,
+   Pour utiliser xdiff, il faut avoir installé libxdiff,
    disponible sur la page d'accueil de
    <link xlink:href="&url.xdiff;">&url.xdiff;</link>.
   </para>
   <note>
    <para>
-    Vous avez besoin au minimum de la version libxdiff 0.7 pour ces fonctions.
+    La version libxdiff 0.7 au minimum est nécessaire pour ces fonctions.
    </para>
   </note>
  </section>

--- a/reference/xhprof/book.xml
+++ b/reference/xhprof/book.xml
@@ -41,7 +41,7 @@
    une vue plate ainsi qu'une vue hiérarchique du profilage.
   </para>
   <para>
-   Vous pouvez trouver plus d'informations sur la page
+   Il est possible de trouver plus d'informations sur la page
    <link xlink:href="&url.xhprof.docs.facebook;">facebook de xhprof</link>.
   </para>
  </preface>

--- a/reference/xlswriter/configure.xml
+++ b/reference/xlswriter/configure.xml
@@ -6,7 +6,7 @@
 <section xml:id="xlswriter.installation" xmlns="http://docbook.org/ns/docbook">
  &reftitle.install;
  <para>
-  Le support XML-RPC en PHP n'est pas activé par défaut. Vous aurez besoin
+  Le support XML-RPC en PHP n'est pas activé par défaut. Il sera besoin
   d'utiliser l'option de configuration
   <option role="configure">--with-xmlrpc[=DIR]</option> au moment de la
   compilation de PHP pour activer le support XML-RPC.

--- a/reference/xml/book.xml
+++ b/reference/xml/book.xml
@@ -19,19 +19,19 @@
   </para>
   <para>
    Cette extension PHP implémente la bibliothèque <productname>expat</productname>
-   de James Clark sous PHP. Cela vous permettra d'analyser mais
+   de James Clark sous PHP. Cela permet d'analyser mais
    pas de valider les documents XML. Ce langage supporte trois types de
    <link linkend="xml.encoding">jeux de caractères</link> différents,
    disponibles aussi sous PHP : <literal>US-ASCII</literal>, <literal>ISO-8859-1</literal>
    et <literal>UTF-8</literal>. <literal>UTF-16</literal> n'est pas supporté.
   </para>
   <para>
-   Cette extension vous permet de créer des
+   Cette extension permet de créer des
    <link linkend="function.xml-parser-create">analyseurs XML</link>
    puis de définir des <emphasis>gestionnaires</emphasis>
    pour chaque événement XML. Les analyseurs XML disposent
    de quelques <link linkend="function.xml-parser-set-option">paramètres</link>
-   que vous pouvez régler.
+   que il est possible de régler.
   </para>
  </preface>
  <!-- }}} -->

--- a/reference/xml/configure.xml
+++ b/reference/xml/configure.xml
@@ -11,16 +11,16 @@
  </para>
  <para>
   Ces fonctions sont activées par défaut, et utilisent la 
-  bibliothèque expat fournie avec la distribution. Vous pouvez
+  bibliothèque expat fournie avec la distribution. Il est possible de
   désactiver le support de XML en utilisant l'option de
   compilation <option role="configure">--disable-xml</option>.
-  Si vous compilez PHP comme module pour Apache 1.3.9 ou supérieur, 
+  Lors de la compilation de PHP comme module pour Apache 1.3.9 ou supérieur,
   PHP va automatiquement utiliser la bibliothèque
-  <productname>expat</productname> fournie par Apache. Si vous ne 
-  souhaitez pas utiliser la bibliothèque expat intégrée, 
-  il faut que vous compiliez PHP avec l'option 
+  <productname>expat</productname> fournie par Apache. Pour ne pas
+  utiliser la bibliothèque expat intégrée,
+  il faut compiler PHP avec l'option
   <option role="configure">--with-expat-dir=DIR</option>, où DIR est le
-  dossier d'installation de votre bibliothèque expat.
+  dossier d'installation de le bibliothèque expat.
  </para>
  &windows.builtin;
 </section>

--- a/reference/xml/eventhandlers.xml
+++ b/reference/xml/eventhandlers.xml
@@ -34,7 +34,7 @@
        <literal>"Character data"</literal> correspond grosso modo à tout ce qui n'est
        pas une balise XML, y compris les espaces entre les balises. Notez
        bien que l'analyseur XML n'ajoute ou n'efface aucun espace, et que
-       c'est à l'application (c'est-à-dire vous) de
+       c'est à l'application de
        décider de la signification de ces espaces.
       </entry>
      </row>
@@ -55,7 +55,7 @@
       <entry><function>xml_set_default_handler</function></entry>
       <entry>
        Tout ce qui n'a pas trouvé de gestionnaire est transmis
-       au gestionnaire par défaut. Vous retrouverez par exemple,
+       au gestionnaire par défaut. On retrouvera par exemple,
        les déclarations de type de document dans ce gestionnaire.
       </entry>
      </row>
@@ -83,7 +83,7 @@
       <entry>
        Ce gestionnaire est appelé lorsque l'analyseur XML trouve une
        référence à une entité générale externe. Cela peut être une
-       référence à un fichier ou à une URL. Reportez-vous à
+       référence à un fichier ou à une URL. Se reporter à
        <link linkend="example.xml-external-entity">entité externe</link>
        pour un exemple.
       </entry>

--- a/reference/xml/functions/xml-parse-into-struct.xml
+++ b/reference/xml/functions/xml-parse-into-struct.xml
@@ -96,7 +96,7 @@
  <refsect1 role="examples">
   &reftitle.examples;
   <para>
-   Ci-dessous, vous trouverez un exemple qui illustre la structure
+   Ci-dessous se trouve un exemple qui illustre la structure
    des deux tableaux générés par la fonction. On utilise une balise
    simple <literal>note</literal>, placée dans une autre balise
    <literal>para</literal>. On analyse le tout, et on

--- a/reference/xml/functions/xml-parser-get-option.xml
+++ b/reference/xml/functions/xml-parser-get-option.xml
@@ -41,7 +41,7 @@
        <constant>XML_OPTION_PARSE_HUGE</constant>,
        <constant>XML_OPTION_SKIP_TAGSTART</constant>, <constant>XML_OPTION_SKIP_WHITE</constant>
        et <constant>XML_OPTION_TARGET_ENCODING</constant> sont disponibles.
-       Reportez-vous à <function>xml_parser_set_option</function> pour leurs
+       Se reporter à <function>xml_parser_set_option</function> pour leurs
        descriptions.
       </simpara>
      </listitem>

--- a/reference/xmldiff/setup.xml
+++ b/reference/xmldiff/setup.xml
@@ -9,7 +9,7 @@
   &reftitle.required;
   <para>
    libdiffmark - version 0.10 est comprise dans l'extension. Si diffmark est
-   disponible pour votre système de paquets, son utilisation est fortement
+   disponible pour le système de paquets, son utilisation est fortement
    encouragée.
   </para>
   <para>extension libxml</para>

--- a/reference/xmldiff/xmldiff-base/construct.xml
+++ b/reference/xmldiff/xmldiff-base/construct.xml
@@ -30,7 +30,7 @@
       Espace de noms personnalisé pour le document de différence.
       L'espace de noms par défaut est http://www.locus.cz/diffmark
       et est suffisant pour éviter les conflits d'espaces de noms.
-      Utilisez ce paramètre si vous voulez changer d'espace de noms.
+      Utilisez ce paramètre pour changer d'espace de noms.
      </para>
     </listitem>
    </varlistentry>

--- a/reference/xmlrpc/book.xml
+++ b/reference/xmlrpc/book.xml
@@ -12,7 +12,7 @@
   &reftitle.intro;
   <para>
    Ces fonctions servent à écrire des serveurs et des clients XML-RPC.
-   Vous pouvez trouver plus
+   Il est possible de trouver plus
    d'informations sur XML-RPC sur
   <link xlink:href="&url.xmlrpc;">&url.xmlrpc;</link>, et plus de
   documentation sur cette extension et ses fonctions, sur

--- a/reference/xmlrpc/configure.xml
+++ b/reference/xmlrpc/configure.xml
@@ -7,7 +7,7 @@
  &reftitle.install;
  <para>
   Le support de XML-RPC n'est pas activé par défaut en PHP. 
-  Vous devez l'activer avec l'option de compilation
+  Il faut l'activer avec l'option de compilation
   <option role="configure">--with-xmlrpc[=DIR]</option>.
  </para>
 </section>

--- a/reference/xmlwriter/xmlwriter/flush.xml
+++ b/reference/xmlwriter/xmlwriter/flush.xml
@@ -46,9 +46,9 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Si vous aviez ouvert le gestionnaire d'écriture en mémoire,
-   cette fonction retourne le buffer XML généré. Si vous utilisez
-   une URI, cette fonction écrira le buffer et retournera
+   Si le gestionnaire d'écriture a été ouvert en mémoire,
+   cette fonction retourne le buffer XML généré. Lors de l'utilisation
+   d'une URI, cette fonction écrira le buffer et retournera
    le nombre d'octets écrits.
   </para>
  </refsect1>

--- a/reference/xpass/constants.xml
+++ b/reference/xpass/constants.xml
@@ -73,7 +73,7 @@
    <listitem>
     <simpara>
      Un hachage basé sur le chiffrement par bloc Blowfish, modifié pour avoir un calendrier de clés extra-coûteux.
-     Développé à l'origine par Niels Provos et David Mazieres pour OpenBSD et également supporté sur les versions récentes
+     Développé à l'origine par Niels Proles et David Mazieres pour OpenBSD et également supporté sur les versions récentes
      de FreeBSD et NetBSD, sur Solaris 10 et plus récent, et sur plusieurs distributions GNU/*/Linux.
     </simpara>
    </listitem>

--- a/reference/xsl/configure.xml
+++ b/reference/xsl/configure.xml
@@ -8,7 +8,7 @@
   <para>
    PHP inclut l'extension XSL par défaut et peut être activée en ajoutant
    l'argument <option role="configure">--with-xsl[=DIR]</option>
-   à votre ligne de configuration. <literal>DIR</literal> est le dossier
+   à le ligne de configuration. <literal>DIR</literal> est le dossier
    d'installation de la bibliothèque <literal>libxslt</literal>.
   </para>
 </section>

--- a/reference/yac/yac/add.xml
+++ b/reference/yac/yac/add.xml
@@ -63,8 +63,8 @@
    <note>
     <para>
      La méthode <methodname>Yac::add</methodname> peut échouer si le verrou
-     ne peut être obtenu, aussi, si vous voulez que l'élément soit stocké
-     proprement, vous devriez écrire le code comme ceci :
+     ne peut être obtenu, aussi, pour que l'élément soit stocké
+     proprement, il est recommandé de écrire le code comme ceci :
      <example>
       <title>Permet de s'assurer que l'élément est stocké</title>
       <programlisting role="php">

--- a/reference/yaconf/book.xml
+++ b/reference/yaconf/book.xml
@@ -20,7 +20,7 @@
   <para>
    Yaconf enregistre toutes les configurations en tant que
    chaîne internée ou un tableau immuable, ce qui signifie qu'ils ne sont pas
-   comptabilisés dans les références, ainsi quand vous récupérez les
+   comptabilisés dans les références, ainsi lors de la récupération des
    configurations depuis <acronym>Yaconf</acronym>, ceci peut être considéré sans copie,
    très rapide.
   </para>

--- a/reference/yaconf/ini.xml
+++ b/reference/yaconf/ini.xml
@@ -48,7 +48,7 @@
      <listitem>
       <para>
        Intervalle dans laquelle Yaconf détectera les modifications de fichier
-       INI (grâce au mtime du dossier), si ceci est définie à zéro, vous devez
+       INI (grâce au mtime du dossier), si ceci est définie à zéro, il faut
        redémarrer PHP pour recharger les configurations.
       </para>
      </listitem>

--- a/reference/yaf/appconfig.xml
+++ b/reference/yaf/appconfig.xml
@@ -5,7 +5,7 @@
 <chapter xml:id="yaf.appconfig" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title xmlns="http://docbook.org/ns/docbook">Application Configuration</title>
  <para>
-  Vous devez fournir un tableau de configuration, ou un fichier
+  Il faut fournir un tableau de configuration, ou un fichier
   au format ini de configuration (voir le chemin
   <classname>Yaf_Config_Ini</classname>) de la méthode
   <methodname>Yaf_Application::__construct</methodname>. 
@@ -168,7 +168,7 @@ yaf.dispatcher.catchException = 0
        <note>
         <para>
          Cette entrée de configuration est la seule qui n'a pas de valeur
-         par défaut. Vous devez toujours la définir manuellement.
+         par défaut. Il faut toujours la définir manuellement.
         </para>
        </note>
       </para>
@@ -282,7 +282,7 @@ yaf.dispatcher.catchException = 0
       <para>
        Utilisé pour supprimer un préfixe fixé d'une URI de requête
        dans le processus de routage. Par exemple, une requête
-       dont l'URI est "/prefix/controller/action". Si vous définissez
+       dont l'URI est "/prefix/controller/action". Si on définit
        application.baseUri à "/prefix", alors seul "/controller/action"
        sera pris comme PATH_INFO dans le processus de routage.
       </para>

--- a/reference/yaf/book.xml
+++ b/reference/yaf/book.xml
@@ -19,7 +19,7 @@
    xlink:href="&url.yaf.benchmarks;">performances Yaf</link>.
   </para>
   <para>
-   Pour un démarrage rapide, référez-vous à ces <link
+   Pour un démarrage rapide, se référer à ces <link
     linkend="yaf.tutorials">tutoriaux</link>.
   </para>
  </preface>

--- a/reference/yaf/ini.xml
+++ b/reference/yaf/ini.xml
@@ -167,7 +167,7 @@
     <listitem>
      <para>
       Le nombre maximal de redirection ; par défaut, 5.
-      Cela signifie que vous pouvez avoir un nombre maximal de 5 redirections
+      Cela signifie que il est possible de avoir un nombre maximal de 5 redirections
       dans la pile des redirections.
      </para>
      <para>
@@ -215,7 +215,7 @@
     </term>
     <listitem>
      <para>
-      Si activé, et dans le même temps, vous utilisez un fichier de configuration
+      Si activé, et dans le même temps, on utilise un fichier de configuration
       au format ini comme paramètre de la méthode <methodname>Yaf_Application</methodname>,
       le résultat de la compilation du fichier de configuration au format ini
       sera mis en cache dans le processus PHP.
@@ -228,7 +228,7 @@
       <warning>
        <para>
         Yaf utilise le chemin vers le fichier ini comme clé de l'entrée du cache,
-        aussi, n'utilisez pas un chemin absolu pour votre chemin vers le fichier ini,
+        aussi, n'utilisez pas un chemin absolu pour le chemin vers le fichier ini,
         sinon, il se pourrait qu'il y ait des conflit si deux applications
         utilisent le même chemin relatif pour le chemin vers le fichier de configuration ini.
        </para>

--- a/reference/yaf/tutorials.xml
+++ b/reference/yaf/tutorials.xml
@@ -33,8 +33,8 @@
   <title>Entry</title>
   <para>
    index.php dans le premier dossier est le seul point d'entrée de
-   votre application ; vous devez rediriger toutes les requêtes vers ce fichier.
-   (Vous pouvez utiliser un fichier .htaccess avec Apache + php_mod.)
+   l'application ; il faut rediriger toutes les requêtes vers ce fichier.
+   (Il est possible de utiliser un fichier .htaccess avec Apache + php_mod.)
   </para>
    <programlisting role="php">
 <![CDATA[
@@ -146,7 +146,7 @@ class IndexController extends Yaf_Controller_Abstract {
    </screen> 
    <note>
     <para>
-     vous pouvez aussi générer l'exemple ci-dessus en utilisant un
+     il est possible de aussi générer l'exemple ci-dessus en utilisant un
      générateur de code Yaf, qui peut être trouvé sur
      yaf@github.
     </para>

--- a/reference/yaf/yaf-action-abstract.xml
+++ b/reference/yaf/yaf-action-abstract.xml
@@ -21,7 +21,7 @@
    </para>
    <para>
     Bien que ce doit être un point d'entrée pouvant être appelé par Yaf,
-    vous devez implémenter la méthode
+    il faut implémenter la méthode
     abstraite <methodname>Yaf_Action_Abstract::execute</methodname>
     dans la classe personnalisée de l'action.
    </para>

--- a/reference/yaf/yaf-application.xml
+++ b/reference/yaf/yaf-application.xml
@@ -22,11 +22,11 @@
      <para>
       <classname>Yaf_Application</classname> implémente le patron singleton, et
       <classname>Yaf_Application</classname> ne peut être sérialisé, ni désérialisé
-      ce qui peut poser des problèmes lorsque vous tentez d'utiliser PHPUnit
+      ce qui peut poser des problèmes lorsque on tente d'utiliser PHPUnit
       pour écrire des cas de test pour Yaf.
       </para>
       <para>
-       Vous devriez utiliser les annotations @backupGlobals de PHPUnit pour contrôler
+       Il est recommandé de utiliser les annotations @backupGlobals de PHPUnit pour contrôler
        la sauvegarde et la restauration des opérations pour les variables globales.
        Ceci peut régler le problème.
      </para>

--- a/reference/yaf/yaf-config-ini.xml
+++ b/reference/yaf/yaf-config-ini.xml
@@ -26,7 +26,7 @@
     les données sont héritées.
     <note>
      <para>
-      Yaf_Config_Ini utilise la fonction PHP parse_ini_file(). Reportez-vous
+      Yaf_Config_Ini utilise la fonction PHP parse_ini_file(). Se reporter
       à la documentation de cette fonction afin de mieux apprécier son
       comportement, ainsi propagé à Yaf_Config_Ini, comme la façon dont
       sont gérées les valeurs spéciales "&true;", "&false;", "yes", "no", et "&null;".

--- a/reference/yaf/yaf-controller-abstract.xml
+++ b/reference/yaf/yaf-controller-abstract.xml
@@ -23,14 +23,14 @@
     <classname>Yaf_Controller_Abstract</classname>.
    </para>
    <para>
-    Vous devriez vous apercevoir que vous ne pouvez pas définir de fonction
-    __construct pour votre contrôleur personnalisé, aussi, la classe
+    Il est à noter qu'il n'est pas possible de définir de fonction
+    __construct pour le contrôleur personnalisé, aussi, la classe
     <classname>Yaf_Controller_Abstract</classname> fournit une méthode magique
     pour cela : <methodname>Yaf_Controller_Abstract::init</methodname>.
    </para>
    <para>
-    Si vous avez défini une méthode init() dans votre contrôleur personnalisé,
-    elle sera appelée lors de l'instanciation de votre contrôleur.
+    Si l'on a défini une méthode init() dans le contrôleur personnalisé,
+    elle sera appelée lors de l'instanciation de le contrôleur.
    </para>
    <para>
     Les actions peuvent avoir des arguments, lorsqu'une requête arrive,
@@ -111,7 +111,7 @@
      <term><varname>actions</varname></term>
      <listitem>
       <para>
-       Vous pouvez aussi définir une méthode d'action dans un script PHP séparé
+       Il est possible de aussi définir une méthode d'action dans un script PHP séparé
        en utilisant cette propriété et <classname>Yaf_Action_Abstract</classname>.
       <example>
        <title>Définission d'une action dans un fichier séparé</title>

--- a/reference/yaf/yaf-loader.xml
+++ b/reference/yaf/yaf-loader.xml
@@ -19,7 +19,7 @@
     La première fois qu'une instance de la classe
     <classname>Yaf_Application</classname> est récupérée, 
     <classname>Yaf_Loader</classname> instancie un singleton, et
-    l'enregistre avec spl_autoload. Vous pouvez récupérer cette
+    l'enregistre avec spl_autoload. Il est possible de récupérer cette
     instance en utilisant la méthode <methodname>Yaf_Loader::getInstance</methodname>.
    </para>
    <para>
@@ -48,12 +48,12 @@
    </para>
    
    <para>
-    Si vous voulez que la classe <classname>Yaf_Loader</classname> cherche
+    Pour que la classe <classname>Yaf_Loader</classname> cherche
     des classes (ou des bibliothèques) dans le
     <link linkend="yaf-loader.props.library">dossier des classes locales</link>
     (qui est défini dans le fichier application.ini, et par défaut, vaut
     <link linkend="configuration.yaf.directory">application.directory</link> . "/library"), 
-    vous devez enregistrer le préfixe de la classe en utilisant la méthode
+    il faut enregistrer le préfixe de la classe en utilisant la méthode
     <methodname>Yaf_Loader::registerLocalNameSpace</methodname>
    </para>
    
@@ -120,8 +120,8 @@ class \FooBar\Bar\Dummy =>
    </para>
    
    <para>
-    Vous pouvez noter que tous les noms de dossiers commençent par une lettre majuscule ;
-    vous pouvez utiliser une lettre minuscule en définissant l'option de
+    Il est possible de noter que tous les noms de dossiers commençent par une lettre majuscule ;
+    il est possible de utiliser une lettre minuscule en définissant l'option de
     configuration <link linkend="ini.yaf.lowcase-path">yaf.lowcase_path</link> = On dans
     le fichier php.ini.
    </para>
@@ -145,7 +145,7 @@ Plugin Classes =>
     </programlisting>
    </example>
    
-   Yaf identifie un suffixe de classe (comportement par défaut, vous pouvez également
+   Yaf identifie un suffixe de classe (comportement par défaut, il est possible de également
    modifier ce comportement via l'option de configuration <link
    linkend="ini.yaf.name-suffix">yaf.name_suffix</link>) pour décider si c'est
    une classe MVC :
@@ -259,7 +259,7 @@ class A_B_TestModel =>
       <para>
        Par défaut, cette valeur vaut <link
        linkend="configuration.yaf.directory">application.directory</link> . "/library" ;
-       vous pouvez modifier ce comportement soit via l'option de configuration
+       il est possible de modifier ce comportement soit via l'option de configuration
        application.ini(application.library), soit en appelant la méthode
       <methodname>Yaf_Loader::setLibraryPath</methodname>.
       </para>

--- a/reference/yaf/yaf-plugin-abstract.xml
+++ b/reference/yaf/yaf-plugin-abstract.xml
@@ -14,12 +14,12 @@
   <section xml:id="yaf-plugin-abstract.intro">
    &reftitle.intro;
    <para>
-    Les plugins vous apportent la possibilité d'étendre et de personnaliser
+    Les plugins apportent la possibilité d'étendre et de personnaliser
     facilement le framework.
    </para>
    <para>
     Les plugins sont des classes. La définition actuelle d'une classe varie
-    suivant le composant -- vous pouvez avoir besoin d'implémenter cette interface,
+    suivant le composant -- il est possible de avoir besoin d'implémenter cette interface,
     mais il s'agit bel et bien d'une classe en tant que telle.
    </para>
    <para>

--- a/reference/yaf/yaf-registry.xml
+++ b/reference/yaf/yaf-registry.xml
@@ -16,7 +16,7 @@
     Toutes les méthodes de la classe <classname>Yaf_Registry</classname>
     sont déclarées en statique, les rendant ainsi accessible de façon universelle.
     Ceci permet de récupérer ou de définir des données personnalisées
-    depuis n'importe quel endroit de votre code.
+    depuis n'importe quel endroit de le code.
    </para>
   </section>
 <!-- }}} -->

--- a/reference/yaf/yaf-request-http.xml
+++ b/reference/yaf/yaf-request-http.xml
@@ -14,25 +14,25 @@
    &reftitle.intro;
    <para>
     Toutes les requêtes depuis le client sont initialisées
-    comme <classname>Yaf_Request_Http</classname>. Vous pouvez
+    comme <classname>Yaf_Request_Http</classname>. Il est possible de
     récupérer les diverses informations, tel que l'URI de requêtes
     et les paramètres POST via les méthodes de cette classe.
     <note>
      <para>
       Pour des raisons de sécurité, $_GET/$_POST sont accessibles
-      en lecture seule dans Yaf, ce qui signifie que si vous définissez une
-      valeur à ces variables globales, vous ne pourrez pas les
+      en lecture seule dans Yaf, ce qui signifie que si on définit une
+      valeur à ces variables globales, il ne sera pas possible de les
       récupérer via les méthode <methodname>Yaf_Request_Http::getQurey</methodname> ou
       <methodname>Yaf_Request_Http::getPost</methodname>.
      </para>
      <para>
-      Mais vous pouvez avoir des cas où cette fonctionnalité est nécessaire,
+      Mais il est possible de avoir des cas où cette fonctionnalité est nécessaire,
       comme lors de test unitaire, par exemple. Aussi, Yaf peut être construit
       avec l'option --enable-yaf-debug, ce qui va permettre à Yaf de lire une
       valeur utilisateur définie par un script.
      </para>
      <para>
-      Dans ce cas, Yaf va émettre une alerte de niveau E_STRICT pour vous le rappeler :
+      Dans ce cas, Yaf va émettre une alerte de niveau E_STRICT pour le rappeler :
       "Strict Standards: you are running yaf in debug mode".
      </para>
     </note>

--- a/reference/yaf/yaf-route-rewrite.xml
+++ b/reference/yaf/yaf-route-rewrite.xml
@@ -13,7 +13,7 @@
   <section xml:id="yaf-route-rewrite.intro">
    &reftitle.intro;
    <para>
-    Pour des exemples d'utilisation, reportez-vous à la section
+    Pour des exemples d'utilisation, se reporter à la section
     d'exemple sur la page du manuel concernant
     <methodname>Yaf_Route_Rewrite::__construct</methodname>.
    </para>

--- a/reference/yaf/yaf-route-simple.xml
+++ b/reference/yaf/yaf-route-simple.xml
@@ -17,7 +17,7 @@
     y trouver les informations quant à la route.
    </para>
    <para>
-    Tout ce que vous avez à faire est de dire à <classname>Yaf_Route_Simple</classname>
+    Il suffit d'indiquer à <classname>Yaf_Route_Simple</classname>
     la clé dans $_GET représentant le module, celle représentant le contrôleur,
     et celle représentant l'action.
    </para>

--- a/reference/yaf/yaf-router.xml
+++ b/reference/yaf/yaf-router.xml
@@ -50,7 +50,7 @@ RewriteRule ^.*$ index.php [NC,L]
 ]]>
      </programlisting>
     </example>
-    Si vous utilisez Lighttpd, la règle suivante est valide :
+    Lors de l'utilisation de Lighttpd, la règle suivante est valide :
     <example>
      <title>Règle de réécriture pour Lighttpd</title>
      <programlisting role="conf">
@@ -63,7 +63,7 @@ url.rewrite-once = (
 ]]>
      </programlisting>
     </example>
-    Si vous utilisez Nginx, la règle suivante est valide :
+    Lors de l'utilisation de Nginx, la règle suivante est valide :
     <example>
      <title>Règle de réécriture pour Nginx</title>
      <programlisting role="conf">
@@ -204,7 +204,7 @@ http://example/blog/archive/list/sort/alpha/date/desc
      <listitem>
       <para>
        Après la phase de routage, ceci indique le nom de la route
-       utilisé pour router la demande courante. Vous pouvez récupérer
+       utilisé pour router la demande courante. Il est possible de récupérer
        ce nom en utilisant la méthode
        <methodname>Yaf_Router::getCurrentRoute</methodname>.
       </para>

--- a/reference/yaf/yaf-view-interface.xml
+++ b/reference/yaf/yaf-view-interface.xml
@@ -17,7 +17,7 @@
     Yaf fournit la possibilité aux développeurs d'utiliser
     des moteurs de viasualisation personnalisés au lieu
     de celui fourni par défaut (<classname>Yaf_View_Simple</classname>).
-    Pour voir un exemple d'utilisation, reportez-vous à la documentation
+    Pour voir un exemple d'utilisation, se reporter à la documentation
     sur la méthode <methodname>Yaf_Dispatcher::setView</methodname>.
    </para>
   </section>

--- a/reference/yaf/yaf_action_abstract/execute.xml
+++ b/reference/yaf/yaf_action_abstract/execute.xml
@@ -22,7 +22,7 @@
    peut avoir des arguments.
    <note>
     <para>
-     La valeur récupérée depuis la requête n'est pas sécurisée. Vous devriez
+     La valeur récupérée depuis la requête n'est pas sécurisée. Il est recommandé de
      effectuer quelques filtres avant de l'utiliser.
     </para>
    </note>

--- a/reference/yaf/yaf_application/app.xml
+++ b/reference/yaf/yaf_application/app.xml
@@ -17,7 +17,7 @@
   </methodsynopsis>
   <para>
    Récupère l'instance <classname>Yaf_Application</classname>,
-   que vous pouvez aussi récupérer en utilisant la méthode
+   que il est possible de aussi récupérer en utilisant la méthode
    <methodname>Yaf_Dispatcher::getApplication</methodname>.
   </para>
  </refsect1>

--- a/reference/yaf/yaf_application/construct.xml
+++ b/reference/yaf/yaf_application/construct.xml
@@ -34,8 +34,8 @@
       <link linkend="ini.yaf.environ">yaf.environ</link>, qui est "product" par défaut.
       <note>
        <para>
-        Si vous utilisez un fichier de configuration au format ini pour
-        la configuration de votre application, vous devriez utiliser
+        Lors de l'utilisation de un fichier de configuration au format ini pour
+        la configuration de l'application, il est recommandé de utiliser
         la méthode <link linkend="ini.yaf.cache-config">yaf.cache_config</link>
         à la place pour améliorer les performances.
        </para>

--- a/reference/yaf/yaf_controller_abstract/construct.xml
+++ b/reference/yaf/yaf_controller_abstract/construct.xml
@@ -17,7 +17,7 @@
   <para>
    <methodname>Yaf_Controller_Abstract::__construct</methodname> est final,
    ce qui signifie qu'il ne peut pas être surchargé.
-   Pour cela, reportez-vous plutôt à la méthode
+   Pour cela, se reporter plutôt à la méthode
    <methodname>Yaf_Controller_Abstract::init</methodname>.
   </para>
  </refsect1>

--- a/reference/yaf/yaf_dispatcher/autorender.xml
+++ b/reference/yaf/yaf_dispatcher/autorender.xml
@@ -18,12 +18,12 @@
   <para>
    
    <classname>Yaf_Dispatcher</classname> affiche automatiquement
-   le contenu après la répartition d'une requête entrante ; vous pouvez
+   le contenu après la répartition d'une requête entrante ; il est possible de
    désactiver cet affichage en appelant cette méthode avec le paramètre
    <parameter>flag</parameter> à &true;.
    <note>
     <para>
-     vous pouvez tout simplement retourner &false; dans une action
+     il est possible de tout simplement retourner &false; dans une action
      pour éviter l'auto-affichage de cette action.
     </para>
    </note>

--- a/reference/yaf/yaf_dispatcher/catchexception.xml
+++ b/reference/yaf/yaf_dispatcher/catchexception.xml
@@ -16,17 +16,17 @@
    <methodparam choice="opt"><type>bool</type><parameter>flag</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Lorsque application.dispatcher.throwException est actif (vous pouvez aussi
+   Lorsque application.dispatcher.throwException est actif (il est possible de aussi
    appeler la méthode <methodname>Yaf_Dispatcher::throwException(TRUE)</methodname>
    pour l'activer), Yaf émettra une exception lorsqu'une erreur survient au lieu
    d'émettre une erreur.
   </para>
   <para>
-   Si vous activez <methodname>Yaf_Dispatcher::catchException</methodname>
+   Si l'on active <methodname>Yaf_Dispatcher::catchException</methodname>
    (peut aussi être activé via
    <link linkend="configuration.yaf.dispatcher.catchexception">application.dispatcher.catchException</link>),
    toutes les exceptions non-capturées le seront par
-   la méthode ErrorController::error si vous en avez définie une.
+   la méthode ErrorController::error si l'on en a définie une.
   </para>
  </refsect1>
 

--- a/reference/yaf/yaf_dispatcher/disableview.xml
+++ b/reference/yaf/yaf_dispatcher/disableview.xml
@@ -20,7 +20,7 @@
    l'utilisation s'occupe lui même de l'affichage.
    <note>
     <para>
-     Vous pouvez simplement retourner &false; dans une action pour éviter
+     Il est possible de simplement retourner &false; dans une action pour éviter
      que l'affichage de l'action ne se produise.
     </para>
    </note>

--- a/reference/yaf/yaf_dispatcher/setview.xml
+++ b/reference/yaf/yaf_dispatcher/setview.xml
@@ -16,7 +16,7 @@
    <methodparam><type>Yaf_View_Interface</type><parameter>view</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Cette méthode fournit une solution si vous souhaitez utiliser
+   Cette méthode fournit une solution pour utiliser
    un moteur de visualisation personnalisé au lieu de celui proposé par
    <classname>Yaf_View_Simple</classname>
   </para>

--- a/reference/yaf/yaf_dispatcher/throwexception.xml
+++ b/reference/yaf/yaf_dispatcher/throwexception.xml
@@ -21,7 +21,7 @@
    attrapables.
   </para>
   <para>
-   Vous pouvez également utiliser
+   Il est possible de également utiliser
    <link linkend="configuration.yaf.dispatcher.throwexception">
    application.dispatcher.throwException</link> pour arriver au même résultat.
   </para>

--- a/reference/yaf/yaf_loader/registerlocalnamespace.xml
+++ b/reference/yaf/yaf_loader/registerlocalnamespace.xml
@@ -37,8 +37,8 @@
      Si yaf.library n'est pas configuré, alors le dossier global de bibliothèques
      sera le dossier local de bibliothèques. Dans ce cas, tous les
      autochargements rechercheront les classes dans le dossier local de bibliothèques.
-     Mais si vous voulez renforcer votre application Yaf, il est conseillé de toujours
-     enregistrer vos propres classes comme classes locales.
+     Mais pour renforcer l'application Yaf, il est conseillé de toujours
+     enregistrer les propres classes comme classes locales.
     </para>
    </note>
   </para>

--- a/reference/yaf/yaf_request_abstract/setbaseuri.xml
+++ b/reference/yaf/yaf_request_abstract/setbaseuri.xml
@@ -21,7 +21,7 @@
    est "a/b", seul "/c" sera utilisé lors de la phase de routage.
    <note>
     <para>
-     Généralement, vous n'avez pas à le définir, Yaf va le déterminer automatiquement.
+     Généralement, il n'est pas à le définir, Yaf va le déterminer automatiquement.
     </para>
    </note>
   </para>

--- a/reference/yaf/yaf_response_abstract/appendbody.xml
+++ b/reference/yaf/yaf_response_abstract/appendbody.xml
@@ -36,8 +36,8 @@
     <term><parameter>key</parameter></term>
     <listitem>
      <para>
-      La clé du contenu ; vous pouvez définir un contenu avec sa clé ;
-      si vous n'en spécifiez pas, alors Yaf_Response_Abstract::DEFAULT_BODY
+      La clé du contenu ; il est possible de définir un contenu avec sa clé ;
+      si l'on n'en spécifie pas, alors Yaf_Response_Abstract::DEFAULT_BODY
       sera utilisé.
       <note>
        <para>

--- a/reference/yaf/yaf_response_abstract/clearbody.xml
+++ b/reference/yaf/yaf_response_abstract/clearbody.xml
@@ -27,7 +27,7 @@
     <term><parameter>key</parameter></term>
     <listitem>
      <para>
-      La clé du contenu ; si vous n'en spécifiez pas,
+      La clé du contenu ; si l'on n'en spécifie pas,
       tous les contenus seront supprimés.
       <note>
        <para>

--- a/reference/yaf/yaf_response_abstract/getbody.xml
+++ b/reference/yaf/yaf_response_abstract/getbody.xml
@@ -27,8 +27,8 @@
     <term><parameter>key</parameter></term>
     <listitem>
      <para>
-      La clé du contenu ; si vous n'en spécifiez pas une, alors
-      Yaf_Response_Abstract::DEFAULT_BODY sera utilisé. Si vous passez
+      La clé du contenu ; si l'on n'en spécifie pas une, alors
+      Yaf_Response_Abstract::DEFAULT_BODY sera utilisé. Si l'on passe
       la valeur &null;, alors tous les contenus seront retournés sous la forme
       d'un tableau.
       <note>

--- a/reference/yaf/yaf_response_abstract/prependbody.xml
+++ b/reference/yaf/yaf_response_abstract/prependbody.xml
@@ -36,8 +36,8 @@
     <term><parameter>key</parameter></term>
     <listitem>
      <para>
-      La clé du contenu ; vous pouvez spécifier un contenu avec une clé ;
-      si vous n'en spécifiez pas, alors Yaf_Response_Abstract::DEFAULT_BODY
+      La clé du contenu ; il est possible de spécifier un contenu avec une clé ;
+      si l'on n'en spécifie pas, alors Yaf_Response_Abstract::DEFAULT_BODY
       sera utilisé.
       <note>
        <para>

--- a/reference/yaf/yaf_response_abstract/setbody.xml
+++ b/reference/yaf/yaf_response_abstract/setbody.xml
@@ -36,8 +36,8 @@
     <term><parameter>key</parameter></term>
     <listitem>
      <para>
-      La clé du contenu ; vous pouvez définir un contenu avec une clé ;
-      si vous ne la spécifiez pas, alors
+      La clé du contenu ; il est possible de définir un contenu avec une clé ;
+      pour ne pas la spécifiez pas, alors
       Yaf_Response_Abstract::DEFAULT_BODY sera utilisé.
       <note>
        <para>

--- a/reference/yaf/yaf_route_regex/construct.xml
+++ b/reference/yaf/yaf_route_regex/construct.xml
@@ -46,7 +46,7 @@
       quel m/c/a doit être routé.
      </para>
      <para>
-      Les éléments du tableau m/c/a sont optionnels ; si vous n'assignez pas
+      Les éléments du tableau m/c/a sont optionnels ; si on n'assigne pas
       de valeurs spécifiques à ces éléments, ils seront routés vers la route
       par défaut.
      </para>

--- a/reference/yaf/yaf_route_rewrite/construct.xml
+++ b/reference/yaf/yaf_route_rewrite/construct.xml
@@ -34,7 +34,7 @@
       retournera &false;.
      </para>
      <para>
-      Vous pouvez utiliser le style :name pour nommer le segment recherché,
+      Il est possible de utiliser le style :name pour nommer le segment recherché,
       et utiliser le caractère * pour récupérer le reste du segment de l'URL.
      </para>
     </listitem>
@@ -48,7 +48,7 @@
       pour savoir quel module/controller/action doit être routé.
      </para>
      <para>
-      Les éléments du tableau module/controller/action sont optionnels, si vous ne les
+      Les éléments du tableau module/controller/action sont optionnels, pour ne pas les
       assignez pas en une valeur spécifique, ils seront routés vers la
       cible par défaut.
      </para>

--- a/reference/yaf/yaf_router/addroute.xml
+++ b/reference/yaf/yaf_router/addroute.xml
@@ -17,7 +17,7 @@
   </methodsynopsis>
   <para>
    Par défaut, Yaf_Router utilise une instance de la classe
-   <classname>Yaf_Route_Static</classname> comme route par défaut. Vous pouvez
+   <classname>Yaf_Route_Static</classname> comme route par défaut. Il est possible de
    ajouter de nouvelles routes dans la pile des routes du routeur en appelant
    cette méthode.
   </para>

--- a/reference/yaf/yaf_router/getcurrentroute.xml
+++ b/reference/yaf/yaf_router/getcurrentroute.xml
@@ -19,7 +19,7 @@
    dans le processus routeur.
    <note>
     <para>
-     Vous devriez appeler cette méthode une fois le processus
+     Il est recommandé de appeler cette méthode une fois le processus
      routeur terminé, sachant qu'avant la fin du processus,
      cette méthode retourne toujours &null;.
     </para>

--- a/reference/yaml/functions/yaml-parse-url.xml
+++ b/reference/yaml/functions/yaml-parse-url.xml
@@ -34,7 +34,7 @@
       <para>
        <parameter>url</parameter> doit être de la forme "scheme://...". PHP
        cherchera le protocole pour cette URL. Si aucun protocole n'a été
-       enregistré pour ce flux, PHP émettra une notice pour vous aider à
+       enregistré pour ce flux, PHP émettra une notice pour aider à
        trouver le problème et continuera.
       </para>
      </listitem>

--- a/reference/yar/setup.xml
+++ b/reference/yar/setup.xml
@@ -8,8 +8,8 @@
  <section xml:id="yar.requirements">
   &reftitle.required;
   <para>
-   Si vous voulez utiliser msgpack comme packager, vous devez compiler
-   Yar vous même avec l'option de configuration ./configure --enable-msgpack
+   Pour utiliser msgpack comme packager, il faut compiler
+   Yar soi-même avec l'option de configuration ./configure --enable-msgpack
   </para>
  </section>
 

--- a/reference/yaz/book.xml
+++ b/reference/yaz/book.xml
@@ -15,7 +15,7 @@
    <productname>YAZ</productname> qui implémente le
    <link xlink:href="&url.yaz-loc;">protocole Z39.50
    pour récupérer des informations</link>.
-   Avec cette extension, vous pouvez simplement implémenter une
+   Avec cette extension, il est possible de simplement implémenter une
    origine Z39.50 (client) qui cherche ou analyse des cibles
    Z39.50 (serveurs) en parallèle.
   </para>
@@ -29,7 +29,7 @@
   </para>
   <para>
    <productname>YAZ</productname> est disponible sur <link
-   xlink:href="&url.yaz;">&url.yaz;</link>. Vous pouvez trouver
+   xlink:href="&url.yaz;">&url.yaz;</link>. Il est possible de trouver
    des informations supplémentaires, des exemples de scripts, etc.
    pour cette extension sur <link
    xlink:href="&url.yaz-phpyaz;">&url.yaz-phpyaz;</link>.

--- a/reference/yaz/configure.xml
+++ b/reference/yaz/configure.xml
@@ -22,9 +22,9 @@
    <link xlink:href="&url.yaz.ftp.win32;">espace YAZ WIN32</link>.
   </para>
   <para>
-   Sous Windows, n'oubliez pas d'ajouter le dossier PHP à votre <envar>PATH</envar>
+   Sous Windows, n'oubliez pas d'ajouter le dossier PHP à le <envar>PATH</envar>
    pour que le fichier <filename>yaz.dll</filename> soit trouvé par
-   votre système.
+   le système.
   </para>
  </note>
 

--- a/reference/yaz/functions/yaz-connect.xml
+++ b/reference/yaz/functions/yaz-connect.xml
@@ -111,7 +111,7 @@
           </para>
           <note>
            <para>
-            Si vous ouvrez une connexion persistante, vous ne serez pas
+            Lors de l'ouverture d' une connexion persistante, il ne sera pas
             capable de la fermer plus tard avec
             <function>yaz_close</function>.
            </para>

--- a/reference/yaz/functions/yaz-database.xml
+++ b/reference/yaz/functions/yaz-database.xml
@@ -19,7 +19,7 @@
    <methodparam><type>string</type><parameter>databases</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Cette fonction vous permet de changer de base de données à l'intérieur de
+   Cette fonction permet de changer de base de données à l'intérieur de
    la session en spécifiant une ou plusieurs bases de données à utiliser dans
    la recherche, récupération de données, etc. Écrase les bases de données
    spécifiées dans l'appel de <function>yaz_connect</function>.

--- a/reference/yaz/functions/yaz-es.xml
+++ b/reference/yaz/functions/yaz-es.xml
@@ -78,7 +78,7 @@
       <para>
        Un tableau avec les options de service étendu et les options
        spécifiques du paquet. Les options sont identiques à celles offertes
-       par l'API C de ZOOM C. Reportez-vous à ZOOM
+       par l'API C de ZOOM C. Se reporter à ZOOM
        <link xlink:href="&url.yaz.zoom.ext;">Services Étendus</link>.
       </para>
      </listitem>

--- a/reference/yaz/functions/yaz-itemorder.xml
+++ b/reference/yaz/functions/yaz-itemorder.xml
@@ -22,7 +22,7 @@
    Cette fonction prépare une requête de type "Extended Services" en
    utilisant le <literal>"Profile"</literal> avec <literal>
    "Use of Z39.50 Item Order Extended Service to Transport ILL (Profile/1)"</literal>. 
-   Reportez-vous <link xlink:href="&url.yaz.ill;">ici</link> ou aux
+   Se reporter <link xlink:href="&url.yaz.ill;">ici</link> ou aux
    <link xlink:href="&url.yaz.specs;">spécifications</link>.
   </para>
   </refsect1>

--- a/reference/yaz/functions/yaz-search.xml
+++ b/reference/yaz/functions/yaz-search.xml
@@ -112,12 +112,12 @@
        </tgroup>
       </table>
       <para>
-       Vous pouvez trouver des informations sur les attributs sur le site
+       Il est possible de trouver des informations sur les attributs sur le site
        <link xlink:href="&url.yaz-loc-bib1;">Z39.50 Maintenance Agency</link>.
       </para>
       <note>
        <para>
-        Dans le cas où vous voudriez utiliser une notation plus facile, utilisez
+        Dans le cas où l'on souhaiterait utiliser une notation plus facile, utiliser
         l'analyseur CCL - fonctions <function>yaz_ccl_conf</function> et
         <function>yaz_ccl_parse</function>.
        </para>
@@ -138,7 +138,7 @@
   <example>
    <title>Exemples de Requête</title>
    <para>
-    Vous pouvez chercher pour des termes simples, comme ceci :
+    Il est possible de chercher pour des termes simples, comme ceci :
     <screen>
 <![CDATA[
 ordinateur

--- a/reference/yaz/functions/yaz-set-option.xml
+++ b/reference/yaz/functions/yaz-set-option.xml
@@ -48,7 +48,7 @@
       </para>
       <para>
        Si donné comme chaîne de caractères, cela sera le nom de l'option
-       à spécifier. Vous devrez donner sa valeur <parameter>value</parameter>.
+       à spécifier. Il faudra donner sa valeur <parameter>value</parameter>.
       </para>
       <para>
        Si donné comme tableau, cela sera un tableau associatif (nom de

--- a/reference/yaz/functions/yaz-sort.xml
+++ b/reference/yaz/functions/yaz-sort.xml
@@ -113,7 +113,7 @@
    <title>Critères de Tri</title>
    <para>
     Pour effectuer des tris avec l'attribut Bib1 du champ <literal>"title"</literal>, de manière
-    insensible à la casse, vous pouvez utiliser le critère suivant :
+    insensible à la casse, il est possible de utiliser le critère suivant :
     <screen>
 <![CDATA[
 1=4 ia
@@ -122,7 +122,7 @@
    </para>
    <para>
     Si le second critère de tri doit être l'auteur, en tenant compte
-    de la casse, et dans l'ordre alphabétique, vous pouvez utiliser :
+    de la casse, et dans l'ordre alphabétique, il est possible de utiliser :
     <screen>
 <![CDATA[
 1=4 ia 1=1003 sa

--- a/reference/zip/functions/zip-entry-read.xml
+++ b/reference/zip/functions/zip-entry-read.xml
@@ -45,7 +45,7 @@
       </para>
       <note>
        <para>
-        Ceci doit être la taille non-compressée que vous voulez lire.
+        Ceci doit être la taille non-compressée que on souhaite lire.
        </para>
       </note>
      </listitem>

--- a/reference/zip/ziparchive/addfile.xml
+++ b/reference/zip/ziparchive/addfile.xml
@@ -157,7 +157,7 @@ if ($zip->open('test.zip') === TRUE) {
     verrouiller ce fichier. Le verrou sera relâché uniquement lorsque l'objet
     <classname>ZipArchive</classname> sera fermé, soit via
     <methodname>ZipArchive::close</methodname> soit via destruction de l'objet
-    <classname>ZipArchive</classname>. Ceci peut vous empêcher de supprimer le
+    <classname>ZipArchive</classname>. Ceci peut empêcher de supprimer le
     fichier en cours d'ajout même après que le verrou soit
     relâché.       
    </para>

--- a/reference/zlib/book.xml
+++ b/reference/zlib/book.xml
@@ -12,7 +12,7 @@
  <preface xml:id="intro.zlib">
   &reftitle.intro;
   <para>
-   Ce module vous permet de lire et d'écrire des fichiers
+   Ce module permet de lire et d'écrire des fichiers
    compressés gzip (.gz), via la plupart des fonctions
    du <link linkend="book.filesystem">système de fichiers</link>
    qui fonctionnent avec les fichiers compressés gzip (ainsi qu'avec

--- a/reference/zlib/configure.xml
+++ b/reference/zlib/configure.xml
@@ -7,7 +7,7 @@
  &reftitle.install;
  <para>
   Le support de Zlib dans PHP n'est pas activé par défaut.
-  Vous devez compiler PHP avec l'option
+  Il faut compiler PHP avec l'option
   <option role="configure">--with-zlib[=DIR]</option>.
  </para>
  &windows.builtin;

--- a/reference/zlib/functions/deflate_add.xml
+++ b/reference/zlib/functions/deflate_add.xml
@@ -48,7 +48,7 @@
       <constant>ZLIB_PARTIAL_FLUSH</constant>,
       <constant>ZLIB_SYNC_FLUSH</constant> (par défaut),
       <constant>ZLIB_FULL_FLUSH</constant>, <constant>ZLIB_FINISH</constant>.
-      Normalement, vous voudrez définir <constant>ZLIB_NO_FLUSH</constant> pour
+      Normalement, on voudra définir <constant>ZLIB_NO_FLUSH</constant> pour
       maximiser la compression, et <constant>ZLIB_FINISH</constant> pour terminer
       avec le dernier morceau de données. Consultez le <link
       xlink:href="&url.zlib.manual;">manuel de zlib</link> pour une

--- a/reference/zlib/functions/gzgetss.xml
+++ b/reference/zlib/functions/gzgetss.xml
@@ -56,7 +56,7 @@
      <term><parameter>allowable_tags</parameter></term>
      <listitem>
       <para>
-       Vous pouvez utiliser ce paramètre optionnel pour spécifier les balises
+       Il est possible de utiliser ce paramètre optionnel pour spécifier les balises
        à ne pas supprimer.
       </para>
      </listitem>

--- a/reference/zlib/functions/gzopen.xml
+++ b/reference/zlib/functions/gzopen.xml
@@ -69,7 +69,7 @@
   <para>
    Retourne un pointeur de fichier vers le fichier ouvert, ainsi, la lecture
    depuis ce pointeur de fichier sera des données décompressées et ce que
-   vous y écrirez, sera compressé.
+   l'on y écrira, sera compressé.
   </para>
   <para>
    Si l'ouverture échoue, cette fonction retourne &false;.

--- a/reference/zlib/functions/gzpassthru.xml
+++ b/reference/zlib/functions/gzpassthru.xml
@@ -22,17 +22,17 @@
   </para>
   <note>
    <para>
-    Vous pourriez avoir besoin d'appeler la fonction <function>gzrewind</function>
-    pour réinitialiser le pointeur de fichier au début du fichier si vous avez
+    Il serait possible de avoir besoin d'appeler la fonction <function>gzrewind</function>
+    pour réinitialiser le pointeur de fichier au début du fichier si l'on a
     déjà écrit des données dedans.
    </para>
   </note>
   <tip>
    <para>
-    Si vous voulez uniquement afficher le contenu d'un fichier, sans le modifier
-    auparavant ou sans déplacer le pointeur à une position particulière, vous
-    devriez utiliser la fonction <function>readgzfile</function>, ce qui
-    vous évitera d'appeler la fonction <function>gzopen</function>.
+    Pour uniquement afficher le contenu d'un fichier, sans le modifier
+    auparavant ou sans déplacer le pointeur à une position particulière, il
+    est recommandé d'utiliser la fonction <function>readgzfile</function>, ce qui
+    évitera d'appeler la fonction <function>gzopen</function>.
    </para>
   </tip>
  </refsect1>

--- a/reference/zlib/functions/inflate_add.xml
+++ b/reference/zlib/functions/inflate_add.xml
@@ -52,7 +52,7 @@
       <constant>ZLIB_PARTIAL_FLUSH</constant>,
       <constant>ZLIB_SYNC_FLUSH</constant> (par défaut),
       <constant>ZLIB_FULL_FLUSH</constant>, <constant>ZLIB_FINISH</constant>.
-      Normalement vous voudrez définir <constant>ZLIB_NO_FLUSH</constant> pour
+      Normalement on voudra définir <constant>ZLIB_NO_FLUSH</constant> pour
       maximiser la compression, et <constant>ZLIB_FINISH</constant> pour terminer
       avec le dernier morceau de données. Consultez le <link
       xlink:href="&url.zlib.manual;">manuel de zlib</link> pour une

--- a/reference/zlib/functions/ob-gzhandler.xml
+++ b/reference/zlib/functions/ob-gzhandler.xml
@@ -91,7 +91,7 @@ ob_start("ob_gzhandler");
   </note>
   <note>
    <para>
-    Vous ne pouvez pas utiliser simultanément
+    Il n'est pas possible d'utiliser simultanément
     <function>ob_gzhandler</function> et
     <link linkend="ini.zlib.output-compression">zlib.output_compression</link>.
     De plus, notez bien que

--- a/reference/zlib/ini.xml
+++ b/reference/zlib/ini.xml
@@ -66,13 +66,13 @@
      </para>
      <para>
       Cette option accepte aussi des valeurs entières au lieu des booléens,
-      "On"/"Off", ce qui vous permet de configurer la taille du tampon de sortie
+      "On"/"Off", ce qui permet de configurer la taille du tampon de sortie
       (par défaut, il vaut 4ko).
      </para>
      <note>
       <para>
        <link linkend="ini.output-handler">output_handler</link> doit être
-       laissée à vide si cette option est activée. Sinon, vous devez
+       laissée à vide si cette option est activée. Sinon, il faut
        utiliser <literal>zlib.output_handler</literal>.
       </para>
      </note>
@@ -101,7 +101,7 @@
     </term>
     <listitem>
      <para>
-      Vous ne pouvez pas spécifier de gestionnaire de sortie supplémentaire si
+      Il n'est pas possible de spécifier de gestionnaire de sortie supplémentaire si
       zlib.output_compression est activée. Cette configuration est la même que
       <link linkend="ini.output-handler">output_handler</link> mais dans un
       ordre différent.

--- a/reference/zmq/book.xml
+++ b/reference/zmq/book.xml
@@ -13,7 +13,7 @@
   &reftitle.intro;
   <para>
    &warn.experimental;
-   "ØMQ est une bibliothèque qui vous permet d'implémenter
+   "ØMQ est une bibliothèque qui permet d'implémenter
    rapidement une application rapide à base de message." --Site Web 0MQ
   </para>
   <para>

--- a/reference/zmq/zmq.xml
+++ b/reference/zmq/zmq.xml
@@ -414,7 +414,7 @@
       <term><constant>ZMQ::SOCKET_XPUB</constant></term>
       <listitem>
        <para>
-        Similaire à SOCKET_PUB, sauf que vous pouvez recevoir des souscriptions
+        Similaire à SOCKET_PUB, sauf que il est possible de recevoir des souscriptions
         comme messages. Le message de souscription est 0 (désabonner)
         ou 1 (abonner) suivi du topic.</para>
       </listitem>
@@ -423,7 +423,7 @@
      <varlistentry xml:id="zmq.constants.socket-xsub">
       <term><constant>ZMQ::SOCKET_XSUB</constant></term>
       <listitem>
-       <para>Similaire à SOCKET_SUB, sauf que vous pouvez envoyer des
+       <para>Similaire à SOCKET_SUB, sauf que il est possible de envoyer des
         souscriptions. Voir SOCKET_XPUB pour le format.</para>
       </listitem>
      </varlistentry>

--- a/reference/zookeeper/functions/zookeeper_dispatch.xml
+++ b/reference/zookeeper/functions/zookeeper_dispatch.xml
@@ -20,12 +20,12 @@
 
   <caution>
    <para>
-    Depuis la version 0.4.0, cette fonction doit être appelée manuellement pour réaliser des opérations asynchrones. Si vous voulez que cela soit fait automatiquement, vous pouvez également déclarer des ticks au début de votre programme.
+    Depuis la version 0.4.0, cette fonction doit être appelée manuellement pour réaliser des opérations asynchrones. Pour que cela soit fait automatiquement, il est possible de également déclarer des ticks au début de le programme.
    </para>
   </caution>
 
   <para>
-   Après PHP 7.1, vous pouvez ignorer cette fonction. Cette extension utilise EG(vm_interrupt) pour implémenter la répartition asynchrone.
+   Après PHP 7.1, il est possible de ignorer cette fonction. Cette extension utilise EG(vm_interrupt) pour implémenter la répartition asynchrone.
   </para>
 
  </refsect1>


### PR DESCRIPTION
Remplacement des formulations directes (vous/votre/vos) par des tournures impersonnelles dans `reference/` (extensions t à z), conformément à TRADUCTIONS.txt.