### PR TITLE
Style impersonnel dans reference/ (j-o)

### DIFF
--- a/reference/json/functions/json-encode.xml
+++ b/reference/json/functions/json-encode.xml
@@ -384,8 +384,8 @@ string(2) "12"
     sachant que la spécification est ambiguë sur ce point.
    </para>
    <para>
-    Pour résumer, testez toujours que votre décodeur JSON peut gérer
-    la sortie que vous générez depuis la fonction
+    Pour résumer, testez toujours que le décodeur JSON peut gérer
+    la sortie qu'on génère depuis la fonction
     <function>json_encode</function>.
    </para>
   </note>

--- a/reference/ldap/book.xml
+++ b/reference/ldap/book.xml
@@ -18,15 +18,15 @@
    sous forme d'arborescence.
   </para>
   <para>
-   Le concept d'arborescence est similaire à celui de la structure de votre
+   Le concept d'arborescence est similaire à celui de la structure du
    système de fichiers, hormis le fait que dans ce contexte, la racine
    s'appelle "le monde", et que le premier niveau de sous-dossier
    s'appelle "pays". Les niveaux encore en dessous sont des "compagnies"
-   "organisation" ou "places", et encore plus bas, vous trouverez des
+   "organisation" ou "places", et encore plus bas, on trouvera des
    "personnes" et même des "équipements" et "documents".
   </para>
   <para>
-   Pour identifier un fichier dans votre disque, vous utilisez un chemin tel
+   Pour identifier un fichier dans le disque, on utilise un chemin tel
    que
   </para>
   <literallayout>
@@ -59,9 +59,9 @@
    comment organiser les fichiers sur un disque dur, un
    responsable de serveur de dossiers peut organiser le serveur
    comme cela lui semble le plus pratique. Cependant, il y a
-   des conventions à utiliser. Le principe est que vous ne pouvez
-   pas accéder à un serveur de dossier à moins que vous
-   ne connaissiez sa structure, de même que vous ne pouvez écrire
+   des conventions à utiliser. Le principe est qu'on ne peut
+   pas accéder à un serveur de dossier à moins que l'on
+   ne connaisse sa structure, de même qu'on ne peut écrire
    une base de données sans en connaître les tables et les bases.
   </para>
   <para>

--- a/reference/ldap/configure.xml
+++ b/reference/ldap/configure.xml
@@ -6,13 +6,13 @@
 <section xml:id="ldap.installation" xmlns="http://docbook.org/ns/docbook">
  &reftitle.install;
  <para>
-  Le support LDAP de PHP n'est pas activé par défaut. Vous devez
+  Le support LDAP de PHP n'est pas activé par défaut. L'on doit
   utiliser l'option de configuration 
   <option role="configure">--with-ldap[=DIR]</option>
-  lorsque vous compilez PHP, où DIR est le répertoire d'installation du serveur LDAP.
-  Pour activer le support SASL, assurez-vous que l'option de configuration
+  lorsqu'on compile PHP, où DIR est le répertoire d'installation du serveur LDAP.
+  Pour activer le support SASL, il faut s'assurer que l'option de configuration
   <option role="configure">--with-ldap-sasl[=DIR]</option> est utilisée et que
-  le fichier <filename>sasl.h</filename> existe sur votre système.
+  le fichier <filename>sasl.h</filename> existe sur le système.
  </para>
  <note>
   <title>Note aux utilisateurs Win32</title>

--- a/reference/ldap/constants.xml
+++ b/reference/ldap/constants.xml
@@ -160,7 +160,7 @@
    </term>
    <listitem>
     <simpara>
-     Définit/obtient les hôtes séparés par un espace lorsque vous essayez de vous connecter.
+     Définit/obtient les hôtes séparés par un espace lorsqu'on essaie de se connecter.
     </simpara>
    </listitem>
   </varlistentry>

--- a/reference/ldap/controls.xml
+++ b/reference/ldap/controls.xml
@@ -13,7 +13,7 @@
   <note>
    <para>
     Tous les contrôles ne sont pas supportés par tous les serveurs LDAP. Pour savoir
-    quels contrôles sont supportés par un serveur, vous devez interroger le DSE
+    quels contrôles sont supportés par un serveur, il faut interroger le DSE
     racine en lisant un dn vide avec le filtre (objectClass=*).
    </para>
    <example>
@@ -34,9 +34,9 @@ if (!in_array(LDAP_CONTROL_PAGEDRESULTS, ldap_get_entries($ds, $result)[0]['supp
  </para>
 
  <para>
-   Depuis PHP 7.3, vous pouvez envoyer des contrôles avec votre requête dans toutes
+   Depuis PHP 7.3, il est possible d'envoyer des contrôles avec le requête dans toutes
    les fonctions de requête en utilisant le paramètre <parameter>controls</parameter>. Lorsqu'une version
-   étendue d'une fonction existe, vous devriez l'utiliser si vous voulez
+   étendue d'une fonction existe, il est recommandé de l'utiliser si on veut
    accéder à l'objet de réponse complet et être capable de parser
    les contrôles de réponse à partir de celui-ci en utilisant <function>ldap_parse_result</function>.
  </para>
@@ -52,7 +52,7 @@ if (!in_array(LDAP_CONTROL_PAGEDRESULTS, ldap_get_entries($ds, $result)[0]['supp
      </term>
      <listitem>
       <simpara>
-       L'OID du contrôle. Vous devriez utiliser les constantes commençant par
+       L'OID du contrôle. Il est recommandé d'utiliser les constantes commençant par
        LDAP_CONTROL_ pour cela. Voir <link linkend="ldap.constants">constantes de LDAP</link>.
       </simpara>
      </listitem>
@@ -66,7 +66,7 @@ if (!in_array(LDAP_CONTROL_PAGEDRESULTS, ldap_get_entries($ds, $result)[0]['supp
       <simpara>
        Si un contrôle est marqué comme critique, la requête échouera si le
        contrôle n'est pas supporté par le serveur, ou s'il échoue à être
-       appliqué. Notez que certains contrôles devraient toujours être marqués
+       appliqué. À noter que certains contrôles devraient toujours être marqués
        comme critiques comme noté dans le RFC les introduisant. Par défaut à &false;.
       </simpara>
      </listitem>
@@ -88,9 +88,9 @@ if (!in_array(LDAP_CONTROL_PAGEDRESULTS, ldap_get_entries($ds, $result)[0]['supp
 
  <para>
    La plupart des valeurs de contrôle sont envoyées au serveur en BER-encodé.
-   Vous pouvez soit BER-encoder la valeur vous-même, ou vous pouvez plutôt
+   Il est possible de soit BER-encoder la valeur soi-même, ou il est possible de plutôt
    passer un tableau avec les clés correctes pour que l'encodage soit fait
-   pour vous.
+   pour l'on.
    Les contrôles supportés à passer en tant que tableau sont :
   <itemizedlist>
    <listitem>
@@ -161,7 +161,7 @@ if (!in_array(LDAP_CONTROL_PAGEDRESULTS, ldap_get_entries($ds, $result)[0]['supp
 
  <para>
    Le contrôle <constant>LDAP_CONTROL_PROXY_AUTHZ</constant> est un cas spécial
-   car sa valeur n'est pas attendue d'être BER-encodée, vous pouvez donc
+   car sa valeur n'est pas attendue d'être BER-encodée, il est possible de donc
    directement utiliser une chaîne pour sa valeur.
  </para>
 

--- a/reference/ldap/functions/ldap-8859-to-t61.xml
+++ b/reference/ldap/functions/ldap-8859-to-t61.xml
@@ -18,7 +18,7 @@
    Convertit les caractères <literal>ISO-8859</literal> en caractères <literal>t61</literal>.
   </para>
   <para>
-   Cette fonction est utile si vous devez utiliser un serveur
+   Cette fonction est utile si il faut utiliser un serveur
    <literal>LDAPv2</literal>.
   </para>
  </refsect1>

--- a/reference/ldap/functions/ldap-connect.xml
+++ b/reference/ldap/functions/ldap-connect.xml
@@ -48,10 +48,10 @@
        ou <literal>LDAPS://hostname:port</literal> pour le chiffrement SSL.
       </para>
       <para>
-       Vous pouvez également fournir plusieurs URI LDAP séparés par un espace comme une chaîne
+       Il est également possible de fournir plusieurs URI LDAP séparés par un espace comme une chaîne
       </para>
       <para>
-       Notez que <literal>hostname:port</literal> n'est pas un URI LDAP pris en
+       À noter que <literal>hostname:port</literal> n'est pas un URI LDAP pris en
        charge car le schéma est manquant.
       </para>
      </listitem>

--- a/reference/ldap/functions/ldap-errno.xml
+++ b/reference/ldap/functions/ldap-errno.xml
@@ -63,8 +63,8 @@
  <refsect1 role="examples">
   &reftitle.examples;
   <para>
-   À moins que vous n'abaissiez suffisamment le niveau d'erreur dans
-   &php.ini;, ou que vous ne préfixiez vos commandes LDAP avec <literal>@</literal>
+   À moins que l'on n'abaissiez suffisamment le niveau d'erreur dans
+   &php.ini;, ou qu'on ne préfixiez les commandes LDAP avec <literal>@</literal>
    (arobase) pour supprimer les affichages, les erreurs LDAP s'afficheront aussi
    dans la sortie HTML.
    <example>

--- a/reference/ldap/functions/ldap-error.xml
+++ b/reference/ldap/functions/ldap-error.xml
@@ -18,12 +18,12 @@
    <parameter>ldap</parameter>. Même si les
    numéros d'erreur LDAP sont standardisés, différentes
    bibliothèques retournent différents messages, ou parfois, des messages
-   en langue locale. Ne vous fiez pas au message d'erreur, mais bien au
+   en langue locale. Il ne faut pas se fier au message d'erreur, mais bien au
    numéro d'erreur.
   </para>
   <para>
-   À moins que vous n'abaissiez suffisamment le niveau d'erreur dans
-   &php.ini;, ou que vous ne préfixiez vos commandes LDAP avec
+   À moins que l'on n'abaissiez suffisamment le niveau d'erreur dans
+   &php.ini;, ou qu'on ne préfixiez les commandes LDAP avec
    <literal>@</literal> pour supprimer les affichages, les erreurs
    LDAP s'afficheront aussi dans la sortie HTML.
   </para>

--- a/reference/ldap/functions/ldap-escape.xml
+++ b/reference/ldap/functions/ldap-escape.xml
@@ -69,7 +69,7 @@
  <refsect1 role="examples">
   &reftitle.examples;
   <para>
-   Lors de la construction d'un filtre LDAP, vous devriez utiliser ldap_escape avec le drapeau LDAP_ESCAPE_FILTER.
+   Lors de la construction d'un filtre LDAP, il est recommandé d'utiliser ldap_escape avec le drapeau LDAP_ESCAPE_FILTER.
    <example>
     <title>Chercher une adresse email</title>
 <programlisting role="php">

--- a/reference/ldap/functions/ldap-exop.xml
+++ b/reference/ldap/functions/ldap-exop.xml
@@ -40,7 +40,7 @@
     <term><parameter>request_oid</parameter></term>
     <listitem>
      <para>
-       L'OID de l'opération étendue. Vous pouvez utiliser <constant>LDAP_EXOP_START_TLS</constant>, <constant>LDAP_EXOP_MODIFY_PASSWD</constant>, <constant>LDAP_EXOP_REFRESH</constant>, <constant>LDAP_EXOP_WHO_AM_I</constant>, <constant>LDAP_EXOP_TURN</constant>, ou une chaîne avec l'OID de l'opération que vous souhaitez envoyer.
+       L'OID de l'opération étendue. Il est possible d'utiliser <constant>LDAP_EXOP_START_TLS</constant>, <constant>LDAP_EXOP_MODIFY_PASSWD</constant>, <constant>LDAP_EXOP_REFRESH</constant>, <constant>LDAP_EXOP_WHO_AM_I</constant>, <constant>LDAP_EXOP_TURN</constant>, ou une chaîne avec l'OID de l'opération qu'on souhaite envoyer.
      </para>
     </listitem>
    </varlistentry>
@@ -65,7 +65,7 @@
     <listitem>
      <para>
        Va être rempli avec les données de réponse de l'opération étendue si fournies.
-       Si non fournies, vous pouvez utiliser ldap_parse_exop sur l'objet résultat
+       Si non fournies, il est possible d'utiliser ldap_parse_exop sur l'objet résultat
        plus tard pour obtenir ces données.
      </para>
     </listitem>

--- a/reference/ldap/functions/ldap-get-attributes.xml
+++ b/reference/ldap/functions/ldap-get-attributes.xml
@@ -18,11 +18,11 @@
    Lit les attributs et les valeurs pour une entrée d'un résultat de recherche.
   </para>
   <para>
-   Une fois que vous avez repéré une entrée dans un dossier, vous pouvez
+   Une fois qu'on a repéré une entrée dans un dossier, l'on peut
    obtenir plus d'informations sur elle avec cette fonction. Elle pourrait être
    utilisée dans le cadre d'une application qui cartographie les dossiers et les
-   entrées. Dans de nombreuses applications, vous recherchez des entrées
-   ayant un attribut précis, sans vous soucier des autres attributs.
+   entrées. Dans de nombreuses applications, on recherche des entrées
+   ayant un attribut précis, sans l'on soucier des autres attributs.
    <informalexample>
     <programlisting>
 <![CDATA[

--- a/reference/ldap/functions/ldap-get-values.xml
+++ b/reference/ldap/functions/ldap-get-values.xml
@@ -24,8 +24,8 @@
    et de l'une des fonctions permettant d'accéder à une entrée.
   </para>
   <para>
-   Votre application doit contenir des informations permettant
-   de lire certains attributs (comme "nom" ou "mail"), ou bien vous
+   Le application doit contenir des informations permettant
+   de lire certains attributs (comme "nom" ou "mail"), ou bien l'on
    devrez utiliser la fonction <function>ldap_get_attributes</function>
    pour savoir quels sont les attributs qui existent pour une entrée donnée.
   </para>

--- a/reference/ldap/functions/ldap-list.xml
+++ b/reference/ldap/functions/ldap-list.xml
@@ -68,7 +68,7 @@
      <listitem>
       <para>
        Un tableau d'attributs requis, e.g. array("mail", "sn", "cn").
-       Notez que le "dn" est toujours retourné, quel que soit le type de l'attribut
+       À noter que le "dn" est toujours retourné, quel que soit le type de l'attribut
        demandé.
       </para>
       <para>
@@ -93,19 +93,19 @@
      <term><parameter>sizelimit</parameter></term>
      <listitem>
       <para>
-       Vous permet de limiter le nombre d'entrées à récupérer. Le fait
+       Permet de limiter le nombre d'entrées à récupérer. Le fait
        de définir ce paramètre à &zero; signifie qu'il n'y aura aucune limite.
       </para>
       <note>
        <para>
-        Ce paramètre ne peut pas écraser la configuration côté serveur. Vous
+        Ce paramètre ne peut pas écraser la configuration côté serveur. L'on
         pouvez cependant positionner une valeur inférieure.
        </para>
        <para>
         Quelques dossiers serveurs peuvent être configurés afin de ne retourner
         qu'un nombre d'entrées données. Si ce comportement survient, le serveur
         indique qu'il n'a retourné qu'un jeu de résultats partiel. Ce comportement
-        intervient également si vous utilisez ce paramètre pour limiter le nombre
+        intervient également lors de l'utilisation de ce paramètre pour limiter le nombre
         d'entrées récupérées.
        </para>
       </note>
@@ -120,7 +120,7 @@
       </para>
       <note>
        <para>
-        Ce paramètre ne peut pas écraser la configuration côté serveur mais vous
+        Ce paramètre ne peut pas écraser la configuration côté serveur mais l'on
         pouvez l'utiliser pour être plus restrictif.
        </para>
       </note>

--- a/reference/ldap/functions/ldap-mod-add.xml
+++ b/reference/ldap/functions/ldap-mod-add.xml
@@ -48,7 +48,7 @@
       <para>
        Tableau associatif répertoriant les valeurs des attributs à ajouter. Si 
        un attribut n'était pas encore existant, il sera ajouté. Si un attribut 
-       est existant, vous pouvez uniquement y ajouter des valeurs s'il prend en 
+       est existant, il est possible d'uniquement y ajouter des valeurs s'il prend en 
        charge plusieurs valeurs.
       </para>
      </listitem>

--- a/reference/ldap/functions/ldap-read.xml
+++ b/reference/ldap/functions/ldap-read.xml
@@ -54,10 +54,10 @@
      <term><parameter>filter</parameter></term>
      <listitem>
       <para>
-       Un filtre ne peut être vide. Si vous voulez lire toutes les informations
+       Un filtre ne peut être vide. Pour lire toutes les informations
        d'une entrée, utilisez le filtre "<literal>objectClass=*</literal>".
-       Si vous savez quels sont les types qui sont utilisés dans le serveur de
-       dossiers, vous pouvez aussi utiliser un filtre approprié, comme
+       Si on sait quels sont les types qui sont utilisés dans le serveur de
+       dossiers, il est également possible d'utiliser un filtre approprié, comme
        "<literal>objectClass=inetOrgPerson</literal>".
       </para>
      </listitem>
@@ -67,7 +67,7 @@
      <listitem>
       <para>
        Un tableau d'attributs requis, e.g. array("mail", "sn", "cn").
-       Notez que le "dn" est toujours retourné, quel que soit le type de l'attribut
+       À noter que le "dn" est toujours retourné, quel que soit le type de l'attribut
        demandé.
       </para>
       <para>
@@ -92,19 +92,19 @@
      <term><parameter>sizelimit</parameter></term>
      <listitem>
       <para>
-       Vous permet de limiter le nombre d'entrées à récupérer. Le fait
+       Permet de limiter le nombre d'entrées à récupérer. Le fait
        de définir ce paramètre à &zero; signifie qu'il n'y aura aucune limite.
       </para>
       <note>
        <para>
-        Ce paramètre ne peut pas écraser la configuration côté serveur. Vous
+        Ce paramètre ne peut pas écraser la configuration côté serveur. L'on
         pouvez cependant positionner une valeur inférieure.
        </para>
        <para>
         Quelques dossiers serveurs peuvent être configurés afin de ne retourner
         qu'un nombre d'entrées données. Si ce comportement survient, le serveur
         indique qu'il n'a retourné qu'un jeu de résultats partiel. Ce comportement
-        intervient également si vous utilisez ce paramètre pour limiter le nombre
+        intervient également lors de l'utilisation de ce paramètre pour limiter le nombre
         d'entrées récupérées.
        </para>
       </note>
@@ -119,7 +119,7 @@
       </para>
       <note>
        <para>
-        Ce paramètre ne peut pas écraser la configuration côté serveur mais vous
+        Ce paramètre ne peut pas écraser la configuration côté serveur mais l'on
         pouvez l'utiliser pour être plus restrictif.
        </para>
       </note>

--- a/reference/ldap/functions/ldap-rename.xml
+++ b/reference/ldap/functions/ldap-rename.xml
@@ -119,9 +119,9 @@
   <note>
    <para>
     <function>ldap_rename</function> ne fonctionne actuellement qu'avec
-    LDAPv3. Vous pouvez être obligé d'utiliser <function>ldap_set_option</function>
-    avant de vous lier pour pouvoir utiliser LDAPv3. Cette fonction est uniquement
-    disponible lorsque vous utilisez OpenLDAP 2.x.x OU
+    LDAPv3. Il est possible d'être obligé d'utiliser <function>ldap_set_option</function>
+    avant de l'on lier pour pouvoir utiliser LDAPv3. Cette fonction est uniquement
+    disponible lorsqu'on utilise OpenLDAP 2.x.x OU
     Netscape Directory SDK x.x.
    </para>
   </note>

--- a/reference/ldap/functions/ldap-sasl-bind.xml
+++ b/reference/ldap/functions/ldap-sasl-bind.xml
@@ -61,7 +61,7 @@
    <title>Conditions d'utilisation</title>
    <simpara>
     <function>ldap_sasl_bind</function> nécessite le support <acronym>SASL</acronym>
-    (<filename>sasl.h</filename>). Assurez-vous que l'option de configuration
+    (<filename>sasl.h</filename>). Il faut s'assurer que l'option de configuration
     <literal>--with-ldap-sasl</literal> est utilisée lors de la compilation de PHP,
     sinon, cette fonction ne sera pas définie.
    </simpara>

--- a/reference/ldap/functions/ldap-search.xml
+++ b/reference/ldap/functions/ldap-search.xml
@@ -56,7 +56,7 @@
       <para>
        Le filtre de recherche peut être simple ou avancé, et utiliser ces
        opérateurs booléen au format décrit dans la documentation LDAP
-       (reportez-vous à <link xlink:href="&url.ldap.filters;">Netscape Directory SDK</link>
+       (se reporter à <link xlink:href="&url.ldap.filters;">Netscape Directory SDK</link>
        ou <link xlink:href="&url.rfc;4515">RFC4515</link> pour plus d'informations sur les filtres).
       </para>
      </listitem>
@@ -66,7 +66,7 @@
      <listitem>
       <para>
        Un tableau d'attributs requis, e.g. <literal>array("mail", "sn", "cn")</literal>.
-       Notez que le "dn" est toujours retourné, quel que soit le type de l'attribut
+       À noter que le "dn" est toujours retourné, quel que soit le type de l'attribut
        demandé.
       </para>
       <para>
@@ -91,19 +91,19 @@
      <term><parameter>sizelimit</parameter></term>
      <listitem>
       <para>
-       Vous permet de limiter le nombre d'entrées à récupérer. Le fait
+       Permet de limiter le nombre d'entrées à récupérer. Le fait
        de définir ce paramètre à &zero; signifie qu'il n'y aura aucune limite.
       </para>
       <note>
        <para>
-        Ce paramètre ne peut pas écraser la configuration côté serveur. Vous
+        Ce paramètre ne peut pas écraser la configuration côté serveur. L'on
         pouvez cependant positionner une valeur inférieure.
        </para>
        <para>
         Quelques dossiers serveurs peuvent être configurés afin de ne retourner
         qu'un nombre d'entrées données. Si ce comportement survient, le serveur
         indique qu'il n'a retourné qu'un jeu de résultats partiel. Ce comportement
-        intervient également si vous utilisez ce paramètre pour limiter le nombre
+        intervient également lors de l'utilisation de ce paramètre pour limiter le nombre
         d'entrées récupérées.
        </para>
       </note>
@@ -118,7 +118,7 @@
       </para>
       <note>
        <para>
-        Ce paramètre ne peut pas écraser la configuration côté serveur mais vous
+        Ce paramètre ne peut pas écraser la configuration côté serveur mais l'on
         pouvez l'utiliser pour être plus restrictif.
        </para>
       </note>

--- a/reference/ldap/functions/ldap-set-option.xml
+++ b/reference/ldap/functions/ldap-set-option.xml
@@ -207,7 +207,7 @@
        booléenne. Par défaut, <emphasis>iscritical</emphasis> vaut <emphasis>&false;</emphasis>. Voir
        le fichier <link 
        xlink:href="&url.ldap.openldap-c-api;">draft-ietf-ldapext-ldap-c-api-xx.txt</link>
-       pour plus de détails. Reportez-vous au second exemple pour une illustration.
+       pour plus de détails. Se reporter au second exemple pour une illustration.
       </para>
       <note>
        <para>
@@ -296,7 +296,7 @@ if (!ldap_set_option($ds, LDAP_OPT_SERVER_CONTROLS, array($ctrl1, $ctrl2))) {
   &reftitle.notes;
   <note>
    <para>
-    Cette fonction n'est disponible que lorsque vous utilisez 
+    Cette fonction n'est disponible que lorsqu'on utilise 
     OpenLDAP 2.x.x ou Netscape Directory SDK x.x.
    </para>
   </note>

--- a/reference/ldap/functions/ldap-sort.xml
+++ b/reference/ldap/functions/ldap-sort.xml
@@ -25,7 +25,7 @@
   </para>
   <para>
    Comme cette fonction trie les valeurs retournées du côté client, il est 
-   possible que vous n'obteniez pas les résultats escomptés si vous atteignez 
+   possible que l'on n'obtient pas les résultats escomptés si l'on atteint 
    <parameter>sizelimit</parameter> soit du serveur, soit défini dans
    <function>ldap_search</function>.
   </para>

--- a/reference/ldap/setup.xml
+++ b/reference/ldap/setup.xml
@@ -9,10 +9,10 @@
  <section xml:id="ldap.requirements">
   &reftitle.required;
   <para>
-   Vous devez télécharger et compiler les bibliothèques clientes
+   Il faut télécharger et compiler les bibliothèques clientes
    LDAP depuis soit <link xlink:href="&url.ldap.openldap.source;">OpenLDAP</link> ou <link
    xlink:href="&url.ldap.bind9;">Bind9.net</link> pour assurer le support LDAP.
-   Pour PHP 5.6 ou plus récent, vous aurez besoin d'OpenLDAP 2.4 ou plus récent. 
+   Pour PHP 5.6 ou plus récent, on aura besoin d'OpenLDAP 2.4 ou plus récent. 
   </para>
  </section>
  <!-- }}} -->

--- a/reference/ldap/using.xml
+++ b/reference/ldap/using.xml
@@ -6,11 +6,11 @@
 <chapter xml:id="ldap.using" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Utiliser les fonctions LDAP de PHP</title>
   <para>
-   Avant d'utiliser les fonctions LDAP, vous devez connaître :
+   Avant d'utiliser les fonctions LDAP, il faut connaître :
    <itemizedlist>
     <listitem>
      <para>
-      Le nom ou l'adresse du serveur de dossiers que vous voudrez utiliser
+      Le nom ou l'adresse du serveur de dossiers que l'on voudra utiliser
      </para>
     </listitem>
     <listitem>
@@ -30,7 +30,7 @@
    </itemizedlist>
   </para>
   <para>
-   La séquence LDAP typique que vous exécuterez sera la
+   La séquence LDAP typique que l'on exécutera sera la
    suivante :
    <literallayout>
 ldap_connect()    // établit une connexion au serveur

--- a/reference/libxml/book.xml
+++ b/reference/libxml/book.xml
@@ -10,7 +10,7 @@
  <preface xml:id="intro.libxml">
   &reftitle.intro;
   <para>
-   Ces fonctions et constantes sont disponibles depuis PHP 5.1.0 et si vous
+   Ces fonctions et constantes sont disponibles depuis PHP 5.1.0 et si l'on
    avez compilé PHP avec les extensions basées sur libxml, c'est-à-dire
    <link linkend="book.dom">DOM</link>,
    <link linkend="book.libxml">libxml</link>,

--- a/reference/libxml/constants.xml
+++ b/reference/libxml/constants.xml
@@ -31,8 +31,8 @@
    <listitem>
     <simpara>
      Active l'optimisation de l'allocation de petits nœuds. Ceci pourrait
-     augmenter la rapidité de votre application sans avoir besoin de changer
-     votre code.
+     augmenter la rapidité de l'application sans avoir besoin de changer
+     le code.
     </simpara>
     <note>
      <para>

--- a/reference/libxml/functions/libxml-use-internal-errors.xml
+++ b/reference/libxml/functions/libxml-use-internal-errors.xml
@@ -17,8 +17,8 @@
    <methodparam choice="opt"><type class="union"><type>bool</type><type>null</type></type><parameter>use_errors</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
   <para>
-   <function>libxml_use_internal_errors</function> vous permet de désactiver
-   le gestionnaire d'erreurs libxml standard, et d'activer votre propre
+   <function>libxml_use_internal_errors</function> permet de désactiver
+   le gestionnaire d'erreurs libxml standard, et d'activer le propre
    gestionnaire d'erreur.
   </para>
  </refsect1>

--- a/reference/lua/setup.xml
+++ b/reference/lua/setup.xml
@@ -7,7 +7,7 @@
  <section xml:id="lua.requirements">
   &reftitle.required;
   <simpara>
-   Pour utiliser cette extension, vous devez avoir installé Lua,
+   Pour utiliser cette extension, il faut avoir installé Lua,
    disponible sur la page du <link xlink:href="&url.lua;">projet Lua</link>.
   </simpara>
  </section>

--- a/reference/luasandbox/examples.xml
+++ b/reference/luasandbox/examples.xml
@@ -8,7 +8,7 @@
  <section xml:id="luasandbox.examples-basic">
   <title>Utilisation de base de LuaSandbox</title>
   <simpara>
-   Une fois que vous avez compilé PHP avec le support de LuaSandbox, vous pouvez commencer à utiliser LuaSandbox pour exécuter en toute sécurité du code Lua fourni par l'utilisateur.
+   Une fois qu'on a compilé PHP avec le support de LuaSandbox, il est possible de commencer à utiliser LuaSandbox pour exécuter en toute sécurité du code Lua fourni par l'utilisateur.
   </simpara>
   <example>
    <title>Excuter du code Lua</title>

--- a/reference/lzf/configure.xml
+++ b/reference/lzf/configure.xml
@@ -9,10 +9,10 @@
   <link xlink:href="&url.pecl.package;lzf">&url.pecl.package;lzf</link>.
  </simpara>
  <simpara>
-  Si vous voulez utiliser ces fonctions, vous devez compiler PHP avec le support
+  Pour utiliser ces fonctions, il faut compiler PHP avec le support
   lzf en utilisant l'option de configuration
   <option role="configure">--with-lzf[=DIR]</option>.
-  Vous pouvez également passer l'option
+  Il est également possible de passer l'option
   <option role="configure">--enable-lzf-better-compression</option>
   pour optimiser LZF d'un point de vue d'espace au détriment de la vitesse.
  </simpara>

--- a/reference/mail/functions/mail.xml
+++ b/reference/mail/functions/mail.xml
@@ -158,7 +158,7 @@
        Depuis que la fonction <function>escapeshellcmd</function> est appliquée automatiquement,
        quelques caractères autorisés dans les adresses emails par les RFCs d'internet ne peuvent
        plus être utilisés. La fonction <function>mail</function> ne peut autoriser ces caractères,
-       aussi, dans les programmes où leur utilisation est nécessaire, vous devriez utiliser
+       aussi, dans les programmes où leur utilisation est nécessaire, il est recommandé d'utiliser
        une méthode alternative pour l'envoi des emails (comme l'utilisation d'un framework
        ou d'une bibliothèque.
       </para>
@@ -353,7 +353,7 @@ mail($to, $subject, $message, $headers);
   <para>
    <note>
     <para>
-     Si vous prévoyez d'envoyer des mails HTML ou autrement plus complexes,
+     Si l'on prévoir d'envoyer des mails HTML ou autrement plus complexes,
      il est recommandé d'utiliser le paquet PEAR <link xlink:href="&url.pear.package;Mail_Mime">PEAR::Mail_Mime</link>.
     </para>
    </note>
@@ -397,7 +397,7 @@ mail($to, $subject, $message, $headers);
     pas très efficace.
    </para>
    <para>
-    Pour envoyer de gros volumes de mails, reportez-vous aux paquets
+    Pour envoyer de gros volumes de mails, se reporter aux paquets
     <link xlink:href="&url.pear.package;Mail">PEAR::Mail</link> et
     <link xlink:href="&url.pear.package;Mail_Queue">PEAR::Mail_Queue</link>.
    </para>

--- a/reference/mail/ini.xml
+++ b/reference/mail/ini.xml
@@ -190,7 +190,7 @@
       <filename>/usr/sbin/sendmail</filename> ou <filename>/usr/lib/sendmail</filename>.
       <command>configure</command> essaye de repérer la présence de sendmail
       par lui-même, et affecte ce résultat par défaut. En cas de
-      problème de localisation, vous pouvez établir une nouvelle valeur
+      problème de localisation, il est possible d'établir une nouvelle valeur
       par défaut ici.
      </para>
      <para>

--- a/reference/mail/setup.xml
+++ b/reference/mail/setup.xml
@@ -12,13 +12,13 @@
   <para>
    Pour que la fonction <function>mail</function> soit disponible,
    il faut que PHP ait accès au service <literal>sendmail</literal>
-   sur le serveur, au moment de la compilation. Si vous utilisez un
+   sur le serveur, au moment de la compilation. Lors de l'utilisation d'un
    autre programme de mail, comme <productname>qmail</productname> ou
-   <productname>postfix</productname>, assurez-vous d'utiliser les bonnes
-   API. PHP va commencer à chercher sendmail dans votre <envar>PATH</envar>,
+   <productname>postfix</productname>, il faut s'assurer d'utiliser les bonnes
+   API. PHP va commencer à chercher sendmail dans le <envar>PATH</envar>,
    puis, dans les dossiers suivants :
    <literal>/usr/bin:/usr/sbin:/usr/etc:/etc:/usr/ucblib:/usr/lib</literal>.
-   Il est hautement recommandé d'avoir sendmail de disponible dans votre
+   Il est hautement recommandé d'avoir sendmail de disponible dans le
    <envar>PATH</envar>. De plus, l'utilisateur qui compile PHP
    doit avoir le droit d'accéder à l'exécutable sendmail.
   </para>

--- a/reference/mailparse/configure.xml
+++ b/reference/mailparse/configure.xml
@@ -10,7 +10,7 @@
   <link xlink:href="&url.pecl.package;mailparse">&url.pecl.package;mailparse</link>.
  </simpara>
  <simpara>
-  Si vous voulez utiliser ces fonctions, vous devez compiler PHP avec le support
+  Pour utiliser ces fonctions, il faut compiler PHP avec le support
   mailparse en utilisant l'option de configuration
   <option role="configure">--enable-mailparse</option>.
  </simpara>

--- a/reference/mailparse/functions/mailparse-msg-parse-file.xml
+++ b/reference/mailparse/functions/mailparse-msg-parse-file.xml
@@ -14,7 +14,7 @@
    <methodparam><type>string</type><parameter>filename</parameter></methodparam>
   </methodsynopsis>
   <simpara>
-   Analyse un fichier. C'est la façon optimale d'analyser un email que vous avez sur votre disque.
+   Analyse un fichier. C'est la façon optimale d'analyser un email qu'on a sur le disque.
   </simpara>
  </refsect1>
 

--- a/reference/mailparse/functions/mailparse-msg-parse.xml
+++ b/reference/mailparse/functions/mailparse-msg-parse.xml
@@ -18,7 +18,7 @@
    Analyse incrémentalement des données dans une ressource <literal>MIME</literal> fournie.
   </simpara>
   <simpara>
-   Cette fonction vous permet d'envoyer sous forme de flux des portions d'un
+   Cette fonction permet d'envoyer sous forme de flux des portions d'un
    fichier à la fois, plutôt que de tout lire et de tout analyser en une seule fois.
   </simpara>
  </refsect1>

--- a/reference/math/functions/base-convert.xml
+++ b/reference/math/functions/base-convert.xml
@@ -21,7 +21,7 @@
    <parameter>from_base</parameter>. <parameter>from_base</parameter> et
    <parameter>to_base</parameter> doivent être compris entre 2 et 36 inclus.
    Les chiffres supérieurs à 10 des bases supérieures à 10 seront représentés
-   par les lettres de A à Z, avec A = 10 et Z = 35.
+   par les lettres d'A à Z, avec A = 10 et Z = 35.
    La casse des lettres n'a pas d'importance, c'est-à-dire
    <parameter>num</parameter> est interprété de façon insensible à la casse.
   </para>

--- a/reference/math/functions/max.xml
+++ b/reference/math/functions/max.xml
@@ -38,7 +38,7 @@
   </note>
   <caution>
    <simpara>
-    Soyez prudent lorsque vous passez des arguments avec des types différents,
+    Il faut être prudent lorsqu'on passe des arguments avec des types différents,
     car <function>max</function> peut produire des résultats imprévisibles.
    </simpara>
   </caution>

--- a/reference/math/functions/min.xml
+++ b/reference/math/functions/min.xml
@@ -22,7 +22,7 @@
    Si le premier et le seul paramètre est un tableau, <function>min</function>
    retournera la plus petite valeur contenue dans le tableau. Si le
    premier paramètre est un entier, une chaîne ou un nombre décimal,
-   vous devez fournir au moins deux paramètres et <function>min</function>
+   il faut fournir au moins deux paramètres et <function>min</function>
    retournera la plus petite de ces valeurs.
   </para>
   <note>
@@ -38,7 +38,7 @@
   </note>
   <caution>
    <simpara>
-    Soyez prudent lorsque vous passez des arguments avec des types différents,
+    Il faut être prudent lorsqu'on passe des arguments avec des types différents,
     car <function>min</function> peut produire des résultats imprévisibles.
    </simpara>
   </caution>

--- a/reference/math/functions/pi.xml
+++ b/reference/math/functions/pi.xml
@@ -16,7 +16,7 @@
   </methodsynopsis>
   <simpara>
    Retourne une approximation de pi.
-   De plus, vous pouvez utiliser la constante <constant>M_PI</constant>,
+   De plus, il est possible d'utiliser la constante <constant>M_PI</constant>,
    qui retourne un résultat identique à la fonction 
    <function>pi</function>.
   </simpara>

--- a/reference/mbstring/book.xml
+++ b/reference/mbstring/book.xml
@@ -16,15 +16,15 @@
    multioctets ont été développées pour résoudre ce type de problème.
   </para>
   <para>
-   Lorsque vous manipulez des chaînes de caractères multioctets,
-   pour couper, rechercher ou nettoyer une chaîne, vous devez utiliser deux
-   octets consécutifs, qui représentent un seul caractère. Si vous n'y prenez
-   pas garde, vous allez obtenir une chaîne corrompue et invalide, avec
+   Lorsqu'on manipule des chaînes de caractères multioctets,
+   pour couper, rechercher ou nettoyer une chaîne, il faut utiliser deux
+   octets consécutifs, qui représentent un seul caractère. Si l'on n'y prenez
+   pas garde, on va obtenir une chaîne corrompue et invalide, avec
    une représentation totalement incompréhensible.
   </para>
   <para>
    <literal>mbstring</literal> fournit les fonctions spécifiques de manipulations
-   de chaînes qui vous permettent de travailler avec les encodages multioctets en PHP.
+   de chaînes qui permettent de travailler avec les encodages multioctets en PHP.
    En plus de cela, <literal>mbstring</literal> gère la traduction
    entre les jeux de caractères disponibles. <literal>mbstring</literal> est
    également connu pour gérer l'Unicode, comme UTF-8 et UCS-2 ainsi que de

--- a/reference/mbstring/constants.xml
+++ b/reference/mbstring/constants.xml
@@ -159,7 +159,7 @@
    </term>
    <listitem>
     <simpara>
-     La version de Oniguruma, par exemple <literal>6.9.4</literal>.
+     La version d'Oniguruma, par exemple <literal>6.9.4</literal>.
      Disponible à partir de PHP 7.4.
     </simpara>
    </listitem>

--- a/reference/mbstring/encoding-requirements.xml
+++ b/reference/mbstring/encoding-requirements.xml
@@ -63,26 +63,26 @@ JIS, SJIS, ISO-2022-JP, BIG-5
  <para>
   Même si aucun script PHP écrit avec ces jeux de caractères ne fonctionne,
   notamment si des chaînes encodées sont utilisées comme identifiants,
-  ou valeurs littérales dans le script, vous pouvez éviter d'utiliser ces
+  ou valeurs littérales dans le script, il est possible d'éviter d'utiliser ces
   jeux en activant le filtre transparent <literal>mbstring</literal> pour les
   données d'entrées HTTP.
  </para>
  <note>
   <para>
    Il est déconseillé d'utiliser les jeux SJIS, BIG5, CP936, CP949 et
-   GB18030 pour l'encodage interne, à moins que vous ne soyez très familiers
+   GB18030 pour l'encodage interne, à moins qu'on ne soyez très familiers
    avec l'analyseur, l'exécuteur et le jeu de caractère lui-même.
   </para>
  </note>
  <note>
   <para>
-   Si vous vous connectez à une base de données avec PHP, il est recommandé
+   Si l'on on connecte à une base de données avec PHP, il est recommandé
    d'utiliser le même jeu de caractères pour la base de données et pour le
    <literal>jeu interne</literal> pour améliorer le confort d'utilisation
    mais aussi les performances.
   </para>
   <para>
-   Si vous utilisez PostgreSQL, le jeu de caractères utilisé dans la base
+   Lors de l'utilisation de PostgreSQL, le jeu de caractères utilisé dans la base
    de données et celui de PHP peuvent différer car cette base supporte
    la traduction automatique de jeu de caractères.
   </para>

--- a/reference/mbstring/encodings.xml
+++ b/reference/mbstring/encodings.xml
@@ -198,11 +198,11 @@
      Extended_UNIX_Code_Packed_Format_for_Japanese / csEUCPkdFmtJapanese
     </seg>
     <seg>
-     Composé de US-ASCII / JIS X0201:1997 (hankaku kana) /
+     Composé d'US-ASCII / JIS X0201:1997 (hankaku kana) /
      JIS X0208:1990 / JIS X0212:1990
     </seg>
     <seg>
-     Comme vous le voyez, le nom est dérivé de l'abréviation de 
+     Comme on peut le voir, le nom est dérivé de l'abréviation de 
      <literal>Extended UNIX Code Packed Format for Japanese</literal>, 
      ce jeu est essentiellement utilisé sur les plates-formes Unix.
      Le jeu original, <literal>Extended UNIX Code</literal>, 

--- a/reference/mbstring/functions/mb-detect-encoding.xml
+++ b/reference/mbstring/functions/mb-detect-encoding.xml
@@ -211,11 +211,11 @@ string(10) "ISO-8859-1"
   <para>
    <simplelist>
     <member>
-     "Ä¢" (U+00C4 LATIN CAPITAL LETTER A WITH DIAERESIS suivi de U+00A2 CENT SIGN)
-     encodé dans un de ISO-8859-1, ISO-8859-15, ou Windows-1252
+     "Ä¢" (U+00C4 LATIN CAPITAL LETTER A WITH DIAERESIS suivi d'U+00A2 CENT SIGN)
+     encodé dans un d'ISO-8859-1, ISO-8859-15, ou Windows-1252
     </member>
     <member>
-     "ФЂ" (U+0424 CYRILLIC CAPITAL LETTER EF suivi de U+0402 CYRILLIC CAPITAL LETTER
+     "ФЂ" (U+0424 CYRILLIC CAPITAL LETTER EF suivi d'U+0402 CYRILLIC CAPITAL LETTER
      DJE) encodé en ISO-8859-5
     </member>
     <member>

--- a/reference/mbstring/functions/mb-ereg-replace-callback.xml
+++ b/reference/mbstring/functions/mb-ereg-replace-callback.xml
@@ -55,13 +55,13 @@
         la chaîne remplacée.
       </para>
       <para>
-        Vous aurez souvent besoin de la fonction <parameter>callback</parameter> 
+        On aura souvent besoin de la fonction <parameter>callback</parameter> 
         pour <function>mb_ereg_replace_callback</function> juste une fois.
-        Dans ce cas vous pouvez utiliser les
+        Dans ce cas il est possible d'utiliser les
         <link linkend="functions.anonymous">fonctions anonymes</link> pour 
         déclarer une fonction de rappel lors de l'appel de la fonction
         <function>mb_ereg_replace_callback</function>. En faisant cela de cette manière
-        vous avez toutes les informations nécessaires à l'appel de la fonction
+        on a toutes les informations nécessaires à l'appel de la fonction
         en un seul endroit, ce qui permet d'éviter d'encombrer l'espace de noms
         des fonctions avec un callback de fonction qui n'est pas utilisé ailleurs.
       </para>

--- a/reference/mbstring/functions/mb-internal-encoding.xml
+++ b/reference/mbstring/functions/mb-internal-encoding.xml
@@ -29,7 +29,7 @@
       <para>
        <parameter>encoding</parameter> sert lors des conversions des
        chaînes en provenance et en direction du web, ainsi que lors de
-       la création de chaînes avec le module mbstring. Vous devez garder à
+       la création de chaînes avec le module mbstring. Il faut garder à
        l'esprit que l'encodage interne est totalement différent
        de celui pour les regex multioctets.
       </para>

--- a/reference/mbstring/functions/mb-output-handler.xml
+++ b/reference/mbstring/functions/mb-output-handler.xml
@@ -76,7 +76,7 @@ ob_start("mb_output_handler");
   &reftitle.notes;
   <note>
    <para>
-    Si vous souhaitez envoyer des données binaires telles des images, 
+    Pour envoyer des données binaires telles des images, 
     l'en-tête <literal>Content-Type: header</literal> 
     doit être défini en utilisant la fonction <function>header</function>
     avant d'envoyer les données binaires au client (e.g. 
@@ -85,7 +85,7 @@ ob_start("mb_output_handler");
     de l'encodage de sortie ne sera pas effectuée.
    </para>
    <para>
-    Notez que si <literal>Content-Type: text/*</literal> est envoyé,
+    À noter que si <literal>Content-Type: text/*</literal> est envoyé,
     le contenu du corps est vu comme du texte ; la conversion sera
     effectuée.
    </para>

--- a/reference/mbstring/functions/mb-regex-set-options.xml
+++ b/reference/mbstring/functions/mb-regex-set-options.xml
@@ -31,9 +31,9 @@
       <para>
        Les options à définir, sous la forme d'une chaîne
        dont chaque caractère est une option. Pour définir un
-       mode, vous devez placer le caractère représentant ce mode
+       mode, il faut placer le caractère représentant ce mode
        en dernier, le reste des caractères sera les options.
-       Vous ne pouvez définir qu'un seul mode, alors que vous
+       On ne pouvez définir qu'un seul mode, alors que l'on
        pouvez définir plusieurs options.
       </para>
 

--- a/reference/mbstring/functions/mb-send-mail.xml
+++ b/reference/mbstring/functions/mb-send-mail.xml
@@ -81,7 +81,7 @@
         par défaut dans le &php.ini;.
        </para>
        <para>
-        Si vous ne le faites pas, une erreur similaire à :
+        Si on ne le faites pas, une erreur similaire à :
         <literal>Warning: mail(): "sendmail_from" not
         set in php.ini or custom "From:" header missing</literal> sera émise.
         L'en-tête <literal>From</literal> définie également
@@ -94,7 +94,7 @@
         (\n). Quelques agents de transfert de mails Unix (en particulier
         <link xlink:href="&url.qmail;">qmail</link>) remplace un LF par
         un CRLF automatiquement (ce qui résulte en un doublement du CR si
-        CRLF est utilisé). Vous devez tenter cette correction en dernier recourt,
+        CRLF est utilisé). Il faut tenter cette correction en dernier recourt,
         sachant que cela ne respecte pas la
         <link xlink:href="&url.rfc;2822">RFC 2822</link>.
        </para>
@@ -106,9 +106,9 @@
      <listitem>
       <para>
        <parameter>additional_params</parameter> est une ligne
-       de paramètres MTA. Il est pratique lorsque vous voulez 
+       de paramètres MTA. Il est pratique lorsqu'on veut 
        définir un <literal>Return-Path</literal> correct lorsque
-       vous utilisez <literal>sendmail</literal>.
+       on utilise <literal>sendmail</literal>.
       </para>
       <para>
        Ce paramètre est échappé par la fonction <function>escapeshellcmd</function> en interne

--- a/reference/mbstring/http-inout.xml
+++ b/reference/mbstring/http-inout.xml
@@ -45,11 +45,11 @@ mbstring.encoding_translation = Off
      </example>
     </para>
     <para>
-     Lorsque vous utilisez PHP comme module Apache, il est possible
+     Lorsqu'on utilise PHP comme module Apache, il est possible
      d'annuler la configuration du &php.ini; pour
      chaque Virtual Host dans le fichier
      &httpd.conf; ou par dossier avec le fichier
-     <literal>.htaccess</literal>. Reportez-vous à la section de
+     <literal>.htaccess</literal>. Se reporter à la section de
      <link linkend="configuration">configuration</link> ainsi qu'au
      manuel Apache.
     </para>

--- a/reference/mbstring/ini.xml
+++ b/reference/mbstring/ini.xml
@@ -110,7 +110,7 @@
     <listitem>
      <para>
       Définit le langage utilisé
-      par mbstring. Notez que cette option définit
+      par mbstring. À noter que cette option définit
       <literal>mbstring.internal_encoding</literal>
       <literal>mbstring.internal_encoding</literal>
       doit être placé après <literal>mbstring.language</literal>
@@ -283,7 +283,7 @@
   En accord avec <link xlink:href="&url.spec.html401.accept-charset;">HTML 4.01 specification</link>,
   les navigateurs sont supposés utiliser le même jeu de caractères
   lorsqu'ils soumettent un formulaire. Mais, tous les navigateurs
-  ne le font pas. Reportez-vous à la fonction <function>mb_http_input</function>
+  ne le font pas. Se reporter à la fonction <function>mb_http_input</function>
   pour détecter les jeux de caractères utilisés par les navigateurs.
  </para>
 

--- a/reference/mbstring/overloading.xml
+++ b/reference/mbstring/overloading.xml
@@ -10,7 +10,7 @@
 
  &warn.deprecated.feature-7-2-0.removed-8-0-0;
  <para>
-  Vous pourriez trouver difficile de faire fonctionner une application PHP
+  Il est possible que l'on trouver difficile de faire fonctionner une application PHP
   existante dans un environnement multioctets. Ceci est dû au fait
   que la plupart des applications PHP sont écrites avec des fonctions
   de chaînes de caractères standards comme la fonction

--- a/reference/mbstring/reference.xml
+++ b/reference/mbstring/reference.xml
@@ -10,7 +10,7 @@
     <title>Références</title>
     <para>
      Les jeux de caractères multioctets et leurs techniques sont très complexes et ne
-     peuvent être traités totalement dans cette documentation. Reportez-vous aux
+     peuvent être traités totalement dans cette documentation. Se reporter aux
      URL suivantes pour d'autres ressources complémentaires :
      <itemizedlist>
       <listitem>

--- a/reference/mcrypt/ciphers.xml
+++ b/reference/mcrypt/ciphers.xml
@@ -7,8 +7,8 @@
  <para>
   Voici une liste non exhaustive des modes de chiffrement de l'extension
   mcrypt. Pour disposer d'une liste complète des chiffrements supportés,
-  voyez les définitions dans le fichier <filename>mcrypt.h</filename>. La règle
-  générale avec l'API mcrypt-2.2.x est que vous pouvez accéder au
+  voir les définitions dans le fichier <filename>mcrypt.h</filename>. La règle
+  générale avec l'API mcrypt-2.2.x est qu'il est possible d'accéder au
   mode de chiffrement depuis PHP avec la constante MCRYPT_ciphername. Avec
   la bibliothèque libmcrypt-2.4.x et libmcrypt-2.5.x, ces constantes fonctionnent
   toujours, mais il est possible de spécifier le nom du chiffrement dans une chaîne,
@@ -59,13 +59,13 @@
   </itemizedlist>
  </para>
  <simpara>
-  Vous devez (mode <constant>CFB</constant> et <constant>OFB</constant>)
+  Il faut (mode <constant>CFB</constant> et <constant>OFB</constant>)
   ou pouvez (mode <constant>CBC</constant>) fournir un vecteur d'initialisation
   (IV) pour ces modes de chiffrement. IV doit être unique, et avoir la même
   valeur au chiffrement et au déchiffrement. Pour des données qui seront
-  enregistrées après chiffrement, vous pouvez prendre le résultat d'une
-  fonction telle que MD5, appliquée sur le nom du fichier. Sinon, vous
-  pouvez envoyer IV avec les données chiffrées, (reportez-vous au chapitre
+  enregistrées après chiffrement, il est possible de prendre le résultat d'une
+  fonction telle que MD5, appliquée sur le nom du fichier. Sinon, l'on
+  pouvez envoyer IV avec les données chiffrées, (se reporter au chapitre
   9.3 de &book.applied.cryptography; de Schneier (ISBN 0-471-11709-9)
   pour plus de détails sur le sujet).
  </simpara>

--- a/reference/mcrypt/functions/mcrypt-create-iv.xml
+++ b/reference/mcrypt/functions/mcrypt-create-iv.xml
@@ -31,8 +31,8 @@
   <simpara>
    Le vecteur d'initialisation est le seul moyen de fournir une initialisation
    de remplacement aux méthodes d'initialisation. Ce vecteur n'a pas besoin
-   d'être particulièrement secret, même si c'est mieux. Vous pouvez l'envoyer
-   avec vos documents chiffrés sans perdre en sécurité.
+   d'être particulièrement secret, même si c'est mieux. Il est possible de l'envoyer
+   avec les documents chiffrés sans perdre en sécurité.
   </simpara>
  </refsect1>
 
@@ -60,12 +60,12 @@
       supportée par Windows.
      </simpara>
      <simpara>
-      Notez que la valeur par défaut de ce paramètre était
+      À noter que la valeur par défaut de ce paramètre était
       <constant>MCRYPT_DEV_RANDOM</constant> avant PHP 5.6.0.
      </simpara>
      <note>
       <simpara>
-       Notez que la constante <constant>MCRYPT_DEV_RANDOM</constant>
+       À noter que la constante <constant>MCRYPT_DEV_RANDOM</constant>
        peut se bloquer en attendant que plus d'entropie ne soit disponible.
       </simpara>
      </note>

--- a/reference/mcrypt/functions/mcrypt-generic-deinit.xml
+++ b/reference/mcrypt/functions/mcrypt-generic-deinit.xml
@@ -20,8 +20,8 @@
   <simpara>
    Prépare le module de chiffrement <parameter>td</parameter> pour le déchargement.
    Tous les tampons sont vidés, mais le module n'est pas déchargé.
-   Vous devez appeler <function>mcrypt_module_close</function> vous-même
-   (mais PHP le fera pour vous a la fin du script).
+   Il faut appeler <function>mcrypt_module_close</function> soi-même
+   (mais PHP le fera pour l'on a la fin du script).
   </simpara>
  </refsect1>
 

--- a/reference/mcrypt/functions/mcrypt-generic-init.xml
+++ b/reference/mcrypt/functions/mcrypt-generic-init.xml
@@ -19,7 +19,7 @@
    <methodparam><type>string</type><parameter>iv</parameter></methodparam>
   </methodsynopsis>
   <simpara>
-   Vous devez appeler <function>mcrypt_generic_init</function>
+   Il faut appeler <function>mcrypt_generic_init</function>
    avant chaque appel à <function>mcrypt_generic</function> ou
    <function>mdecrypt_generic</function>.
   </simpara>
@@ -50,13 +50,13 @@
     <listitem>
      <simpara>
       Le vecteur d'initialisation (VI) doit avoir la taille d'un bloc,
-      mais vous devez lire sa taille en appelant
+      mais il faut lire sa taille en appelant
       <function>mcrypt_enc_get_iv_size</function>. IV est ignoré en mode
       ECB. IV DOIT exister en modes <literal>"CFB"</literal>,
       <literal>"CBC"</literal>, <literal>"STREAM"</literal>, <literal>"nOFB"</literal>
       et <literal>"OFB"</literal>. Il doit être aléatoire et unique (mais pas secret).
       Le même VI doit être utilisé pour le chiffrement et le déchiffrement.
-      Si vous ne voulez pas l'utiliser, remplissez-le de zéros, mais
+      Si on ne voulez pas l'utiliser, remplissez-le de zéros, mais
       ce n'est pas recommandé.
      </simpara>
     </listitem>

--- a/reference/mcrypt/functions/mcrypt-generic.xml
+++ b/reference/mcrypt/functions/mcrypt-generic.xml
@@ -22,24 +22,24 @@
    <function>mcrypt_generic</function> chiffre les données
    <parameter>data</parameter>. Les données sont complétées
    par des "<literal>\0</literal>" pour obtenir une taille multiple de la taille
-   d'un bloc. Elle retourne les données chiffrées. Notez que la longueur
+   d'un bloc. Elle retourne les données chiffrées. À noter que la longueur
    de la chaîne retournée peut être plus longue que celle
    passée en argument, à cause du complément.
   </simpara>
   <simpara>
-   Si vous voulez enregistrer les données chiffrées dans une base de données
-   assurez-vous d'enregistrer la chaîne entière retournée par cette fonction,
-   sinon la chaîne ne sera pas décryptée correctement. Si votre chaîne d'origine
+   Pour enregistrer les données chiffrées dans une base de données
+   il faut s'assurer d'enregistrer la chaîne entière retournée par cette fonction,
+   sinon la chaîne ne sera pas décryptée correctement. Si le chaîne d'origine
    comporte 10 caractères et que la taille d'un bloc est de 8 (utilisez
    <function>mcrypt_enc_get_block_size</function> pour déterminer cette taille),
-   vous aurez besoin d'au moins 16 caractères dans le champ de votre base de données.
-   Notez que la chaîne retournée par <function>mdecrypt_generic</function> aura
+   on aura besoin d'au moins 16 caractères dans le champ de la base de données.
+   À noter que la chaîne retournée par <function>mdecrypt_generic</function> aura
    16 caractères de long... utilisez <literal>rtrim($str, "\0")</literal>
    pour supprimer le complément.
   </simpara>
   <simpara>
-   Par exemple, si vous enregistrez les données dans une base de données MySQL,
-   souvenez-vous que les champs de type VARCHAR suppriment automatiquement les
+   Par exemple, si on enregistre les données dans une base de données MySQL,
+   il faut se souvenir que les champs de type VARCHAR suppriment automatiquement les
    espaces en trop durant l'insertion. Comme les données chiffrés peuvent se
    terminer avec un espace (ASCII 32), les données seront endommagées par cette
    suppression. Stockez les données dans un champ de type TINYBLOB/TINYTEXT
@@ -60,9 +60,9 @@
       Le gestionnaire de chiffrement <parameter>td</parameter> doit être
       initialisé avec la fonction <function>mcrypt_generic_init</function>,
       avec une clé et un VI, avant d'appeler cette fonction. Lorsque le chiffrement
-      est réalisé, vous devez libérer les buffers en appelant la fonction
+      est réalisé, il faut libérer les buffers en appelant la fonction
       <function>mcrypt_generic_deinit</function>.
-      Voyez <function>mcrypt_module_open</function> pour un exemple.
+      Voir <function>mcrypt_module_open</function> pour un exemple.
      </simpara>
     </listitem>
    </varlistentry>

--- a/reference/mcrypt/functions/mcrypt-get-iv-size.xml
+++ b/reference/mcrypt/functions/mcrypt-get-iv-size.xml
@@ -44,8 +44,8 @@
      &mcrypt.parameter.mode;
      <simpara>
       IV est ignoré en mode ECB sachant que ce mode ne le demande pas.
-      Vous devez avoir le même IV (point de départ) lors du chiffrement
-      et du déchiffrement, sinon, votre chiffrement échouera.
+      Il faut avoir le même IV (point de départ) lors du chiffrement
+      et du déchiffrement, sinon, le chiffrement échouera.
      </simpara>
     </listitem>
    </varlistentry>

--- a/reference/mcrypt/functions/mcrypt-module-open.xml
+++ b/reference/mcrypt/functions/mcrypt-module-open.xml
@@ -43,8 +43,8 @@
     <listitem>
      <simpara>
       Le paramètre <parameter>algorithm_directory</parameter> est utilisé
-      pour localiser le module de cryptage. Lorsque vous spécifiez un
-      nom de dossier, il sera utilisé. Si vous spécifiez une chaîne vide
+      pour localiser le module de cryptage. Lorsqu'on spécifie un
+      nom de dossier, il sera utilisé. Si on spécifie une chaîne vide
       (<literal>""</literal>), la valeur définie dans la directive
       <literal>mcrypt.algorithms_dir</literal> du fichier &php.ini; sera
       utilisée. Lorsqu'elle n'est pas définie, le dossier par défaut utilisé
@@ -65,7 +65,7 @@
      <simpara>
       Le paramètre <parameter>mode_directory</parameter> est utilisé pour localiser
       le module de cryptage. Si un nom de dossier est spécifié, il sera utilisé.
-      Lorsque vous spécifiez une chaîne vide (<literal>""</literal>), la valeur
+      Lorsqu'on spécifie une chaîne vide (<literal>""</literal>), la valeur
       de la directive <literal>mcrypt.modes_dir</literal> du fichier &php.ini;
       sera utilisée. Si elle n'est pas définie, le dossier par défaut utilisé
       sera celui dans lequel se trouve la bibliothèque libmcrypt

--- a/reference/mcrypt/functions/mdecrypt-generic.xml
+++ b/reference/mcrypt/functions/mdecrypt-generic.xml
@@ -19,7 +19,7 @@
    <methodparam><type>string</type><parameter>data</parameter></methodparam>
   </methodsynopsis>
   <simpara>
-   Déchiffre les données <parameter>data</parameter>. Notez que la longueur de
+   Déchiffre les données <parameter>data</parameter>. À noter que la longueur de
    la chaîne déchiffrée peut être plus longue que la chaîne originale, car elle
    peut avoir été complétée par des caractères.
   </simpara>
@@ -108,7 +108,7 @@ if (strncmp($p_t, $plain_text, strlen($plain_text)) == 0) {
    Le gestionnaire de déchiffrement doit toujours être initialisé
    par la fonction <function>mcrypt_generic_init</function> avec une clé
    et un VI avant d'appeler cette fonction. Lorsque le chiffrement est fait,
-   il faut que vous libériez les données chiffrées en appelant
+   il faut qu'on libère les données chiffrées en appelant
    <function>mcrypt_generic_deinit</function>.
    Voir <function>mcrypt_module_open</function> pour un exemple.
   </simpara>

--- a/reference/mcrypt/setup.xml
+++ b/reference/mcrypt/setup.xml
@@ -24,7 +24,7 @@
    de la bibliothèque MCrypt, aucune DLL n'est nécessaire.
   </simpara>
   <simpara>
-   Si vous compilez PHP avec la bibliothèque <literal>libmcrypt 2.4.x</literal>,
+   Si on compile PHP avec la bibliothèque <literal>libmcrypt 2.4.x</literal>,
    les algorithmes suivants sont supportés : <literal>"CAST"</literal>, <literal>"LOKI97"</literal>, <literal>"RIJNDAEL"</literal>, <literal>"SAFERPLUS"</literal>,
    <literal>"SERPENT"</literal> ainsi que les chiffrements suivants : <literal>"ENIGMA"</literal> (chiffrement), <literal>"PANAMA"</literal>,
    <literal>"RC4"</literal> et <literal>"WAKE"</literal>. Avec <literal>libmcrypt 2.4.x</literal> un autre mode de chiffrement

--- a/reference/memcache/configure.xml
+++ b/reference/memcache/configure.xml
@@ -12,7 +12,7 @@
  <note>
   <simpara>
    Il est possible de désactiver le support du gestionnaire de sessions memcache.
-   L'option 'pecl install' vous le permet (activé par défaut), cependant, lors
+   L'option 'pecl install' l'on le permet (activé par défaut), cependant, lors
    de la compilation statique dans PHP, l'option de configuration
    <option role="configure">--disable-memcache-session</option> peut être utilisée.
   </simpara>

--- a/reference/memcache/ini.xml
+++ b/reference/memcache/ini.xml
@@ -154,7 +154,7 @@
    <simpara>
     Les données doivent être transférées en morceaux de cette taille ;
     Configurer cette valeur à une petite valeur provoque plus d'écritures
-    sur le réseau. Essayez d'augmenter cette valeur à 32768 si vous
+    sur le réseau. Il est recommandé d'augmenter cette valeur à 32768 si l'on
     rencontrez des ralentissements inexplicables.
    </simpara>
   </listitem>

--- a/reference/memcache/memcache/add.xml
+++ b/reference/memcache/memcache/add.xml
@@ -68,7 +68,7 @@
     <listitem>
      <simpara>
       Temps d'expiration de l'élément. Si égal à zéro, l'élément n'expirera jamais.
-      Vous pouvez aussi utiliser un timestamp Unix ou un nombre de secondes partant
+      Il est également possible d'utiliser un timestamp Unix ou un nombre de secondes partant
       du temps actuel, mais dans ce cas le nombre de secondes ne doit pas excéder
       2592000 (30 jours).
      </simpara>

--- a/reference/memcache/memcache/addserver.xml
+++ b/reference/memcache/memcache/addserver.xml
@@ -121,8 +121,8 @@
      <simpara>
       Valeur en seconde qui sera utilisée pour se connecter au démon.
       Pensez-y deux fois avant de changer la valeur par défaut d'une seconde
-      - vous pourriez perdre tous les avantages de l'utilisation de la cache
-      si votre connexion est trop lente.
+      - il est possible que l'on perdre tous les avantages de l'utilisation de la cache
+      si le connexion est trop lente.
      </simpara>
     </listitem>
    </varlistentry>
@@ -224,7 +224,7 @@ memcache_add_server($memcache_obj, 'memcache_host2', 11211);
     Lorsque le paramètre <parameter>port</parameter> n'est pas spécifié, cette méthode
     prendra la valeur de la directive de configuration INI
     <link linkend="ini.memcache.default-port">memcache.default_port</link>.
-    Si cette valeur a été modifiée à un autre endroit dans votre application,
+    Si cette valeur a été modifiée à un autre endroit dans le application,
     cela peut conduire à des résultats inattendus : pour cette raison, il convient
     de toujours spécifier le port explicitement lors de l'appel à la méthode.
    </simpara>

--- a/reference/memcache/memcache/connect.xml
+++ b/reference/memcache/memcache/connect.xml
@@ -28,7 +28,7 @@
    de cache <literal>Memcache</literal>.
    La connexion, qui a été ouverte en utilisant la fonction
    <function>Memcache::connect</function> sera automatiquement fermée
-   à la fin de votre script. Vous pouvez néanmoins la refermer en utilisant la
+   à la fin du script. Il est possible de néanmoins la refermer en utilisant la
    fonction <function>Memcache::close</function>.
   </simpara>
 
@@ -69,8 +69,8 @@
      <simpara>
       Valeur en seconde qui sera utilisée pour se connecter au démon.
       Pensez-y deux fois avant de changer la valeur par défaut d'une seconde
-      - vous pourriez perdre tous les avantages de l'utilisation de la cache
-      si votre connexion est trop lente.
+      - il est possible que l'on perdre tous les avantages de l'utilisation de la cache
+      si le connexion est trop lente.
      </simpara>
     </listitem>
    </varlistentry>
@@ -114,7 +114,7 @@ $memcache->connect('memcache_host', 11211);
     Lorsque le paramètre <parameter>port</parameter> n'est pas spécifié, cette méthode
     prendra la valeur de la directive de configuration INI
     <link linkend="ini.memcache.default-port">memcache.default_port</link>.
-    Si cette valeur a été modifiée à un autre endroit dans votre application,
+    Si cette valeur a été modifiée à un autre endroit dans le application,
     cela peut conduire à des résultats inattendus : pour cette raison, il convient
     de toujours spécifier le port explicitement lors de l'appel à la méthode.
    </simpara>

--- a/reference/memcache/memcache/get.xml
+++ b/reference/memcache/memcache/get.xml
@@ -40,7 +40,7 @@
   </simpara>
 
   <simpara>
-   Vous pouvez passer un tableau de clés à la fonction
+   Il est possible de passer un tableau de clés à la fonction
    <function>Memcache::get</function> pour obtenir un tableau de valeurs. Le
    tableau résultant contiendra seulement les paires de clé-valeur trouvées.
   </simpara>

--- a/reference/memcache/memcache/pconnect.xml
+++ b/reference/memcache/memcache/pconnect.xml
@@ -64,8 +64,8 @@
      <simpara>
       Valeur en seconde qui sera utilisée pour se connecter au démon.
       Pensez-y deux fois avant de changer la valeur par défaut d'une seconde
-      - vous pourriez perdre tous les avantages de l'utilisation de la cache
-      si votre connexion est trop lente.
+      - il est possible que l'on perdre tous les avantages de l'utilisation de la cache
+      si le connexion est trop lente.
      </simpara>
     </listitem>
    </varlistentry>

--- a/reference/memcache/memcache/replace.xml
+++ b/reference/memcache/memcache/replace.xml
@@ -72,7 +72,7 @@
     <listitem>
      <simpara>
       Temps d'expiration pour l'élément. S'il égal &zero;, l'élément n'expirera
-      jamais. Vous pouvez aussi utiliser un timestamp Unix ou un nombre de
+      jamais. Il est également possible d'utiliser un timestamp Unix ou un nombre de
       seconde en commençant par la date d'aujourd'hui, mais dans le dernier
       cas, le nombre de secondes ne doit pas excéder 2592000 (30 jours).
      </simpara>

--- a/reference/memcache/memcache/set.xml
+++ b/reference/memcache/memcache/set.xml
@@ -33,12 +33,12 @@
    d'expiration de l'élément. S'il vaut 0, l'élément n'expirera jamais (mais le serveur
    de cache ne garantit pas que cet élément sera toujours stocké, il peut être
    effacé du cache pour faire de la place à d'autres éléments).
-   Vous pouvez utiliser la constante <constant>MEMCACHE_COMPRESSED</constant>
+   Il est possible d'utiliser la constante <constant>MEMCACHE_COMPRESSED</constant>
    comme valeur du paramètre <parameter>flag</parameter>
-   si vous voulez utiliser la compression à la volée (utilisation de la bibliothèque zlib).
+   pour utiliser la compression à la volée (utilisation de la bibliothèque zlib).
    <note>
     <simpara>
-     Souvenez-vous que les ressources (i.e. identifiant de fichiers ou de connexion)
+     Il faut se souvenir que les ressources (i.e. identifiant de fichiers ou de connexion)
      ne peuvent pas être stockées dans le cache, car elles ne peuvent pas être
      représentées linéairement.
     </simpara>
@@ -82,7 +82,7 @@
     <listitem>
      <simpara>
       Temps d'expiration pour l'élément. S'il égal &zero;, l'élément n'expirera
-      jamais. Vous pouvez aussi utiliser un timestamp Unix ou un nombre de
+      jamais. Il est également possible d'utiliser un timestamp Unix ou un nombre de
       seconde en commençant par la date d'aujourd'hui, mais dans le dernier
       cas, le nombre de secondes ne doit pas excéder 2592000 (30 jours).
      </simpara>

--- a/reference/memcache/memcache/setserverparams.xml
+++ b/reference/memcache/memcache/setserverparams.xml
@@ -67,8 +67,8 @@
      <simpara>
       Valeur en seconde qui sera utilisée pour se connecter au démon.
       Pensez-y deux fois avant de changer la valeur par défaut d'une seconde
-      - vous pourriez perdre tous les avantages de l'utilisation de la cache
-      si votre connexion est trop lente.
+      - il est possible que l'on perdre tous les avantages de l'utilisation de la cache
+      si le connexion est trop lente.
      </simpara>
     </listitem>
    </varlistentry>

--- a/reference/memcached/constants.xml
+++ b/reference/memcached/constants.xml
@@ -159,7 +159,7 @@
    <term><constant>Memcached::OPT_PREFIX_KEY</constant></term>
    <listitem>
     <simpara>
-     Cette option peut être utilisée pour créer un "domaine" pour vos clés.
+     Cette option peut être utilisée pour créer un "domaine" pour les clés.
      La valeur spécifiée ici sera préfixée à chaque clé. Elle ne peut pas être
      plus longue que <literal>128</literal> caractères, et réduira d'autant 
      la taille maximale de clé disponible. Le préfixe est appliqué uniquement
@@ -176,7 +176,7 @@
      Spécifie l'algorithme de hachage utilisé pour les clés. Les valeurs valides
      sont fournies avec les constantes <constant>Memcached::HASH_<replaceable>*</replaceable></constant>.
      Chaque algorithme de hachage a ses avantages et inconvénients. Utilisez
-     celui qui est donné par défaut, si vous ne comprenez pas, ou que peu vous
+     celui qui est donné par défaut, si on ne comprenez pas, ou que peu l'on
      importe.
     </simpara>
     <para>Type : <type>int</type>, par défaut : <constant>Memcached::HASH_DEFAULT</constant></para>
@@ -319,7 +319,7 @@
     </para>
     <note>
      <para>
-      Cette option est hautement recommandée, si vous voulez utiliser 
+      Cette option est hautement recommandée, pour utiliser 
       le hachage cohérent, et il est probable qu'elle soit activée
       par défaut dans de futures versions.
      </para>
@@ -368,7 +368,7 @@
    <listitem>
     <simpara>
      Activez cette option pour utiliser le protocole binaire. 
-     Notez que vous ne pouvez pas changer cette option pour 
+     À noter qu'il n'est pas possible de changer cette option pour 
      une connexion déjà ouverte.
     </simpara>
     <para>Type : <type>bool</type>, par défaut : &false;.</para>
@@ -473,7 +473,7 @@
    <listitem>
     <simpara>
      Délai d'expiration d'envoi pour le socket, en microsecondes. Dans les cas
-     où vous utilisez un socket non bloquant, cela vous permettra d'avoir
+     où on utilise un socket non bloquant, cela permettra d'avoir
      des délais d'expiration en envoi de données, malgré tout.
     </simpara>
     <para>Type : <type>int</type>, par défaut : <literal>0</literal>.</para>
@@ -485,7 +485,7 @@
    <listitem>
     <simpara>
      Délai d'expiration de réception pour le socket, en microsecondes. Dans les cas
-     où vous utilisez un socket non bloquant, cela vous permettra d'avoir
+     où on utilise un socket non bloquant, cela permettra d'avoir
      des délais d'expiration en réception de données, malgré tout.
     </simpara>
     <para>Type : <type>int</type>, par défaut : <literal>0</literal>.</para>
@@ -771,8 +771,8 @@
    <term><constant>Memcached::RES_DATA_EXISTS</constant></term>
    <listitem>
     <para>
-     Échec de la comparaison et échange : l'élément que vous essayez
-     de stocker a été modifié depuis votre dernière lecture.
+     Échec de la comparaison et échange : l'élément qu'on essaie
+     de stocker a été modifié depuis le dernière lecture.
     </para>
    </listitem>
   </varlistentry>

--- a/reference/memcached/ini.xml
+++ b/reference/memcached/ini.xml
@@ -248,7 +248,7 @@
      </term>
      <listitem>
       <para>
-       La durée d'attente du verrou de session en microsecondes. Soyez prudent lorsque vous définissez cette valeur.
+       La durée d'attente du verrou de session en microsecondes. Il faut être prudent lorsqu'on définit cette valeur.
        Les valeurs valides sont des entiers, où <literal>0</literal> est interprété comme la valeur par défaut.
        Les valeurs négatives entraînent une réduction du verrouillage à un verrou d'essai.
        La valeur par défaut est <literal>150000</literal>.

--- a/reference/memcached/memcached/addserver.xml
+++ b/reference/memcached/memcached/addserver.xml
@@ -19,10 +19,10 @@
   <para>
    <function>Memcached::addServer</function> ajoute le serveur indiqué
    au pool de serveurs. Aucune connexion n'est établie à ce moment-là, mais
-   si vous utilisez la clé de distribution par hachage cohérent (via
+   lors de l'utilisation de la clé de distribution par hachage cohérent (via
    <constant>Memcached::DISTRIBUTION_CONSISTENT</constant> ou
    <constant>Memcached::OPT_LIBKETAMA_COMPATIBLE</constant>), certaines structures
-   internes vont être mises à jour. Par conséquent, si vous devez ajouter plusieurs
+   internes vont être mises à jour. Par conséquent, si il faut ajouter plusieurs
    serveurs, il est recommandé d'utiliser <methodname>Memcached::addServers</methodname> 
    pour que la mise à jour n'arrive qu'une seule fois.
   </para>
@@ -59,7 +59,7 @@
       <para>
        Le port sur lequel memcache fonctionne. Généralement, c'est
        <literal>11211</literal>. Depuis la version 2.0.0b1, définissez
-       ce paramètre à <literal>0</literal> lorsque vous utilisez des sockets
+       ce paramètre à <literal>0</literal> lorsqu'on utilise des sockets
        de domaine Unix.
       </para>
      </listitem>

--- a/reference/memcached/memcached/cas.xml
+++ b/reference/memcached/memcached/cas.xml
@@ -24,7 +24,7 @@
    est faite via le paramètre <parameter>cas_token</parameter> qui est une
    valeur 64 bits unique, assignée à l'élément par memcached. Voir la documentation
    de <methodname>Memcached::get*</methodname> pour savoir comment obtenir cette
-   valeur. Notez que cette valeur est représentée par un nombre flottant, à cause
+   valeur. À noter que cette valeur est représentée par un nombre flottant, à cause
    de limitations dans l'espace des entiers de PHP.
   </para>
  </refsect1>
@@ -75,7 +75,7 @@
    &return.success;
    La méthode <methodname>Memcached::getResultCode</methodname> va retourner
    la constante <constant>Memcached::RES_DATA_EXISTS</constant> si l'élément que
-   vous essayez de stocker a été modifié depuis votre dernière lecture.
+   on essaie de stocker a été modifié depuis le dernière lecture.
   </para>
  </refsect1>
 

--- a/reference/memcached/memcached/casbykey.xml
+++ b/reference/memcached/memcached/casbykey.xml
@@ -79,8 +79,8 @@
   <para>
    &return.success;
    La méthode <methodname>Memcached::getResultCode</methodname> va retourner
-   <constant>Memcached::RES_DATA_EXISTS</constant> si l'élément que vous essayez
-   de stocker a été modifié depuis votre dernière lecture.
+   <constant>Memcached::RES_DATA_EXISTS</constant> si l'élément qu'on essaie
+   de stocker a été modifié depuis le dernière lecture.
   </para>
  </refsect1>
 

--- a/reference/memcached/memcached/getallkeys.xml
+++ b/reference/memcached/memcached/getallkeys.xml
@@ -19,7 +19,7 @@
    et récupère un tableau contenant toutes les clés stockées sur chacun d'eux.
    Ce n'est pas une opération atomique, aussi, ce n'est pas une image
    réellement consistante des clés à l'instant donné. Sachant que memcache
-   ne garantit pas de retourner toutes les clés, vous ne pouvez pas être certain
+   ne garantit pas de retourner toutes les clés, il n'est pas possible d'être certain
    que toutes les clés ont bien été retournées.
   </para>
   <note>

--- a/reference/memcached/memcached/getdelayed.xml
+++ b/reference/memcached/memcached/getdelayed.xml
@@ -19,13 +19,13 @@
   <para>
    <function>Memcached::getDelayed</function> émet une commande à memcache pour
    lire plusieurs clés qui sont spécifiées dans le tableau <parameter>keys</parameter>.
-   La méthode n'attend pas la réponse et retourne immédiatement. Lorsque vous êtes prêts
+   La méthode n'attend pas la réponse et retourne immédiatement. Lorsqu'on êtes prêts
    à lire les éléments, appelez les méthodes <methodname>Memcached::fetch</methodname> ou
    <methodname>Memcached::fetchAll</methodname>. Si <parameter>with_cas</parameter>
    vaut &true; le CAS sera aussi lu.
   </para>
   <para>
-   Au lieu de lire les résultats explicitement, vous pouvez spécifier une
+   Au lieu de lire les résultats explicitement, il est possible de spécifier une
    <link linkend="memcached.callbacks">fonction de rappel de résultats</link> via
    le paramètre <parameter>value_cb</parameter>.
   </para>

--- a/reference/memcached/memcached/replacebykey.xml
+++ b/reference/memcached/memcached/replacebykey.xml
@@ -21,7 +21,7 @@
    <function>Memcached::replaceByKey</function> est fonctionnellement équivalent
    à la fonction <methodname>Memcached::replace</methodname>, hormis le fait que la
    variable libre <parameter>server_key</parameter> peut être utilisée pour diriger la
-   clé <parameter>key</parameter> vers un serveur spécifique. Ceci est utile si vous voulez 
+   clé <parameter>key</parameter> vers un serveur spécifique. Ceci est utile pour 
    conserver un groupe de variables groupées sur un serveur.
   </para>
  </refsect1>

--- a/reference/memcached/memcached/setbykey.xml
+++ b/reference/memcached/memcached/setbykey.xml
@@ -21,7 +21,7 @@
    <function>Memcached::setByKey</function> est fonctionnellement équivalente à 
    <methodname>Memcached::set</methodname>, hormis le fait que la variable libre
    <parameter>server_key</parameter> peut être utilisée pour envoyer la clé
-   <parameter>key</parameter> sur un serveur spécifique. Ceci est utile si vous voulez
+   <parameter>key</parameter> sur un serveur spécifique. Ceci est utile si on veut
    grouper certaines clés sur un serveur.
   </para>
  </refsect1>

--- a/reference/memcached/memcached/setmultibykey.xml
+++ b/reference/memcached/memcached/setmultibykey.xml
@@ -21,7 +21,7 @@
    de <methodname>Memcached::setMulti</methodname>, hormis le fait que le
    paramètre libre <parameter>server_key</parameter> peut être utilisé pour 
    diriger les clés de <parameter>items</parameter> vers un serveur spécifique.
-   Ceci est utile si vous voulez conserver certaines clés groupées sur un seul
+   Ceci est utile pour conserver certaines clés groupées sur un seul
    serveur.
   </para>
  </refsect1>

--- a/reference/memcached/memcached/setsaslauthdata.xml
+++ b/reference/memcached/memcached/setsaslauthdata.xml
@@ -25,7 +25,7 @@
     Cette méthode n'est disponible que lorsque l'extension memcache
     a été compilée avec le support SASL.
    </emphasis>
-   Pour plus d'informations, veuillez vous reporter à la section sur l'<link
+   Pour plus d'informations, se reporter à la section sur l'<link
     linkend="memcached.setup">installation de Memcache</link>.
   </para>
  </refsect1>

--- a/reference/memcached/sessions.xml
+++ b/reference/memcached/sessions.xml
@@ -8,10 +8,10 @@
  <para>
   Memcached fournit un gestionnaire de sessions qui peut être utilisé
   pour stocker les sessions sur memcache. Une instance distincte de
-  memcached est utilisée en interne, ce qui fait que vous pouvez avoir
+  memcached est utilisée en interne, ce qui fait qu'il est possible d'avoir
   un pool de serveurs différent, si nécessaire. Les clés de sessions sont
   stockées avec le préfixe <literal>memc.sess.key.</literal>, alors
-  soyez-en conscient si vous utilisez le même serveur pour les sessions
+  il faut en être conscient lors de l'utilisation du même serveur pour les sessions
   et pour le cache.
  </para>
  <para>

--- a/reference/mhash/book.xml
+++ b/reference/mhash/book.xml
@@ -18,11 +18,11 @@
    Cet ensemble de fonctions représente une interface avec la bibliothèque mhash.
    Mhash accepte un grand nombre d'algorithmes différents, tels MD5,
    SHA1, GOST et bien d'autres. Pour une liste complète des hashes supportés,
-   reportez-vous à la <link linkend="mhash.constants">page sur les constantes</link>.
-   La règle générale est que vous
+   se reporter à la <link linkend="mhash.constants">page sur les constantes</link>.
+   La règle générale est que l'on
    pouvez accéder à un algorithme depuis PHP avec la constante
    <constant>MHASH_hashname</constant>. Par exemple, pour accéder à l'algorithme TIGER,
-   vous pouvez utiliser la constante PHP <constant>MHASH_TIGER</constant>.
+   il est possible d'utiliser la constante PHP <constant>MHASH_TIGER</constant>.
   </para>
   <note>
    <para>

--- a/reference/mhash/configure.xml
+++ b/reference/mhash/configure.xml
@@ -6,7 +6,7 @@
 <section xml:id="mhash.installation" xmlns="http://docbook.org/ns/docbook">
  &reftitle.install;
  <para>
-  Vous aurez besoin de compiler PHP avec l'option
+  On aura besoin de compiler PHP avec l'option
   <option role="configure">--with-mhash[=DIR]</option>
   pour activer cette extension. DIR est le chemin
   du dossier d'installation de la bibliothèque MHASH.

--- a/reference/mhash/constants.xml
+++ b/reference/mhash/constants.xml
@@ -10,7 +10,7 @@
  <para>
   Voici une liste des modes qui sont supportés par mhash.
   Si un mode n'est pas listé ici, mais listé dans la documentation
-  mhash comme étant supporté, vous pouvez considéré que cette liste
+  mhash comme étant supporté, il est possible de considéré que cette liste
   n'est plus à jour.
  </para>
  <variablelist>

--- a/reference/mhash/functions/mhash-keygen-s2k.xml
+++ b/reference/mhash/functions/mhash-keygen-s2k.xml
@@ -67,11 +67,11 @@
      <listitem>
       <para>
        Doit être différent et suffisamment aléatoire pour chaque
-       clé que vous générez, afin de créer des clés différentes.
+       clé qu'on génère, afin de créer des clés différentes.
        Du fait que le paramètre <parameter>salt</parameter>
-       doit être connu lorsque vous vérifiez les clés, c'est une
+       doit être connu lorsqu'on vérifie les clés, c'est une
        bonne idée de l'ajouter à la clé. Le paramètre salt doit avoir
-       une longueur de 8 octets, et sera complété de zéro si vous en
+       une longueur de 8 octets, et sera complété de zéro si l'on en
        fournissez un d'une taille inférieure.
       </para>
      </listitem>

--- a/reference/misc/functions/constant.xml
+++ b/reference/misc/functions/constant.xml
@@ -17,8 +17,8 @@
    Retourne la valeur de la constante <parameter>name</parameter>.
   </simpara>
   <simpara>
-   <function>constant</function> est pratique lorsque vous devez lire la
-   valeur d'une constante, mais que vous ne connaissez son nom que durant
+   <function>constant</function> est pratique lorsqu'il faut lire la
+   valeur d'une constante, mais qu'on ne connaissez son nom que durant
    l'exécution du script. Par exemple, ce nom peut être le résultat
    d'une fonction.
   </simpara>

--- a/reference/misc/functions/defined.xml
+++ b/reference/misc/functions/defined.xml
@@ -24,10 +24,10 @@
   </para>
   <note>
    <para>
-    Si vous voulez vérifier si une variable existe,
+    Pour vérifier si une variable existe,
     utilisez <function>isset</function> car <function>defined</function> 
     ne s'applique qu'aux <link linkend="language.constants">constantes</link>.
-    Si vous voulez voir si une fonction existe, utilisez
+    Pour voir si une fonction existe, utilisez
     <function>function_exists</function>.
    </para>
   </note>

--- a/reference/misc/functions/eval.xml
+++ b/reference/misc/functions/eval.xml
@@ -33,7 +33,7 @@
     La construction de langage <function>eval</function> est
     <emphasis>très dangereuse</emphasis> car elle autorise l'exécution
     de code PHP arbitraire. <emphasis>Son utilisation est vivement
-    déconseillée.</emphasis> Si vous avez soigneusement vérifié qu'il
+    déconseillée.</emphasis> Si on a soigneusement vérifié qu'il
     n'y a pas d'autres options que de l'utiliser, gardez une attention
     toute particulière <emphasis>à ne pas y passer de données provenant
     d'un utilisateur</emphasis> sans les avoir précédemment validées

--- a/reference/misc/functions/get-browser.xml
+++ b/reference/misc/functions/get-browser.xml
@@ -32,11 +32,11 @@
       <para>
        L'entête user agent à analyser. Par défaut, la valeur de
        l'en-tête <literal>User-Agent</literal> est utilisé; cependant, 
-       vous pouvez l'altérer (i.e. cherche d'autres informations sur 
+       il est possible de l'altérer (i.e. cherche d'autres informations sur 
        le navigateur) en passant ce paramètre.
       </para>
       <para>
-       Vous pouvez annuler ce paramètre en y passant la valeur &null;.
+       Il est possible d'annuler ce paramètre en y passant la valeur &null;.
       </para>
      </listitem>
     </varlistentry>
@@ -141,11 +141,11 @@ Array
    <para>
     Afin de pouvoir fonctionner, la directive de configuration 
     <link linkend="ini.browscap">browscap</link> dans le fichier &php.ini; 
-    doit pointer vers le fichier <filename>browscap.ini</filename> de votre
+    doit pointer vers le fichier <filename>browscap.ini</filename> du
     système.
    </para>
    <para>
-    <filename>browscap.ini</filename> n'est pas distribué avec PHP, mais vous
+    <filename>browscap.ini</filename> n'est pas distribué avec PHP, mais l'on
     pouvez le télécharger sur 
     <link xlink:href="&url.browscap.download;">php_browscap.ini</link>.
    </para>

--- a/reference/misc/functions/highlight-file.xml
+++ b/reference/misc/functions/highlight-file.xml
@@ -99,7 +99,7 @@ AddType application/x-httpd-php-source .phps
   <caution>
    <para>
     Beaucoup de soin doit être apporté lors de l'utilisation de
-    <function>highlight_file</function> pour s'assurer que vous ne
+    <function>highlight_file</function> pour s'assurer que l'on ne
     révélez pas d'informations critiques telles que des mots de passe
     ou d'autres informations qui pourraient créer des fuites d'informations.
    </para>

--- a/reference/misc/functions/php-strip-whitespace.xml
+++ b/reference/misc/functions/php-strip-whitespace.xml
@@ -19,7 +19,7 @@
    Retourne le code source PHP du paramètre <parameter>filename</parameter>
    en ayant supprimé les commentaires ainsi que les espaces. Cela peut être
    utile pour comparer la quantité de code avec la quantité de commentaire dans
-   votre code. Cela revient à utiliser la commande <command>php -w</command>
+   le code. Cela revient à utiliser la commande <command>php -w</command>
    depuis la <link linkend="features.commandline">ligne de commande</link>.
   </para>
  </refsect1>
@@ -82,7 +82,7 @@ do_nothing();
 ]]>
     </screen>
     <para>
-     Notez que les commentaires PHP ne sont plus là, tout comme les espaces et les 
+     À noter que les commentaires PHP ne sont plus là, tout comme les espaces et les 
      nouvelles lignes après le premier <literal>echo</literal>.
     </para>
    </example>

--- a/reference/misc/functions/sapi-windows-vt100-support.xml
+++ b/reference/misc/functions/sapi-windows-vt100-support.xml
@@ -119,7 +119,7 @@ true true
   <example>
    <title><function>sapi_windows_vt100_support</function> changing state</title>
    <para>
-    Vous ne pourrez pas activer la fonctionnalité VT100 de <constant>STDOUT</constant> ou <constant>STDERR</constant> si le flux est redirigé.
+    Il ne sera pas possible d'activer la fonctionnalité VT100 de <constant>STDOUT</constant> ou <constant>STDERR</constant> si le flux est redirigé.
    </para>
    <programlisting role="sh">
     php -r "var_export(sapi_windows_vt100_support(STDOUT, true));echo ' ';var_export(sapi_windows_vt100_support(STDERR, true));" 2&gt;NUL

--- a/reference/misc/functions/uniqid.xml
+++ b/reference/misc/functions/uniqid.xml
@@ -40,7 +40,7 @@
      <term><parameter>prefix</parameter></term>
      <listitem>
       <para>
-       Peut être utile, par exemple, pour identifier facilement différents hôtes, si vous générez
+       Peut être utile, par exemple, pour identifier facilement différents hôtes, si on génère
        simultanément sur plusieurs hôtes pouvant générer le
        même identifiant à la même microseconde. (Cela peut se produire
        même sur un seul hôte si l'horloge système est déplacée en arrière,

--- a/reference/misc/functions/unpack.xml
+++ b/reference/misc/functions/unpack.xml
@@ -177,7 +177,7 @@ Array
   <caution>
    <para>
     Il faut noter que PHP gère les valeurs en interne
-    sous forme signée. Si vous déconditionnez
+    sous forme signée. Si on déconditionne
     une valeur qui est aussi grande que la taille utilisée
     en interne par PHP, le résultat se trouvera être
     un nombre négatif, même s'il a été
@@ -186,8 +186,8 @@ Array
   </caution>
   <caution>
    <para>
-    Si vous ne nommez pas un élément, les index numériques à partir de 
-    <literal>1</literal> sont utilisés. Sachez que si vous avez plus d'un 
+    Si on ne nommez pas un élément, les index numériques à partir de 
+    <literal>1</literal> sont utilisés. Sachez que si on a plus d'un 
     élément sans nom, certaines données sont écrasées parce que la numérotation 
     redémarre à partir de <literal>1</literal> pour chaque élément.
    </para>
@@ -215,7 +215,7 @@ array(2) {
 ]]>
      </screen>
      <para>
-      Notez que la première
+      À noter que la première
       valeur depuis le spécificateur <literal>c</literal> est écrasé
       par la première valeur depuis le spécificateur <literal>n</literal>.
      </para>

--- a/reference/mongodb/architecture.xml
+++ b/reference/mongodb/architecture.xml
@@ -378,10 +378,10 @@ foreach ($managers as $manager) {
       <methodname>MongoDB\BSON\Serializable::bsonSerialize</methodname>, ce qui
       signifie qu'elle écrasera toute clé/propriété <property>__pclass</property>
       dans la valeur de retour de
-      <methodname>MongoDB\BSON\Serializable::bsonSerialize</methodname>. Si vous
-      voulez éviter ce comportement et définir votre propre valeur
+      <methodname>MongoDB\BSON\Serializable::bsonSerialize</methodname>. Si l'on
+      voulez éviter ce comportement et définir le propre valeur
       <property>__pclass</property>,
-      vous ne devez <emphasis>pas</emphasis> implémenter
+      il ne faut <emphasis>pas</emphasis> implémenter
       <interfacename>MongoDB\BSON\Persistable</interfacename> et devriez plutôt
       implémenter
       <interfacename>MongoDB\BSON\Serializable</interfacename> directement.
@@ -597,8 +597,8 @@ class UpperClass implements MongoDB\BSON\Persistable
 
    <para>
     A part les trois types collectifs, il est aussi possible de configurer des
-    champs spécifiques dans votre document pour mapper les types de données
-    mentionnés ci-dessous. Par exemple, le type de carte suivant vous permet de
+    champs spécifiques dans le document pour mapper les types de données
+    mentionnés ci-dessous. Par exemple, le type de carte suivant permet de
     mapper chaque document intégré dans un tableau <literal>"addresses"</literal>
     à une classe <classname>Address</classname> <emphasis>et</emphasis> chaque
     champ <literal>"city"</literal> dans ces documents d'adresse intégrés à une
@@ -677,10 +677,10 @@ class UpperClass implements MongoDB\BSON\Persistable
           </para>
           <para>
            La fonctionnalité <property>__pclass</property> repose sur le fait
-           que la propriété soit partie d'un document MongoDB récupéré. Si vous
+           que la propriété soit partie d'un document MongoDB récupéré. Si l'on
            utilisez une
            <link linkend="mongodb-driver-query.construct-queryOptions">projection</link>
-           lors de la recherche de documents, vous devez inclure le champ
+           lors de la recherche de documents, il faut inclure le champ
            <property>__pclass</property> dans la projection pour que cette
            fonctionnalité fonctionne.
           </para>
@@ -840,7 +840,7 @@ class UpperClass implements MongoDB\BSON\Persistable
 
      <para>
       La méthode <methodname>MongoDB\BSON\Unserializable::bsonUnserialize</methodname>
-      de YourClass, OurClass, TheirClass itère sur le tableau et définit les
+      d'YourClass, OurClass, TheirClass itère sur le tableau et définit les
       propriétés sans modifications. Elle <emphasis>ajoute aussi</emphasis> la
       propriété <literal>$unserialized</literal> à &true;:
 

--- a/reference/mongodb/bson/document/fromphp.xml
+++ b/reference/mongodb/bson/document/fromphp.xml
@@ -22,7 +22,7 @@
     <term><parameter>value</parameter> (<type class="union"><type>object</type><type>array</type></type>)</term>
     <listitem>
      <para>
-      Un objet PHP ou un tableau contenant le document. Lorsque vous passez un
+      Un objet PHP ou un tableau contenant le document. Lorsqu'on passe un
       tableau avec des clés numériques, les valeurs numériques sont converties
       en chaînes de caractères et utilisées comme clés de document.
      </para>

--- a/reference/mongodb/bson/int64/tostring.xml
+++ b/reference/mongodb/bson/int64/tostring.xml
@@ -5,7 +5,7 @@
 <refentry xml:id="mongodb-bson-int64.tostring" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>MongoDB\BSON\Int64::__toString</refname>
-  <refpurpose>Retourne la représentation sous forme de chaîne de caractères de Int64</refpurpose>
+  <refpurpose>Retourne la représentation sous forme de chaîne de caractères d'Int64</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -24,7 +24,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Retourne la représentation sous forme de chaîne de caractères de Int64.
+   Retourne la représentation sous forme de chaîne de caractères d'Int64.
   </para>
  </refsect1>
 

--- a/reference/mongodb/bson/objectid/gettimestamp.xml
+++ b/reference/mongodb/bson/objectid/gettimestamp.xml
@@ -6,7 +6,7 @@
 <refentry xml:id="mongodb-bson-objectid.gettimestamp" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>MongoDB\BSON\ObjectId::getTimestamp</refname>
-  <refpurpose>Retourne le composant d'horodatage de ObjectId</refpurpose>
+  <refpurpose>Retourne le composant d'horodatage d'ObjectId</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -31,7 +31,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Retourne le composant d'horodatage de ObjectId.
+   Retourne le composant d'horodatage d'ObjectId.
   </para>
  </refsect1>
 

--- a/reference/mongodb/bson/objectidinterface/gettimestamp.xml
+++ b/reference/mongodb/bson/objectidinterface/gettimestamp.xml
@@ -6,7 +6,7 @@
 <refentry xml:id="mongodb-bson-objectidinterface.gettimestamp" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>MongoDB\BSON\ObjectIdInterface::getTimestamp</refname>
-  <refpurpose>Retourne le composant d'horodatage de ObjectIdInterface</refpurpose>
+  <refpurpose>Retourne le composant d'horodatage d'ObjectIdInterface</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -25,7 +25,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Retourne le composant d'horodatage de ObjectIdInterface.
+   Retourne le composant d'horodatage d'ObjectIdInterface.
   </para>
  </refsect1>
 

--- a/reference/mongodb/bson/objectidinterface/tostring.xml
+++ b/reference/mongodb/bson/objectidinterface/tostring.xml
@@ -6,7 +6,7 @@
 <refentry xml:id="mongodb-bson-objectidinterface.tostring" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>MongoDB\BSON\ObjectIdInterface::__toString</refname>
-  <refpurpose>Retourne la représentation hexadécimale de ObjectIdInterface</refpurpose>
+  <refpurpose>Retourne la représentation hexadécimale d'ObjectIdInterface</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -25,7 +25,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Retourne la représentation hexadécimale de ObjectIdInterface.
+   Retourne la représentation hexadécimale d'ObjectIdInterface.
   </para>
  </refsect1>
 

--- a/reference/mongodb/bson/utcdatetimeinterface/todatetime.xml
+++ b/reference/mongodb/bson/utcdatetimeinterface/todatetime.xml
@@ -6,7 +6,7 @@
 <refentry xml:id="mongodb-bson-utcdatetimeinterface.todatetime" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>MongoDB\BSON\UTCDateTimeInterface::toDateTime</refname>
-  <refpurpose>Retourne la représentation DateTime de UTCDateTimeInterface</refpurpose>
+  <refpurpose>Retourne la représentation DateTime d'UTCDateTimeInterface</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/mongodb/bson/utcdatetimeinterface/tostring.xml
+++ b/reference/mongodb/bson/utcdatetimeinterface/tostring.xml
@@ -6,7 +6,7 @@
 <refentry xml:id="mongodb-bson-utcdatetimeinterface.tostring" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>MongoDB\BSON\UTCDateTimeInterface::__toString</refname>
-  <refpurpose>Retourne la représentation sous forme de chaîne de caractères de UTCDateTimeInterface</refpurpose>
+  <refpurpose>Retourne la représentation sous forme de chaîne de caractères d'UTCDateTimeInterface</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -25,7 +25,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Retourne la représentation sous forme de chaîne de caractères de UTCDateTimeInterface.
+   Retourne la représentation sous forme de chaîne de caractères d'UTCDateTimeInterface.
   </para>
  </refsect1>
 

--- a/reference/mongodb/bson/vectortype.xml
+++ b/reference/mongodb/bson/vectortype.xml
@@ -41,7 +41,7 @@
      <enumidentifier>PackedBit</enumidentifier>
      <enumitemdescription>
        Chaque élément dans le vecteur est une valeur de 1 bit. Lors de la création de vecteurs
-       de ce type, vous pouvez passer soit des valeurs <type>bool</type>, soit des valeurs <type>int</type> de 1 bit, c'est-à-dire <literal>0</literal> ou <literal>1</literal>.
+       de ce type, il est possible de passer soit des valeurs <type>bool</type>, soit des valeurs <type>int</type> de 1 bit, c'est-à-dire <literal>0</literal> ou <literal>1</literal>.
      </enumitemdescription>
     </enumitem>
    </enumsynopsis>

--- a/reference/mongodb/configure.xml
+++ b/reference/mongodb/configure.xml
@@ -78,7 +78,7 @@ $ sudo pecl install --configureoptions='with-mongodb-system-libs="yes" enable-mo
    <link xlink:href="&url.mongodb.libbson;">libbson</link>,
    <link xlink:href="&url.mongodb.libmongoc;">libmongoc</link>, et
    <link xlink:href="&url.mongodb.libmongocrypt;">libmongocrypt</link> et essayera automatiquement
-   de les configurer.
+   de configurer.
   </para>
 
   <note>
@@ -131,7 +131,7 @@ $ brew install shivammathur/extensions/mongodb@8.4
   <note>
    <title>Installer les dépendances requises</title>
    <para>
-    Pour garantir que le support SSL peut être configuré correctement, assurez-vous que les
+    Pour garantir que le support SSL peut être configuré correctement, il faut s'assurer que les
     formules <literal>openssl</literal> et <literal>pkgconf</literal> sont
     installées. Si l'un de ces paquets est manquant, l'extension sera compilée
     avec Secure Transport, ce qui peut entraîner des problèmes de compatibilité.
@@ -172,7 +172,7 @@ PHP Warning:  PHP Startup: Unable to load dynamic library 'mongodb'
   </para>
 
   <para>
-   Assurez-vous que la DLL téléchargée correspond aux propriétés d'exécution PHP
+   Il faut s'assurer que la DLL téléchargée correspond aux propriétés d'exécution PHP
    suivantes :
    <simplelist>
     <member>Version de PHP(<constant>PHP_VERSION</constant>)</member>
@@ -231,7 +231,7 @@ $ sudo make install
    <link xlink:href="&url.mongodb.libbson;">libbson</link>,
    <link xlink:href="&url.mongodb.libmongoc;">libmongoc</link>, et
    <link xlink:href="&url.mongodb.libmongocrypt;">libmongocrypt</link> et
-   essayera de les configurer automatiquement. Si ces bibliothèques sont déjà
+   essayera de configurer automatiquement. Si ces bibliothèques sont déjà
    installées en tant que bibliothèques système, l'extension peut les utiliser en
    spécifiant <literal>--with-mongodb-system-libs=yes</literal> comme option à
    <literal>configure</literal>.
@@ -243,7 +243,7 @@ $ sudo make install
   </para>
 
   <para>
-   Lorsque vous utilisez les versions groupées de libmongoc et libmongocrypt,
+   Lorsqu'on utilise les versions groupées de libmongoc et libmongocrypt,
    l'extension tentera également de sélectionner une bibliothèque SSL selon
    l'option de <literal>configuration</literal> <literal>--with-mongodb-ssl</literal>.
    À partir de la version 1.17.0 de l'extension, OpenSSL est toujours préféré par défaut.
@@ -260,7 +260,7 @@ $ sudo make install
    </para>
 
    <para>
-    Lorsque vous utilisez Homebrew sur macOS, il est courant qu'un système ait
+    Lorsqu'on utilise Homebrew sur macOS, il est courant qu'un système ait
     plusieurs versions d'OpenSSL installées. Pour garantir que la version d'OpenSSL
     souhaitée est sélectionnée, la variable d'environnement <literal>PKG_CONFIG_PATH</literal>
     peut être utilisée pour contrôler le chemin de recherche de <literal>pkg-config</literal>.
@@ -278,7 +278,7 @@ Installing shared extensions:     /usr/lib/php/extensions/debug-non-zts-20220829
   </para>
 
   <para>
-   Assurez-vous que l'option <link linkend="ini.extension-dir">extension_dir</link>
+   Il faut s'assurer que l'option <link linkend="ini.extension-dir">extension_dir</link>
    dans &php.ini; pointe vers le répertoire où <filename>mongodb.so</filename>
    a été installé. L'option peut être interrogée en exécutant :
    <programlisting role="shell">

--- a/reference/mongodb/functions/bson/tojson.xml
+++ b/reference/mongodb/functions/bson/tojson.xml
@@ -48,7 +48,7 @@
     format JSON étendu de MongoDB ne définit pas une autre représentation pour 
     ces valeurs (<link xlink:href="&url.mongodb.libbson;">libbson</link> va 
     produire <literal>nan</literal> et <literal>inf</literal> littérallement, 
-    qui ne peuvent pas être analysés comme JSON valide). Si vous travaillez avec 
+    qui ne peuvent pas être analysés comme JSON valide). Si on travaille avec 
     BSON qui peut contenir des nombres non finis, utilisez svp 
     <function>MongoDB\BSON\toCanonicalExtendedJSON</function> ou  
     <function>MongoDB\BSON\toRelaxedExtendedJSON</function>.

--- a/reference/mongodb/mongodb/driver/command/construct.xml
+++ b/reference/mongodb/mongodb/driver/command/construct.xml
@@ -196,7 +196,7 @@ array(13) {
    <title>Exemple avec <function>MongoDB\Driver\Command::__construct</function></title>
    <para>
     Les commandes peuvent également accepter des options, dans le cadre de la 
-    structure normale que vous créez pour envoyer au serveur. Par exemple, 
+    structure normale qu'on crée pour envoyer au serveur. Par exemple, 
     l'option <literal>maxTimeMS</literal> peut être passée avec la plupart des 
     commandes pour restreindre la durée pendant laquelle une commande spécifique 
     peut s'exécuter sur le serveur.

--- a/reference/mongodb/mongodb/driver/cursor.xml
+++ b/reference/mongodb/mongodb/driver/cursor.xml
@@ -94,7 +94,7 @@
     </para>
     <para>
      Parce que <classname>MongoDB\Driver\Cursor</classname> implémente l'interface
-     <interfacename>Traversable</interfacename>, vous pouvez simplement itérer 
+     <interfacename>Traversable</interfacename>, il est possible de simplement itérer 
      sur le jeu de résultats avec
      <link linkend="control-structures.foreach"><literal>foreach</literal></link>.
     </para>

--- a/reference/mongodb/mongodb/driver/exception/runtimeexception/haserrorlabel.xml
+++ b/reference/mongodb/mongodb/driver/exception/runtimeexception/haserrorlabel.xml
@@ -18,8 +18,8 @@
   <para>
    Retourne si le <parameter>errorLabel</parameter> a été défini pour cette exception.
    Les labels d'erreurs sont définis soit par le serveur soit par l'extension pour
-   indiquer des situations spécifiques où vous voudriez décider comment vous gérerez
-   une exception spécifique. Une situation commune serait de déterminer si vous pouvez
+   indiquer des situations spécifiques où on voudrait décider comment on gèrera
+   une exception spécifique. Une situation commune serait de déterminer si l'on peut
    relancer une transaction qui a échoué à cause d'une erreur passagère
    (telle qu'une erreur de réseau, ou un conflit de transaction) sans encombre.
    Des exemples de labels d'erreurs sont <literal>TransientTransactionError</literal>

--- a/reference/mongodb/mongodb/driver/manager.xml
+++ b/reference/mongodb/mongodb/driver/manager.xml
@@ -60,7 +60,7 @@
      <function>var_dump</function>er un
      <classname>MongoDB\Driver\Manager</classname> affichera divers
      détails sur le Manager qui ne sont pas normalement exposés.
-     Cela peut être utile pour déboguer comment le pilote voit votre configuration MongoDB, et
+     Cela peut être utile pour déboguer comment le pilote voit le configuration MongoDB, et
      quels options sont utilisées.
     </para>
     <programlisting role="php">

--- a/reference/mongodb/mongodb/driver/query/construct.xml
+++ b/reference/mongodb/mongodb/driver/query/construct.xml
@@ -120,8 +120,8 @@
            <para>
             Le flux de données en aval à pleine puissance dans plusieurs paquets
             "more", en supposant que le client lira entièrement toutes les données
-            interrogées. Plus rapide lorsque vous tirez beaucoup de données et
-            savez que vous voulez tout tirer. Remarque : le client n'est pas autorisé
+            interrogées. Plus rapide lorsqu'on tire beaucoup de données et
+            savez qu'on veut tout tirer. Remarque : le client n'est pas autorisé
             à ne pas lire toutes les données sauf s'il ferme la connexion.
            </para>
            <para>
@@ -250,10 +250,10 @@
             pour déterminer quels champs inclure dans les documents retournés.
            </para>
            <para>
-            Si vous utilisez la
+            Lors de l'utilisation de la
             <link linkend="mongodb.persistence.deserialization">fonctionnalité ODM</link>
             pour désérialiser les documents en tant que leur classe PHP d'origine,
-            assurez-vous d'inclure le champ <property>__pclass</property> dans la
+            il faut s'assurer d'inclure le champ <property>__pclass</property> dans la
             projection. Cela est nécessaire pour que la désérialisation fonctionne
             et sans cela, l'extension renverra (par défaut) un objet
             <classname>stdClass</classname> à la place.

--- a/reference/mongodb/mongodb/driver/readconcern.xml
+++ b/reference/mongodb/mongodb/driver/readconcern.xml
@@ -135,7 +135,7 @@
        en cas de perte d'un membre de l'ensemble de réplicas.
       </para>
       <para>
-       Vous pouvez spécifier un niveau de lecture linéarisable pour les opérations de lecture sur le
+       Il est possible de spécifier un niveau de lecture linéarisable pour les opérations de lecture sur le
        primaire uniquement.
       </para>
       <para>

--- a/reference/mongodb/mongodb/driver/readconcern/construct.xml
+++ b/reference/mongodb/mongodb/driver/readconcern/construct.xml
@@ -27,7 +27,7 @@
     <listitem>
      <para>
       Le <link xlink:href="&url.mongodb.docs.readconcern;#read-concern-levels">niveau du read concern</link>.
-      Vous pouvez utiliser, mais n'êtes pas limité à, une des
+      Il est possible d'utiliser, mais n'êtes pas limité à, une des
       <link linkend="mongodb-driver-readconcern.constants">constantes de classe</link>.
      </para>
     </listitem>

--- a/reference/mongodb/mongodb/driver/readpreference/construct.xml
+++ b/reference/mongodb/mongodb/driver/readpreference/construct.xml
@@ -96,7 +96,7 @@
     <term><parameter>tagSets</parameter></term>
     <listitem>
      <para>
-      Les jeux de tag vous permettent de cibler des opérations de lecture sur des 
+      Les jeux de tag permettent de cibler des opérations de lecture sur des 
       membres spécifiques d'un jeu de réplicas. Ce paramètre doit être un tableau de 
       tableaux associatifs, qui contiennent chacun zéro ou plusieurs paires 
       clé/valeur. Lors de la sélection d'un serveur pour une opération de lecture, 

--- a/reference/mongodb/mongodb/driver/session/advanceclustertime.xml
+++ b/reference/mongodb/mongodb/driver/session/advanceclustertime.xml
@@ -21,7 +21,7 @@
    En utilisant cette méthode en conjonction avec
    <methodname>MongoDB\Driver\Session::advanceOperationTime</methodname> pour copier
    les temps du cluster et des opérations d'une autre session
-   vous pouvez vous assurer que les opérations dans cette session sont cohérentes
+   il est possible de s'assurer que les opérations dans cette session sont cohérentes
    avec la dernière opération dans l'autre session.
   </para>
  </refsect1>

--- a/reference/mongodb/mongodb/driver/session/advanceoperationtime.xml
+++ b/reference/mongodb/mongodb/driver/session/advanceoperationtime.xml
@@ -21,7 +21,7 @@
    En utilisant cette méthode en conjonction avec
    <methodname>MongoDB\Driver\Session::advanceClusterTime</methodname> pour copier
    les temps d'opération et de cluster d'une autre session
-   vous pouvez vous assurer que les opérations dans cette session sont cohérentes
+   il est possible de s'assurer que les opérations dans cette session sont cohérentes
    avec la dernière opération dans l'autre session.
   </para>
  </refsect1>

--- a/reference/mongodb/mongodb/driver/session/starttransaction.xml
+++ b/reference/mongodb/mongodb/driver/session/starttransaction.xml
@@ -15,7 +15,7 @@
   </methodsynopsis>
   <para>
    Commence une transaction multi-document associée à la session. À un moment donné,
-   vous ne pouvez avoir qu'une seule transaction ouverte pour une session. Après avoir
+   on ne pouvez avoir qu'une seule transaction ouverte pour une session. Après avoir
    commencé une transaction, l'objet de session doit être passé à chaque opération via
    l'option <literal>"session"</literal> (par exemple
    <methodname>MongoDB\Driver\Manager::executeBulkWrite</methodname>) pour associer

--- a/reference/mongodb/mongodb/driver/writeresult/getinsertedcount.xml
+++ b/reference/mongodb/mongodb/driver/writeresult/getinsertedcount.xml
@@ -5,7 +5,7 @@
 <refentry xml:id="mongodb-driver-writeresult.getinsertedcount" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>MongoDB\Driver\WriteResult::getInsertedCount</refname>
-  <refpurpose>Renvoie le nombre de documents insérés (à l'exception de Upserts)</refpurpose>
+  <refpurpose>Renvoie le nombre de documents insérés (à l'exception d'Upserts)</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -28,7 +28,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Renvoie le nombre de documents insérés (à l'exception de Upserts permettent).
+   Renvoie le nombre de documents insérés (à l'exception d'Upserts permettent).
   </para>
  </refsect1>
 

--- a/reference/mongodb/security.xml
+++ b/reference/mongodb/security.xml
@@ -7,36 +7,36 @@
  <section xml:id="mongodb.security.request_injection">
   <title>Attaques par injection de requêtes</title>
   <para>
-   Si vous passez des paramètres <literal>$_GET</literal> (ou <literal>$_POST</literal>)
-   à vos requêtes, assurez-vous de les convertir en chaînes de caractères avant.
+   Si on passe des paramètres <literal>$_GET</literal> (ou <literal>$_POST</literal>)
+   à les requêtes, il faut s'assurer de convertir en chaînes de caractères avant.
    Les utilisateurs peuvent insérer des tableaux associatifs dans les requêtes
    GET et POST, qui pourraient alors devenir des requêtes $ indésirables.
   </para>
 
   <para>
-   Un exemple assez anodin : supposez que vous cherchez les informations d'un
+   Un exemple assez anodin : supposez qu'on cherche les informations d'un
    utilisateur avec la requête <emphasis>http://www.example.com?username=bob</emphasis>.
-   Votre application crée la requête
+   Le application crée la requête
    <literal>$q = new \MongoDB\Driver\Query( [ 'username' => $_GET['username'] ])</literal>.
   </para>
 
   <para>
    Cela fonctionne bien, mais quelqu'un pourrait subvertir cela en passant
    <emphasis>http://www.example.com?username[$ne]=foo</emphasis>, que PHP
-   transformera magiquement en un tableau associatif, transformant votre requête en
+   transformera magiquement en un tableau associatif, transformant le requête en
    <literal>$q = new \MongoDB\Driver\Query( [ 'username' => [ '$ne' => 'foo' ] ] )</literal>,
-   qui renverra tous les utilisateurs dont le nom n'est pas "foo" (tous vos utilisateurs, probablement).
+   qui renverra tous les utilisateurs dont le nom n'est pas "foo" (tous les utilisateurs, probablement).
   </para>
 
   <para>
-   C'est une attaque assez facile à contrer : assurez-vous que les paramètres
+   C'est une attaque assez facile à contrer : il faut s'assurer que les paramètres
    <literal>$_GET</literal> et <literal>$_POST</literal> sont du type attendu
-   avant de les envoyer à la base de données. PHP dispose de la fonction
-   <function>filter_var</function> pour vous aider.
+   avant d'envoyer à la base de données. PHP dispose de la fonction
+   <function>filter_var</function> pour aider.
   </para>
 
   <para>
-   Notez que ce type d'attaque peut être utilisé avec n'importe quelle interaction
+   À noter que ce type d'attaque peut être utilisé avec n'importe quelle interaction
    avec la base de données qui localise un document, y compris les mises à jour,
    les upserts, les suppressions et les commandes findAndModify.
   </para>
@@ -50,12 +50,12 @@
  <section xml:id="mongodb.security.script_injection">
   <title>Attaque par injection de scripts</title>
   <para>
-   Si vous utilisez JavaScript, assurez-vous que toutes les variables qui
+   Lors de l'utilisation de JavaScript, il faut s'assurer que toutes les variables qui
    traversent la frontière PHP-JavaScript sont passées dans le champ
    <literal>scope</literal> de <classname>MongoDB\BSON\Javascript</classname>,
    et non interpolées dans la chaîne JavaScript. Cela peut se produire lorsque
-   vous utilisez des clauses <literal>$where</literal> dans les requêtes, les
-   commandes mapReduce et group, et à tout autre moment où vous pouvez passer
+   on utilise des clauses <literal>$where</literal> dans les requêtes, les
+   commandes mapReduce et group, et à tout autre moment où il est possible de passer
    du JavaScript à la base de données.
   </para>
   <para>
@@ -130,14 +130,14 @@ $r = $m->executeCommand( 'dramio', $cmd );
 
   <para>
    Utiliser des arguments aide à empêcher l'exécution d'entrées malveillantes par
-   la base de données. Cependant, vous devez vous assurer que votre code ne
+   la base de données. Cependant, il faut s'assurer que le code ne
    retourne pas et n'exécute pas l'entrée de toute façon ! Il est préférable
    d'éviter d'exécuter <emphasis>quelconque</emphasis> JavaScript sur le serveur
    en premier lieu.
   </para>
 
   <para>
-   Nous vous recommandons de rester à l'écart de la clause <link
+   Il est recommandé de rester à l'écart de la clause <link
    xlink:href="&url.mongodb.docs;reference/operator/query/where/#considerations">$where</link>
    dans les requêtes, car elle impacte significativement les performances. Dans
    la mesure du possible, utilisez soit des opérateurs de requête normaux, soit

--- a/reference/mongodb/tutorial.xml
+++ b/reference/mongodb/tutorial.xml
@@ -8,7 +8,7 @@
   <info xml:id="mongodb.tutorial.intro">
    <abstract>
     <para>
-     Dans cette section, vous trouverez plusieurs tutoriels sur l'utilisation du
+     Dans cette section, on trouvera plusieurs tutoriels sur l'utilisation du
      pilote MongoDB pour PHP.
     </para>
    </abstract>

--- a/reference/mongodb/tutorial/library.xml
+++ b/reference/mongodb/tutorial/library.xml
@@ -53,7 +53,7 @@ Generating autoload files
    <para>
     Composer va créer plusieurs fichiers: <code>composer.json</code>,
     <code>composer.lock</code>, et un répertoire <code>vendor</code> qui
-    contiendra la bibliothèque et toutes les autres dépendances que votre projet pourrait nécessiter.
+    contiendra la bibliothèque et toutes les autres dépendances que le projet pourrait nécessiter.
    </para>
   </section>
 
@@ -61,10 +61,10 @@ Generating autoload files
    <title>Utiliser la bibliothèque PHP</title>
 
    <para>
-    En plus de gérer vos dépendances, Composer vous fournira également un
-    autochargement (pour les classes de ces dépendances). Assurez-vous
-    qu'il est inclus au début de votre script ou dans le code d'amorçage de
-    votre application:
+    En plus de gérer les dépendances, Composer fournira également un
+    autochargement (pour les classes de ces dépendances). Il faut s'assurer
+    qu'il est inclus au début du script ou dans le code d'amorçage de
+    le application:
     <programlisting role="php">
 <![CDATA[
 <?php
@@ -75,14 +75,14 @@ require 'vendor/autoload.php';
    </para>
 
    <para>
-    Avec cela fait, vous pouvez maintenant utiliser n'importe quelle
+    Avec cela fait, il est possible de maintenant utiliser n'importe quelle
     fonctionnalité comme décrit dans la
     <link xlink:href="&url.mongodb.library.docs;">documentation de la bibliothèque</link>.
    </para>
 
    <para>
-    Si vous avez utilisé des pilotes MongoDB dans d'autres langages, l'API de la
-    bibliothèque devrait vous sembler familière. Elle contient une classe
+    Si on a utilisé des pilotes MongoDB dans d'autres langages, l'API de la
+    bibliothèque devrait sembler familière. Elle contient une classe
     <link xlink:href="&url.mongodb.library.apidocs;/class/MongoDBClient/">Client</link>
     pour se connecter à MongoDB, une classe
     <link xlink:href="&url.mongodb.library.apidocs;/class/MongoDBDatabase/">Database</link>
@@ -94,7 +94,7 @@ require 'vendor/autoload.php';
    </para>
 
    <para>
-    En tant qu'exemple, voici comment vous insérez un document dans la collection
+    En tant qu'exemple, voici comment on insère un document dans la collection
     <emphasis>beers</emphasis> de la base de données <emphasis>demo</emphasis>:
     <programlisting role="php">
 <![CDATA[
@@ -120,8 +120,8 @@ echo "Inserted with Object ID '{$result->getInsertedId()}'";
    </para>
 
    <para>
-    Après l'insertion, vous pouvez interroger les données que vous venez d'insérer.
-    Pour cela, vous utilisez la méthode <code>find</code>, qui retourne un curseur
+    Après l'insertion, il est possible d'interroger les données qu'on vient d'insérer.
+    Pour cela, on utilise la méthode <code>find</code>, qui retourne un curseur
     itérable:
     <programlisting role="php">
 <![CDATA[

--- a/reference/mqseries/book.xml
+++ b/reference/mqseries/book.xml
@@ -21,7 +21,7 @@
    C est nécessaire.
   </simpara>
   <simpara>
-   Pour les MQ-options, MQ-structures, MQ-results etc., reportez-vous au "WebSphere MQ
+   Pour les MQ-options, MQ-structures, MQ-results etc., se reporter au "WebSphere MQ
    Application Programming Guide" et "WebSphere MQ Application Programming
    Reference".
   </simpara>

--- a/reference/mqseries/constants.xml
+++ b/reference/mqseries/constants.xml
@@ -7,7 +7,7 @@
  <simpara>
   Pour chaque constante WebSphere MQ Constant, il y a un équivalent mqseries.
  </simpara>
- <simpara>Pour les définitions et utilisation, reportez-vous au
+ <simpara>Pour les définitions et utilisation, se reporter au
  "WebSphere MQ Application Programming Guide" et "WebSphere MQ
   Application Programming Reference red books".
  </simpara>

--- a/reference/mqseries/functions/mqseries-put1.xml
+++ b/reference/mqseries/functions/mqseries-put1.xml
@@ -26,7 +26,7 @@
    La file d'attente n'a pas besoin d'être ouverte.
   </simpara>
   <simpara>
-   Vous pouvez utiliser à la fois des appels à <function>mqseries_put</function>
+   Il est possible d'utiliser à la fois des appels à <function>mqseries_put</function>
    ainsi qu'à <function>mqseries_put1</function> pour ajouter des messages
    à une file d'attente ; quel appel à utiliser dépend des circonstances.
    calls to put messages on a queue; which call to use depends on the circumstances.

--- a/reference/mqseries/resources.xml
+++ b/reference/mqseries/resources.xml
@@ -5,7 +5,7 @@
 <section xmlns="http://docbook.org/ns/docbook" xml:id="mqseries.resources">
  &reftitle.resources;
  <simpara>
-  Cette extension définit une ressource de connexion et de object_handle.
+  Cette extension définit une ressource de connexion et d'object_handle.
  </simpara>
  <simpara>
   Les fonctions <function>mqseries_conn</function> et <function>mqseries_connx</function> définissent

--- a/reference/mqseries/setup.xml
+++ b/reference/mqseries/setup.xml
@@ -11,11 +11,11 @@
   &reftitle.required;
   <simpara>
    Une installation fonctionnelle IBM WebSphere MQ. Pour la compilation de l'extension,
-   le SDK de IBM WebSphere MQ est aussi nécessaire.
+   le SDK d'IBM WebSphere MQ est aussi nécessaire.
   </simpara>
   <note>
    <simpara>
-    Soyez prévenus que lorsque vous fonctionnez avec le client IBM WebSphere MQ,
+    Il faut savoir que lorsqu'on fonctionne avec le client IBM WebSphere MQ,
     certaines méthodes ne sont pas disponibles. Ce n'est pas un problème avec
     l'extension, mais simplement la manière de fonctionner de 
     WebSphere MQ Client Interface.

--- a/reference/mysql/book.xml
+++ b/reference/mysql/book.xml
@@ -17,7 +17,7 @@
    <link linkend="ref.pdo-mysql">PDO_MySQL</link> devrait être utilisée. Voir aussi la <link linkend="mysqlinfo.api.choosing">vue d'ensemble de l'API MySQL</link> pour plus d'aide dans le choix d'une API MySQL.
   </simpara>
   <simpara>
-   Ces fonctions vous permettent d'accéder aux bases de données
+   Ces fonctions permettent d'accéder aux bases de données
    MySQL. Le site officiel de cette base est
    <link xlink:href="&url.mysql;">&url.mysql;</link>.
   </simpara>

--- a/reference/mysql/configure.xml
+++ b/reference/mysql/configure.xml
@@ -21,8 +21,8 @@
   Pour cela, utilisez plutôt l'extension <link linkend="book.mysqli">MySQLi</link>.
  </simpara>
  <simpara>
-  Si vous voulez installer l'extension mysqli en même temps que l'extension
-  mysql, vous devez utiliser la même bibliothèque client afin d'éviter les
+  Pour installer l'extension mysqli en même temps que l'extension
+  mysql, il faut utiliser la même bibliothèque client afin d'éviter les
   conflits.
  </simpara>
 
@@ -34,7 +34,7 @@
    téléchargée depuis le site de <link xlink:href="&url.mysql;">MySQL</link>.
   </simpara>
   <table xml:id="mysql.installation.compile.support">
-   <title>Matrice du support de ext/mysql</title>
+   <title>Matrice du support d'ext/mysql</title>
    <tgroup cols="5">
     <thead>
      <row>
@@ -114,7 +114,7 @@
    </simpara>
    <note>
     <simpara>
-     Si lorsque vous démarrez le serveur web une erreur similaire à ceci apparaît :
+     Si lorsqu'on démarre le serveur web une erreur similaire à ceci apparaît :
      <literal>"Unable to load dynamic library './php_mysql.dll'"</literal>,
      c'est parce que <filename>php_mysql.dll</filename> et/ou
      <filename>libmysql.dll</filename> n'ont pû être trouvés par le système.
@@ -136,15 +136,15 @@
   <warning>
    <simpara>
     Des crashes et des problèmes de démarrage de PHP peuvent
-    être rencontrés lorsque vous chargez cette fonction en même temps que
-    l'extension recode. Voyez l'extension <link linkend="ref.recode">recode</link>
+    être rencontrés lorsqu'on charge cette fonction en même temps que
+    l'extension recode. Voir l'extension <link linkend="ref.recode">recode</link>
     pour plus de détails.
    </simpara>
   </warning>
   <note>
    <simpara>
-    Si vous avez besoin d'autres jeux de caractères que celui par
-    défaut (<emphasis>latin</emphasis>), vous devez installer la
+    Si on a besoin d'autres jeux de caractères que celui par
+    défaut (<emphasis>latin</emphasis>), il faut installer la
     bibliothèque externe libmysqlclient (non fournie), compilée avec ce
     jeu de caractères.
    </simpara>

--- a/reference/mysql/functions/mysql-affected-rows.xml
+++ b/reference/mysql/functions/mysql-affected-rows.xml
@@ -52,7 +52,7 @@
    retourner 0 avec les versions de MySQL antérieures à 4.1.2.
   </simpara>
   <simpara>
-   Lorsque vous utilisez UPDATE, MySQL ne mettra pas à jour les colonnes si
+   Lorsqu'on utilise UPDATE, MySQL ne mettra pas à jour les colonnes si
    la nouvelle valeur est identique à l'ancienne. Il est donc possible que
    <function>mysql_affected_rows</function> ne représente pas forcément
    le nombre de lignes correspondantes mais plutôt le nombre de lignes
@@ -134,8 +134,8 @@ Lignes modifiées : 10
   <note>
    <title>Transactions</title>
    <simpara>
-    Si vous utilisez des transactions, vous devez appeler
-    <function>mysql_affected_rows</function> après votre requête INSERT,
+    Lors de l'utilisation de des transactions, il faut appeler
+    <function>mysql_affected_rows</function> après le requête INSERT,
     UPDATE ou DELETE et non après le COMMIT.
    </simpara>
   </note>

--- a/reference/mysql/functions/mysql-connect.xml
+++ b/reference/mysql/functions/mysql-connect.xml
@@ -186,10 +186,10 @@ mysql_close($link);
   &reftitle.notes;
   <note>
    <simpara>
-    Toutes les fois que vous spécifiez &quot;localhost&quot; ou
+    Toutes les fois qu'on spécifie &quot;localhost&quot; ou
     &quot;localhost:port&quot; en tant que serveur, la bibliothèque client
     MySQL surchargera cela et essaiera de se connecter à un socket local
-    (nommé pipe sous Windows). Si vous souhaitez utiliser TCP/IP, utilisez
+    (nommé pipe sous Windows). Pour utiliser TCP/IP, utilisez
     &quot;127.0.0.1&quot; au lieu de &quot;localhost&quot;. Si la bibliothèque
     client MySQL essaie de se connecter au mauvais socket local,
     le chemin correct doit être défini comme <link linkend="ini.mysql.default-host">mysql.default_host</link>

--- a/reference/mysql/functions/mysql-db-query.xml
+++ b/reference/mysql/functions/mysql-db-query.xml
@@ -114,9 +114,9 @@ mysql_free_result($result);
    <simpara>
     Soyez avertis que cette fonction <emphasis role="strong">ne restaure pas</emphasis>
     la base de données qui était utilisée initialement. En d'autres termes,
-    vous ne pouvez utiliser cette fonction pour exécuter
+    on ne pouvez utiliser cette fonction pour exécuter
     <emphasis>temporairement</emphasis> une requête SQL dans une autre
-    base de données, il vous faudra sélectionner manuellement la bonne
+    base de données, il faudra sélectionner manuellement la bonne
     base à nouveau. Il est fortement recommandé d'utiliser la syntaxe SQL
     <literal>database.table</literal> ou <function>mysql_select_db</function>
     au lieu de cette fonction.

--- a/reference/mysql/functions/mysql-drop-db.xml
+++ b/reference/mysql/functions/mysql-drop-db.xml
@@ -85,7 +85,7 @@ echo 'Erreur lors de l\'effacement de la base : ' . mysql_error() . "\n";
   &reftitle.notes;
   <warning>
    <simpara>
-    Cette fonction ne sera pas disponible si vous avez compilé MySQL
+    Cette fonction ne sera pas disponible si on a compilé MySQL
     avec la bibliothèque cliente MySQL 4.x.
    </simpara>
   </warning>

--- a/reference/mysql/functions/mysql-errno.xml
+++ b/reference/mysql/functions/mysql-errno.xml
@@ -31,11 +31,11 @@
    Les erreurs qui
    sont remontées depuis le serveur MySQL ne sont plus des alertes.
    À la place, il faut utiliser <function>mysql_errno</function> pour
-   obtenir le numéro d'erreur. Notez que cette fonction retourne uniquement
+   obtenir le numéro d'erreur. À noter que cette fonction retourne uniquement
    le code erreur depuis la dernière fonction MySQL exécutée
    (n'incluant pas les fonctions <function>mysql_error</function> et
-   <function>mysql_errno</function>), donc, si vous voulez l'utiliser,
-   assurez-vous de récupérer la valeur avant d'appeler une autre fonction
+   <function>mysql_errno</function>), donc, pour l'utiliser,
+   il faut s'assurer de récupérer la valeur avant d'appeler une autre fonction
    MySQL.
   </simpara>
  </refsect1>

--- a/reference/mysql/functions/mysql-error.xml
+++ b/reference/mysql/functions/mysql-error.xml
@@ -29,12 +29,12 @@
    <function>mysql_error</function> retourne le message d'erreur
    généré par la dernière commande MySQL.
    Les erreurs retournées par le serveur MySQL ne génèrent plus
-   de message d'alerte. À la place, vous devez utiliser la fonction
+   de message d'alerte. À la place, il faut utiliser la fonction
    <function>mysql_error</function> pour lire le contenu du message.
-   Notez que cette fonction ne retourne que le texte de l'erreur la
+   À noter que cette fonction ne retourne que le texte de l'erreur la
    plus récente(n'incluant pas <function>mysql_error</function> et
-   <function>mysql_errno</function>), ce qui fait que si vous souhaitez
-   l'utiliser, vous devez vous assurer de sa valeur avant de lancer une autre
+   <function>mysql_errno</function>), ce qui fait que si on souhaite
+   l'utiliser, il faut s'assurer de sa valeur avant de lancer une autre
    requête.
   </simpara>
  </refsect1>

--- a/reference/mysql/functions/mysql-fetch-array.xml
+++ b/reference/mysql/functions/mysql-fetch-array.xml
@@ -59,20 +59,20 @@
    Retourne un tableau de chaînes qui correspond à la ligne récupérée ou &false;
    s'il n'y a plus de lignes. Le type de tableau retourné dépend de la
    définition du paramètre <parameter>result_type</parameter>.
-   En utilisant <constant>MYSQL_BOTH</constant> (défaut), vous
+   En utilisant <constant>MYSQL_BOTH</constant> (défaut), l'on
    récupérerez un tableau contenant des indices associatifs et numériques.
-   En utilisant <constant>MYSQL_ASSOC</constant>, vous ne récupérerez que
+   En utilisant <constant>MYSQL_ASSOC</constant>, on ne récupérerez que
    les indices associatifs (comme le fonctionnement de la fonction
    <function>mysql_fetch_assoc</function>), en utilisant <constant>MYSQL_NUM</constant>,
-   vous ne récupérerez que les indices numériques (comme le fonctionnement
+   on ne récupérerez que les indices numériques (comme le fonctionnement
    de la fonction <function>mysql_fetch_row</function>).
   </simpara>
   <simpara>
    Si plusieurs colonnes portent le même nom, la dernière colonne
    aura la priorité. Pour accéder aux autres colonnes du
-   même nom, vous devez utiliser l'index numérique, ou
+   même nom, il faut utiliser l'index numérique, ou
    faire un alias pour chaque colonne. Pour les alias de colonnes,
-   vous ne pourrez pas accéder aux contenus avec les noms originaux
+   il ne sera pas possible d'accéder aux contenus avec les noms originaux
    des colonnes.
   </simpara>
  </refsect1>

--- a/reference/mysql/functions/mysql-fetch-assoc.xml
+++ b/reference/mysql/functions/mysql-fetch-assoc.xml
@@ -53,7 +53,7 @@
   </simpara>
   <simpara>
    Si plusieurs colonnes portent le même nom, la dernière aura la priorité.
-   Pour accéder aux autres colonnes du même nom, vous devez utiliser
+   Pour accéder aux autres colonnes du même nom, il faut utiliser
    la fonction <function>mysql_fetch_row</function> avec les indices numériques
    ou utiliser les alias sur les noms.
    Regardez la documentation sur la fonction <function>mysql_fetch_array</function>

--- a/reference/mysql/functions/mysql-fetch-object.xml
+++ b/reference/mysql/functions/mysql-fetch-object.xml
@@ -125,7 +125,7 @@ var_dump($obj);
     <function>mysql_fetch_object</function> est identique à
     <function>mysql_fetch_array</function>, à la
     différence qu'elle retourne un objet à la place
-    d'un tableau. Vous pourrez ainsi accéder aux valeurs
+    d'un tableau. On pourra ainsi accéder aux valeurs
     des champs par leur nom, mais plus par leur offset (les
     nombres ne sont pas des noms MySQL).
    </simpara>

--- a/reference/mysql/functions/mysql-free-result.xml
+++ b/reference/mysql/functions/mysql-free-result.xml
@@ -30,8 +30,8 @@
   </simpara>
   <simpara>
    <function>mysql_free_result</function> n'est à appeler que si
-   vous avez peur d'utiliser trop de mémoire durant l'exécution
-   de votre script. Toute la mémoire associée à
+   on a peur d'utiliser trop de mémoire durant l'exécution
+   du script. Toute la mémoire associée à
    l'identifiant de résultat sera automatiquement libérée.
   </simpara>
  </refsect1>

--- a/reference/mysql/functions/mysql-insert-id.xml
+++ b/reference/mysql/functions/mysql-insert-id.xml
@@ -79,18 +79,18 @@ printf("Le dernier ID inséré dans est le id %d\n", mysql_insert_id());
     <function>mysql_insert_id</function> convertira le type retourné
     de la fonction native MySQL C API <literal>mysql_insert_id()</literal>
     en un type <literal>long</literal> (nommé <type>int</type> en PHP).
-    Si votre colonne AUTO_INCREMENT a une colonne de type BIGINT (64 bits),
+    Si le colonne AUTO_INCREMENT a une colonne de type BIGINT (64 bits),
     la conversion peut résulter en une valeur incorrecte. À la place, utilisez
     la fonction SQL interne à MySQL LAST_INSERT_ID() dans une requête SQL.
     Pour plus d'informations sur les valeurs entières maximales en PHP,
-    reportez-vous à la documentation sur les
+    se reporter à la documentation sur les
     <link linkend="language.types.integer">entiers</link>.
    </simpara>
   </caution>
   <note>
    <simpara>
     Parce que <function>mysql_insert_id</function> agit sur la dernière requête
-    exécutée, assurez-vous d'appeler la fonction <function>mysql_insert_id</function>
+    exécutée, il faut s'assurer d'appeler la fonction <function>mysql_insert_id</function>
     immédiatement après l'exécution de la requête qui a générée la valeur.
    </simpara>
   </note>

--- a/reference/mysql/functions/mysql-num-rows.xml
+++ b/reference/mysql/functions/mysql-num-rows.xml
@@ -74,7 +74,7 @@ echo "$num_rows Rows\n";
   &reftitle.notes;
   <note>
    <simpara>
-    Si vous utilisez <function>mysql_unbuffered_query</function>,
+    Lors de l'utilisation de <function>mysql_unbuffered_query</function>,
     <function>mysql_num_rows</function> ne retournera pas
     une valeur correcte tant que toutes les lignes du jeu de résultats
     n'auront pas été récupérées.

--- a/reference/mysql/functions/mysql-pconnect.xml
+++ b/reference/mysql/functions/mysql-pconnect.xml
@@ -126,7 +126,7 @@
   &reftitle.notes;
   <note>
    <simpara>
-    Notez que les connexions persistantes ne fonctionnent que si vous utilisez
+    À noter que les connexions persistantes ne fonctionnent que si on utilise
     PHP en version module. Lisez la section sur les
     <link linkend="features.persistent-connections">connexions persistantes
     aux bases de données</link> pour plus d'informations.
@@ -135,7 +135,7 @@
   <warning>
    <simpara>
     L'utilisation des connexions persistantes requiert des paramétrages
-    d'Apache et de MySQL pour vous assurer que vous n'atteindrez pas
+    d'Apache et de MySQL pour s'assurer que l'on n'atteindrez pas
     la limite maximale de nombre de connexions simultanées autorisée
     par MySQL.
    </simpara>

--- a/reference/mysql/functions/mysql-real-escape-string.xml
+++ b/reference/mysql/functions/mysql-real-escape-string.xml
@@ -42,7 +42,7 @@
   </simpara>
   <simpara>
    Cette fonction doit toujours (avec quelques exceptions) être utilisée
-   avant d'envoyer la requête à MySQL afin de protéger vos données d'injection
+   avant d'envoyer la requête à MySQL afin de protéger les données d'injection
    de caractères pouvant dévoyer cette requête.
   </simpara>
 
@@ -188,7 +188,7 @@ SELECT * FROM users WHERE user='aidan' AND password='' OR ''=''
   </note>
   <note>
    <simpara>
-    Si cette fonction n'est pas utilisée pour protéger vos données, la requête
+    Si cette fonction n'est pas utilisée pour protéger les données, la requête
     sera vulnérable aux <link linkend="security.database.sql-injection">attaques
     par injection SQL</link>.
    </simpara>

--- a/reference/mysql/functions/mysql-result.xml
+++ b/reference/mysql/functions/mysql-result.xml
@@ -34,7 +34,7 @@
    Retourne le contenu d'un champ d'un jeu de résultats MySQL.
   </simpara>
   <simpara>
-   Lorsque vous travaillez sur des résultats de grande taille,
+   Lorsqu'on travaille sur des résultats de grande taille,
    il est conseillé d'utiliser une des fonctions qui vont rechercher une ligne
    entière dans un tableau. Ces fonctions sont NETTEMENT plus
    rapides. De plus, utiliser un offset numérique est

--- a/reference/mysql/functions/mysql-stat.xml
+++ b/reference/mysql/functions/mysql-stat.xml
@@ -45,7 +45,7 @@
    les threads, les requêtes, les tables ouvertes et sur disque,
    et le nombre de requêtes par seconde. Pour une liste complète
    des autres variables de statuts,
-   vous devez utiliser la commande SQL <literal>SHOW STATUS</literal>.
+   il faut utiliser la commande SQL <literal>SHOW STATUS</literal>.
    Si <parameter>link_identifier</parameter> est invalide, &null; est retourné.
   </simpara>
  </refsect1>

--- a/reference/mysql/functions/mysql-thread-id.xml
+++ b/reference/mysql/functions/mysql-thread-id.xml
@@ -26,9 +26,9 @@
   <simpara>
    <function>mysql_thread_id</function> retourne l'identifiant du thread courant.
    Si la connexion <parameter>link_identifier</parameter> est perdue
-   et que vous vous reconnectez (avec <function>mysql_ping</function>,
+   et que l'on on se reconnecte (avec <function>mysql_ping</function>,
    par exemple), alors l'identifiant de thread va changer. Cela signifie que
-   vous devez le récupérer lorsque vous en avez besoin.
+   il faut le récupérer lorsqu'on en avez besoin.
   </simpara>
  </refsect1>
 

--- a/reference/mysql/functions/mysql-unbuffered-query.xml
+++ b/reference/mysql/functions/mysql-unbuffered-query.xml
@@ -32,11 +32,11 @@
    et mettre en mémoire les lignes du résultat, comme pourrait le faire
    la fonction <function>mysql_query</function>. Ce comportement permet
    d'épargner une grande quantité de mémoire lorsque les requêtes SQL
-   produisent un gros jeu de résultats, et vous pouvez commencer à travailler
+   produisent un gros jeu de résultats, et il est possible de commencer à travailler
    sur le jeu de résultats immédiatement après que la première ligne ait été
-   récupérée que vous n'avez pas à attendre la fin du traitement de la requête SQL.
+   récupérée que l'on n'avez pas à attendre la fin du traitement de la requête SQL.
    Pour utiliser la fonction <function>mysql_unbuffered_query</function> lorsque
-   plusieurs connexions à des bases de données sont ouvertes, vous devez spécifier
+   plusieurs connexions à des bases de données sont ouvertes, il faut spécifier
    le paramètre optionnel <parameter>link_identifier</parameter> pour identifier
    la connexion à utiliser.
   </simpara>
@@ -84,7 +84,7 @@
     et <function>mysql_data_seek</function> ne fonctionnent pas sur une
     ressource retournée par <function>mysql_unbuffered_query</function>, tant que
     toutes les lignes sont récupérées.
-    Vous devez aussi lire tous les résultats d'une première requête exécutée
+    Il faut aussi lire tous les résultats d'une première requête exécutée
     avec <function>mysql_unbuffered_query</function>, avant de pouvoir en
     exécuter une autre en utilisant le même <parameter>link_identifier</parameter>.
    </simpara>

--- a/reference/mysql/setup.xml
+++ b/reference/mysql/setup.xml
@@ -9,7 +9,7 @@
  <section xml:id="mysql.requirements">
   &reftitle.required;
   <simpara>
-   Afin de pouvoir les utiliser, vous devez compiler PHP avec le support
+   Afin de pouvoir les utiliser, il faut compiler PHP avec le support
    MySQL.
   </simpara>
   <warning>

--- a/reference/mysql_xdevapi/book.xml
+++ b/reference/mysql_xdevapi/book.xml
@@ -21,7 +21,7 @@
    du serveur MySQL 8.0.
   </para>
   <para>
-   Pour des informations générales sur MySQL Document Store, référez-vous au chapitre
+   Pour des informations générales sur MySQL Document Store, se référer au chapitre
    <link xlink:href="&url.mysql.docs.document-store;">MySQL Document Store</link>
    du manuel MySQL.
   </para>

--- a/reference/mysql_xdevapi/examples.xml
+++ b/reference/mysql_xdevapi/examples.xml
@@ -41,7 +41,7 @@ $collection = $schema->createCollection("example");
   </programlisting>
  </example>
  <para>
-  Lorsque vous stockez des données, généralement <function>json_encode</function> est utilisé pour encoder
+  Lorsqu'on stocke des données, généralement <function>json_encode</function> est utilisé pour encoder
   les données en JSON, qui peuvent ensuite être stockées dans une collection.
  </para>
  <para>
@@ -96,7 +96,7 @@ array(4) {
  <para>
   Cet exemple démontre également que les données récupérées sont triées par ordre alphabétique.
   Cet ordre spécifique provient du stockage binaire efficace à l'intérieur du serveur MySQL, mais
-  il ne faut pas s'y fier. Référez-vous à la documentation du type de données JSON de MySQL pour plus de détails.
+  il ne faut pas s'y fier. Se référer à la documentation du type de données JSON de MySQL pour plus de détails.
  </para>
  <para>
   Optionnellement, utilisez les itérateurs de PHP pour récupérer plusieurs documents :

--- a/reference/mysql_xdevapi/mysql_xdevapi/collection/add.xml
+++ b/reference/mysql_xdevapi/mysql_xdevapi/collection/add.xml
@@ -119,7 +119,7 @@ Array
   <note>
    <para>
     Un identifiant unique _id est généré par MySQL Server 8.0 ou supérieur, comme démontré
-    dans l'exemple. Le champ _id doit être défini manuellement si vous utilisez
+    dans l'exemple. Le champ _id doit être défini manuellement si on utilise
     MySQL Server 5.7.
    </para>
   </note>

--- a/reference/mysql_xdevapi/mysql_xdevapi/collectionadd/construct.xml
+++ b/reference/mysql_xdevapi/mysql_xdevapi/collectionadd/construct.xml
@@ -84,7 +84,7 @@ Array
   <note>
    <para>
     Un identifiant unique _id est généré par MySQL Server 8.0 ou supérieur, comme démontré
-    dans l'exemple. Le champ _id doit être défini manuellement si vous utilisez
+    dans l'exemple. Le champ _id doit être défini manuellement si on utilise
     MySQL Server 5.7.
    </para>
   </note>

--- a/reference/mysql_xdevapi/mysql_xdevapi/collectionfind/lockshared.xml
+++ b/reference/mysql_xdevapi/mysql_xdevapi/collectionfind/lockshared.xml
@@ -17,7 +17,7 @@
    Autorise le partage des documents entre plusieurs transactions qui sont verrouillées en mode partagé.
   </para>
   <para>
-   D'autres sessions peuvent lire les lignes, mais ne peuvent pas les modifier tant que votre transaction n'a pas validé.
+   D'autres sessions peuvent lire les lignes, mais ne peuvent pas les modifier tant que le transaction n'a pas validé.
   </para>
   <para>
    Si l'une de ces lignes a été modifiée par une autre transaction qui n'a pas été validée,

--- a/reference/mysql_xdevapi/setup.xml
+++ b/reference/mysql_xdevapi/setup.xml
@@ -106,7 +106,7 @@ pdo_mysql
           et <literal>make clean-protobufs</literal> pour supprimer les fichiers protobuf générés.
         </para>
         <para>
-          Note spécifique à Windows: selon votre environnement, la bibliothèque statique avec
+          Note spécifique à Windows: selon le environnement, la bibliothèque statique avec
           un runtime DLL multi-thread peut être nécessaire.
           Pour préparer, utilisez les options suivantes :
           <emphasis>-Dprotobuf_MSVC_STATIC_RUNTIME=OFF -Dprotobuf_BUILD_SHARED_LIBS=OFF</emphasis>
@@ -114,7 +114,7 @@ pdo_mysql
       </listitem>
       <listitem>
         <para>
-          Google Protocol Buffers / protoc: requis, assurez-vous que le bon
+          Google Protocol Buffers / protoc: requis, il faut s'assurer que le bon
           'protoc' est disponible dans le PATH lors de la compilation. C'est particulièrement
           important car les scripts batch du SDK PHP Windows peuvent écraser l'environnement.
         </para>

--- a/reference/mysqli/book.xml
+++ b/reference/mysqli/book.xml
@@ -14,9 +14,9 @@
  <preface xml:id="intro.mysqli">
   &reftitle.intro;
   <para>
-   L'extension <literal>mysqli</literal> vous permet d'accéder aux
+   L'extension <literal>mysqli</literal> permet d'accéder aux
    fonctionnalités fournies par MySQL 4.1 et supérieur. Pour plus
-   d'informations sur le serveur de base de données MySQL, veuillez-vous rendre
+   d'informations sur le serveur de base de données MySQL, se rendre
    sur <link xlink:href="&url.mysql;">&url.mysql;</link>
   </para>
 
@@ -33,7 +33,7 @@
 
   <para>
    Des morceaux du manuel MySQL ont été inclus dans la documentation PHP
-   avec la permission de Oracle Corporation.
+   avec la permission d'Oracle Corporation.
   </para>
   
   <para>

--- a/reference/mysqli/configure.xml
+++ b/reference/mysqli/configure.xml
@@ -21,7 +21,7 @@ xmlns:xlink="http://www.w3.org/1999/xlink">
    Les distributions Linux incluent des versions binaires de PHP qui peuvent
    être installées. Même si ces binaires sont construits avec les extensions
    MySQL, les bibliothèques clientes doivent souvent être installées au
-   moyen d'un paquet additionnel. Voyez si c'est le cas pour votre distribution.
+   moyen d'un paquet additionnel. Voir si c'est le cas pour le distribution.
   </para>
   
   <para>
@@ -31,7 +31,7 @@ xmlns:xlink="http://www.w3.org/1999/xlink">
   </para>
   
   <para>
-   Alternativement, vous pouvez compiler cette extension vous-même. Construire
+   Alternativement, il est possible de compiler cette extension soi-même. Construire
    PHP depuis les sources permet de préciser les extensions MySQL à embarquer,
    mais aussi les bibliothèques clientes de chaque extension.
   </para>
@@ -40,7 +40,7 @@ xmlns:xlink="http://www.w3.org/1999/xlink">
    Le driver natif MySQL est la bibliothèque cliente recommandée, vu qu'il apporte
    un gain de performance et donne l'accès à des fonctionnalités
    qui ne sont pas disponibles lors de l'utilisation de la bibliothèque
-   cliente MySQL. Reportez-vous à la section
+   cliente MySQL. Se reporter à la section
    <link linkend="mysqli.overview.mysqlnd">Qu'est-ce que le driver
     natif MySQL de PHP ?</link> pour une brève description des avantages
    du driver natif MySQL.
@@ -110,14 +110,14 @@ xmlns:xlink="http://www.w3.org/1999/xlink">
     Pour activer une extension PHP (telle que
     <filename>php_mysqli.dll</filename>), la directive PHP
     <link linkend="ini.extension-dir">extension_dir</link> doit pointer vers
-    le dossier contenant les extensions PHP. Voyez aussi
+    le dossier contenant les extensions PHP. Voir aussi
     <link linkend="install.windows.manual">Installation manuelle sous Windows
     </link>. Par exemple, <literal>extension_dir</literal> pourrait valoir
     <filename>c:\php\ext</filename>.
    </para>
    <note>
     <para>
-     Si lorsque vous démarrez le serveur web, une erreur telle que
+     Si lorsqu'on démarre le serveur web, une erreur telle que
      <literal>"Unable to load dynamic library './php_mysqli.dll'"</literal> se
      produit, c'est que <filename>php_mysqli.dll</filename> et/ou
      <filename>libmysql.dll</filename> ne peut être trouvée sur le système.

--- a/reference/mysqli/ini.xml
+++ b/reference/mysqli/ini.xml
@@ -96,7 +96,7 @@
  </para>
  <para>
   Pour plus de détails et de définitions concernant les constantes INI_*
-  ci-dessus, reportez-vous au chapitre sur les <link linkend="configuration.changes">
+  ci-dessus, se reporter au chapitre sur les <link linkend="configuration.changes">
   modifications de configuration</link>.
  </para>
  
@@ -273,7 +273,7 @@
  <para>
   Les utilisateurs ne peuvent changer <literal>MYSQL_OPT_READ_TIMEOUT</literal> via un appel
   de l'API ou au runtime.
-  Notez que même si c'est possible, il y aura des différences sur la manière dont
+  À noter que même si c'est possible, il y aura des différences sur la manière dont
   <literal>libmysqlclient</literal> et les flux vont interpréter la valeur de
   <literal>MYSQL_OPT_READ_TIMEOUT</literal>. 
  </para>

--- a/reference/mysqli/mysqli/debug.xml
+++ b/reference/mysqli/mysqli/debug.xml
@@ -162,7 +162,7 @@ mysqli_debug("d:t:o,/tmp/client.trace");
   &reftitle.notes;
   <note>
    <para>
-    Pour utiliser la fonction <function>mysqli_debug</function>, vous devez
+    Pour utiliser la fonction <function>mysqli_debug</function>, l'on doit
     compiler la bibliothèque cliente MySQL avec le support du débogage.
    </para>
   </note>

--- a/reference/mysqli/mysqli/multi-query.xml
+++ b/reference/mysqli/mysqli/multi-query.xml
@@ -92,7 +92,7 @@
   &reftitle.returnvalues;
   <para>
    Retourne &false; uniquement si la première requête échoue. Pour récupérer
-   les sous-séquences d'erreurs issues des autres requêtes, vous devez appeler
+   les sous-séquences d'erreurs issues des autres requêtes, il faut appeler
    d'abord la fonction <function>mysqli_next_result</function>.
   </para>
  </refsect1>

--- a/reference/mysqli/mysqli/options.xml
+++ b/reference/mysqli/mysqli/options.xml
@@ -45,7 +45,7 @@
      <term><parameter>option</parameter></term>
      <listitem>
       <para>
-       L'option que vous voulez définir. Il peut prendre une des valeurs suivantes :
+       L'option qu'on veut définir. Il peut prendre une des valeurs suivantes :
        <table xml:id="mysqli.options.parameters">
         <title>Options valides</title>
         <tgroup cols="2">

--- a/reference/mysqli/mysqli/query.xml
+++ b/reference/mysqli/mysqli/query.xml
@@ -36,10 +36,10 @@
   </para>
   <note>
    <para>
-    Si vous passez une requête à
+    Si on passe une requête à
     <function>mysqli_query</function> qui est plus longue que
     <literal>max_allowed_packet</literal>, les codes d'erreur en retour seront
-    différents selon si vous utilisez MySQL Native Driver
+    différents selon lors de l'utilisation de MySQL Native Driver
     (<literal>mysqlnd</literal>) ou la MySQL Client Library
     (<literal>libmysqlclient</literal>). Le comportement est défini comme suit:
    </para>

--- a/reference/mysqli/mysqli/real-connect.xml
+++ b/reference/mysqli/mysqli/real-connect.xml
@@ -127,7 +127,7 @@
      <term><parameter>flags</parameter></term>
      <listitem>
       <para>
-       Avec le paramètre <parameter>flags</parameter>, vous pouvez configurer
+       Avec le paramètre <parameter>flags</parameter>, il est possible de configurer
        différentes directives de connexion : 
       </para>
       <table xml:id="mysqli.real-connect.flags">
@@ -178,7 +178,7 @@
       <note>
        <para>
         Pour des raisons de sécurité, l'option <constant>MULTI_STATEMENT</constant> n'est
-        pas supportée en PHP. Si vous voulez exécuter plusieurs commandes, utilisez
+        pas supportée en PHP. Pour exécuter plusieurs commandes, utilisez
         la fonction <function>mysqli_multi_query</function>.
        </para>
       </note>

--- a/reference/mysqli/mysqli/select-db.xml
+++ b/reference/mysqli/mysqli/select-db.xml
@@ -30,7 +30,7 @@
   <note>
    <para>
     Cette fonction ne doit être utilisée que pour changer la base de données par défaut pour 
-    la connexion courante. Vous pouvez sélectionner la base de données par défaut avec
+    la connexion courante. Il est possible de sélectionner la base de données par défaut avec
     le 4ème paramètre de la fonction <function>mysqli_connect</function>.
    </para>
   </note>

--- a/reference/mysqli/mysqli/ssl-set.xml
+++ b/reference/mysqli/mysqli/ssl-set.xml
@@ -89,7 +89,7 @@
   &reftitle.returnvalues;
   <para>
    &return.true.always; Si SSL n'est pas correctement installé,
-   <function>mysqli_real_connect</function> retournera une erreur lorsque vous tenterez une
+   <function>mysqli_real_connect</function> retournera une erreur lorsqu'on tente une
    connexion.
   </para>
  </refsect1>

--- a/reference/mysqli/mysqli/store-result.xml
+++ b/reference/mysqli/mysqli/store-result.xml
@@ -37,7 +37,7 @@
      <term><parameter>mode</parameter></term>
      <listitem>
       <para>
-       L'option que vous souhaitez définir. À partir de PHP 8.1, ce paramètre n'a aucun effet.
+       L'option qu'on souhaite définir. À partir de PHP 8.1, ce paramètre n'a aucun effet.
        Elle peut prendre l'une des valeurs suivantes :
        <table xml:id="mysqli.store-result.parameters">
         <title>Options valides</title>
@@ -80,7 +80,7 @@
     <function>mysqli_store_result</function> retourne &false; dans le cas
     où la requête ne retourne pas de jeu de résultat (si la requête est de
     type INSERT par exemple). Cette fonction retournera toujours &false; si
-    le jeu de résultats ne peut être lu. Vous pouvez savoir s'il y a une
+    le jeu de résultats ne peut être lu. Il est possible de savoir s'il y a une
     erreur en utilisant la fonction <function>mysqli_error</function> et en
     regardant si elle renvoie une chaîne vide, ou si
     <function>mysqli_errno</function> retourne zéro, ou bien si

--- a/reference/mysqli/mysqli/thread-id.xml
+++ b/reference/mysqli/mysqli/thread-id.xml
@@ -22,9 +22,9 @@
    La fonction <function>mysqli_thread_id</function> retourne l'identifiant
    du thread de la connexion courante qui peut être terminé par la suite
    en utilisant la fonction <function>mysqli_kill</function>. Si la connexion
-   est perdue et que vous vous reconnectez avec la fonction
+   est perdue et que l'on on se reconnecte avec la fonction
    <function>mysqli_ping</function>, l'identifiant du thread sera différent.
-   Ainsi, vous devez récupérer l'identifiant du thread uniquement lorsque vous
+   Ainsi, il faut récupérer l'identifiant du thread uniquement lorsque l'on
    en avez besoin.
   </para>
   <note>
@@ -34,7 +34,7 @@
     identifiant de thread lui sera assigné.
    </para>
    <para>
-    Pour terminer une requête en cours d'exécution, vous pouvez utiliser
+    Pour terminer une requête en cours d'exécution, il est possible d'utiliser
     la commande SQL <literal>KILL QUERY processid</literal>.
    </para>
   </note>

--- a/reference/mysqli/mysqli/use-result.xml
+++ b/reference/mysqli/mysqli/use-result.xml
@@ -38,7 +38,7 @@
     le jeu de résultats en entier à partir de la base de données
     et on ne peut donc pas utiliser des fonctions telle
     <function>mysqli_data_seek</function> pour se déplacer entre les
-    enregistrements. Pour utiliser cette fonctionnalité, vous devez
+    enregistrements. Pour utiliser cette fonctionnalité, l'on doit
     récupérer le jeu de résultats en utilisant
     <function>mysqli_store_result</function>.
    </para>

--- a/reference/mysqli/mysqli_result/fetch-array.xml
+++ b/reference/mysqli/mysqli_result/fetch-array.xml
@@ -34,7 +34,7 @@
   <para>
    Si deux ou plusieurs colonnes du résultat ont le même nom,
    la dernière colonne sera prioritaire et écrasera toutes les données précédentes.
-   Pour accéder aux autres colonnes du même nom, vous devez
+   Pour accéder aux autres colonnes du même nom, l'on doit
    utiliser l'index numérique, ou faire un alias pour chaque colonne.
   </para>
   &database.field-case;

--- a/reference/mysqli/mysqli_result/fetch-column.xml
+++ b/reference/mysqli/mysqli_result/fetch-column.xml
@@ -38,7 +38,7 @@
      <term><parameter>column</parameter></term>
      <listitem>
       <para>
-       Le numéro indexé à 0 de la colonne que vous souhaitez récupérer de la ligne.
+       Le numéro indexé à 0 de la colonne qu'on souhaite récupérer de la ligne.
        Si aucune valeur n'est fournie, la première colonne sera retournée.
       </para>
      </listitem>
@@ -55,7 +55,7 @@
   </para>
   <warning>
    <para>
-    Il n'y a aucun moyen de retourner une autre colonne de la même ligne si vous
+    Il n'y a aucun moyen de retourner une autre colonne de la même ligne si l'on
     utilisez cette fonction pour récupérer des données.
    </para>
   </warning>

--- a/reference/mysqli/mysqli_result/lengths.xml
+++ b/reference/mysqli/mysqli_result/lengths.xml
@@ -42,7 +42,7 @@
   </para>
   <para>
    <function>mysqli_fetch_lengths</function> n'est valide que pour la ligne courant du
-   jeu de résultats. Elle retourne &false; si vous l'appelez avant les fonctions
+   jeu de résultats. Elle retourne &false; si l'on l'appelez avant les fonctions
    <function>mysqli_fetch_row</function>, <function>mysqli_fetch_array</function>,
    <function>mysqli_fetch_object</function>
    ou après avoir récupéré toutes les lignes du résultat.

--- a/reference/mysqli/mysqli_stmt/attr-get.xml
+++ b/reference/mysqli/mysqli_stmt/attr-get.xml
@@ -35,7 +35,7 @@
      <term><parameter>attribute</parameter></term>
      <listitem>
       <para>
-       L'attribut que vous voulez récupérer.
+       L'attribut qu'on veut récupérer.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/mysqli/mysqli_stmt/attr-set.xml
+++ b/reference/mysqli/mysqli_stmt/attr-set.xml
@@ -36,7 +36,7 @@
      <term><parameter>attribute</parameter></term>
      <listitem>
       <para>
-       L'attribut que vous voulez définir. Il peut avoir une des valeurs
+       L'attribut qu'on veut définir. Il peut avoir une des valeurs
        suivantes :
        <table xml:id="mysqli-stmt.attr-set.parameters">
         <title>Valeurs des attributs</title>
@@ -81,7 +81,7 @@
        </table>
       </para>
       <para>
-       Si vous utilisez l'option <constant>MYSQLI_STMT_ATTR_CURSOR_TYPE</constant>
+       Lors de l'utilisation de l'option <constant>MYSQLI_STMT_ATTR_CURSOR_TYPE</constant>
        avec <constant>MYSQLI_CURSOR_TYPE_READ_ONLY</constant>, un curseur sera
        ouvert pour la requête lors de l'appel à la fonction
        <function>mysqli_stmt_execute</function>. S'il y a déjà un curseur d'ouvert
@@ -93,7 +93,7 @@
        ferme tout curseur ouvert.
       </para>
       <para>
-       Si vous ouvrez un curseur pour une requête préparée, la fonction
+       Si on ouvre un curseur pour une requête préparée, la fonction
        <function>mysqli_stmt_store_result</function> n'est pas nécessaire.
       </para>
      </listitem>

--- a/reference/mysqli/mysqli_stmt/bind-param.xml
+++ b/reference/mysqli/mysqli_stmt/bind-param.xml
@@ -32,7 +32,7 @@
   <note>
    <para>
     Si la taille des données dépasse la taille maximale d'un paquet,
-    (<literal>max_allowed_packet</literal>), vous devez spécifier
+    (<literal>max_allowed_packet</literal>), il faut spécifier
     le caractère <literal>b</literal> dans le paramètre
     <parameter>types</parameter> et utiliser la fonction 
     <function>mysqli_stmt_send_long_data</function> pour envoyer le
@@ -41,9 +41,9 @@
   </note>
   <note>
    <para>
-    Vous devez être prudent lors de l'utilisation de
+    Il faut être prudent lors de l'utilisation de
     <function>mysqli_stmt_bind_param</function> avec la fonction
-    <function>call_user_func_array</function>. Notez que
+    <function>call_user_func_array</function>. À noter que
     <function>mysqli_stmt_bind_param</function> nécessite que ses paramètres
     soient passés par référence, alors que la fonction
     <function>call_user_func_array</function> peut accepter comme paramètre

--- a/reference/mysqli/mysqli_stmt/prepare.xml
+++ b/reference/mysqli/mysqli_stmt/prepare.xml
@@ -33,10 +33,10 @@
   </para>
   <note>
    <para>
-    Si vous passez une requête à
+    Si on passe une requête à
     <function>mysqli_stmt_prepare</function> qui est plus longue que
     <literal>max_allowed_packet</literal>, les codes d'erreur en retour seront
-    différents selon si vous utilisez MySQL Native Driver
+    différents selon lors de l'utilisation de MySQL Native Driver
     (<literal>mysqlnd</literal>) ou la MySQL Client Library
     (<literal>libmysqlclient</literal>). Le comportement est défini comme suit:
    </para>

--- a/reference/mysqli/mysqli_stmt/store-result.xml
+++ b/reference/mysqli/mysqli_stmt/store-result.xml
@@ -30,9 +30,9 @@
   <note>
    <para>
     Il n'est pas nécessaire d'appeler <function>mysqli_stmt_store_result</function>
-    pour d'autres types de requête, mais si vous le faites, ce n'est pas grave et ne causera 
-    aucune perte notable de performance dans tous les cas. Vous pouvez détecter dans
-    tous les cas si votre requête va produire un jeu de résultats en regardant si la fonction
+    pour d'autres types de requête, mais si l'on le faites, ce n'est pas grave et ne causera 
+    aucune perte notable de performance dans tous les cas. Il est possible de détecter dans
+    tous les cas si le requête va produire un jeu de résultats en regardant si la fonction
     <function>mysqli_stmt_result_metadata</function> retourne &false;.
    </para>
   </note>

--- a/reference/mysqli/overview.xml
+++ b/reference/mysqli/overview.xml
@@ -8,7 +8,7 @@
 
   <para>
     Cette section fournit des informations sur les solutions qui
-    s'offrent à vous quand vous développez une application PHP qui a
+    sont disponibles quand on développe une application PHP qui a
     besoin de s'interfacer avec une base de données MySQL.
   </para>
 
@@ -19,7 +19,7 @@
   <para>
     Une Interface de programmation d'application, une 
     <literal>Application Programming Interface</literal>, ou encore API,
-    définit les classes, méthodes, fonctions et variables dont votre
+    définit les classes, méthodes, fonctions et variables dont une
     application va faire usage pour exécuter différentes tâches. Dans le cas
     des applications PHP, les communications avec une base de données
     se font généralement par une API qui est exposée dans une extension PHP.
@@ -27,8 +27,8 @@
 
   <para>
     Les API peuvent être procédurales ou orientées objet. Avec une API procédurale,
-    vous pouvez appeler les fonctions pour exécuter des commandes; avec une
-    API orientée objet, vous devez créer des objets et appeler les méthodes
+    il est possible d'appeler les fonctions pour exécuter des commandes; avec une
+    API orientée objet, il faut créer des objets et appeler les méthodes
     de ces objets. Des deux, c'est la dernière qui est généralement préférée,
     car elle est plus moderne et conduit à du code plus organisé.
   </para>
@@ -36,8 +36,8 @@
   <para>
     Lors de l'écriture d'applications PHP qui doivent se connecter à MySQL,
     il y a plusieurs API disponibles. Ce document présente ces API, et 
-    vous donne les informations pour choisir la meilleure solution pour 
-    votre application.
+    donne les informations pour choisir la meilleure solution pour 
+    le application.
   </para>
 
   <para>
@@ -52,11 +52,11 @@
   </para>
 
   <para>
-    Si votre application PHP a besoin de communiquer avec un serveur de
-    base de données, vous devez écrire du code pour pouvoir vous connecter,
+    Si le application PHP a besoin de communiquer avec un serveur de
+    base de données, il faut écrire du code pour pouvoir l'on connecter,
     envoyer des requêtes au serveur, etc. Un logiciel est nécessaire pour
     assurer l'interface que PHP va utiliser et gérer les communications 
-    entre votre application et le serveur de base de données : éventuellement,
+    entre le application et le serveur de base de données : éventuellement,
     des bibliothèques intermédiaires sont nécessaires. Ces logiciels sont appelés
     de manière générique des connecteurs, car ils permettent de se 
     <emphasis>connecter</emphasis> à un serveur de base de données.
@@ -95,7 +95,7 @@
   </para>
 
   <para>
-   Dans la documentation PHP, vous rencontrerez un autre terme : 
+   Dans la documentation PHP, on rencontrera un autre terme : 
    <emphasis>extension</emphasis>. Le code PHP est constitué d'un cœur,
    avec des extensions optionnelles. Les extensions liées à MySQL de PHP,
    telles que l'extension <literal>mysqli</literal> et l'extension de pilote
@@ -145,7 +145,7 @@
 
   <para>
     Chacune a ses avantages et ses inconvénients. Les sections suivantes
-    tendent à vous donner une présentation rapide de chaque API.
+    tendent à l'on donner une présentation rapide de chaque API.
   </para>
 
   <para>
@@ -211,7 +211,7 @@
 
   <para>
     Pour plus d'informations sur l'extension <literal>mysqli</literal>,
-    voyez <xref linkend="book.mysqli"/>.
+    voir <xref linkend="book.mysqli"/>.
   </para>
 
   <para xml:id="mysqli.overview.pdo">
@@ -220,11 +220,11 @@
 
   <para>
     <literal>PHP Data Objects</literal>, ou PDO, est une couche d'abstraction
-    de base de données, spécifique à PHP. PDO propose une API cohérente pour vos
+    de base de données, spécifique à PHP. PDO propose une API cohérente pour les
     applications PHP, indépendamment du type de base de données avec laquelle
-    vous travaillez. En théorie, si vous utilisez PDO, vous pouvez
+    on travaille. En théorie, lors de l'utilisation de PDO, il est possible de
     changer de base de données, disons de Firebird à MySQL, et ne faire que
-    des changements mineurs à votre code PHP.
+    des changements mineurs au code PHP.
   </para>
 
   <para>
@@ -234,9 +234,9 @@
 
   <para>
     Si PDO a ses avantages, comme une API propre, simple et portable, 
-    ses inconvénients principaux sont qu'elle ne vous permet pas d'utiliser
+    ses inconvénients principaux sont qu'elle ne permet pas d'utiliser
     toutes les fonctionnalités avancées des dernières versions de MySQL.
-    Par exemple, PDO ne vous permet pas de faire des requêtes multiples.
+    Par exemple, PDO ne permet pas de faire des requêtes multiples.
   </para>
 
   <para>
@@ -245,7 +245,7 @@
   </para>
 
   <para>
-    Pour plus d'informations sur PDO, voyez <xref linkend="book.pdo"/>.
+    Pour plus d'informations sur PDO, voir <xref linkend="book.pdo"/>.
   </para>
 
   <para>
@@ -273,7 +273,7 @@
   </para>
 
   <para>
-    Pour plus de détails sur le pilote PDO de MySQL, voyez 
+    Pour plus de détails sur le pilote PDO de MySQL, voir 
     <xref linkend="ref.pdo-mysql"/>.
   </para>
 
@@ -305,7 +305,7 @@
     <literal>libmysqlclient</literal> soit <literal>mysqlnd</literal>. Comme
     <literal>mysqlnd</literal> a été conçu spécifiquement pour utiliser le système
     PHP, il propose de nombreux avantages et améliorations par rapport à 
-    <literal>libmysqlclient</literal>. Vous êtes vivement encouragés à en profiter.
+    <literal>libmysqlclient</literal>. On est vivement encouragés à en profiter.
   </para>
 
   <para>

--- a/reference/mysqli/persistconns.xml
+++ b/reference/mysqli/persistconns.xml
@@ -17,7 +17,7 @@
  <para>
   Contrairement à l'extension MySQL, MySQLi ne fournit pas de fonction
   séparée pour ouvrir des connexions persistantes. Pour ouvrir une connexion
-  persistante, vous devez ajouter <literal>p:</literal> au nom de l'hôte
+  persistante, il faut ajouter <literal>p:</literal> au nom de l'hôte
   lors de la connexion.
  </para>
 

--- a/reference/mysqli/quickstart.xml
+++ b/reference/mysqli/quickstart.xml
@@ -6,7 +6,7 @@
 <chapter xml:id="mysqli.quickstart" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Guide de démarrage rapide</title>
  <para>
-  Ce guide de démarrage rapide va vous aider à vous familiariser
+  Ce guide de démarrage rapide va aider à l'on familiariser
   avec l'API PHP MySQL.
  </para>
  <para>
@@ -16,7 +16,7 @@
   comprendre les spécificités des concepts de MySQL.
  </para>
  <para>
-  Requis : Vous devez être familier avec le langage de programmation PHP,
+  Requis : Il faut être familier avec le langage de programmation PHP,
   le langage SQL ainsi qu'avoir quelques bases avec le serveur MySQL.
  </para>
  <section xml:id="mysqli.quickstart.dual-interface">
@@ -479,7 +479,7 @@ foreach ($result as $row) {
    requêtes non-préparées. Au niveau du protocole client-serveur MySQL, la commande
    <literal>COM_QUERY</literal> ainsi que le protocole texte sont utilisés pour
    l'exécution de la requête. Avec le protocole texte, le serveur MySQL convertit
-   toutes les données d'un jeu de résultats en chaînes de caractères avant de les envoyer.
+   toutes les données d'un jeu de résultats en chaînes de caractères avant d'envoyer.
    La bibliothèque cliente mysql reçoit toutes les valeurs des colonnes sous forme
    de chaîne de caractères. Aucun autre transtypage côté client n'est effectué
    pour retrouver le type natif des colonnes. A la place de cela, toutes les valeurs sont
@@ -518,7 +518,7 @@ label = a (string)
   <para>
    Il est possible de convertir des colonnes de type entières et nombres à virgule flottante
    en nombre PHP en définissant l'option de connexion
-   <constant>MYSQLI_OPT_INT_AND_FLOAT_NATIVE</constant>, si vous utilisez la bibliothèque
+   <constant>MYSQLI_OPT_INT_AND_FLOAT_NATIVE</constant>, lors de l'utilisation de la bibliothèque
    mysqlnd. Si défini, la bibliothèque mysqlnd va vérifier les méta-données des types
    des colonnes dans le jeu de résultats et va convertir les colonnes SQL numériques
    en nombres PHP, si la valeur entre dans l'intervalle autorisé de PHP.
@@ -706,7 +706,7 @@ array(3) {
   </para>
   <para>
    Chaque requête préparée occupe des ressources sur le serveur. Elles doivent
-   être fermées explicitement immédiatement après utilisation. Si vous ne
+   être fermées explicitement immédiatement après utilisation. Si l'on ne
    le faîtes pas, la requête sera fermée lorsque le gestionnaire de requête
    sera libéré par PHP.
   </para>
@@ -718,7 +718,7 @@ array(3) {
    n'est pas exécutée comme requête préparée dans l'exemple ci-dessus.
   </para>
   <para>
-   De plus, vous devez prendre en considération l'utilisation des syntaxes
+   De plus, il faut prendre en considération l'utilisation des syntaxes
    multi-INSERT MySQL pour les INSERTs. Par exemple, les multi-INSERTs requièrent
    moins d'aller-retour client-serveur que la requête préparée vue dans l'exemple ci-dessus.
   </para>
@@ -855,7 +855,7 @@ id = 1 (integer), label = a (string)
    et transférés depuis le serveur vers le client pour une mise en mémoire tampon
    côté client. Le jeu de résultats prend des ressources serveur tant que tous
    les résultats n'ont pas été récupérés par le client. Aussi, il est recommandé
-   de les récupérer rapidement. Si un client échoue dans la récupération de
+   de récupérer rapidement. Si un client échoue dans la récupération de
    tous les résultats, ou si le client ferme la requête avant d'avoir récupéré
    toutes les données, les données doivent être récupérées implicitement par
    <literal>mysqli</literal>.
@@ -984,7 +984,7 @@ array(2) {
    Une telle séparation est souvent considérée comme la seule fonctionnalité
    pour se protéger des injections SQL, mais le même degré de sécurité peut
    être atteint avec les requêtes non-préparées, si toutes les valeurs sont
-   correctement formatées. Notez qu'un formattage correct n'est pas la même
+   correctement formatées. À noter : qu'un formattage correct n'est pas la même
    chose qu'un échappement et nécessite plus de logique qu'un simple échappement.
    Aussi, les requêtes préparées sont simplement une méthode plus simple
    et moins prompte aux erreurs concernant cette approche sécuritaire.
@@ -1033,7 +1033,7 @@ array(2) {
   </para>
   <para>
    Les paramètres d'entrée sont fournis avec la requête <literal>CALL</literal>.
-   Assurez-vous d'échapper correctement les valeurs.
+   Il faut s'assurer d'échapper correctement les valeurs.
   </para>
   <para>
    <example>

--- a/reference/mysqli/setup.xml
+++ b/reference/mysqli/setup.xml
@@ -10,7 +10,7 @@
  <section xml:id="mysqli.requirements">
   &reftitle.required;
   <para>
-   Pour que ces fonctions soient disponibles, vous devez compiler PHP avec
+   Pour que ces fonctions soient disponibles, il faut compiler PHP avec
    le support de l'extension mysqli.
   </para>
   

--- a/reference/mysqlinfo/concepts.xml
+++ b/reference/mysqlinfo/concepts.xml
@@ -32,7 +32,7 @@
 
   <note>
    <simpara>
-    Lorsque vous utilisez libmysqlclient comme bibliothèque, la limite
+    Lorsqu'on utilise libmysqlclient comme bibliothèque, la limite
     mémoire de PHP ne comptera pas la mémoire utilisée pour les
     jeux de résultats à moins que les données ne soient lues dans les
     variables PHP. Avec mysqlnd, la mémoire utilisée comprendra
@@ -63,7 +63,7 @@
 
   <simpara>
    En raison du fait que les requêtes sont mises en mémoire tampon
-   par défaut, les exemples ci-dessous vont vous montrer comment
+   par défaut, les exemples ci-dessous vont montrer comment
    exécuter des requêtes, avec chaque API, sans mise en mémoire
    tampon.
   </simpara>

--- a/reference/mysqlinfo/set.xml
+++ b/reference/mysqlinfo/set.xml
@@ -42,7 +42,7 @@
      Ce guide explique la <link linkend="mysqlinfo.terminology">terminologie</link>
      utilisée pour décrire chacune d'elles, fournit des informations
      quant <link linkend="mysqlinfo.api.choosing">aux choix de l'API</link>
-     à utiliser, ainsi que des informations vous permettant de vous
+     à utiliser, ainsi que des informations l'on permettant de l'on
      aider à choisir la <link linkend="mysqlinfo.library.choosing">bibliothèque
      MySQL à utiliser</link> avec l'API.
     </simpara>
@@ -51,7 +51,7 @@
   <chapter xmlns="http://docbook.org/ns/docbook" xml:id="mysqlinfo.terminology">
    <title>Aperçu de la terminologie</title>
    <simpara>
-    Cette section fournit une introduction aux options qui vous sont disponibles
+    Cette section fournit une introduction aux options qui sont disponibles
     lors du développement d'une application PHP qui doit interagir avec
     une base de données MySQL.
    </simpara>
@@ -62,7 +62,7 @@
 
    <simpara>
     Une interface de programmation d'application, ou API, définit les classes,
-    les méthodes, les fonctions et les variables dont votre application
+    les méthodes, les fonctions et les variables dont le application
     a besoin pour réaliser les tâches désirées. Dans le cas des applications
     PHP qui ont besoin de communiquer avec des bases de données, les APIs
     nécessaires sont habituellement exposées via des extensions PHP.
@@ -70,8 +70,8 @@
 
    <simpara>
     Les APIs peuvent être procédurales ou orientées objet. Avec une API
-    procédurale, vous appelez des fonctions pour réaliser vos tâches,
-    avec une API orientée objet, vous instanciez les classes, puis vous
+    procédurale, on appelle des fonctions pour réaliser les tâches,
+    avec une API orientée objet, on instancie les classes, puis l'on
     appelez les méthodes sur les objets résultants. La seconde interface
     est généralement préférée car elle est plus moderne et permet
     de mieux organiser le code source.
@@ -81,7 +81,7 @@
     Lors de l'écriture d'applications PHP qui ont besoin de se connecter
     à un serveur MySQL, il y a plusieurs options de l'API disponibles.
     Ce document va aborder ce qui est disponible, et comment choisir
-    la meilleure solution pour votre application.
+    la meilleure solution pour le application.
    </simpara>
 
    <simpara>
@@ -90,22 +90,22 @@
 
    <simpara>
     Dans la documentation MySQL, le terme <emphasis>connecteur</emphasis>
-    se réfère à la partie du programme qui autorise votre application
+    se réfère à la partie du programme qui autorise le application
     à se connecter au serveur de base de données MySQL. MySQL fournit
     des connecteurs pour bon nombre de langages, incluant PHP.
    </simpara>
 
    <simpara>
-    Si votre application PHP a besoin de communiquer avec un serveur
-    de base de données, vous devez écrire votre code PHP pour effectuer
+    Si le application PHP a besoin de communiquer avec un serveur
+    de base de données, il faut écrire le code PHP pour effectuer
     des tâches comme se connecter au serveur de base de données,
     requêter la base de données ainsi que d'autres tâches relatives
     à la base de données. Le programme est requis pour fournir l'API
-    à utiliser par votre application PHP, mais aussi pour gérer
-    la communication entre votre application et le serveur de base
+    à utiliser par le application PHP, mais aussi pour gérer
+    la communication entre le application et le serveur de base
     de données, en utilisant des bibliothèques intermédiaires
     au besoin. Ce programme est généralement appelé connecteur,
-    vu qu'il autorise votre application à se <emphasis>connecter</emphasis>
+    vu qu'il autorise le application à se <emphasis>connecter</emphasis>
     au serveur de base de données.
    </simpara>
 
@@ -142,7 +142,7 @@
    </simpara>
 
    <simpara>
-    Dans la documentation PHP, vous trouverez un autre terme -
+    Dans la documentation PHP, on trouvera un autre terme -
     <emphasis>extension</emphasis>. Le code PHP est constitué
     d'un cœur, avec des extensions optionnelles permettant
     d'étendre les fonctionnalités du cœur. Les extensions PHP relatives
@@ -172,7 +172,7 @@
   <chapter xmlns="http://docbook.org/ns/docbook" xml:id="mysqlinfo.api.choosing">
    <title>Choisir une API</title>
    <simpara>
-    PHP offre des APIs différentes pour se connecter à MySQL. Ci-dessous, vous
+    PHP offre des APIs différentes pour se connecter à MySQL. Ci-dessous, l'on
     trouverez les APIs fournies par les extensions mysqli et PDO.
     Chaque exemple de code crée une connexion à un serveur MySQL s'exécutant sur
     le domaine "example.com", en utilisant le nom d'utilisateur "user", le mot
@@ -318,7 +318,7 @@ echo htmlentities($row['_message']);
     La bibliothèque mysqlnd fait partie de la distribution de PHP.
     Elle offre des fonctionnalités comme les connexions paresseuses,
     la mise en cache de requêtes, qui ne sont pas disponibles avec libmysqlclient,
-    aussi, nous vous recommandons d'utiliser la bibliothèque interne mysqlnd.
+    aussi, il est recommandé d'utiliser la bibliothèque interne mysqlnd.
     Voir la <link linkend="book.mysqlnd">documentation de mysqlnd</link>
     pour plus d'informations, ainsi qu'une liste des fonctionnalités qu'elle offre.
    </simpara>

--- a/reference/mysqlnd/config.xml
+++ b/reference/mysqlnd/config.xml
@@ -105,7 +105,7 @@
    </term>
    <listitem>
     <simpara>
-     Active la collecte de différentes statistiques du client auxquelles vous
+     Active la collecte de différentes statistiques du client auxquelles l'on
      pouvez accéder via <function>mysqli_get_client_stats</function>,
      <function>mysqli_get_connection_stats</function>,
      et qui sont aussi décrites
@@ -313,12 +313,12 @@ d:t:x:O,/tmp/mysqlnd.trace
       (<literal>ext/mysql</literal>, <literal>ext/mysqli</literal>,
       <literal>PDO_MySQL</literal>) qui se repose sur
       <literal>mysqlnd</literal>. <literal>mysqlnd</literal> indique aux flux PHP d'utiliser
-      <literal>mysqlnd.net_read_timeout</literal>. Notez qu'il peut y avoir des différences
+      <literal>mysqlnd.net_read_timeout</literal>. À noter : qu'il peut y avoir des différences
       subtiles entre
       <literal>MYSQL_OPT_READ_TIMEOUT</literal> de la MySQL Client Library et les flux
       PHP, par exemple <literal>MYSQL_OPT_READ_TIMEOUT</literal> est dite fonctionnelle
       uniquement avec des connexions TCP/IP et, avant MySQL 5.1.2, seulement sous Windows.
-      Les flux PHP, eux, n'ont pas cette limite. Voyez la documentation des flux en cas
+      Les flux PHP, eux, n'ont pas cette limite. Voir la documentation des flux en cas
       de doute.
      </simpara>
     </listitem>
@@ -337,12 +337,12 @@ d:t:x:O,/tmp/mysqlnd.trace
       <literal>COM_QUERY</literal> (requête <quote>normale</quote>), ne rentre pas dans
       le buffer, <literal>mysqlnd</literal> va agrandir celui-ci à la taille requise.
       A chaque fois que le buffer est agrandi pour une connexion,
-      <literal>command_buffer_too_small</literal> va être incrémenté de un.
+      <literal>command_buffer_too_small</literal> va être incrémenté d'un.
      </simpara>
      <simpara>
       Si <literal>mysqlnd</literal> doit agrandir le buffer au-delà de sa taille initiale de
       <literal>mysqlnd.net_cmd_buffer_size</literal> octets pour presque toutes les connexions,
-      vous devriez alors augmenter cette taille par défaut afin d'éviter les ré-allocations.
+      il est recommandé d'alors augmenter cette taille par défaut afin d'éviter les ré-allocations.
      </simpara>
      <simpara>
       La taille par défaut du buffer est de 4096 octets.
@@ -416,7 +416,7 @@ d:t:x:O,/tmp/mysqlnd.trace
     <simpara>
      Impose la copie des jeux de résultats depuis les tampons internes vers
      des variables PHP au lieu d'utiliser le mécanisme par défaut de référence
-     et de copie sur écriture. Veuillez vous référer aux,
+     et de copie sur écriture. Se référer aux,
      <link linkend="mysqlnd.memory">notes d'implémentation sur la gestion de mémoire</link>
      pour plus de détails.
     </simpara>

--- a/reference/mysqlnd/incompatibilities.xml
+++ b/reference/mysqlnd/incompatibilities.xml
@@ -13,7 +13,7 @@
    <simpara>
     Les valeurs de type <literal>bit</literal> sont retournées comme des chaînes binaires
     (e.g. "\0" or "\x1F") avec <literal>libmysql</literal> mais comme des chaînes décimales
-    (e.g. "0" or "31") avec <literal>mysqlnd</literal>. Si vous voulez être compatible avec les
+    (e.g. "0" or "31") avec <literal>mysqlnd</literal>. Pour être compatible avec les
     deux bibliothèques, retournez toujours les champs bit comme des nombres, avec des requêtes
     MySQL comme:
     <literal>SELECT bit + 0 FROM table</literal>.

--- a/reference/mysqlnd/memory.xml
+++ b/reference/mysqlnd/memory.xml
@@ -43,7 +43,7 @@
   de jeux de résultats trop importants, excédant la taille de la mémoire restante
   disponible pour PHP. En raison du fait que la bibliothèque cliente MySQL n'utilise
   pas les fonctions de gestion mémoire de PHP, elle ne prend en compte aucune limitation
-  mémoire définie par PHP. Si vous utilisez la bibliothèque cliente MySQL, suivant
+  mémoire définie par PHP. Lors de l'utilisation de la bibliothèque cliente MySQL, suivant
   le modèle de déploiement, l'empreinte mémoire du processus PHP peut s'accroitre
   et dépasser la limite mémoire imposée par PHP. De plus, les scripts PHP peuvent
   analyser des jeux de résultats plus importants, allouant ainsi plus de mémoire
@@ -106,7 +106,7 @@
   <link linkend="mysqlnd.stats">statistiques</link> pour vérifier si un script
   libère le jeu de résultats explicitement, ou si le driver le libère implicitement,
   faisant ainsi que la mémoire soit utilisée plus longtemps que nécessaire.
-  Les statistiques peuvent aussi vous aider à voir les opérations de copie-sur-lecture.
+  Les statistiques peuvent aussi l'on aider à voir les opérations de copie-sur-lecture.
  </simpara>
  <simpara>
   Un script PHP lisant beaucoup de petites lignes d'un jeu de résultat mis en mémoire tampon
@@ -127,12 +127,12 @@
   Il existe plusieurs façons de surveiller l'utilisation mémoire du driver natif MySQL.
   Si le but est d'obtenir une vue rapide haut niveau, ou de vérifier la mémoire
   efficiente des scripts PHP, alors vérifiez les <link linkend="mysqlnd.stats">statistiques</link>
-  collectées par la bibliothèque. Elles vous permettent, par exemple,
+  collectées par la bibliothèque. Elles l'on permettent, par exemple,
   de voir les requêtes SQL qui génèrent plus de résultats que d'analyses par un script PHP.
  </simpara>
  <simpara>
   La trace de <link linkend="ini.mysqlnd.debug">débogage</link> dans l'historisation
-  peut être configurée pour enregistrer les appels au gestionnaire mémoire. Ceci peut vous
+  peut être configurée pour enregistrer les appels au gestionnaire mémoire. Ceci peut l'on
   aider à voir quand la mémoire est allouée ou libérée. Cependant, la taille des
   morceaux mémoire demandés peut ne pas y être listée.
  </simpara>

--- a/reference/mysqlnd/overview.xml
+++ b/reference/mysqlnd/overview.xml
@@ -12,7 +12,7 @@
   de noter qu'il ne fournit pas une nouvelle API au programmeur PHP. Les API programmeur
   sont fournies par l'extension MySQL, <literal>mysqli</literal> et PDO
   MySQL. Ces extensions peuvent maintenant utiliser les services du pilote natif MySQL pour communiquer
-  avec le serveur MySQL. Ainsi, vous ne devez pas considérer le pilote natif MySQL comme une API.
+  avec le serveur MySQL. Ainsi, il ne faut pas considérer le pilote natif MySQL comme une API.
  </simpara>
  <simpara>
   <emphasis role="bold">Pourquoi l'utiliser?</emphasis>
@@ -23,20 +23,20 @@
  </simpara>
  <simpara>
   L'ancienne bibliothèque MySQL cliente a été écrite par MySQL AB (maintenant
-  partie de Oracle Corporation) et a donc été publiée sous licence MySQL,
+  partie d'Oracle Corporation) et a donc été publiée sous licence MySQL,
   ce qui a eu pour conséquence de désactiver le support de MySQL par défaut
   dans PHP? Vu que le pilote natif MySQL a été développé comme partie intégrante
   du projet PHP, il est publié sous licence PHP, ce qui résout les soucis
   de licence problématique dans le passé.
  </simpara>
  <simpara>
-  De plus, auparavant, vous deviez compiler les extensions de base de données
+  De plus, auparavant, on devait compiler les extensions de base de données
   MySQL par rapport à une copie de la bibliothèque MySQL cliente, ce qui signifie que
-  vous deviez avoir MySQL d'installé sur la machine sur laquelle vous compiliez PHP à
-  partir des sources. Ainsi, quand votre application PHP était exécutée, les extensions
+  on devait avoir MySQL d'installé sur la machine sur laquelle l'on compile PHP à
+  partir des sources. Ainsi, quand le application PHP était exécutée, les extensions
   MySQL appelaient les fichiers de la bibliothèque MySQL cliente au démarrage, ceux-ci devant
   être obligatoirement installés sur le système. Avec le pilote natif MySQL, ce n'est plus le cas
-  car il est inclus dans la distribution standard. Ainsi, vous n'aurez plus besoin d'avoir MySQL
+  car il est inclus dans la distribution standard. Ainsi, l'on n'aurez plus besoin d'avoir MySQL
   installé pour compiler PHP ou exécuter des applications PHP faisant appel à une base de données.
  </simpara>
  <simpara>

--- a/reference/mysqlnd/plugin.xml
+++ b/reference/mysqlnd/plugin.xml
@@ -251,7 +251,7 @@
   </simpara>
   <simpara>
    Un proxy MySQL fonctionne au-dessus de la couche physique. Avec un
-   proxy MySQL, vous devez analyser et effectuer du "reverse engineering"
+   proxy MySQL, il faut analyser et effectuer du "reverse engineering"
    du protocole client serveur MySQL. Les actions sont limitées à celles
    qui peuvent être effectuées par la manipulation du protocole
    de communication. Si la couche physique change (ce qui arrive très rarement),
@@ -261,9 +261,9 @@
    Les plugins <literal>Mysqlnd</literal> fonctionnent au-dessus de l'API C,
    reflétant ainsi les APIs client <literal>libmysqlclient</literal>.
    Cette API C est essentiellement une enveloppe du protocole Serveur Client MySQL,
-   ou de la couche physique, vu qu'elle est appelée quelques fois. Vous pouvez
+   ou de la couche physique, vu qu'elle est appelée quelques fois. L'on peut
    intercepter tous les appels à l'API C. PHP utilise l'API C, toutefois,
-   vous pouvez connecter tous les appels PHP, sans avoir besoin de programmer
+   il est possible de connecter tous les appels PHP, sans avoir besoin de programmer
    au niveau de la couche physique.
   </simpara>
   <simpara>
@@ -273,7 +273,7 @@
    généralement pas nécessaire.
   </simpara>
   <simpara>
-   Vu que les plugins vous autorisent à créer des implémentations qui
+   Vu que les plugins permettent d'créer des implémentations qui
    utilisent les 2 niveaux (API C et couche physique), ils ont plus de flexibilité
    que le proxy MySQL. Si un plugin <literal>mysqlnd</literal> est implémenté
    en utilisant l'API C, toutes les modifications ultérieures à la couche
@@ -396,7 +396,7 @@
    pour implémenter l'orientation de l'objet.
   </simpara>
   <simpara>
-   En C, vous utilisez une structure (<literal>struct</literal>)
+   En C, on utilise une structure (<literal>struct</literal>)
    pour représenter un objet. Les membres de cette structure
    représentent les propriétés de l'objet. Les membres de la
    structure pointant vers des fonctions représentent les méthodes.
@@ -569,9 +569,9 @@ MYSQLND_METHOD(my_conn_class, query)(MYSQLND *conn,
    </tgroup>
   </table>
   <simpara>
-   Si vous prévoyez de faire des sous-classes des constructeurs
+   Si l'on prévoir de faire des sous-classes des constructeurs
    des objets <literal>mysqlnd</literal>, ce qui est autorisé,
-   vous devez conserver ceci en mémoire !
+   il faut conserver ceci en mémoire !
   </simpara>
   <simpara>
    Le code suivant montre la façon dont on étend des propriétés :
@@ -668,7 +668,7 @@ static MY_CONN_PROPERTIES** get_conn_properties(const MYSQLND *conn TSRMLS_DC) {
    </tgroup>
   </table>
   <simpara>
-   Vous ne devez pas manipuler les tables de fonction après MINIT si
+   Il ne faut pas manipuler les tables de fonction après MINIT si
    ce n'est pas autorisé suivant la table ci-dessus.
   </simpara>
   <simpara>
@@ -681,9 +681,9 @@ static MY_CONN_PROPERTIES** get_conn_properties(const MYSQLND *conn TSRMLS_DC) {
   <simpara>
    Les autres classes utilisent une copie de la table de fonction
    globale partagée. Cette copie est créée en même temps que l'objet.
-   Chaque objet utilise sa propre table de fonction. Ceci vous donne
-   2 options : vous pouvez manipuler la table de fonction par défaut
-   d'un objet au moment du MINIT, et vous pouvez aussi affiner des
+   Chaque objet utilise sa propre table de fonction. Ceci l'on donne
+   2 options : il est possible de manipuler la table de fonction par défaut
+   d'un objet au moment du MINIT, et il est également possible d'affiner des
    méthodes d'un objet sans impacter les autres instances de la même
    classe.
   </simpara>
@@ -793,9 +793,9 @@ static MY_CONN_PROPERTIES** get_conn_properties(const MYSQLND *conn TSRMLS_DC) {
    Les constructeurs effectuent les allocations mémoires. Les allocations
    mémoires sont vitales pour l'API du plugin <literal>mysqlnd</literal>
    ainsi que pour la logique de l'objet <literal>mysqlnd</literal>. Si
-   vous ne vous souciez pas des alertes et que vous insistez pour
-   remplacer les constructeurs, vous devriez au moins appeler
-   le constructeur parent avant de faire quoi que ce soit dans votre
+   l'on ne se soucie pas des alertes et que l'on insiste pour
+   remplacer les constructeurs, il est recommandé d'au moins appeler
+   le constructeur parent avant de faire quoi que ce soit dans le
    constructeur.
   </simpara>
   <simpara>
@@ -856,16 +856,16 @@ static MY_CONN_PROPERTIES** get_conn_properties(const MYSQLND *conn TSRMLS_DC) {
   <simpara>
    Les destructeurs listés peuvent ne pas être les équivalents aux
    méthodes actuelles <literal>mysqlnd</literal> libérant l'objet lui-même.
-   Cependant, ils sont les meilleurs endroits pour vous pour libérer
-   les données de votre plugin. Tout comme les constructeurs, vous
-   pouvez remplacer les méthodes entières mais ce n'est pas recommandé.
-   Si plusieurs méthodes sont listées dans la table ci-dessus, vous devez
-   modifier toutes les méthodes listées et libérer les données de votre
+   Cependant, ils sont les meilleurs endroits pour l'on pour libérer
+   les données du plugin. Tout comme les constructeurs, il est possible de
+   remplacer les méthodes entières mais ce n'est pas recommandé.
+   Si plusieurs méthodes sont listées dans la table ci-dessus, il faut
+   modifier toutes les méthodes listées et libérer les données du
    plugin dans la méthode appelée en premier par <literal>mysqlnd</literal>.
   </simpara>
   <simpara>
    La méthode recommandée pour les plugins est de modifier simplement les méthodes,
-   libérer votre mémoire et appeler l'implémentation du parent immédiatement après.
+   libérer le mémoire et appeler l'implémentation du parent immédiatement après.
   </simpara>
  </section>
  <section xml:id="mysqlnd.plugin.api">
@@ -987,7 +987,7 @@ static MY_CONN_PROPERTIES** get_conn_properties(const MYSQLND *conn TSRMLS_DC) {
   <simpara>
    Tel que discuté précédemment, les plugins peuvent utiliser librement
    des pointeurs. Ces pointeurs ne sont restreints en aucune manière,
-   aussi, vous pouvez pointer vers les données d'un autre plugin.
+   aussi, il est possible de pointer vers les données d'un autre plugin.
    Une simple position arithmétique peut être utilisée pour lire
    les données d'un autre plugin.
   </simpara>
@@ -1226,7 +1226,7 @@ mysqlnd_plugin_set_conn_proxy(new proxy());
    </listitem>
   </orderedlist>
   <simpara>
-   Vous devez effectuer les opérations suivantes :
+   Il faut effectuer les opérations suivantes :
   </simpara>
   <orderedlist>
    <listitem>
@@ -1250,7 +1250,7 @@ mysqlnd_plugin_set_conn_proxy(new proxy());
   <simpara>
    Les méthodes de l'objet de l'espace utilisateur peuvent soit être
    appelées en utilisant <literal>call_user_function()</literal>,
-   soit vous pouvez opérer à un niveau en dessous du moteur Zend et
+   soit il est possible d'opérer à un niveau en dessous du moteur Zend et
    utiliser <literal>zend_call_method()</literal>.
   </simpara>
   <simpara>
@@ -1273,7 +1273,7 @@ mysqlnd_plugin_set_conn_proxy(new proxy());
 ]]>
   </programlisting>
   <simpara>
-   L'API Zend supporte 2 arguments. Vous pouvez en avoir besoin de plus, par
+   L'API Zend supporte 2 arguments. Il est possible d'en avoir besoin de plus, par
    exemple :
   </simpara>
   <programlisting>
@@ -1288,9 +1288,9 @@ mysqlnd_plugin_set_conn_proxy(new proxy());
 ]]>
   </programlisting>
   <simpara>
-   Pour contourner ce problème, vous devrez faire une copie
+   Pour contourner ce problème, il faudra faire une copie
    de <literal>zend_call_method()</literal> et ajouter une
-   fonctionnalité pour ajouter des paramètres. Vous pouvez
+   fonctionnalité pour ajouter des paramètres. L'on peut
    réaliser ceci en créant un jeu de macros
    <literal>MY_ZEND_CALL_METHOD_WRAPPER</literal>.
   </simpara>
@@ -1410,7 +1410,7 @@ mysqlnd_plugin_set_conn_proxy(new proxy());
   </simpara>
   <simpara>
    Comme résultat d'un sous-classement, il est possible de
-   redéfinir uniquement les méthodes sélectionnées, et vous
+   redéfinir uniquement les méthodes sélectionnées, et l'on
    pouvez choisir d'avoir des actions "pre" ou "post".
   </simpara>
   <simpara>

--- a/reference/mysqlnd/stats.xml
+++ b/reference/mysqlnd/stats.xml
@@ -1607,7 +1607,7 @@ $link->real_connect(/* ... */);
       ne rentre pas dans le tampon,
       mysqlnd étendra le tampon à ce qui est nécessaire pour envoyer la commande.
       Chaque fois que le tampon est étendu pour une connexion
-      <literal>command_buffer_too_small</literal> sera incrémenté de un.
+      <literal>command_buffer_too_small</literal> sera incrémenté d'un.
      </simpara>
      <simpara>
       Si mysql est obligé de faire croître le tampon au-delà de sa taille initiale de

--- a/reference/network/functions/dns-get-record.xml
+++ b/reference/network/functions/dns-get-record.xml
@@ -130,7 +130,7 @@
        <entry>
         Chaîne de caractères contenant le type d'enregistrement. Des attributs
         supplémentaires seront aussi disponibles dans le tableau suivant la
-        valeur de ce type. Reportez-vous à la table ci-dessous.
+        valeur de ce type. Se reporter à la table ci-dessous.
        </entry>
       </row>
       <row>

--- a/reference/network/functions/fsockopen.xml
+++ b/reference/network/functions/fsockopen.xml
@@ -27,7 +27,7 @@
    être trouvée en utilisant la fonction <function>stream_get_transports</function>.
   </para>
   <para>
-   Le socket sera ouvert par défaut en mode bloquant. Vous pouvez
+   Le socket sera ouvert par défaut en mode bloquant. L'on peut
    changer de mode en utilisant : <function>stream_set_blocking</function>.
   </para>
   <para>
@@ -46,9 +46,9 @@
      <listitem>
       <para>
        Si le support OpenSSL <link linkend="openssl.installation">est
-       installé</link>, vous pouvez préfixer <parameter>hostname</parameter>
+       installé</link>, il est possible de préfixer <parameter>hostname</parameter>
        avec <literal>ssl://</literal> ou <literal>tls://</literal> pour utiliser
-       une connexion cliente SSL ou TLS sur TCP/IP pour vous connecter à l'hôte
+       une connexion cliente SSL ou TLS sur TCP/IP pour se connecter à l'hôte
        distant.
       </para>
      </listitem>
@@ -96,7 +96,7 @@
       </para>
       <note>
        <para>
-        Si vous avez besoin de définir un délai limite pour lire/écrire des
+        Si on a besoin de définir un délai limite pour lire/écrire des
         données à travers ce socket, utilisez la fonction
         <function>stream_set_timeout</function>, car le paramètre
         <parameter>timeout</parameter> de la fonction
@@ -184,7 +184,7 @@ if (!$fp) {
     <title>Utilisation d'une connexion UDP</title>
     <para>
      L'exemple ci-dessous décrit comment lire la date et l'heure grâce à
-     un service UDP "daytime" (port 13), sur votre propre machine.
+     un service UDP "daytime" (port 13), sur le propre machine.
     </para>
     <programlisting role="php">
 <![CDATA[
@@ -216,7 +216,7 @@ if (!$fp) {
    <para>
     Les sockets UDP semblent quelques fois avoir été ouverts sans erreur,
     même si l'hôte distant n'est pas accessible. L'erreur apparaît alors
-    uniquement lorsque vous tentez de lire/écrire sur le socket.
+    uniquement lorsqu'on tente de lire/écrire sur le socket.
     La raison de cela est que UDP est un protocole <literal>"connectionless"</literal>,
     ce qui signifie que le système ne tentera pas d'établir un lien pour le socket
     tant qu'il ne doit pas recevoir/envoyer de données.

--- a/reference/network/functions/header.xml
+++ b/reference/network/functions/header.xml
@@ -20,7 +20,7 @@
   <para>
    <function>header</function> permet de spécifier l'en-tête <acronym>HTTP</acronym>
    <parameter>string</parameter> lors de l'envoi des fichiers HTML.
-   Reportez-vous à <link xlink:href="&url.rfc;2616"><literal>HTTP/1.1
+   Se reporter à <link xlink:href="&url.rfc;2616"><literal>HTTP/1.1
      Specification</literal></link> pour plus d'informations sur les en-têtes
    <acronym>HTTP</acronym>.
   </para>
@@ -64,10 +64,10 @@ exit;
       <para>
        Il y a deux en-têtes spéciaux. Le premier commence par la chaîne
        "<literal>HTTP/</literal>" (insensible à la casse), qui est utilisée
-       pour signifier le statut HTTP à envoyer. Par exemple, si vous avez configuré
+       pour signifier le statut HTTP à envoyer. Par exemple, si on a configuré
        Apache pour utiliser les scripts PHP pour gérer les requêtes vers des fichiers
        inexistants (en utilisant la directive <literal>ErrorDocument</literal>),
-       assurez-vous que le script génère un code statut correct.
+       il faut s'assurer que le script génère un code statut correct.
       </para>
       <para>
        <informalexample>
@@ -116,7 +116,7 @@ exit;
        si la fonction <function>header</function> doit remplacer
        un en-tête précédemment émis, ou bien ajouter un autre en-tête
        du même type. Par défaut, un nouvel en-tête va écraser le
-       précédent, mais si vous passez &false; dans cet argument, vous pouvez
+       précédent, mais si on passe &false; dans cet argument, l'on peut
        forcer les en-têtes multiples pour un même type d'en-tête.
        Par exemple :
       </para>
@@ -170,9 +170,9 @@ header('WWW-Authenticate: NTLM', false);
    <example>
     <title>Boîte de téléchargement</title>
     <para>
-     Si vous voulez que vos utilisateurs recoivent une alerte pour sauver
-     les fichiers générés, comme si vous génériez un
-     fichier PDF, vous pouvez utiliser l'en-tête
+     Pour que les utilisateurs recoivent une alerte pour sauver
+     les fichiers générés, comme si l'on génère un
+     fichier PDF, il est possible d'utiliser l'en-tête
      <link xlink:href="&url.rfc;2183">Content-Disposition</link> pour
      fournir un nom de fichier par défaut, à afficher dans le
      dialogue de sauvegarde.
@@ -213,12 +213,12 @@ header("Expires: Sat, 26 Jul 1997 05:00:00 GMT"); // Date dans le passé
     <para>
      <note>
       <para>
-       Vous pouvez vous rendre compte que vos pages ne sont jamais mises
-       en cache même si vous utilisez tous les en-têtes ci-dessus.
+       Il est possible de l'on rendre compte que les pages ne sont jamais mises
+       en cache même lors de l'utilisation de tous les en-têtes ci-dessus.
        Il existe toute une collection de paramètres que les utilisateurs
        peuvent modifier sur leur navigateur pour modifier le
        comportement par défaut du cache. En envoyant les en-têtes
-       ci-dessus, vous pouvez imposer vos propres valeurs.
+       ci-dessus, il est possible d'imposer les propres valeurs.
       </para>
       <para>
        De plus, les paramètres <function>session_cache_limiter</function> et
@@ -258,13 +258,13 @@ header('Set-Cookie: name=value; Secure; Path=/; SameSite=None; Partitioned;');
   &note.network.header.sapi;
   <note>
    <para>
-    Vous pouvez utiliser le système de cache (output buffering)
-    pour contourner ce problème. Tous vos textes générés seront
-    mis en buffer sur le serveur jusqu'à ce que vous les envoyiez. Vous pouvez
+    Il est possible d'utiliser le système de cache (output buffering)
+    pour contourner ce problème. Tous les textes générés seront
+    mis en buffer sur le serveur jusqu'à ce qu'on les envoyiez. L'on peut
     utiliser les fonctions <function>ob_start</function> et
-    <function>ob_end_flush</function> dans vos scripts, ou en
+    <function>ob_end_flush</function> dans les scripts, ou en
     modifiant la directive de configuration <literal>output_buffering</literal>
-    dans votre fichier &php.ini; ou vos fichiers
+    dans le fichier &php.ini; ou les fichiers
     de configuration du serveur.
    </para>
   </note>
@@ -282,10 +282,10 @@ header('Set-Cookie: name=value; Secure; Path=/; SameSite=None; Partitioned;');
     La plupart des clients modernes acceptent des <acronym>URI</acronym> relatives comme argument de
     <link xlink:href="&spec.http1.1;#section-7.1.2">Location:</link>,
     mais certains clients plus anciens exigent une URI absolue
-    y compris le protocole, l'hôte et le chemin absolu. Vous pouvez généralement
+    y compris le protocole, l'hôte et le chemin absolu. Il est possible de généralement
     utiliser les variables globales <varname>$_SERVER['HTTP_HOST']</varname>,
     <varname>$_SERVER['PHP_SELF']</varname> et <function>dirname</function> pour
-    construire vous-même une URI absolue :
+    construire soi-même une URI absolue :
     <informalexample>
      <programlisting role="php">
 <![CDATA[

--- a/reference/network/functions/headers-sent.xml
+++ b/reference/network/functions/headers-sent.xml
@@ -19,8 +19,8 @@
    Vérifie si les en-têtes HTTP ont déjà été envoyés.
   </para>
   <para>
-   Vous ne pouvez plus envoyer d'en-têtes avec la fonction <function>header</function> 
-   une fois que le bloc d'en-tête a été fermé. En utilisant cette fonction, vous pouvez
+   On ne pouvez plus envoyer d'en-têtes avec la fonction <function>header</function> 
+   une fois que le bloc d'en-tête a été fermé. En utilisant cette fonction, l'on peut
    au moins éviter de voir s'afficher les erreurs HTTP reliées. Une autre
    option consiste à utiliser le <link linkend="ref.outcontrol">contrôle de sortie</link>.
   </para>

--- a/reference/network/functions/http-response-code.xml
+++ b/reference/network/functions/http-response-code.xml
@@ -38,7 +38,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Si <parameter>response_code</parameter> est fourni, dans ce cas là le code d'état
+   Si <parameter>response_code</parameter> est fourni, dans ce cas lau code d'état
    précédent sera retourné. Si <parameter>response_code</parameter> n'est pas fourni,
    alors le code d'état actuel sera retourné. Ces deux valeurs seront par défaut le
    code d'état <literal>200</literal> si utilisé dans un environnement de serveur Web.

--- a/reference/network/functions/ip2long.xml
+++ b/reference/network/functions/ip2long.xml
@@ -99,7 +99,7 @@ if ($long == -1 || $long === FALSE) {
   <note>
    <para>
     Comme les &integer; PHP sont signés et que beaucoup d'adresses IP
-    résulteront en des entiers négatifs sur les architectures 32-bits, vous
+    résulteront en des entiers négatifs sur les architectures 32-bits, l'on
     devez utiliser le motif "%u" de la fonction <function>sprintf</function>
     ou de la fonction <function>printf</function> pour récupérer la représentation
     sous forme de &string; d'une adresse IP non signée.

--- a/reference/network/functions/pfsockopen.xml
+++ b/reference/network/functions/pfsockopen.xml
@@ -28,7 +28,7 @@
  <refsect1 role="parameters">
   &reftitle.parameters;
   <para>
-   Pour plus d'informations sur les paramètres, reportez-vous à la
+   Pour plus d'informations sur les paramètres, se reporter à la
    documentation sur la fonction <function>fsockopen</function>.
   </para>
  </refsect1>

--- a/reference/network/functions/setcookie.xml
+++ b/reference/network/functions/setcookie.xml
@@ -277,7 +277,7 @@ setcookie("TestCookie", $value, time()+3600, "/~rasmus/", "example.com", true);
    </programlisting>
   </example>
   <simpara>
-   Notez que la partie "valeur" du cookie sera automatiquement
+   À noter que la partie "valeur" du cookie sera automatiquement
    encodée URL par PHP. Cela peut être évité en utilisant la fonction
    <function>setrawcookie</function> à la place.
   </simpara>
@@ -413,7 +413,7 @@ one : cookieone
     <listitem>
      <simpara>
       Les noms des cookies peuvent être des tableaux de noms et seront
-      disponibles dans vos scripts PHP sous la forme de tableaux, mais
+      disponibles dans les scripts PHP sous la forme de tableaux, mais
       des cookies différents seront placés sur le navigateur.
       Utilisez <function>json_encode</function> pour définir un cookie
       avec des noms et des valeurs multiples. Il n'est pas recommandé d'utiliser

--- a/reference/network/functions/setrawcookie.xml
+++ b/reference/network/functions/setrawcookie.xml
@@ -36,7 +36,7 @@
  <refsect1 role="parameters">
   &reftitle.parameters;
   <para>
-   Pour plus d'informations, reportez-vous à la documentation de la
+   Pour plus d'informations, se reporter à la documentation de la
    fonction <function>setcookie</function>.
   </para>
  </refsect1>

--- a/reference/network/functions/syslog.xml
+++ b/reference/network/functions/syslog.xml
@@ -22,7 +22,7 @@
   </para>
   <para>
    Pour plus d'informations sur comment mettre en place un gestionnaire
-   d'historique, reportez-vous au manuel Unix, page 5
+   d'historique, se reporter au manuel Unix, page 5
    <citerefentry><refentrytitle>syslog.conf</refentrytitle>
    <manvolnum>5</manvolnum></citerefentry>. D'autres informations
    sur les systèmes d'historique et leurs options sont aussi

--- a/reference/oauth/oauth/disabledebug.xml
+++ b/reference/oauth/oauth/disabledebug.xml
@@ -16,7 +16,7 @@
   </methodsynopsis>
   <simpara>
    Désactive les messages de déboguage. Il est désactivé par défaut.
-   Vous pouvez définir la propriété <link linkend="oauth.props.debug">debug</link>
+   Il est possible de définir la propriété <link linkend="oauth.props.debug">debug</link>
    à &false; pour désactiver le déboguage.
   </simpara>
  </refsect1>

--- a/reference/oauth/oauth/setnonce.xml
+++ b/reference/oauth/oauth/setnonce.xml
@@ -26,7 +26,7 @@
     <term><parameter>nonce</parameter></term>
     <listitem>
      <simpara>
-      La valeur de oauth_nonce.
+      La valeur d'oauth_nonce.
      </simpara>
     </listitem>
    </varlistentry>

--- a/reference/oauth/oauth/setversion.xml
+++ b/reference/oauth/oauth/setversion.xml
@@ -15,7 +15,7 @@
    <methodparam><type>string</type><parameter>version</parameter></methodparam>
   </methodsynopsis>
   <simpara>
-   Configure la version de OAuth pour les prochains appels.
+   Configure la version d'OAuth pour les prochains appels.
   </simpara>
  </refsect1>
 

--- a/reference/oci8/book.xml
+++ b/reference/oci8/book.xml
@@ -16,11 +16,11 @@
    </simpara>
   </warning>
   <para>
-   Ces fonctions vous permettent d'accéder aux bases de données Oracle.
+   Ces fonctions permettent d'accéder aux bases de données Oracle.
    Elles supportent les commandes SQL et PL/SQL. Les fonctions de base
    incluent le contrôle de transaction, la liaison de variables PHP avec des
    conteneurs Oracle, le support des types de grands objets (LOB) et des
-   collections. Les fonctions d'extensibilité de Oracle, telles que de Database
+   collections. Les fonctions d'extensibilité d'Oracle, telles que de Database
    Resident Connection Pooling (DRCP) et le cache de résultats sont aussi
    supportés.
   </para>

--- a/reference/oci8/configure.xml
+++ b/reference/oci8/configure.xml
@@ -22,7 +22,7 @@
   <para>
    Le binaire PHP doit être lié avec les mêmes (ou plus récentes) versions
    majeures des bibliothèques Oracle pour lesquelles il a été configuré. Par exemple,
-   si vous compilez OCI8 avec les bibliothèques Oracle 19, alors PHP
+   si on compile OCI8 avec les bibliothèques Oracle 19, alors PHP
    doit aussi être déployé et exécuté avec les bibliothèques Oracle 19.
    Les applications PHP peuvent se connecter à d'autres versions de base
    de données Oracle, sachant qu'Oracle contient des compatibilités de versions
@@ -39,7 +39,7 @@
    <itemizedlist>
     <listitem>
      <para>
-      Si vous êtes derrière un pare-feu, définissez le proxy de PEAR, par exemple :
+      Si on est derrière un pare-feu, définissez le proxy de PEAR, par exemple :
      </para>
      <para>
       <informalexample>
@@ -70,7 +70,7 @@ pecl install oci8
     </listitem>
     <listitem>
      <para>
-      Lorsqu'on vous le demande, saisissez la valeur de <literal>$ORACLE_HOME</literal> ou
+      Lorsqu'on l'on le demande, saisissez la valeur de <literal>$ORACLE_HOME</literal> ou
       <literal>instantclient,/chemin/vers/le/répertoire/instant/client/lib</literal>.
      </para>
      <para>
@@ -82,7 +82,7 @@ pecl install oci8
     </listitem>
     <listitem>
      <para>
-      Si vous obtenez une erreur <literal>oci8_dtrace_gen.h: Aucun fichier ou
+      Si on obtient une erreur <literal>oci8_dtrace_gen.h: Aucun fichier ou
       répertoire de ce type</literal>, cela signifie que PHP a été compilé
       avec <link linkend="features.dtrace">DTrace Dynamic Tracing</link> activé.
       Installez en utilisant la commande :
@@ -100,7 +100,7 @@ $ pecl install oci8
    </listitem>
    <listitem>
     <para>
-      Modifiez votre fichier &php.ini; et ajoutez la ligne :
+      Modifiez le fichier &php.ini; et ajoutez la ligne :
      </para>
      <para>
       <informalexample>
@@ -112,7 +112,7 @@ extension=oci8.so
       </informalexample>
      </para>
      <para>
-      Assurez-vous que la directive &php.ini;
+      Il faut s'assurer que la directive &php.ini;
       <link linkend="ini.extension-dir">extension_dir</link> est
       définie sur le répertoire dans lequel <filename>oci8.so</filename> a été installé.
      </para>
@@ -201,7 +201,7 @@ make install
      </listitem>
      <listitem>
       <para>
-       Si vous obtenez une erreur <literal>oci8_dtrace_gen.h: Aucun fichier ou
+       Si on obtient une erreur <literal>oci8_dtrace_gen.h: Aucun fichier ou
        répertoire de ce type</literal>, cela signifie que PHP a été compilé
        avec <link linkend="features.dtrace">DTrace Dynamic Tracing</link> activé.
        Exécutez à nouveau les commandes <literal>configure</literal> et <literal>make</literal>
@@ -219,7 +219,7 @@ $ export PHP_DTRACE=yes
      </listitem>
      <listitem>
       <para>
-       Modifiez votre fichier &php.ini; et ajoutez la ligne :
+       Modifiez le fichier &php.ini; et ajoutez la ligne :
       </para>
       <para>
        <informalexample>
@@ -231,7 +231,7 @@ extension=oci8.so
       </informalexample>
      </para>
      <para>
-      Assurez-vous que la directive &php.ini;
+      Il faut s'assurer que la directive &php.ini;
       <link linkend="ini.extension-dir">extension_dir</link> est
       configurée sur le répertoire dans lequel <filename>oci8.so</filename>
       a été installé.
@@ -243,7 +243,7 @@ extension=oci8.so
   <section>
   <title>Installation d'OCI8 en tant qu'extension partagée lors de la compilation de PHP</title>
   <para>
-   Si vous compilez PHP à partir du code source, l'option de configuration <literal>shared</literal> peut être utilisée pour construire OCI8 en tant que bibliothèque partagée qui peut être chargée dynamiquement dans PHP. La construction d'une extension partagée permet à OCI8 d'être facilement mis à jour sans avoir d'impact sur le reste de PHP.
+   Si on compile PHP à partir du code source, l'option de configuration <literal>shared</literal> peut être utilisée pour construire OCI8 en tant que bibliothèque partagée qui peut être chargée dynamiquement dans PHP. La construction d'une extension partagée permet à OCI8 d'être facilement mis à jour sans avoir d'impact sur le reste de PHP.
   </para>
   <para>
    Configurez OCI8 en utilisant l'une des options de configuration suivantes.
@@ -252,7 +252,7 @@ extension=oci8.so
    <itemizedlist>
     <listitem>
      <para>
-      Si vous utilisez les bibliothèques gratuites <link xmlns="http://docbook.org/ns/docbook"
+      Lors de l'utilisation de les bibliothèques gratuites <link xmlns="http://docbook.org/ns/docbook"
       xmlns:xlink="http://www.w3.org/1999/xlink"
       xlink:href="&url.oracle.instant.client;">Oracle Instant
       Client</link>, faites ce qui suit :
@@ -267,12 +267,12 @@ extension=oci8.so
       </informalexample>
      </para>
      <para>
-      Si Instant Client 12.2 (ou une version antérieure) est installé à partir de fichiers ZIP, assurez-vous de créer
+      Si Instant Client 12.2 (ou une version antérieure) est installé à partir de fichiers ZIP, il faut s'assurer de créer
       d'abord le lien symbolique vers la bibliothèque, par exemple <literal>ln -s
       libclntsh.so.12.1 libclntsh.so</literal>.
      </para>
      <para>
-      Si vous utilisez une installation basée sur RPM d'Oracle Instant Client,
+      Lors de l'utilisation d'une installation basée sur RPM d'Oracle Instant Client,
       la ligne de configuration ressemblera à ceci :
      </para>
      <para>
@@ -290,7 +290,7 @@ extension=oci8.so
     </listitem>
     <listitem>
      <para>
-      Si vous utilisez une base de données Oracle ou une installation complète d'Oracle Client, procédez comme suit :
+      Lors de l'utilisation d'une base de données Oracle ou une installation complète d'Oracle Client, procédez comme suit :
      </para>
      <para>
       <informalexample>
@@ -302,11 +302,11 @@ extension=oci8.so
       </informalexample>
      </para>
      <para>
-      Assurez-vous que l'utilisateur du serveur web (<literal>nobody</literal>, <literal>www</literal>) a accès aux
+      Il faut s'assurer que l'utilisateur du serveur web (<literal>nobody</literal>, <literal>www</literal>) a accès aux
       bibliothèques, aux fichiers d'initialisation
       et au fichier <filename>tnsnames.ora</filename> (si utilisé) sous
       le répertoire <literal>$ORACLE_HOME</literal>. Avec Oracle
-      10<emphasis>g</emphasis>R2, vous devrez peut-être exécuter
+      10<emphasis>g</emphasis>R2, il faudra peut-être exécuter
       l'utilitaire <filename>$ORACLE_HOME/install/changePerm.sh</filename>
       pour donner accès au répertoire.
     </para>
@@ -317,7 +317,7 @@ extension=oci8.so
   Après la configuration, suivez la procédure habituelle de compilation de PHP,
   par exemple <emphasis>make install</emphasis>. L'extension partagée OCI8 <filename>oci8.so</filename>
   sera créée. Il peut être nécessaire de la déplacer manuellement dans le répertoire des extensions PHP, spécifié par
-  l'option <link linkend="ini.extension-dir">extension_dir</link> dans votre
+  l'option <link linkend="ini.extension-dir">extension_dir</link> dans le
   fichier &php.ini;.
  </para>
  <para>
@@ -336,14 +336,14 @@ extension=oci8.so
 <section>
  <title>Installation d'OCI8 en tant qu'extension statiquement compilée lors de la compilation de PHP</title>
  <para>
-  Si vous compilez PHP à partir du code source, vous pouvez configurer PHP pour inclure
+  Si on compile PHP à partir du code source, il est possible de configurer PHP pour inclure
   OCI8 en tant qu'extension statique en utilisant l'une des options de configuration suivantes.
  </para>
  <para>
   <itemizedlist>
    <listitem>
     <para>
-     Si vous utilisez Oracle Instant Client, faites ce qui suit :
+     Lors de l'utilisation d'Oracle Instant Client, faites ce qui suit :
      </para>
      <para>
       <informalexample>
@@ -357,7 +357,7 @@ extension=oci8.so
     </listitem>
     <listitem>
      <para>
-      Si vous utilisez une base de données Oracle ou une installation complète du client Oracle, faites ce qui suit :
+      Lors de l'utilisation d'une base de données Oracle ou une installation complète du client Oracle, faites ce qui suit :
      </para>
      <para>
       <informalexample>
@@ -374,8 +374,8 @@ extension=oci8.so
   <para>
    Après la configuration, suivez la procédure habituelle
    de construction de PHP, par exemple <emphasis>make install</emphasis>. Après une compilation
-   réussie, vous n'avez pas besoin d'ajouter <filename>oci8.so</filename> à
-   votre &php.ini;. Aucune étape supplémentaire de construction n'est requise.
+   réussie, il n'est pas nécessaire d'ajouter <filename>oci8.so</filename> à
+   le &php.ini;. Aucune étape supplémentaire de construction n'est requise.
   </para>
  </section>
  <section>
@@ -383,21 +383,21 @@ extension=oci8.so
   <para xmlns:xlink="http://www.w3.org/1999/xlink">
    La bibliothèque OCI8 peut être ajoutée à une installation existante de PHP en utilisant
    les DLL du référentiel <link xlink:href="&url.pecl.package;oci8">PECL</link> ou les bibliothèques situées dans le répertoire
-   <literal>ext</literal> de votre installation PHP.
+   <literal>ext</literal> de l'installation PHP.
   </para>
   <para>
    Avec les bibliothèques Oracle 12<emphasis>c</emphasis> (ou ultérieures), décommentez l'une des
-   lignes suivantes dans votre fichier &php.ini; <literal>extension=php_oci8_12c.dll</literal>
+   lignes suivantes dans le fichier &php.ini; <literal>extension=php_oci8_12c.dll</literal>
    ou <literal>extension=php_oci8_11g.dll</literal>, ou bien
    <literal>extension=php_oci8.dll</literal>. Seule une de ces DLL doit
    être active au même moment. Les DLLs avec des versions supérieures peuvent
    contenir plus de fonctionnalités. Toutes les DLLs peuvent ne pas être disponibles
-   pour toutes les versions de PHP. Assurez-vous que l'option
+   pour toutes les versions de PHP. Il faut s'assurer que l'option
    <link linkend="ini.extension-dir">extension_dir</link> est définie sur le dossier
    contenant les extensions DLLs de PHP.
   </para>
   <para>
-   Si vous utilisez le client Oracle Instant, définissez la variable
+   Lors de l'utilisation du client Oracle Instant, définissez la variable
    d'environnement <envar>PATH</envar> du système au dossier contenant les
    bibliothèques Oracle.
   </para>
@@ -405,17 +405,17 @@ extension=oci8.so
  <section>
   <title>Définition de l'environnement Oracle</title>
   <para>
-   Avant d'utiliser cette extension, assurez-vous que les variables d'environnement
+   Avant d'utiliser cette extension, il faut s'assurer que les variables d'environnement
    Oracle sont correctement définies pour l'utilisateur exécutant le serveur Web.
-   Si votre serveur Web est automatiquement démarré au démarrage de votre serveur,
-   alors assurez-vous également de la bonne configuration de la variable
+   Si le serveur Web est automatiquement démarré au démarrage du serveur,
+   alors il faut s'assurer également de la bonne configuration de la variable
    d'environnement utilisée à ce moment-ci.
   </para>
   <note>
    <para>
     Ne définissez pas les variables d'environnement Oracle en utilisant la fonction
-    <function>putenv</function> dans vos scripts PHP, car les bibliothèques
-    Oracle sont chargées et initialisées avant l'exécution de votre script.
+    <function>putenv</function> dans les scripts PHP, car les bibliothèques
+    Oracle sont chargées et initialisées avant l'exécution du script.
     Les variables définies avec <function>putenv</function> pourraient
     ainsi entrer en conflit et provoquer aussi bien des crashs que des
     comportements totalement inattendus. Des fonctions peuvent réagir
@@ -425,10 +425,10 @@ extension=oci8.so
    </para>
   </note>
   <para>
-   Sous les systèmes Red Hat Linux et ces variantes, vous devez exporter
+   Sous les systèmes Red Hat Linux et ces variantes, il faut exporter
    les variables à la fin du fichier <filename>/etc/sysconfig/httpd</filename>.
-   Sous les autres systèmes utilisant Apache 2, vous devez utiliser le
-   script <filename>envvars</filename> que vous trouverez dans le dossier
+   Sous les autres systèmes utilisant Apache 2, il faut utiliser le
+   script <filename>envvars</filename> qu'on trouvera dans le dossier
    <filename>bin</filename> d'Apache. Une autre option consiste à utiliser
    la directive <literal>SetEnv</literal> du fichier
    <filename>httpd.conf</filename>, mais ceci peut ne pas être suffisant
@@ -437,13 +437,13 @@ extension=oci8.so
   <para>
    Pour vérifier si les variables d'environnement ont été définies
    correctement, utilisez la fonction <function>phpinfo</function>
-   et attardez-vous sur la section <emphasis>Environment</emphasis>
+   et s'attarder sur la section <emphasis>Environment</emphasis>
    (et non la section <emphasis>Apache Environment</emphasis>) ;
    elle doit contenir toutes les variables définies.
   </para>
   <para>
-   Les variables qui pourraient vous être nécessaires sont
-   inclues dans la table suivante. Reportez-vous à la documentation Oracle
+   Les variables qui pourraient l'on être nécessaires sont
+   inclues dans la table suivante. Se reporter à la documentation Oracle
    pour plus d'informations sur toutes les variables.
    <table>
     <title>Variables d'environnement Oracle communes</title>
@@ -459,7 +459,7 @@ extension=oci8.so
        <entry>ORACLE_HOME</entry>
        <entry>
         Chemin vers le dossier contenant le logiciel de base de données
-        Oracle. Ne définissez pas cette variable si vous utilisez le client
+        Oracle. Ne définissez pas cette variable lors de l'utilisation du client
         Oracle Instant. En effet, elle n'est pas nécessaire mais peut causer
         des problèmes lors de l'installation.
        </entry>
@@ -468,7 +468,7 @@ extension=oci8.so
        <entry>ORACLE_SID</entry>
        <entry>
         Le nom de la base de données sur la machine locale. Il n'est pas
-        nécessaire de la définir si vous utilisez le client Oracle Instant,
+        nécessaire de la définir lors de l'utilisation du client Oracle Instant,
         ou alors, passez la toujours comme paramètre de connexion à la
         fonction <function>oci_connect</function>.</entry>
       </row>
@@ -531,13 +531,13 @@ extension=oci8.so
   <para>
    Le problème le plus courant lors de l'installation d'OCI8 est
    de ne pas avoir configuré correctement les variables d'environnement.
-   C'est un problème typique lorsque vous recevez un message
+   C'est un problème typique lorsqu'on reçoit un message
    d'erreur lors de l'utilisation des fonctions
    <function>oci_connect</function> ou <function>oci_pconnect</function>.
    L'erreur peut être une erreur purement PHP comme <emphasis>Call to undefined function
    oci_connect()</emphasis>, une erreur Oracle comme ORA-12705 ou
    encore un arrêt brutal d'Apache. Vérifiez le contenu des fichiers de
-   log d'Apache lors de son démarrage et reportez-vous aux sections
+   log d'Apache lors de son démarrage et se reporter aux sections
    ci-dessus pour résoudre le problème.
   </para>
   <para>
@@ -549,13 +549,13 @@ extension=oci8.so
   </para>
   <para>
    Sous Windows, le fait d'avoir plusieurs versions d'Oracle sur la même
-   machine peut facilement faire crasher l'installation tant que vous
-   ne vous êtes pas assuré que PHP n'utilise pas uniquement la bonne
+   machine peut facilement faire crasher l'installation tant que l'on
+   ne on est pas assuré que PHP n'utilise pas uniquement la bonne
    version d'Oracle.
   </para>
   <para>
    Un utilitaire permettant d'examiner les bibliothèques recherchées
-   et chargées peut vous aider quant à la résolution de ce genre
+   et chargées peut aider quant à la résolution de ce genre
    de problème, tout particulièrement sous Windows.
   </para>
   <note>
@@ -595,7 +595,7 @@ extension=oci8.so
     </informalexample>
    </para>
    <para>
-    Notez que sous des systèmes comme UnixWare, la bibliothèque s'appelle
+    À noter que sous des systèmes comme UnixWare, la bibliothèque s'appelle
     libthread au lieu de libpthread. PHP et Apache doivent être configurés
     avec EXTRA_LIBS=-lthread.
    </para>

--- a/reference/oci8/connection.xml
+++ b/reference/oci8/connection.xml
@@ -21,27 +21,27 @@
    processus PHP (ou un fils Apache).
   </para>
   <para>
-   Si votre application se connecte à Oracle en utilisant un jeu différent de droits
+   Si le application se connecte à Oracle en utilisant un jeu différent de droits
    de base de données pour chaque utilisateur web, le cache persistant utilisé
    par la fonction <function>oci_pconnect</function> devient moins approprié
    car l'augmentation du nombre d'utilisateurs concurrents va affecter les performances
-   de votre serveur Oracle, car il devra maintenir trop de connexions en cache.
-   Si votre application est de ce type, il est recommandé d'optimiser votre application
+   du serveur Oracle, car il devra maintenir trop de connexions en cache.
+   Si le application est de ce type, il est recommandé d'optimiser le application
    en utilisant les options de configuration <link
    linkend="ini.oci8.max-persistent">oci8.max_persistent</link> et <link
    linkend="ini.oci8.persistent-timeout">oci8.persistent_timeout</link>
-   (elles vous donnent le contrôle sur la taille et la durée de vie du cache
+   (elles donnent le contrôle sur la taille et la durée de vie du cache
    de connexions persistantes) ou utilisez le pool de connexions résidentes d'Oracle
    (pour les bases de données Oracle 11g et suivants), ou encore, utilisez plutôt
    la fonction <function>oci_connect</function>.
   </para>
   <para>
    Les fonctions <function>oci_connect</function> et <function>oci_pconnect</function>
-   emploient un cache de connexions ; si vous faites des appels multiples
+   emploient un cache de connexions ; si on fait des appels multiples
    à <function>oci_connect</function>, en utilisant les mêmes paramètres dans
    un script donné, le second appel ainsi que les suivants retourneront le gestionnaire
    de connexion existant. Le cache utilisé par la fonction <function>oci_connect</function>
-   est nettoyé à la fin de l'exécution du script ou lorsque vous fermez explicitement
+   est nettoyé à la fin de l'exécution du script ou lorsqu'on ferme explicitement
    le gestionnaire de connexion. <function>oci_pconnect</function> a un comportement
    sensiblement identique, à la différence que le cache est maintenu séparément
    et est conservé entre les requêtes HTTP.
@@ -50,8 +50,8 @@
    Il est important de se souvenir de cette fonctionnalité de cache, car il donne
    l'apparence que les deux gestionnaires ne sont pas isolés au niveau des transactions,
    (ils représentent en fait le même gestionnaire de connexion, ils ne sont donc absolument pas
-   isolés). Si votre connexion a besoin de deux connexions séparées, isolées
-   au niveau des transactions, vous devez utiliser la fonction <function>oci_new_connect</function>.
+   isolés). Si le connexion a besoin de deux connexions séparées, isolées
+   au niveau des transactions, il faut utiliser la fonction <function>oci_new_connect</function>.
   </para>
   <para>
    Le cache de la fonction <function>oci_pconnect</function> est effacé
@@ -115,7 +115,7 @@
   </para>
   <para>
    La documentation sur DRCP peut être trouvé dans les différents manuels
-   Oracle. Par exemple, reportez-vous à la
+   Oracle. Par exemple, se reporter à la
    <link xlink:href="&url.oracle.drcp.configure;">configuration du pool
     de connexions résidentes à la base de données</link> de la documentation
    Oracle pour un exemple d'utilisation.
@@ -182,7 +182,7 @@
       </informalexample>
      </para>
      <para>
-      Sinon, vous pouvez modifier la syntaxe de connexion facile en PHP et ajouter
+      Sinon, il est possible de modifier la syntaxe de connexion facile en PHP et ajouter
       <literal>:POOLED</literal> après le nom du service :
      </para>
      <para>
@@ -217,7 +217,7 @@
     </listitem>
     <listitem>
      <para>
-      Exécutez votre application, connectez-vous à la base de données
+      Exécutez le application, connectez-l'on à la base de données
       11g (ou supérieur).
      </para>
     </listitem>
@@ -229,7 +229,7 @@
     des connexions persistantes, peuvent réduire la quantité de mémoire
     allouée au serveur de la base de données en utilisant les serveurs
     partagés Oracle (connu auparavant comme serveurs multithreadés).
-    Reportez-vous à la documentation Oracle pour plus d'informations.
+    Se reporter à la documentation Oracle pour plus d'informations.
    </para>
   </note>
   <note>

--- a/reference/oci8/constants.xml
+++ b/reference/oci8/constants.xml
@@ -55,7 +55,7 @@
      <entry><constant>OCI_DESCRIBE_ONLY</constant></entry>
      <entry>
       Mode d'exécution des commandes pour <function>oci_execute</function>.
-      Utilisez ce mode si vous ne souhaitez pas exécuter la commande, mais
+      Utilisez ce mode si on ne souhaitez pas exécuter la commande, mais
       obtenir des descriptions.
      </entry>
     </row>
@@ -95,7 +95,7 @@
      <entry>
       Mode d'exécution de la requête pour <function>oci_execute</function>.
       La transaction n'est pas automatiquement validée lors de l'utilisation
-      de ce mode. Pour plus de lisibilité dans votre code, utilisez cette
+      de ce mode. Pour plus de lisibilité dans le code, utilisez cette
       valeur plutôt que l'ancienne valeur <constant>OCI_DEFAULT</constant>.
      </entry>
     </row>

--- a/reference/oci8/dtrace.xml
+++ b/reference/oci8/dtrace.xml
@@ -14,7 +14,7 @@
 <section>
  <title>Installation d'OCI8 avec le support DTrace</title>
   <para>
-   Pour activer le support DTrace en PHP OCI8, vous devez compiler
+   Pour activer le support DTrace en PHP OCI8, il faut compiler
    OCI8 comme extension partagée, après avoir configuré
    <literal>PHP_DTRACE</literal>.
   </para>
@@ -44,10 +44,10 @@ extension=oci8.so
    </informalexample>
   </para>
   <para>
-   Si vous installez PHP OCI8 depuis PECL en utilisant
+   Si on installe PHP OCI8 depuis PECL en utilisant
    <filename>phpize</filename> et
    <filename>configure</filename> (au lieu de <filename>pecl</filename>),
-   vous devez définir <literal>PHP_DTRACE=yes</literal>. Ceci en raison
+   il faut définir <literal>PHP_DTRACE=yes</literal>. Ceci en raison
    du fait que l'option <literal>--enable-dtrace</literal> sera ignoré par
    une limitation du script <filename>configure</filename> du paquet PECL.
   </para>
@@ -180,7 +180,7 @@ extension=oci8.so
    </tgroup>
   </table>
   <para>
-   Ces découvertes sont utiles pour les mainteneurs OCI8. Référez-vous
+   Ces découvertes sont utiles pour les mainteneurs OCI8. Se référer
    au code source d'OCI8 pour les arguments et pour voir quand elles sont
    lancées.
   </para>

--- a/reference/oci8/examples.xml
+++ b/reference/oci8/examples.xml
@@ -14,8 +14,8 @@
 
  <para>
   Ces exemples se connectent à la base de données
-  <literal>XE</literal> de votre machine. Modifiez la chaîne de connexion
-  afin de correspondre à votre base de données avant d'exécuter les
+  <literal>XE</literal> de le machine. Modifiez la chaîne de connexion
+  afin de correspondre à la base de données avant d'exécuter les
   exemples de cette documentation.
  </para>
 
@@ -208,7 +208,7 @@ print '</table>';
  <example>
   <title>Utilisation d'une procédure stockée PL/SQL</title>
   <para>
-   Vous devez lier une variable pour la valeur retournée et, optionnellement,
+   Il faut lier une variable pour la valeur retournée et, optionnellement,
    pour tous les arguments de la fonction PL/SQL.
   </para>
   <programlisting role="php">
@@ -253,7 +253,7 @@ oci_close($conn);
  <example>
   <title>Utilisation d'une procédure stockée PL/SQL</title>
   <para>
-   Avec les procédures stockées, vous devez lier les variables pour tous
+   Avec les procédures stockées, il faut lier les variables pour tous
    les arguments.
   </para>
   <programlisting role="php">

--- a/reference/oci8/fan.xml
+++ b/reference/oci8/fan.xml
@@ -95,7 +95,7 @@
     </listitem>
     <listitem>
      <simpara>
-      Exécutez l'application, connectez-vous à la base de données
+      Exécuter l'application, se connecter à la base de données
       Oracle 10gR2 ou supérieures.
      </simpara>
     </listitem>

--- a/reference/oci8/functions/oci-bind-by-name.xml
+++ b/reference/oci8/functions/oci-bind-by-name.xml
@@ -50,7 +50,7 @@
    pour l'entrée ou la sortie sera déterminé au moment de l'exécution.
   </para>
   <para>
-   Vous devez spécifier le paramètre <parameter>max_length</parameter>
+   Il faut spécifier le paramètre <parameter>max_length</parameter>
    lors de l'utilisation du lien <literal>OUT</literal> afin que PHP alloue
    assez de mémoire pour contenir la valeur de retour.
   </para>
@@ -59,12 +59,12 @@
    définir le paramètre <parameter>max_length</parameter> si la
    requête est exécutée plusieurs fois avec des valeurs différentes
    pour les variables PHP. Sinon, Oracle peut tronquer les données
-   à la longueur de la valeur initiale de la variable PHP. Si vous
-   ne connaissez pas la valeur maximale dont vous avez besoin,
+   à la longueur de la valeur initiale de la variable PHP. Si l'on
+   ne connaissez pas la valeur maximale dont on a besoin,
    alors appelez de nouveau la fonction <function>oci_bind_by_name</function>
    avec les données courantes, avant chaque appel à la fonction
    <function>oci_execute</function>. Le fait de l'associer une taille
-   supérieure à ce dont vous avez besoin a un impact sur la mémoire
+   supérieure à ce dont on a besoin a un impact sur la mémoire
    associée au processus pour la base de données.
   </para>
 
@@ -148,8 +148,8 @@
        lorsque c'est possible.
       </para>
       <para>
-       Si vous devez lier des types abstraits de données (LOB/ROWID/BFILE),
-       vous devrez l'allouer dans un premier temps, avec
+       Si il faut lier des types abstraits de données (LOB/ROWID/BFILE),
+       il faudra l'allouer dans un premier temps, avec
        <function>oci_new_descriptor</function>. La longueur
        <parameter>length</parameter> ne sert pas pour ces types et
        devrait être fixée à -1.
@@ -822,11 +822,11 @@ var_dump($output2);  // false
   </warning>
   <note>
    <para>
-    Si vous associez une chaîne de caractères à une colonne
+    Si l'on associe une chaîne de caractères à une colonne
     de type <literal>CHAR</literal> dans une clause
-    <literal>WHERE</literal>, souvenez-vous qu'Oracle utilise une comparaison
+    <literal>WHERE</literal>, il faut se souvenir qu'Oracle utilise une comparaison
     en ajoutant des caractères vides pour les colonnes de type
-    <literal>CHAR</literal>. Aussi, votre variable PHP doit être
+    <literal>CHAR</literal>. Aussi, le variable PHP doit être
     compléter par des caractères vides afin d'atteindre la même taille
     que la colonne pour que la clause <literal>WHERE</literal> fonctionne.
    </para>

--- a/reference/oci8/functions/oci-close.xml
+++ b/reference/oci8/functions/oci-close.xml
@@ -21,7 +21,7 @@
    ou la fonction <function>oci_new_connect</function>.
   </para>
   <para>
-   Il est recommandé de fermer les connexions qui ne vous sont plus
+   Il est recommandé de fermer les connexions qui ne sont plus
    nécessaires, rendant ainsi plus de ressources disponibles pour
    les autres utilisateurs.
   </para>

--- a/reference/oci8/functions/oci-commit.xml
+++ b/reference/oci8/functions/oci-commit.xml
@@ -110,9 +110,9 @@ if (!$r) {
   &reftitle.notes;
   <note>
    <para>
-    Les transactions sont automatiquement annulées lorsque vous
+    Les transactions sont automatiquement annulées lorsque l'on
     fermez la connexion, ou lorsque le script se termine, un des deux
-    arrivant le premier. Vous devez explicitement appeler la fonction
+    arrivant le premier. Il faut explicitement appeler la fonction
     <function>oci_commit</function> pour valider la transaction.
    </para>
    <para>

--- a/reference/oci8/functions/oci-connect.xml
+++ b/reference/oci8/functions/oci-connect.xml
@@ -330,7 +330,7 @@ echo "c2 is $c2<br>\n";
    <para>
     Si un problème est survenu lors de l'installation de l'extension OCI8,
     une des manifestations sera un problème lors de la connexion.
-    Reportez-vous à la section <link linkend="oci8.setup">Installation/Configuration</link>
+    Se reporter à la section <link linkend="oci8.setup">Installation/Configuration</link>
     pour plus d'informations en cas d'erreurs.
    </para>
   </note>

--- a/reference/oci8/functions/oci-define-by-name.xml
+++ b/reference/oci8/functions/oci-define-by-name.xml
@@ -64,12 +64,12 @@
      <listitem>
       <para>
        Le type de données à retourner. En général, ce paramètre n'est pas nécessaire.
-       Notez que le style Oracle de conversion de données n'est pas
+       À noter que le style Oracle de conversion de données n'est pas
        appliqué ici. Par exemple, <constant>SQLT_INT</constant> sera ignoré et
        le type de données retourné sera <constant>SQLT_CHR</constant>.
       </para>
       <para>
-       Vous pouvez utiliser, optionnellement, la fonction
+       Il est possible d'utiliser, optionnellement, la fonction
        <function>oci_new_descriptor</function> pour allouer des descripteurs
        LOB/ROWID/BFILE.
       </para>

--- a/reference/oci8/functions/oci-execute.xml
+++ b/reference/oci8/functions/oci-execute.xml
@@ -104,8 +104,8 @@
        script même si les données ont changées. Pour éviter ce comportement,
        la plupart des scripts n'utilise pas le mode
        <constant>OCI_NO_AUTO_COMMIT</constant> pour les requêtes ou 
-       les procédures stockées PL/SQL. Assurez-vous de la consistance
-       transactionnelle appropriée de vos applications lors de l'utilisation
+       les procédures stockées PL/SQL. Il faut s'assurer de la consistance
+       transactionnelle appropriée de les applications lors de l'utilisation
        de la fonction <function>oci_execute</function> avec différents modes dans
        le même script.
       </para>

--- a/reference/oci8/functions/oci-fetch-array.xml
+++ b/reference/oci8/functions/oci-fetch-array.xml
@@ -129,7 +129,7 @@
    la casse appropriée à utiliser pour chaque requête.
   </para>
   <para>
-   Le nom de la table n'est pas inclus dans l'index du tableau. Si votre requête
+   Le nom de la table n'est pas inclus dans l'index du tableau. Si le requête
    contient deux colonnes différentes avec le même nom, utilisez la constante
    <constant>OCI_NUM</constant> ou ajoutez un alias à la colonne à la requête
    pour s'assurer l'unicité du nom ; voir l'exemple #7. Sinon, seulement une

--- a/reference/oci8/functions/oci-field-type-raw.xml
+++ b/reference/oci8/functions/oci-field-type-raw.xml
@@ -19,7 +19,7 @@
    Lit les données brutes "SQLT" du type du champ <parameter>column</parameter>.
   </para>
   <para>
-   Si vous souhaitez avoir le nom du type du champ, utilisez la fonction
+   Pour avoir le nom du type du champ, utilisez la fonction
    <function>oci_field_type</function>.
   </para>
  </refsect1>

--- a/reference/oci8/functions/oci-free-statement.xml
+++ b/reference/oci8/functions/oci-free-statement.xml
@@ -18,7 +18,7 @@
   <para>
    Libère toutes les ressources réservées par le résultat ou curseur Oracle
    <parameter>statement</parameter>. Ce dernier a été obtenu de
-   la fonction <function>oci_parse</function>, ou directement de Oracle. 
+   la fonction <function>oci_parse</function>, ou directement d'Oracle. 
   </para>
  </refsect1>
 

--- a/reference/oci8/functions/oci-lob-copy.xml
+++ b/reference/oci8/functions/oci-lob-copy.xml
@@ -21,7 +21,7 @@
    de destination seront écrasées par les nouvelles.
   </para>
   <para>
-   Si vous devez copier une partie spécifique d'un LOB vers une position particulière d'un LOB,
+   Si il faut copier une partie spécifique d'un LOB vers une position particulière d'un LOB,
    utilisez la fonction <function>OCILob::seek</function> pour déplacer le
    pointeur interne de LOB.
   </para>

--- a/reference/oci8/functions/oci-new-connect.xml
+++ b/reference/oci8/functions/oci-new-connect.xml
@@ -24,7 +24,7 @@
    Contrairement aux fonctions <function>oci_connect</function> et
    <function>oci_pconnect</function>, <function>oci_new_connect</function>
    ne met pas en cache les connexions et retourne toujours un gestionnaire de connexion
-   nouvellement ouvert. Ceci est très utile si votre application a besoin d'une isolation
+   nouvellement ouvert. Ceci est très utile si le application a besoin d'une isolation
    transactionnelle entre deux jeux de requêtes.
   </para>
  </refsect1>

--- a/reference/oci8/functions/oci-password-change.xml
+++ b/reference/oci8/functions/oci-password-change.xml
@@ -172,7 +172,7 @@ if (!$c) {  // L'erreur originale n'était pas 28001, ou la modification du mot 
   </note>
   <note>
    <para>
-    Si vous mettez à jour les bibliothèques clients ou la base de données Oracle
+    Si l'on met à jour les bibliothèques clients ou la base de données Oracle
     depuis une version antérieure à 11.2.0.3 vers une version 11.2.0.3 ou supérieure,
     la fonction <function>oci_password_change</function> peut retourner l'erreur
     "ORA-1017: invalid username/password" tant que les versions du client et du
@@ -182,7 +182,7 @@ if (!$c) {  // L'erreur originale n'était pas 28001, ou la modification du mot 
   <note>
    <para>
     La seconde syntaxe de <function>oci_password_change</function> est disponible depuis
-    la version de OCI8 1.1.
+    la version d'OCI8 1.1.
    </para>
   </note>
   

--- a/reference/oci8/functions/oci-rollback.xml
+++ b/reference/oci8/functions/oci-rollback.xml
@@ -138,9 +138,9 @@ oci_commit($conn);  // mytab a maintenant un id de 1111
   &reftitle.notes;
   <note>
    <para>
-    Les transactions sont automatiquement annulées lorsque vous fermez
+    Les transactions sont automatiquement annulées lorsqu'on ferme
     la connexion, ou lorsque le script se termine, un des deux arrivant le premier.
-    Vous devez explicitement appeler la fonction <function>oci_commit</function>
+    Il faut explicitement appeler la fonction <function>oci_commit</function>
     pour valider la connexion.
    </para>
    <para>

--- a/reference/oci8/functions/oci-set-edition.xml
+++ b/reference/oci8/functions/oci-set-edition.xml
@@ -138,7 +138,7 @@ echo "Le résultat est $r\n";
     <link linkend="oci8.connection">DRCP</link> avec Oracle 11.2.0.1,
     conservez une correspondance un-à-un entre
     <link linkend="ini.oci8.connection-class">oci8.connection_class</link>
-    et le nom de l'édition utilisé par vos applications. Chaque serveur
+    et le nom de l'édition utilisé par les applications. Chaque serveur
     pour une classe de connexion donnée doit être utilisé avec une seule
     édition. Cette restriction a été supprimée dans Oracle 11.2.0.2.
    </para>

--- a/reference/oci8/functions/oci-set-prefetch.xml
+++ b/reference/oci8/functions/oci-set-prefetch.xml
@@ -65,7 +65,7 @@
    Lors de l'utilisation de la base de données Oracle 12<emphasis>c</emphasis>,
    le jeu de valeurs préchargées par PHP peut être écrasé par le fichier
    de configuration client d'Oracle <literal>oraaccess.xml</literal>.
-   Référez-vous à la documentation d'Oracle pour plus de détails.
+   Se référer à la documentation d'Oracle pour plus de détails.
   </para>
  </refsect1>
 

--- a/reference/oci8/ini.xml
+++ b/reference/oci8/ini.xml
@@ -142,14 +142,14 @@
       <function>oci_set_prefetch</function> avant l'exécution de la requête.
      </para>
      <para>
-      Lors de l'utilisation de Oracle 12<emphasis>c</emphasis> ou ultérieur, la valeur de
+      Lors de l'utilisation d'Oracle 12<emphasis>c</emphasis> ou ultérieur, la valeur de
       pré-chargement définie par PHP peut être surchargée par le fichier de
       configuration du client oracle : <literal>oraaccess.xml</literal>. 
       Consulter la documentation d'Oracle pour plus d'informations.
      </para>
      <note>
       <simpara>
-       Si vous entrez une valeur trop importante, cela peut conduire à
+       Si l'on entre une valeur trop importante, cela peut conduire à
        une amélioration des performances, au détriment
        de l'utilisation mémoire. Pour des requêtes qui retournent un
        grand nombre de données, le gain de performance peut être vraiment
@@ -179,7 +179,7 @@
       dans le cache des connexions persistantes.
      </para>
      <para>
-      Lorsque vous utilisez <literal>On</literal> comme valeur, la base de données
+      Lorsqu'on utilise <literal>On</literal> comme valeur, la base de données
       doit également être configurée pour émettre les événements FAN.
      </para>
      <para>
@@ -211,9 +211,9 @@
       Cette option contrôle le comportement de la fonction <function>oci_close</function>.
       Activer cette option signifie que <function>oci_close</function> ne fera rien du tout ;
       la connexion ne sera pas fermée tant que la fin du script ne sera pas atteinte. Ceci est uniquement
-      pour assurer une compatibilité ascendante. Si vous pensez que vous devez activer
-      cette option, vous êtes <emphasis>vivement encouragé</emphasis> à
-      effacer les appels à la fonction <function>oci_close</function> de votre application
+      pour assurer une compatibilité ascendante. Si on pense qu'il faut activer
+      cette option, on est <emphasis>vivement encouragé</emphasis> à
+      effacer les appels à la fonction <function>oci_close</function> de l'application
       au lieu d'activer cette option.
      </para>
     </listitem>
@@ -344,9 +344,9 @@
       ré-utilisées.
      </para>
      <para>
-      Définissez cette valeur à la taille de votre jeux de requêtes courantes
-      utilisées par votre application. Le fait de définir une valeur trop petite
-      peut faire que vos requêtes seront supprimées du cache avant qu'elles ne
+      Définissez cette valeur à la taille du jeux de requêtes courantes
+      utilisées par le application. Le fait de définir une valeur trop petite
+      peut faire que les requêtes seront supprimées du cache avant qu'elles ne
       soient utilisées.
      </para>
      <para>

--- a/reference/oci8/ocilob/append.xml
+++ b/reference/oci8/ocilob/append.xml
@@ -18,8 +18,8 @@
   </para>
   <para>
    L'écriture dans un LOB avec <function>OCI-Lob->append</function> échouera
-   si la bufferisation a été préalablement activée. Vous devez désactiver
-   la bufferisation avant d'ajouter des données. Vous aurez peut être
+   si la bufferisation a été préalablement activée. Il faut désactiver
+   la bufferisation avant d'ajouter des données. On aura peut être
    à vider les buffers avec la fonction <xref linkend="ocilob.flush"/>
    avant de la désactiver.
   </para>

--- a/reference/oci8/ocilob/flush.xml
+++ b/reference/oci8/ocilob/flush.xml
@@ -28,11 +28,11 @@
       <para>
        Par défaut, les ressources ne sont pas libérées, mais en utilisant
        l'option <parameter>flag</parameter> avec la valeur
-       <constant>OCI_LOB_BUFFER_FREE</constant>, vous pouvez le faire explicitement.
-       Assurez-vous de bien savoir ce que vous faites : la prochaine lecture
+       <constant>OCI_LOB_BUFFER_FREE</constant>, il est possible de le faire explicitement.
+       Il faut s'assurer de bien savoir ce qu'on fait : la prochaine lecture
        ou écriture dans le même LOB demandera alors une requête au serveur,
        et la réinitialisation des ressources. Il est recommandé d'utiliser l'option
-       <constant>OCI_LOB_BUFFER_FREE</constant> uniquement si vous n'avez
+       <constant>OCI_LOB_BUFFER_FREE</constant> uniquement si l'on n'avez
        plus besoin du LOB.
       </para>
      </listitem>

--- a/reference/oci8/ocilob/setBuffering.xml
+++ b/reference/oci8/ocilob/setBuffering.xml
@@ -22,7 +22,7 @@
    par bufferisation des petites lectures et écritures de LOB : le buffer
    limite les allers/retours avec le serveur.
    <function>OCILob::flush</function> doit être utilisé pour vider les buffers
-   une fois que vous avez fini de travailler avec le LOB.
+   une fois qu'on a fini de travailler avec le LOB.
   </para>
  </refsect1>
 

--- a/reference/oci8/ocilob/writeTemporary.xml
+++ b/reference/oci8/ocilob/writeTemporary.xml
@@ -19,7 +19,7 @@
   </para>
   <para>
    Il faut utiliser la fonction <xref linkend="ocilob.close"/> lorsque
-   vous avez fini de travailler avec le LOB.
+   on a fini de travailler avec le LOB.
   </para>
  </refsect1>
 

--- a/reference/oci8/setup.xml
+++ b/reference/oci8/setup.xml
@@ -25,17 +25,17 @@
    Pour utiliser Oracle Instant Client, installez le fichier
    compressé ZIP <literal>Basic</literal> ou <literal>Basic Light</literal> de
    Oracle Instant Client, le paquet RPM, ou le paquet DMG.
-   Lors de la compilation de OCI8 depuis le code source, installez aussi le
-   <literal>SDK</literal> de Instant Client.
+   Lors de la compilation d'OCI8 depuis le code source, installez aussi le
+   <literal>SDK</literal> d'Instant Client.
   </para>
   <para>
-   Vous devez exécuter PHP avec la même version ou une version plus récente des
+   Il faut exécuter PHP avec la même version ou une version plus récente des
    bibliothèques clients Oracle utilisées pour construire OCI8.
   </para>
   <note>
    <para>
     L'interopérabilité standard du réseau client-serveur d'Oracle permet des
-    connexions entre différentes versions de Oracle Client et Oracle Database.
+    connexions entre différentes versions d'Oracle Client et Oracle Database.
     Pour des configurations certifiées voir la documentation Oracle Support
     ID ID 207303.1. En résumé, Oracle Client 19, 18 et 12.2 peuvent se
     connecter à Oracle Database 11.2 ou supérieur. Oracle Client 12.1 peut se

--- a/reference/oci8/testing.xml
+++ b/reference/oci8/testing.xml
@@ -20,7 +20,7 @@
  </para>
  <para>
   Si la file d'attente de connexion de la base de données Oracle
-  est testée, définissez la variable $test_drcp à &true; et assurez-vous
+  est testée, définissez la variable $test_drcp à &true; et il faut s'assurer
   que la chaîne de connexion utilise un serveur de file d'attente DRCP
   approprié.
  </para>
@@ -35,14 +35,14 @@
     $ export PHP_OCI8_TEST_DRCP=FALSE
 ]]>
   </programlisting>
-  Notez que suivant les shells utilisés, ces variables ne seront pas
+  À noter que suivant les shells utilisés, ces variables ne seront pas
   forcément propagées jusqu'au processus PHP et le test échouera au niveau
   de la connexion si cette méthode est utilisée.
  </para>
  <para>
  Puis, définissez tous les environnements nécessaires à la base de 
- données Oracle. Si vous tournez PHP sur la même machine que la base de
- données Oracle, vous pouvez faire :
+ données Oracle. Si on exécute PHP sur la même machine que la base de
+ données Oracle, il est possible de faire :
   <programlisting>
 <![CDATA[
     $ . /usr/local/bin/oraenv
@@ -83,7 +83,7 @@
   </programlisting>
  </para>
  <para>
-  Lorsque les tests sont terminés, vous pouvez alors investiguer
+  Lorsque les tests sont terminés, il est possible d'alors investiguer
   sur les erreurs rencontrées. Sur les systèmes lents, quelques tests
   peuvent prendre plus de temps que le délai maximal d'exécution défini
   dans le fichier <filename>run-tests.php</filename>. Pour corriger ceci,

--- a/reference/opcache/configure.xml
+++ b/reference/opcache/configure.xml
@@ -7,14 +7,14 @@
 
  <simpara>
   OPcache peut seulement être compilé comme une extension partagée.
-  Si vous avez désactivé la compilation des extensions par défaut avec
-  <option role="configure">--disable-all</option>, vous devez compiler PHP avec
+  Si on a désactivé la compilation des extensions par défaut avec
+  <option role="configure">--disable-all</option>, il faut compiler PHP avec
   l'option <option role="configure">--enable-opcache</option> pour que OPcache
   soit disponible.
  </simpara>
 
  <simpara>
-  Une fois compilé, vous pouvez utiliser la directive de configuration
+  Une fois compilé, il est possible d'utiliser la directive de configuration
   <link linkend="ini.zend-extension">zend_extension</link> pour charger
   l'extension OPcache dans PHP. Ceci peut être réalisé avec
   <literal>zend_extension=/full/path/to/opcache.so</literal> sur les plateformes
@@ -24,8 +24,8 @@
 
  <note>
   <simpara>
-   Si vous voulez utiliser OPcache avec
-   <link xlink:href="&url.xdebug;">Xdebug</link>, vous devez charger
+   Pour utiliser OPcache avec
+   <link xlink:href="&url.xdebug;">Xdebug</link>, il faut charger
    OPcache avant Xdebug.
   </simpara>
  </note>
@@ -52,11 +52,11 @@ opcache.enable_cli=1
   </informalexample>
 
   <simpara>
-   Vous pourriez également vouloir désactiver
+   Il est possible que l'on également vouloir désactiver
    <link linkend="ini.opcache.save-comments">opcache.save_comments</link>
    et activer
    <link linkend="ini.opcache.enable-file-override">opcache.enable_file_override</link>,
-   cependant, notez que vous devez tester votre code avant de l'utiliser en
+   cependant, à noter qu'il faut tester le code avant de l'utiliser en
    production, sachant qu'il peut casser des frameworks et des applications,
    en particulier dans le cas où les annotations des commentaires
    de documentations sont utilisées.

--- a/reference/opcache/functions/opcache-compile-file.xml
+++ b/reference/opcache/functions/opcache-compile-file.xml
@@ -47,7 +47,7 @@
   &reftitle.errors;
   <simpara>
    Si <parameter>filename</parameter> ne peut être chargé ou compilé, une erreur de type
-   <constant>E_WARNING</constant> est renvoyée. Vous pouvez utiliser
+   <constant>E_WARNING</constant> est renvoyée. Il est possible d'utiliser
    <link linkend="language.operators.errorcontrol">@</link> pour la supprimer.
   </simpara>
  </refsect1>

--- a/reference/opcache/ini.xml
+++ b/reference/opcache/ini.xml
@@ -485,7 +485,7 @@
     <para>
      Si activé, OPcache va vérifier les mises à jour des scripts toutes les
      <link linkend="ini.opcache.revalidate-freq">opcache.revalidate_freq</link>
-     secondes. Lorsque cette directive est désactivée, vous devez réinitialiser
+     secondes. Lorsque cette directive est désactivée, il faut réinitialiser
      OPcache manuellement via la fonction <function>opcache_reset</function>,
      la fonction <function>opcache_invalidate</function> ou en redémarrant le serveur
      Web pour que les modifications du système de fichiers ne prennent effet.
@@ -1149,7 +1149,7 @@ function getA() { return A; }
     <para>
      Sur Windows, tous les processus exécutant le même <acronym>PHP</acronym>
      <acronym>SAPI</acronym> sous le même compte utilisateur ayant le même ID
-     de cache partage une instance unique de OPcache.
+     de cache partage une instance unique d'OPcache.
      La valeur de l'ID de cache peut être choisie librement.
     </para>
     <tip>

--- a/reference/openal/functions/openal-source-set.xml
+++ b/reference/openal/functions/openal-source-set.xml
@@ -59,7 +59,7 @@
      <simpara>
       La valeur à assigner à la propriété spécifiée par le paramètre
       <parameter>property</parameter>.
-      Référez-vous à la description de la propriété
+      Se référer à la description de la propriété
       <parameter>property</parameter> pour une
       description des valeurs attendues.
      </simpara>

--- a/reference/openssl/cert-verification.xml
+++ b/reference/openssl/cert-verification.xml
@@ -6,7 +6,7 @@
 <appendix xml:id="openssl.cert.verification" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
 <title>Vérification de certificats</title>
  <para>
-  Lorsque vous appelez une fonction qui va vérifier une signature ou
+  Lorsqu'on appelle une fonction qui va vérifier une signature ou
   un certificat, le paramètre <parameter>ca_info</parameter> doit être un
   tableau contenant les noms d'un dossier et d'un fichier indiquant les
   tiers de confiance. Si un dossier est spécifié, il doit être correct,

--- a/reference/openssl/certparams.xml
+++ b/reference/openssl/certparams.xml
@@ -99,7 +99,7 @@
       </listitem>
       <listitem>
        <simpara>
-        Pour les clés privées, vous pouvez aussi utiliser la
+        Pour les clés privées, il est également possible d'utiliser la
         syntaxe <literal>array($key, $passphrase)</literal>, où
         <varname>$key</varname>
         représente une clé spécifiée par un

--- a/reference/openssl/configure.xml
+++ b/reference/openssl/configure.xml
@@ -6,11 +6,11 @@
 <section xml:id="openssl.installation" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.install;
  <para>
-  Pour utiliser le support OpenSSL de PHP, vous devez aussi compiler PHP avec l'option
+  Pour utiliser le support OpenSSL de PHP, il faut aussi compiler PHP avec l'option
   de configuration <option role="configure">--with-openssl</option>.
  </para>
  <para>
-  La bibliothèque OpenSSL possède aussi des dépendances à l'exécution. Par exemple,
+  La bibliothèque OpenSSL possèd'aussi des dépendances à l'exécution. Par exemple,
   OpenSSL a besoin d'accéder à un générateur de nombres pseudo-aléatoires; sur la
   plupart des plateformes Unix (incluant donc Linux), elle doit avoir accès au
   périphérique <literal>/dev/urandom</literal> ou <literal>/dev/random</literal>.
@@ -26,12 +26,12 @@
   <para>
    &ext.windows.path.dll;
    <filename>libeay32.dll</filename>,
-   ou, à partir de OpenSSL 1.1, <filename>libcrypto-*.dll</filename>
+   ou, à partir d'OpenSSL 1.1, <filename>libcrypto-*.dll</filename>
   </para>
   <para>
-   De plus, si vous avez prévu d'utiliser les fonctions relatives à la génération
-   de clés et aux certificats, vous devez installer un fichier
-   <filename>openssl.cnf</filename> valide sur votre système.
+   De plus, si on a prévu d'utiliser les fonctions relatives à la génération
+   de clés et aux certificats, il faut installer un fichier
+   <filename>openssl.cnf</filename> valide sur le système.
    Un fichier de configuration de base est inclus dans les distributions de PHP
    pour win32 dans le dossier <filename class="directory">extras/ssl</filename>.
   </para>
@@ -66,10 +66,10 @@
    </itemizedlist>
   </para>
   <simpara>
-   Dans votre installation, vous devrez décider si vous allez installer le fichier
-   de configuration dans le chemin par défaut ou si vous allez
+   Dans le installation, il faudra décider si on va installer le fichier
+   de configuration dans le chemin par défaut ou si on va
    le faire ailleurs et configurer une variable d'environnement (possiblement
-   par site virtuel). Notez qu'il est possible de remplacer le chemin par
+   par site virtuel). À noter : qu'il est possible de remplacer le chemin par
    défaut en utilisant le paramètre <parameter>options</parameter> des fonctions
    qui requièrent un fichier de configuration.
   </simpara>

--- a/reference/openssl/constants.xml
+++ b/reference/openssl/constants.xml
@@ -275,7 +275,7 @@
         qui utilise effectivement des <literal>CR</literal> et <literal>LF</literal>
         comme fin de ligne, comme demandé dans les spécifications de S/MIME.
         Lorsque cette option est activée, le message ne sera
-        pas converti. Cela sert lorsque vous manipulez des données
+        pas converti. Cela sert lorsqu'on manipule des données
         binaires qui ne sont pas au format MIME.
        </entry>
       </row>
@@ -354,7 +354,7 @@
         C'est la valeur par défaut du paramètre
         <parameter>flags</parameter>
         pour la fonction <function>openssl_pkcs7_sign</function>.
-        Si vous annulez cette option, le message sera signé de
+        Si on annule cette option, le message sera signé de
         manière opaque, ce qui résiste mieux à la traduction
         des relais mail (certains anciens serveurs mail corrompent les
         messages), mais empêche la lecture par les client emails qui ne
@@ -485,9 +485,9 @@
        <entry>
         Lors de la signature d'un message, la signature en clair est utilisée
         avec le MIME type <literal>"multipart/signed"</literal>. Ceci est le
-        comportement par défaut, si vous ne spécifiez aucun
+        comportement par défaut, si on ne spécifiez aucun
         <parameter>flags</parameter> à <function>openssl_cms_sign</function>.
-        Si vous désactivez cette option, le message sera signé en utilisant
+        Si on désactive cette option, le message sera signé en utilisant
         une signature opaque, qui est plus résistante à la translation par
         les relais mail mais ne peut pas être lu par les agents mail qui ne
         supportent pas S/MIME.
@@ -626,7 +626,7 @@
       Cette constante n'est disponible que
       lorsque PHP est compilé avec le support MD2. Il est nécessaire de
       passer le CFLAG <literal>-DHAVE_OPENSSL_MD2_H</literal> lors de la compilation de PHP
-      et de passer <literal>enable-md2</literal> lors de la compilation de OpenSSL 1.0.0+.
+      et de passer <literal>enable-md2</literal> lors de la compilation d'OpenSSL 1.0.0+.
      </simpara>
     </listitem>
    </varlistentry>

--- a/reference/openssl/functions/openssl-csr-new.xml
+++ b/reference/openssl/functions/openssl-csr-new.xml
@@ -61,10 +61,10 @@
      <term><parameter>options</parameter></term>
      <listitem>
       <para>
-       Par défaut, le fichier <literal>openssl.conf</literal> de votre système
-       est utilisé pour initialiser la requête; vous pouvez spécifier une section 
+       Par défaut, le fichier <literal>openssl.conf</literal> du système
+       est utilisé pour initialiser la requête; il est possible de spécifier une section 
        du fichier de configuration en paramétrant la clé <literal>config_section_section</literal> dans
-       <parameter>options</parameter>. Vous pouvez aussi spécifier un fichier de
+       <parameter>options</parameter>. Il est également possible de spécifier un fichier de
        configuration OpenSSL alternatif en paramétrant la valeur de 
        <literal>config</literal> avec le chemin du fichier à utiliser.
        Si les clés suivantes sont présentes dans <parameter>options</parameter>, elles se
@@ -146,7 +146,7 @@
            <entry><type>string</type></entry>
            <entry>N/A</entry>
            <entry>
-            Chemin vers votre fichier openssl.conf alternatif.
+            Chemin vers le fichier openssl.conf alternatif.
            </entry>
           </row>
          </tbody>

--- a/reference/openssl/functions/openssl-csr-sign.xml
+++ b/reference/openssl/functions/openssl-csr-sign.xml
@@ -72,7 +72,7 @@
      <term><parameter>options</parameter></term>
      <listitem>
       <para>
-       Vous pouvez affiner la signature <acronym>CSR</acronym> avec <parameter>options</parameter>.
+       Il est possible d'affiner la signature <acronym>CSR</acronym> avec <parameter>options</parameter>.
        Voir la fonction <function>openssl_csr_new</function> pour plus d'informations sur 
        <parameter>options</parameter>.
       </para>
@@ -170,7 +170,7 @@
   <para>
    <example>
     <title>Exemple avec <function>openssl_csr_sign</function> - signer une
-     <acronym>CSR</acronym> (comment être votre propre Autorité de Certification)</title>
+     <acronym>CSR</acronym> (comment être le propre Autorité de Certification)</title>
     <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/openssl/functions/openssl-dh-compute-key.xml
+++ b/reference/openssl/functions/openssl-dh-compute-key.xml
@@ -110,8 +110,8 @@ openssl pkey -in privatekey.pem -pubout -out publickey.pem
 ]]>
     </programlisting>
     <simpara>
-     Maintenant, envoyez votre clé publique à la partie distante. Utilisez la
-     commande <literal>openssl pkey</literal> pour afficher la clé publique qui vous
+     Maintenant, envoir le clé publique à la partie distante. Utilisez la
+     commande <literal>openssl pkey</literal> pour afficher la clé publique qui l'on
      sera envoyé par la partie distante.
     </simpara>
     <programlisting role="shell">

--- a/reference/openssl/functions/openssl-get-cipher-methods.xml
+++ b/reference/openssl/functions/openssl-get-cipher-methods.xml
@@ -28,7 +28,7 @@
      <term><parameter>aliases</parameter></term>
      <listitem>
       <para>
-       Passez &true; si vous voulez que les alias des méthodes chiffrements
+       Passez &true; pour que les alias des méthodes chiffrements
        soient inclus dans le tableau retourné.
       </para>
      </listitem>
@@ -42,7 +42,7 @@
   <para>
    Un <type>array</type> des méthodes de chiffrements disponibles.
    Il est à noter que antérieur à OpenSSL 1.1.1, les méthodes de chiffrements
-   étaient retournées en majuscule et en minuscule ; à partir de OpenSSL 1.1.1
+   étaient retournées en majuscule et en minuscule ; à partir d'OpenSSL 1.1.1
    seul la variante en minuscule est retourné.
   </para>
  </refsect1>

--- a/reference/openssl/functions/openssl-get-curve-names.xml
+++ b/reference/openssl/functions/openssl-get-curve-names.xml
@@ -21,7 +21,7 @@
    standardisées / supportées sont <emphasis>prime256v1</emphasis>
    (NIST P-256) et <emphasis>secp384r1</emphasis> (NIST P-384).
    <table>
-    <title>Équivalences approximatives des taille de clés de AES, RSA, DSA et ECC</title>
+    <title>Équivalences approximatives des taille de clés d'AES, RSA, DSA et ECC</title>
     <tgroup cols="3">
      <thead>
       <row>

--- a/reference/openssl/functions/openssl-get-md-methods.xml
+++ b/reference/openssl/functions/openssl-get-md-methods.xml
@@ -29,7 +29,7 @@
      <term><parameter>aliases</parameter></term>
      <listitem>
       <para>
-       Passez &true; si vous voulez que les alias de digest soient inclus
+       Passez &true; pour que les alias de digest soient inclus
        dans le tableau retourné.
       </para>
      </listitem>

--- a/reference/openssl/functions/openssl-pkcs7-sign.xml
+++ b/reference/openssl/functions/openssl-pkcs7-sign.xml
@@ -36,7 +36,7 @@
      <term><parameter>input_filename</parameter></term>
      <listitem>
       <para>
-       Le fichier d'entrée que vous avez l'intention de signer numériquement.
+       Le fichier d'entrée qu'on a l'intention de signer numériquement.
       </para>
      </listitem>
     </varlistentry>
@@ -95,7 +95,7 @@
        <parameter>untrusted_certificates_filename</parameter> spécifie le nom du fichier contenant
        un ensemble de certificats supplémentaires à inclure dans la
        signature, qui pourront aider le destinataire à vérifier les
-       données que vous utilisez.
+       données qu'on utilise.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/openssl/functions/openssl-pkcs7-verify.xml
+++ b/reference/openssl/functions/openssl-pkcs7-verify.xml
@@ -44,7 +44,7 @@
      <listitem>
       <para>
        <parameter>flags</parameter> sert à modifier la façon dont la signature est vérifiée.
-       Voyez les <link linkend="openssl.pkcs7.flags">constantes PKCS7</link>. Par
+       Voir les <link linkend="openssl.pkcs7.flags">constantes PKCS7</link>. Par
        défaut, la valeur est : PKCS7_DETACHED.
       </para>
      </listitem>
@@ -85,7 +85,7 @@
      <term><parameter>content</parameter></term>
      <listitem>
       <para>
-       Vous pouvez spécifier un nom de fichier avec le paramètre
+       Il est possible de spécifier un nom de fichier avec le paramètre
        <parameter>content</parameter> qui peut être remplit avec les données vérifiées,
        mais avec les informations de signature.
       </para>

--- a/reference/openssl/functions/openssl-private-decrypt.xml
+++ b/reference/openssl/functions/openssl-private-decrypt.xml
@@ -25,8 +25,8 @@
    dans la variable <parameter>decrypted_data</parameter>.
   </para>
   <para>
-   Vous pouvez utiliser cette fonction, par exemple pour déchiffrer des données 
-   qui ne sont censées être disponibles que pour vous.
+   Il est possible d'utiliser cette fonction, par exemple pour déchiffrer des données 
+   qui ne sont censées être disponibles que pour l'on.
   </para>
  </refsect1>
 

--- a/reference/openssl/functions/openssl-public-decrypt.xml
+++ b/reference/openssl/functions/openssl-public-decrypt.xml
@@ -24,7 +24,7 @@
    <parameter>decrypted_data</parameter>.
   </para>
   <para>
-   Vous pouvez utiliser cette fonction pour vérifier si le message a été écrit par le
+   Il est possible d'utiliser cette fonction pour vérifier si le message a été écrit par le
    propriétaire de la clé privée.
   </para>
  </refsect1>

--- a/reference/openssl/functions/openssl-sign.xml
+++ b/reference/openssl/functions/openssl-sign.xml
@@ -22,7 +22,7 @@
    <function>openssl_sign</function> calcule la signature des données
    <parameter>data</parameter> en générant une signature numérique cryptographique
    en utilisant la clé privée associée avec le paramètre
-   <parameter>private_key</parameter>. Notez que les données elles-mêmes
+   <parameter>private_key</parameter>. À noter que les données elles-mêmes
    ne sont pas chiffrées.
   </para>
  </refsect1>
@@ -35,7 +35,7 @@
      <term><parameter>data</parameter></term>
      <listitem>
       <para>
-       La chaîne de données que vous souhaitez signer.
+       La chaîne de données qu'on souhaite signer.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/openssl/functions/openssl-x509-checkpurpose.xml
+++ b/reference/openssl/functions/openssl-x509-checkpurpose.xml
@@ -103,7 +103,7 @@
          </tbody>
         </tgroup>
        </table>
-       Ces options ne sont pas des champs de bits : vous ne pouvez en
+       Ces options ne sont pas des champs de bits : on ne pouvez en
        passer qu'une seule à la fois.
       </para>
      </listitem>

--- a/reference/openssl/setup.xml
+++ b/reference/openssl/setup.xml
@@ -9,7 +9,7 @@
  <section xml:id="openssl.requirements">
   &reftitle.required;
   <para>
-   Afin de pouvoir utiliser les fonctions OpenSSL, vous devez installer la bibliothèque
+   Afin de pouvoir utiliser les fonctions OpenSSL, il faut installer la bibliothèque
    <link xlink:href="&url.openssl;">OpenSSL</link>.
    PHP 7.0 nécessite OpenSSL &gt;= 0.9.8, &lt; 1.2. PHP 7.1-8.0 nécessitent
    OpenSSL &gt;= 1.0.1, &lt; 3.0. PHP &gt;= 8.1 nécessite OpenSSL
@@ -18,8 +18,8 @@
   </para>
   <warning>
    <para>
-    Vous êtes vivement encouragé à utiliser la version maintenue d'OpenSSL afin
-    d'éviter certaines vulnérabilités sur votre serveur web.
+    On est vivement encouragé à utiliser la version maintenue d'OpenSSL afin
+    d'éviter certaines vulnérabilités sur le serveur web.
    </para>
   </warning>
  </section>

--- a/reference/outcontrol/book.xml
+++ b/reference/outcontrol/book.xml
@@ -11,9 +11,9 @@
  <preface xml:id="intro.outcontrol">
   &reftitle.intro;
   <para>
-   Les fonctions de bufferisation de sortie vous permettent de contrôler
+   Les fonctions de bufferisation de sortie permettent de contrôler
    quand les données sont envoyées par le script. Cela peut
-   être utile dans certaines situations, notamment si vous devez
+   être utile dans certaines situations, notamment si l'on doit
    envoyer des en-têtes au navigateur après avoir envoyé
    des données. Ces fonctions n'affectent pas les en-têtes
    envoyés par la fonction <function>header</function> ou les

--- a/reference/outcontrol/functions/ob-get-level.xml
+++ b/reference/outcontrol/functions/ob-get-level.xml
@@ -34,7 +34,7 @@
   <caution>
    <simpara>
     La valeur pour les niveaux identiques entre <function>ob_get_level</function>
-    et <function>ob_get_status</function> diffère de un.
+    et <function>ob_get_status</function> diffère d'un.
 
     Pour <function>ob_get_level</function>,
     le premier niveau est <literal>1</literal>.

--- a/reference/outcontrol/ini.xml
+++ b/reference/outcontrol/ini.xml
@@ -124,7 +124,7 @@
    </term>
    <listitem>
     <para>
-     &false; par défaut. En changeant cette valeur pour &true; vous indiquez
+     &false; par défaut. En changeant cette valeur pour &true; on indique
      à PHP que le buffer de sortie doit être vidé automatiquement après
      chaque fonction d'affichage. Cela revient à appeler la fonction
      <function>flush</function> après chaque appel à
@@ -133,7 +133,7 @@
      et chaque bloc HTML.
     </para>
     <para>
-     Lorsque vous utilisez PHP en environnement web, activer cette
+     Lorsqu'on utilise PHP en environnement web, activer cette
      option a de sérieuses implications et généralement, cela n'est conseillé
      que pour les débogages. Cette valeur est par défaut à &true; lorsque PHP
      fonctionne en mode <literal>CLI SAPI</literal>.


### PR DESCRIPTION
Remplacement des formulations directes (vous/votre/vos) par des tournures impersonnelles dans `reference/` (extensions j à o), conformément à TRADUCTIONS.txt.