### PR TITLE
Style impersonnel dans reference/ (p-s)

### DIFF
--- a/reference/password/constants.xml
+++ b/reference/password/constants.xml
@@ -30,7 +30,7 @@
       <listitem>
        <para>
         <literal>salt</literal> (<type>string</type>) - permet de fournir manuellement un salt à utiliser
-        pour le hachage du mot de passe. Notez que ceci va écraser tout salt généré
+        pour le hachage du mot de passe. À noter que ceci va écraser tout salt généré
         automatiquement.
        </para>
        <para>

--- a/reference/pcntl/constants.xml
+++ b/reference/pcntl/constants.xml
@@ -6,7 +6,7 @@
  &reftitle.constants;
  <para>
   La liste suivante représente les signaux supportés par les fonctions
-  de gestion des processus. Reportez-vous au manuel de votre système
+  de gestion des processus. Se reporter au manuel de votre système
   (signal(7)) pour plus de détails sur ces signaux.
  </para>
  <variablelist xml:id="pcntl.constants.common">

--- a/reference/pcntl/functions/pcntl-fork.xml
+++ b/reference/pcntl/functions/pcntl-fork.xml
@@ -16,7 +16,7 @@
   <para>
    <function>pcntl_fork</function> crée un processus fils, qui ne diffère du
    processus père que par l'identifiant de processus et l'identifiant
-   PPID. Reportez-vous à la page de man fork(2) pour avoir des détails
+   PPID. Se reporter à la page de man fork(2) pour avoir des détails
    sur le comportement de cette fonction sur votre système.
   </para>
  </refsect1>

--- a/reference/pcntl/functions/pcntl-signal.xml
+++ b/reference/pcntl/functions/pcntl-signal.xml
@@ -76,7 +76,7 @@
       </para>
       <note>
        <para>
-        Notez que lorsque vous configurez le gestionnaire avec une méthode d'objet,
+        À noter que lorsque vous configurez le gestionnaire avec une méthode d'objet,
         le compteur de référence de l'objet est incrémenté, ce qui le rend persistant
         jusqu'à ce que vous changiez le gestionnaire de signaux pour un autre, ou que
         le script se termine.

--- a/reference/pcntl/functions/pcntl-wait.xml
+++ b/reference/pcntl/functions/pcntl-wait.xml
@@ -61,7 +61,7 @@
      <listitem>
       <para>
        Si wait3 est disponible sur votre système (c'est le cas de la plupart
-       des systèmes BSD-), vous pouvez ajouter le paramètre optionnel
+       des systèmes BSD-), il est possible de ajouter le paramètre optionnel
        <parameter>flags</parameter>. S'il n'est pas fourni,
        wait() sera utilisé pour l'appel système. Si wait3 n'est pas disponible,
        le paramètre <parameter>flags</parameter> n'aura pas d'effet. La valeur

--- a/reference/pcntl/functions/pcntl-waitpid.xml
+++ b/reference/pcntl/functions/pcntl-waitpid.xml
@@ -28,7 +28,7 @@
    terminé au moment de l'appel de cette fonction (on les appelle
    des processus "zombie"), la fonction se termine immédiatement.
    Toute ressource système utilisée par le processus fils est libérée.
-   Reportez-vous à la page de man waitpid(2) pour avoir des détails
+   Se reporter à la page de man waitpid(2) pour avoir des détails
    sur le comportement de cette fonction sur votre système.
   </para>
  </refsect1>

--- a/reference/pcre/configure.xml
+++ b/reference/pcre/configure.xml
@@ -8,7 +8,7 @@
  <para>
   L'extension PCRE est une extension native de PHP, elle est donc toujours 
   activée. Par défaut, cette extension est compilée en utilisant la 
-  bibliothèque PCRE empaquetée. Optionnellement, vous pouvez utiliser une 
+  bibliothèque PCRE empaquetée. Optionnellement, il est possible de utiliser une 
   bibliothèque PCRE externe en passant l'option de configuration 
   <option role="configure">--with-pcre-regex=DIR</option> ou 
   <literal>DIR</literal> est l'emplacement des fichiers de la bibliothèque PCRE.
@@ -26,7 +26,7 @@
   fonctionnalités PHP changent également. Il est possible que certaines
   parties du manuel PHP soient obsolètes et qu'elles ne couvrent pas
   les nouvelles fonctionnalités que fournit PCRE. Pour une liste des
-  modifications, reportez-vous au
+  modifications, se reporter au
   <link xlink:href="&url.pcre.changelog;">changelog de la bibliothèque PCRE</link>
   ainsi qu'à l'historique suivant de la version PCRE incluse dans PHP :
  </para>

--- a/reference/pcre/functions/preg-match.xml
+++ b/reference/pcre/functions/preg-match.xml
@@ -67,7 +67,7 @@
          <listitem>
           <para>
            Si cette option est activée, toutes les sous-chaînes qui satisfont
-           le masque seront aussi identifiées par leur offset (en octets). Notez que cela
+           le masque seront aussi identifiées par leur offset (en octets). À noter que cela
            modifie la valeur de <parameter>matches</parameter> qui devient un
            tableau dont chaque élément est un tableau contenant la chaîne
            correspondant au masque à l'offset <literal>0</literal> ainsi

--- a/reference/pcre/functions/preg-quote.xml
+++ b/reference/pcre/functions/preg-quote.xml
@@ -26,11 +26,11 @@
    <literal>. \ + * ? [ ^ ] $ ( ) { } = ! &lt; &gt; | : - #</literal>
   </para>
   <para>
-   Notez que <literal>/</literal> n'est pas un caractère spécial d'expression régulière.
+   À noter que <literal>/</literal> n'est pas un caractère spécial d'expression régulière.
   </para>
   <note>
    <para>
-    Notez que <function>preg_quote</function> n'est pas destiné à être appliqué aux
+    À noter que <function>preg_quote</function> n'est pas destiné à être appliqué aux
     chaînes de caractères $replacement de <function>preg_replace</function> etc.
    </para>
   </note>

--- a/reference/pcre/functions/preg-replace-callback.xml
+++ b/reference/pcre/functions/preg-replace-callback.xml
@@ -58,7 +58,7 @@
       <para>
        Vous aurez souvent besoin de la fonction <parameter>callback</parameter>
        avec <function>preg_replace_callback</function> à un seul endroit.
-       Dans ce cas, vous pouvez simplement utiliser une
+       Dans ce cas, il est possible de simplement utiliser une
        <link linkend="functions.anonymous">fonction anonyme</link>
        pour déclarer une fonction de rappel pour la fonction
        <function>preg_replace_callback</function>.

--- a/reference/pcre/functions/preg-replace.xml
+++ b/reference/pcre/functions/preg-replace.xml
@@ -78,7 +78,7 @@
       <para>
        Lorsque vous travaillez avec un masque de remplacement où une référence arrière 
        est directement suivie par un nombre (i.e.: placer un nombre littéral immédiatement
-       après une référence arrière), vous ne pouvez pas utiliser la syntaxe classique
+       après une référence arrière), il n'est pas possible de utiliser la syntaxe classique
        <literal>\1</literal> pour la référence arrière. <literal>\11</literal>, par exemple,
        sera confus pour la fonction <function>preg_replace</function> dans le sens où
        elle ne saura pas si vous désirez la référence arrière <literal>\1</literal> suivi du nombre
@@ -94,7 +94,7 @@
        Ce comportement se justifie afin d'assurer qu'aucune erreur de syntaxe
        ne survient lors de l'utilisation des références arrières avec des guillemets
        simples et doubles (e.g. <literal>'strlen(\'$1\')+strlen("$2")'</literal>).
-       Assurez-vous d'être familier avec la <link linkend="language.types.string">syntaxe
+       Il faut s'assurer d'être familier avec la <link linkend="language.types.string">syntaxe
        des chaînes</link> afin de savoir exactement à quoi la chaîne interprétée doit ressembler.
       </para>
      </listitem>

--- a/reference/pcre/functions/preg-split.xml
+++ b/reference/pcre/functions/preg-split.xml
@@ -83,7 +83,7 @@
          <listitem>
           <para>
            Si cette option est activée, pour chaque résultat, la position de celui-ci sera retournée.
-           Notez que cela change la valeur retournée en un tableau où chaque élément est un
+           À noter que cela change la valeur retournée en un tableau où chaque élément est un
            tableau constitué de la chaîne trouvée à la position &zero;
            et la position de la chaîne dans <parameter>subject</parameter> à
            la position &one;.
@@ -214,7 +214,7 @@ Array
   <tip>
    <para>
     Si vous n'avez pas besoin de la puissance des expressions régulières,
-    vous pouvez choisir des alternatives plus rapides (quoique plus simples)
+    il est possible de choisir des alternatives plus rapides (quoique plus simples)
     comme <function>explode</function> ou <function>str_split</function>.
    </para>
   </tip>

--- a/reference/pcre/ini.xml
+++ b/reference/pcre/ini.xml
@@ -65,7 +65,7 @@
     </term>
     <listitem>
      <para>
-      Limite de récurrence PCRE. Notez que si vous définissez
+      Limite de récurrence PCRE. À noter que si vous définissez
       cette valeur à un nombre très élevé, vous pourriez consommer
       tous les processus disponibles et, éventuellement, faire 
       planter PHP (la taille limite de la pile imposée par

--- a/reference/pcre/pattern.modifiers.xml
+++ b/reference/pcre/pattern.modifiers.xml
@@ -130,7 +130,7 @@
       <listitem>
        <simpara>
         Cette option inverse la tendance à la gourmandise des
-        expressions régulières. Vous pouvez aussi inverser
+        expressions régulières. Il est aussi possible de inverser
         cette tendance au coup par coup avec un <literal>?</literal> mais
         cela rendra gourmand la séquence. Cette option n'est pas compatible
         avec Perl. Elle peut aussi être mise dans le masque avec

--- a/reference/pcre/pattern.syntax.xml
+++ b/reference/pcre/pattern.syntax.xml
@@ -88,7 +88,7 @@
    qui doit être échappé.
   </para>
   <para>
-   Vous pouvez aussi utiliser des <link linkend="reference.pcre.pattern.modifiers">
+   Il est aussi possible de utiliser des <link linkend="reference.pcre.pattern.modifiers">
    modificateurs de motif</link> après le délimiteur final. L'exemple suivant montre
    une correspondance insensible à la casse.
    <informalexample>
@@ -381,7 +381,7 @@
    Dans chacun des cas, le métacaractère tente de lire autant
    de caractères que possible. Ainsi, la séquence
    "<literal>\0\x\07</literal>" sera comprise comme deux caractères nuls,
-   suivis d'un caractère alarme (BEL). Assurez-vous que vous fournissez
+   suivis d'un caractère alarme (BEL). Il faut s'assurer que vous fournissez
    suffisamment de chiffres après le métacaractère.
   </para>
   <para>
@@ -1247,7 +1247,7 @@
    <link linkend="reference.pcre.pattern.modifiers">PCRE_MULTILINE</link> est choisie.
   </para>
   <para>
-   Notez que les métacaractères <literal>\A</literal>,
+   À noter que les métacaractères <literal>\A</literal>,
    <literal>\Z</literal>, et <literal>\z</literal> peuvent servir à
    repérer le début et la fin du sujet, et toutes les
    parties du masque qui commenceront par <literal>\A</literal> seront toujours
@@ -1445,7 +1445,7 @@
     </tgroup>
    </table>
    Les caractères d'espacement (<literal>space</literal>) sont HT (9), LF (10), VT (11), FF (12), CR (13),
-   et l'espace (32). Notez que cette liste inclut le caractère VT (code 11). Ceci rend la classe
+   et l'espace (32). À noter que cette liste inclut le caractère VT (code 11). Ceci rend la classe
    "space" différente de <literal>\s</literal>, qui n'inclut pas ce caractère VT (pour une raison de compatibilité
    Perl).
   </para>
@@ -1461,7 +1461,7 @@
    À partir de libpcre 8.10 certains caractères de classes ont été
    modifiées pour utiliser des caractères de propriétés Unicode, dans ce cas les
    restrictions mentionnées ne s'appliquent pas.
-   Référez-vous au <link xlink:href="&url.pcre.man;">manuel PCRE(3)</link> pour plus de détails.
+   Se référer au <link xlink:href="&url.pcre.man;">manuel PCRE(3)</link> pour plus de détails.
   </para>
   <para>
    Les propriétés des caractères Unicode peuvent apparaître à l'intérieur d'une
@@ -2055,7 +2055,7 @@
    s'assure qu'un mot est suivi d'un point-virgule,
    mais n'inclut pas le point virgule dans la capture et <literal>foo(?!bar)</literal>
    trouve toutes les occurrences de "foo" qui ne sont pas suivies par "bar".
-   Notez que,
+   À noter que,
    
    <literal>(?!foo)bar</literal>
    
@@ -2122,7 +2122,7 @@
    <literal>(?&lt;=\d{3})(?&lt;!999)foo</literal>
    
    recherche les chaînes "<literal>foo</literal>" précédées
-   par trois chiffres qui ne sont pas "999". Notez que chaque assertion
+   par trois chiffres qui ne sont pas "999". À noter que chaque assertion
    est appliquée indépendamment, au même point de
    la chaîne à traiter. Tout d'abord, il est
    vérifié que les trois premiers caractères ont
@@ -2613,7 +2613,7 @@ int(1)
    s'assure qu'il y a au moins un "<literal>b</literal>" dans la
    chaîne, et si ce n'est pas le cas, l'échec est
    annoncé immédiatement. Sinon, il n'y a pas
-   d'optimisation dans la recherche. Vous pouvez voir la
+   d'optimisation dans la recherche. Il est possible de voir la
    différence de comportement avec le masque suivant :
    
    <literal>(a+)*\d</literal>.

--- a/reference/pdo/book.xml
+++ b/reference/pdo/book.xml
@@ -16,7 +16,7 @@
    une interface légère et cohérente pour accéder à une base de données depuis PHP.
    Chaque pilote de base de données implémenté dans l'interface PDO peut utiliser
    des fonctionnalités spécifiques de chacune des bases de données
-   en utilisant des extensions de fonctions. Notez que vous ne pouvez
+   en utilisant des extensions de fonctions. À noter que il n'est pas possible de
    exécuter aucune fonction de base de données en utilisant l'extension PDO
    par elle-même ; vous devez utiliser un <link linkend="pdo.drivers">driver
    PDO spécifique à la base de données</link> pour accéder au serveur de base

--- a/reference/pdo/configure.xml
+++ b/reference/pdo/configure.xml
@@ -21,7 +21,7 @@
    </para>
    <note>
     <para>
-     Notez que lors de la compilation de PDO comme extension partagée
+     À noter que lors de la compilation de PDO comme extension partagée
      (<emphasis>non recommandé</emphasis>), alors tous les pilotes PDO
      <emphasis>doivent</emphasis> être chargés <emphasis>après</emphasis>
      le chargement de PDO.
@@ -33,11 +33,11 @@
     Lors de l'installation de PDO comme module partagé, le fichier &php.ini;
     doit être mis à jour afin de charger l'extension PDO automatiquement
     lorsque PHP entre en fonctionnement. Vous devez également y activer
-    les pilotes spécifiques à votre base de données ; assurez-vous que
+    les pilotes spécifiques à votre base de données ; il faut s'assurer que
     ces pilotes seront listés après la ligne extension=pdo, vu que PDO doit
     être initialisé avant le chargement des extensions spécifiques aux
     bases de données. Si vous compilez PDO et les extensions relatives
-    aux bases de données de façon statique, vous pouvez ignorer cette étape.
+    aux bases de données de façon statique, il est possible de ignorer cette étape.
     <screen>
 <![CDATA[
 extension=pdo
@@ -72,7 +72,7 @@ extension=pdo_sqlite
  </procedure>
  <note>
   <para>
-   Gardez à l'esprit qu'après modification de votre &php.ini;, vous
+   Il faut garder à l'esprit qu'après modification de votre &php.ini;, vous
    devez redémarrer PHP pour que vos nouvelles directives de configuration
    prennent effet.
   </para>

--- a/reference/pdo/connections.xml
+++ b/reference/pdo/connections.xml
@@ -25,7 +25,7 @@ $dbh = new PDO('mysql:host=localhost;dbname=test', $user, $pass);
  </para>
  <para>
   S'il y a des erreurs de connexion, un objet <literal>PDOException</literal>
-  est lancé. Vous pouvez attraper cette exception si vous voulez gérer
+  est lancé. Il est possible de attraper cette exception si vous voulez gérer
   cette erreur, ou laisser le gestionnaire global d'exception défini
   via la fonction <function>set_exception_handler</function> la traiter.
  </para>
@@ -60,7 +60,7 @@ try {
   Lorsque la connexion à la base de données a réussi, une instance de la classe
   PDO est retournée à votre script. La connexion est active tant que l'objet PDO
   l'est. Pour clore la connexion, vous devez détruire l'objet en vous assurant que
-  toutes ses références sont effacées. Vous pouvez faire cela en assignant &null;
+  toutes ses références sont effacées. Il est possible de faire cela en assignant &null;
   à la variable gérant l'objet. Si vous ne le faites pas explicitement, PHP fermera
   automatiquement la connexion lorsque le script arrivera à la fin.
  </para>

--- a/reference/pdo/error-handling.xml
+++ b/reference/pdo/error-handling.xml
@@ -20,11 +20,11 @@
     grâce aux méthodes <methodname>PDO::errorCode</methodname> et
     <methodname>PDO::errorInfo</methodname> sur les objets représentant
     les requêtes, mais aussi ceux représentant les bases de données ; si l'erreur
-    résulte d'un appel à l'objet représentant la requête, vous pouvez appeler
+    résulte d'un appel à l'objet représentant la requête, il est possible de appeler
     la méthode <methodname>PDOStatement::errorCode</methodname> ou la méthode
     <methodname>PDOStatement::errorInfo</methodname> sur l'objet.
     Si l'erreur résulte d'un appel sur l'objet représentant une base de données,
-    vous pouvez également appeler ces deux mêmes méthodes sur l'objet.
+    il est également possible de appeler ces deux mêmes méthodes sur l'objet.
    </para>
   </listitem>
   <listitem>
@@ -48,12 +48,12 @@
     afin de représenter le code d'erreur et les informations complémentaires.
     Cette configuration est également utile lors du débogage, car elle
     va « contourner » le point critique de votre code, vous montrer
-    rapidement le problème rencontré (souvenez-vous : les transactions
+    rapidement le problème rencontré (il faut se rappeler : les transactions
     sont automatiquement annulées si l'exception fait que votre script
     se termine).
    </para>
    <para>
-    Le mode "exception" est également très utile car ainsi, vous pouvez
+    Le mode "exception" est également très utile car ainsi, il est possible de
     structurer votre gestionnaire d'erreur plus clairement qu'avec
     les alertes traditionnelles PHP et, ce, avec moins de code que
     lorsque vous exécutez votre code en mode silence, et que vous

--- a/reference/pdo/lobs.xml
+++ b/reference/pdo/lobs.xml
@@ -63,7 +63,7 @@ $stmt = $db->prepare("insert into images (id, contenttype, imagedata) values (?,
 $id = get_new_id(); // fonction pour allouer un nouvel ID
 
 // assumons que nous récupérons un fichier depuis un formulaire
-// vous pouvez trouver plus de détails dans la documentation de PHP
+// il est possible de trouver plus de détails dans la documentation de PHP
 
 $fp = fopen($_FILES['file']['tmp_name'], 'rb');
 
@@ -97,7 +97,7 @@ $stmt = $db->prepare("insert into images (id, contenttype, imagedata) " .
 $id = get_new_id(); // fonction pour allouer un nouvel ID
 
 // assumons que nous récupérons un fichier depuis un formulaire
-// vous pouvez trouver plus de détails dans la documentation de PHP
+// il est possible de trouver plus de détails dans la documentation de PHP
 
 $fp = fopen($_FILES['file']['tmp_name'], 'rb');
 

--- a/reference/pdo/pdo/getattribute.xml
+++ b/reference/pdo/pdo/getattribute.xml
@@ -17,7 +17,7 @@
 
   <para>
    Cette fonction retourne la valeur d'un attribut d'une connexion à une base
-   de données. Pour récupérer les attributs <classname>PDOStatement</classname>, référez-vous
+   de données. Pour récupérer les attributs <classname>PDOStatement</classname>, se référer
    à la fonction <methodname>PDOStatement::getAttribute</methodname>.
   </para>
 

--- a/reference/pdo/pdo/prepare.xml
+++ b/reference/pdo/pdo/prepare.xml
@@ -30,7 +30,7 @@
   <para>
    Vous devez inclure un marqueur avec un nom unique pour chaque valeur que
    vous souhaitez passer dans la requête lorsque vous appelez
-   <methodname>PDOStatement::execute</methodname>. Vous ne pouvez pas utiliser
+   <methodname>PDOStatement::execute</methodname>. Il n'est pas possible de utiliser
    un marqueur avec deux noms identiques dans une requête préparée, à moins que 
    le mode émulation ne soit actif.
   </para>
@@ -40,7 +40,7 @@
     données complet.
     Ni une partie de littéral, ni un mot clé, ni un identifiant, ni toute autre 
     requête arbitraire ne peuvent être liés en utilisant les paramètres.       
-    Par exemple, vous ne pouvez associer plusieurs valeurs à un seul marqueur de nom entrant, dans la clause IN() d'une requête SQL. 
+    Par exemple, il n'est pas possible de associer plusieurs valeurs à un seul marqueur de nom entrant, dans la clause IN() d'une requête SQL. 
    </para>
   </note>
   <para>
@@ -97,7 +97,7 @@
       <para>
        Ce tableau contient une ou plusieurs paires clé=&gt;valeur pour définir
        les valeurs des attributs pour l'objet <classname>PDOStatement</classname>
-       que cette méthode retourne. Vous pouvez utiliser ceci pour définir la valeur
+       que cette méthode retourne. Il est possible de utiliser ceci pour définir la valeur
        <literal>PDO::ATTR_CURSOR</literal> à
        <literal>PDO::CURSOR_SCROLL</literal> pour demander un curseur scrollable.
        Quelques pilotes ont des options spécifiques qui peuvent être définies

--- a/reference/pdo/pdostatement/bindcolumn.xml
+++ b/reference/pdo/pdostatement/bindcolumn.xml
@@ -55,7 +55,7 @@
       <para>
        Numéro de la colonne (en commençant à 1) ou nom de la colonne dans 
        le jeu de résultats. Si vous utilisez les noms de colonnes, 
-       assurez-vous que le nom corresponde à la casse de la colonne, comme
+       il faut s'assurer que le nom corresponde à la casse de la colonne, comme
        retourné par le pilote.
       </para>
      </listitem>

--- a/reference/pdo/pdostatement/execute.xml
+++ b/reference/pdo/pdostatement/execute.xml
@@ -16,7 +16,7 @@
   </methodsynopsis>
   <para>
    Exécute une <link linkend="pdo.prepared-statements">requête préparée</link>. 
-   Si la requête préparée inclut des marqueurs de positionnement, vous pouvez :
+   Si la requête préparée inclut des marqueurs de positionnement, il est possible de :
    <itemizedlist>
     <listitem><para><methodname>PDOStatement::bindParam</methodname> et/ou 
      <methodname>PDOStatement::bindValue</methodname> doit être appelé pour lier 

--- a/reference/pdo/pdostatement/fetchall.xml
+++ b/reference/pdo/pdostatement/fetchall.xml
@@ -51,7 +51,7 @@
       <para>
        Pour retourner un tableau contenant toutes les valeurs d'une seule colonne
        depuis le jeu de résultats, spécifiez <constant>PDO::FETCH_COLUMN</constant>.
-       Vous pouvez spécifier quelle colonne vous voulez avec le paramètre
+       Il est possible de spécifier quelle colonne vous voulez avec le paramètre
        <parameter>column</parameter>.
       </para>
       <para>

--- a/reference/pdo/prepared-statements.xml
+++ b/reference/pdo/prepared-statements.xml
@@ -7,7 +7,7 @@
  <title>Requêtes préparées et procédures stockées</title>
  <para>
   La plupart des bases de données supportent le concept des requêtes préparées.
-  Qu'est-ce donc ? Vous pouvez les voir comme une sorte de modèle compilé
+  Qu'est-ce donc ? Il est possible de les voir comme une sorte de modèle compilé
   pour le SQL que vous voulez exécuter, qui peut être personnalisé en utilisant
   des variables en guise de paramètres. Les requêtes préparées offrent
   deux fonctionnalités essentielles :
@@ -30,7 +30,7 @@
    <simpara>
     Les paramètres pour préparer les requêtes n'ont pas besoin d'être entre
     guillemets ; le pilote gère cela pour vous. Si votre application utilise exclusivement
-    les requêtes préparées, vous pouvez être sûr qu'aucune injection SQL
+    les requêtes préparées, il est possible de être sûr qu'aucune injection SQL
     n'est possible (Cependant, si vous construisez d'autres parties de la requête
     en vous basant sur des entrées utilisateurs, vous continuez à prendre un risque).
    </simpara>
@@ -124,7 +124,7 @@ foreach ($stmt as $row) {
   <example>
    <title>Appel d'une procédure stockée avec un paramètre de sortie</title>
    <simpara>
-    Si le pilote de la base de données le prend en charge, vous pouvez également lier
+    Si le pilote de la base de données le prend en charge, il est également possible de lier
     des paramètres aussi bien pour l'entrée que pour la sortie. Les paramètres de sortie
     sont utilisés typiquement pour récupérer les valeurs d'une procédure stockée.
     Les paramètres de sortie sont un peu plus complexes à utiliser que les paramètres d'entrée

--- a/reference/pdo/transactions.xml
+++ b/reference/pdo/transactions.xml
@@ -147,11 +147,11 @@ try {
  </para>
  <para>
   Vous n'êtes pas limités dans le nombre de mises à jour dans une transaction ;
-  vous pouvez également y effectuer des requêtes complexes et bien sûr, utiliser
+  il est également possible de y effectuer des requêtes complexes et bien sûr, utiliser
   ces informations pour construire d'autres mises à jour et requêtes ; durant l'activité
   de la transaction, vous êtes sûrs que personne d'autre ne peut effectuer des
   modifications alors que vous êtes au milieu de vos modifications.
-  Pour plus d'informations sur les transactions, reportez-vous à la documentation
+  Pour plus d'informations sur les transactions, se reporter à la documentation
   fournie par votre base de données.
  </para>
 </chapter>

--- a/reference/pdo_cubrid/reference.xml
+++ b/reference/pdo_cubrid/reference.xml
@@ -27,7 +27,7 @@
    <title>Curseurs défilables</title>
    <simpara>
     PDO_CUBRID prend en charge les curseurs défilables. Le type de curseur par défaut est
-    forward only, et vous pouvez utiliser le paramètre driver_options dans
+    forward only, et il est possible de utiliser le paramètre driver_options dans
     <methodname>PDO::prepare</methodname> pour changer le type de curseur.
    </simpara>
   </section>
@@ -36,7 +36,7 @@
    <title>Délai d'expiration</title>
    <simpara>
     PDO_CUBRID prend en charge le paramétrage du délai d'exécution de l'instruction SQL ;
-    Vous pouvez utiliser <methodname>PDO::setAttribute</methodname> pour définir la valeur du délai d'expiration.
+    Il est possible de utiliser <methodname>PDO::setAttribute</methodname> pour définir la valeur du délai d'expiration.
    </simpara>
   </section>
 
@@ -45,7 +45,7 @@
 
    <simpara>
     PDO_CUBRID prend en charge à la fois le mode autocommit et la transaction, et
-    le mode autocommit est activé par défaut. Vous pouvez utiliser
+    le mode autocommit est activé par défaut. Il est possible de utiliser
     <methodname>PDO::setAttribute</methodname> pour changer son état.
    </simpara>
 
@@ -87,7 +87,7 @@
 
    <simpara>
     PDO_CUBRID prend en charge les types de données BLOB/CLOB. Le LOB dans PDO est
-    représenté comme un flux, vous pouvez donc insérer des LOBs en liant un flux,
+    représenté comme un flux, il est possible de donc insérer des LOBs en liant un flux,
     et obtenir des LOBs en lisant un flux retourné par CUBRID PDO.
     Par exemple :
    </simpara>

--- a/reference/pdo_dblib/reference.xml
+++ b/reference/pdo_dblib/reference.xml
@@ -26,7 +26,7 @@
     </link>.
    </para>
    <para>
-    Si vous ne pouvez pas utiliser SqlSrv, vous pouvez utiliser le driver
+    Si il n'est pas possible de utiliser SqlSrv, il est possible de utiliser le driver
     <link linkend="ref.pdo-odbc">PDO_ODBC</link> pour se connecter à un serveur
     de bases de données Microsoft SQL et Sybase, sachant que le driver natif
     Windows DB-LIB est ancien, non sécurisé niveau thread et plus supporté par

--- a/reference/pdo_mysql/configure.xml
+++ b/reference/pdo_mysql/configure.xml
@@ -17,7 +17,7 @@
  </para>
 
  <para>
-  Alternativement, vous pouvez compiler cette extension vous-même. Construire
+  Alternativement, il est possible de compiler cette extension vous-même. Construire
   PHP depuis les sources permet de préciser les extensions MySQL à embarquer,
   mais aussi les bibliothèques clientes de chaque extension.
  </para>

--- a/reference/pdo_odbc/reference.xml
+++ b/reference/pdo_odbc/reference.xml
@@ -82,7 +82,7 @@
         <para>
          Le préfixe DSN est <userinput>odbc:</userinput>. Si vous vous
          connectez à une base de données cataloguée dans le pilote de ODBC
-         Manager ou dans le catalogue de DB2, vous pouvez ajouter le nom du
+         Manager ou dans le catalogue de DB2, il est possible de ajouter le nom du
          catalogue de la base de données au DSN.
         </para>
        </listitem>
@@ -92,7 +92,7 @@
        <listitem>
         <para>
          Le nom de la base de données étant catalogué dans le pilote ODBC
-         Manager ou le catalogue DB2. Alternativement, vous pouvez fournir une
+         Manager ou le catalogue DB2. Alternativement, il est possible de fournir une
          chaîne de connexion complète pour ODBC pour vous connecter à une base
          de données comme décrit à
          <link xlink:href="&url.connectionstrings;">&url.connectionstrings;</link>.

--- a/reference/pdo_sqlsrv/reference.xml
+++ b/reference/pdo_sqlsrv/reference.xml
@@ -191,7 +191,7 @@ $c = new PDO("sqlsrv:Server=localhost,1521;Database=bddtest", "Utilisateur", "Mo
     </para>
     <para>
      L'exemple suivant montre comment se connecter à une base de données SQL Azure avec
-     l'ID serveur 12345abcde. Notez que, quand vous vous connectez à Azure avec PDO,
+     l'ID serveur 12345abcde. À noter que, quand vous vous connectez à Azure avec PDO,
      votre nom d'utilisateur sera Utilisateur@12345abcde (Utilisateur@IdServeur).
      <programlisting>
 <![CDATA[

--- a/reference/pgsql/functions/pg-cancel-query.xml
+++ b/reference/pgsql/functions/pg-cancel-query.xml
@@ -20,7 +20,7 @@
    <function>pg_send_query</function>,
    <function>pg_send_query_params</function> ou
    <function>pg_send_execute</function>. 
-   Vous ne pouvez pas annuler une requête démarrée avec <function>pg_query</function>.
+   Il n'est pas possible de annuler une requête démarrée avec <function>pg_query</function>.
   </para>
  </refsect1>
  

--- a/reference/pgsql/functions/pg-client-encoding.xml
+++ b/reference/pgsql/functions/pg-client-encoding.xml
@@ -28,7 +28,7 @@
     le support de l'encodage multioctets,
     <function>pg_client_encoding</function> retournera toujours
     <literal>SQL_ASCII</literal>. Le support de l'encodage dépend de la version
-    de PostgreSQL. Référez-vous à la documentation de PostgreSQL sur les
+    de PostgreSQL. Se référer à la documentation de PostgreSQL sur les
     encodages supportés.
    </para>
    <para>

--- a/reference/pgsql/functions/pg-execute.xml
+++ b/reference/pgsql/functions/pg-execute.xml
@@ -121,7 +121,7 @@ $dbconn = pg_connect("dbname=marie");
 // Prépare une requête pour l'exécution
 $result = pg_prepare($dbconn, "my_query", 'SELECT * FROM magasins WHERE nom = $1');
 
-// Exécute la requête préparée. Notez qu'il n'est pas nécessaire d'échapper
+// Exécute la requête préparée. À noter qu'il n'est pas nécessaire d'échapper
 // la chaîne "Joe's Widgets"
 $result = pg_execute($dbconn, "my_query", array("Joe's Widgets"));
 

--- a/reference/pgsql/functions/pg-field-type-oid.xml
+++ b/reference/pgsql/functions/pg-field-type-oid.xml
@@ -22,7 +22,7 @@
    l'instance<parameter>result</parameter>.
   </para>
   <para>
-   Vous pouvez obtenir plus d'informations à propos du type de champ en
+   Il est possible de obtenir plus d'informations à propos du type de champ en
    interrogeant la table système de PostgreSQL <function>pg_type</function> avec
    le OID obtenu par cette fonction.
   </para>

--- a/reference/pgsql/functions/pg-last-notice.xml
+++ b/reference/pgsql/functions/pg-last-notice.xml
@@ -24,7 +24,7 @@
    une table.
   </para>
   <para>
-   Avec <function>pg_last_notice</function>, vous pouvez éviter des requêtes
+   Avec <function>pg_last_notice</function>, il est possible de éviter des requêtes
    inutiles en vérifiant si des notes sont liées ou pas à votre transaction.
   </para>
   <para>

--- a/reference/pgsql/functions/pg-prepare.xml
+++ b/reference/pgsql/functions/pg-prepare.xml
@@ -127,7 +127,7 @@ $dbconn = pg_connect("dbname=marie");
 // Prépare une requête pour l'exécution
 $result = pg_prepare($dbconn, "my_query", 'SELECT * FROM magasins WHERE nom = $1');
 
-// Exécute la requête préparée. Notez qu'il n'est pas nécessaire d'échapper
+// Exécute la requête préparée. À noter qu'il n'est pas nécessaire d'échapper
 // la chaîne "Joe's Widgets"
 $result = pg_execute($dbconn, "my_query", array("Joe's Widgets"));
 

--- a/reference/pgsql/functions/pg-put-line.xml
+++ b/reference/pgsql/functions/pg-put-line.xml
@@ -32,7 +32,7 @@
   </para>
   <note>
    <para>
-    Notez que l'application doit explicitement ajouter les deux caractères
+    À noter que l'application doit explicitement ajouter les deux caractères
     "\." à la fin de la chaîne pour indiquer au serveur qu'elle a finit
     d'envoyer des données, avant d'appeler <function>pg_end_copy</function>.
    </para>
@@ -41,7 +41,7 @@
    <para>
     L'utilisation de <function>pg_put_line</function> cause sur la plupart des
     objets de grande taille à échouer, incluant <function>pg_lo_read</function>
-    et <function>pg_lo_tell</function>. Vous pouvez utiliser
+    et <function>pg_lo_tell</function>. Il est possible de utiliser
     <function>pg_copy_from</function> et <function>pg_copy_to</function> à la
     place.
    </para>

--- a/reference/pgsql/functions/pg-query-params.xml
+++ b/reference/pgsql/functions/pg-query-params.xml
@@ -75,8 +75,8 @@
        requête, où elles peuvent potentiellement former des
        <link linkend="security.database.sql-injection">injections SQL</link>
        et introduire des bogues lorsque ces données contiennent des guillemets.
-       Si pour une raison quelconque vous ne pouvez pas utiliser de paramètres,
-       assurez-vous que les valeurs interpolées sont
+       Si pour une raison quelconque il n'est pas possible de utiliser de paramètres,
+       il faut s'assurer que les valeurs interpolées sont
        <link  linkend="function.pg-escape-string">proprement échappées</link>.
       </para>
      </listitem>
@@ -137,7 +137,7 @@
 // Connexion à une base de données nommée "marie"
 $dbconn = pg_connect("dbname=marie");
 
-// Cherche tous les magasins nommés Joe's Widgets. Notez qu'il n'est pas
+// Cherche tous les magasins nommés Joe's Widgets. À noter qu'il n'est pas
 // nécessaire d'échapper la chaîne "Joe's Widgets"
 $result = pg_query_params($dbconn, 'SELECT * FROM magasins WHERE nom = $1', array("Joe's Widgets"));
 

--- a/reference/pgsql/functions/pg-trace.xml
+++ b/reference/pgsql/functions/pg-trace.xml
@@ -29,7 +29,7 @@
    requêtes et les erreurs : avec la commande
    <command>grep '^To backend' trace.log</command>, vous pourrez voir les
    requêtes réellement envoyées au serveur PostgreSQL. Pour plus
-   d'informations, référez-vous à la 
+   d'informations, se référer à la 
    <link xlink:href="&url.pgsql.manual;">Documentation PostgreSQL</link>.
   </para>
  </refsect1>

--- a/reference/phar/Phar/setSignatureAlgorithm.xml
+++ b/reference/phar/Phar/setSignatureAlgorithm.xml
@@ -60,7 +60,7 @@ $p->setSignatureAlgorithm(Phar::OPENSSL, $pkey);
 ?>
         ]]>
        </programlisting>
-       Reportez-vous à 
+       Se reporter à 
        <link linkend="phar.using">l'introduction de phar</link> 
        pour les instructions de nommage et de placement du 
        fichier de clé publique.

--- a/reference/phar/setup.xml
+++ b/reference/phar/setup.xml
@@ -10,7 +10,7 @@
  <section xml:id="phar.requirements">
   &reftitle.required;
   <para>
-   Vous pouvez éventuellement souhaiter activer les extensions <link linkend="book.zlib" >zlib</link>
+   Il est possible de éventuellement souhaiter activer les extensions <link linkend="book.zlib" >zlib</link>
    et <link linkend="book.bzip2" >bzip2</link> pour tirer parti du support
    phar compressé. De plus, pour exploiter les signatures OpenSSL, l'extension
    <link linkend="book.openssl">OpenSSL</link> doit être activée.

--- a/reference/phar/using.xml
+++ b/reference/phar/using.xml
@@ -321,7 +321,7 @@ $f = file_get_contents('phar://monphar.phar/nimportequoi.txt');
      (<literal>phar://monphar.phar/fichier.php</literal>), ou écrase
      un fichier existant au sein de <literal>monphar.phar</literal>. <literal>$v</literal>
      peut être soit une chaîne ou un pointeur vers un fichier ouvert, dans quel cas
-     le contenu du fichier sera utilisé pour créer le nouveau fichier. Notez que
+     le contenu du fichier sera utilisé pour créer le nouveau fichier. À noter que
      <literal>$p-&gt;addFromString('fichier.php', $v)</literal> est équivalent en termes de
      fonctionnalité au cas ci-dessus. Il est aussi possible d'ajouter le contenu d'un fichier
      avec <literal>$p-&gt;addFile('/chemin/vers/fichier.php', 'fichier.php')</literal>.

--- a/reference/posix/constants.xml
+++ b/reference/posix/constants.xml
@@ -64,7 +64,7 @@
   <title>Constantes <function>posix_mknod</function></title>
   <note>
    <para>
-    Notez que quelques unes d'entre elles peuvent pas être disponibles sur votre système.
+    À noter que quelques unes d'entre elles peuvent pas être disponibles sur votre système.
    </para>
   </note>
   <variablelist>
@@ -130,7 +130,7 @@
   <title>Constantes <function>posix_setrlimit</function></title>
   <note>
    <para>
-    Notez que quelques unes d'entre elles peuvent ne pas être disponibles sur votre système.
+    À noter que quelques unes d'entre elles peuvent ne pas être disponibles sur votre système.
    </para>
   </note>
   <note>

--- a/reference/posix/functions/posix-geteuid.xml
+++ b/reference/posix/functions/posix-geteuid.xml
@@ -16,7 +16,7 @@
    <void/>
   </methodsynopsis>
   <para>
-   Retourne l'UID effectif de l'utilisateur du processus courant. Reportez-vous à
+   Retourne l'UID effectif de l'utilisateur du processus courant. Se reporter à
    <function>posix_getpwuid</function> pour obtenir le nom d'utilisateur.
   </para>
  </refsect1>

--- a/reference/posix/functions/posix-getpgrp.xml
+++ b/reference/posix/functions/posix-getpgrp.xml
@@ -36,7 +36,7 @@
   &reftitle.seealso;
   <para>
    <simplelist>
-    <member>Reportez-vous à POSIX.1 et
+    <member>Se reporter à POSIX.1 et
      à getpgrp(2) dans le manuel de votre système POSIX pour
      plus d'informations sur les groupes de processus.</member>
    </simplelist>

--- a/reference/posix/functions/posix-kill.xml
+++ b/reference/posix/functions/posix-kill.xml
@@ -57,7 +57,7 @@
   <para>
    <simplelist>
     <member>
-     Reportez-vous à la page de manuel de kill(2) de votre
+     Se reporter à la page de manuel de kill(2) de votre
      système POSIX, qui contient plus de détails sur
      les identifiants négatifs de processus, les pid
      spéciaux 0 et -1, et le signal numéro 0.

--- a/reference/posix/functions/posix-setpgid.xml
+++ b/reference/posix/functions/posix-setpgid.xml
@@ -57,7 +57,7 @@
   <para>
    <simplelist>
     <member>
-     Reportez-vous à POSIX.1 et setsid(2) dans le manuel de votre
+     Se reporter à POSIX.1 et setsid(2) dans le manuel de votre
      système POSIX pour plus d'informations sur le contrôle
      de tâche.
     </member>

--- a/reference/posix/functions/posix-setsid.xml
+++ b/reference/posix/functions/posix-setsid.xml
@@ -37,7 +37,7 @@
   <para>
    <simplelist>
     <member>
-     Reportez-vous à POSIX.1 et setsid(2) dans le manuel de
+     Se reporter à POSIX.1 et setsid(2) dans le manuel de
      votre système POSIX pour plus d'informations sur le contrôle
      de tâche.
     </member>

--- a/reference/posix/functions/posix-strerror.xml
+++ b/reference/posix/functions/posix-strerror.xml
@@ -16,7 +16,7 @@
   </methodsynopsis>
   <para>
    Retourne le message d'erreur POSIX associé au numéro
-   d'erreur <parameter>error_code</parameter>. Vous pouvez récupérer le paramètre
+   d'erreur <parameter>error_code</parameter>. Il est possible de récupérer le paramètre
    <parameter>error_code</parameter> en appelant la fonction
    <function>posix_get_last_error</function>.
   </para>

--- a/reference/ps/functions/ps-show-boxed.xml
+++ b/reference/ps/functions/ps-show-boxed.xml
@@ -272,7 +272,7 @@
     Le texte est coupé si le paramètre <literal>hyphenation</literal> est fixé à
     &true; et un dictionnaire de césure valide est fixé. pslib ne fournit pas
     son propre dictionnaire de césure, mais utilise un de openoffice, scribus
-    ou koffice. Vous pouvez trouver ces dictionnaires pour différentes langues
+    ou koffice. Il est possible de trouver ces dictionnaires pour différentes langues
     dans un des dossiers suivants si le programme est installé :
     <simplelist>
      <member>

--- a/reference/pspell/functions/pspell-config-create.xml
+++ b/reference/pspell/functions/pspell-config-create.xml
@@ -25,7 +25,7 @@
    <function>pspell_config_create</function> suivi immédiatement
    par <function>pspell_new_config</function> produira exactement le
    même résultat. Cependant, après avoir créé
-   une nouvelle configuration, vous pouvez aussi utiliser les fonctions
+   une nouvelle configuration, il est aussi possible de utiliser les fonctions
    <function>pspell_config_*</function>  avant d'appeler 
    <function>pspell_new_config</function>
    pour tirer profit des fonctionnalités avancées.

--- a/reference/pspell/functions/pspell-new.xml
+++ b/reference/pspell/functions/pspell-new.xml
@@ -23,7 +23,7 @@
    fonctions pspell.
   </para>
   <para>
-   Pour plus d'informations et d'exemples, reportez-vous au site
+   Pour plus d'informations et d'exemples, se reporter au site
    <link xlink:href="&url.pspell;">&url.pspell;</link>.
   </para>
  </refsect1>

--- a/reference/quickhash/quickhashinthash/construct.xml
+++ b/reference/quickhash/quickhashinthash/construct.xml
@@ -38,7 +38,7 @@
     <term><parameter>options</parameter></term>
     <listitem>
      <simpara>
-      Les options que vous pouvez passer sont: <constant>QuickHashIntHash::CHECK_FOR_DUPES</constant>,
+      Les options que il est possible de passer sont: <constant>QuickHashIntHash::CHECK_FOR_DUPES</constant>,
       qui s'assure qu'aucune entrée dupliquée n'est ajoutée au hachage;
       <constant>QuickHashIntHash::DO_NOT_USE_ZEND_ALLOC</constant> pour ne pas utiliser le gestionnaire de mémoire interne de PHP
       ainsi que l'une des <constant>QuickHashIntHash::HASHER_NO_HASH</constant>,

--- a/reference/quickhash/quickhashintset/construct.xml
+++ b/reference/quickhash/quickhashintset/construct.xml
@@ -38,7 +38,7 @@
     <term><parameter>options</parameter></term>
     <listitem>
      <simpara>
-      Les options que vous pouvez passer sont: <constant>QuickHashIntSet::CHECK_FOR_DUPES</constant>,
+      Les options que il est possible de passer sont: <constant>QuickHashIntSet::CHECK_FOR_DUPES</constant>,
       qui s'assure qu'aucune entrée dupliquée n'est ajoutée à l'ensemble;
       <constant>QuickHashIntSet::DO_NOT_USE_ZEND_ALLOC</constant> pour ne pas utiliser le gestionnaire de mémoire
       interne de PHP ainsi que l'une des <constant>QuickHashIntSet::HASHER_NO_HASH</constant>,

--- a/reference/quickhash/quickhashintstringhash/construct.xml
+++ b/reference/quickhash/quickhashintstringhash/construct.xml
@@ -38,7 +38,7 @@
     <term><parameter>options</parameter></term>
     <listitem>
      <simpara>
-      Les options que vous pouvez passer sont : <constant>QuickHashIntStringHash::CHECK_FOR_DUPES</constant>,
+      Les options que il est possible de passer sont : <constant>QuickHashIntStringHash::CHECK_FOR_DUPES</constant>,
       qui s'assure qu'aucune entrée dupliquée n'est ajoutée au hachage ;
       <constant>QuickHashIntStringHash::DO_NOT_USE_ZEND_ALLOC</constant> pour ne pas utiliser le gestionnaire de mémoire interne de PHP
       ainsi que l'une des valeurs <constant>QuickHashIntStringHash::HASHER_NO_HASH</constant>,

--- a/reference/quickhash/quickhashstringinthash/construct.xml
+++ b/reference/quickhash/quickhashstringinthash/construct.xml
@@ -38,7 +38,7 @@
     <term><parameter>options</parameter></term>
     <listitem>
      <simpara>
-      Les options que vous pouvez passer sont :
+      Les options que il est possible de passer sont :
       <constant>QuickHashStringIntHash::CHECK_FOR_DUPES</constant>, qui vérifie qu'aucune entrée dupliquée
       n'est ajoutée au hachage et
       <constant>QuickHashStringIntHash::DO_NOT_USE_ZEND_ALLOC</constant> pour ne pas utiliser le gestionnaire de mémoire

--- a/reference/rar/examples.xml
+++ b/reference/rar/examples.xml
@@ -35,8 +35,8 @@ $orfilename = $entries[$index]->getName(); //Encodage UTF-8
 
 $filesize = $entries[$index]->getUnpackedSize();
 
-/* Vous pouvez vérifier ici HTTP_IF_MODIFIED_SINCE et le comparer
- * avec $entries[$index]->getFileTime(). Vous pouvez également envoyer
+/* Il est possible de vérifier ici HTTP_IF_MODIFIED_SINCE et le comparer
+ * avec $entries[$index]->getFileTime(). Il est également possible de envoyer
  * un en-tête "Last modified" */
 
 $fp = $entries[$index]->getStream();

--- a/reference/recode/functions/recode-string.xml
+++ b/reference/recode/functions/recode-string.xml
@@ -76,7 +76,7 @@ echo recode_string("us..flat", "Le caractère suivant est diacritique : á");
   &reftitle.seealso;
   <simplelist>
    <member>
-    Reportez-vous à la documentation GNU Recode de votre installation
+    Se reporter à la documentation GNU Recode de votre installation
     pour plus de détails sur les requêtes.
    </member>
    <member><function>mb_convert_encoding</function></member>

--- a/reference/reflection/extending.xml
+++ b/reference/reflection/extending.xml
@@ -72,7 +72,7 @@ object(My_Reflection_Method)#1 (3) {
  </example>
  <caution>
   <para>
-   Si vous écrasez le constructeur, souvenez-vous d'appeler
+   Si vous écrasez le constructeur, il faut se rappeler d'appeler
    le constructeur parent avant d'insérer le moindre code.
    Si vous ne le faites pas, voici ce qui arrivera :
    <literal>Fatal error: Internal error: Failed to retrieve the reflection object</literal>

--- a/reference/rrd/functions/rrd-create.xml
+++ b/reference/rrd/functions/rrd-create.xml
@@ -36,7 +36,7 @@
     <listitem>
      <simpara>
       Options pour la création rrd - listes de chaînes.
-      Reportez-vous à la page man de rrd pour une liste
+      Se reporter à la page man de rrd pour une liste
       complète des options disponibles pour la création.
      </simpara>
     </listitem>

--- a/reference/rrd/functions/rrd-graph.xml
+++ b/reference/rrd/functions/rrd-graph.xml
@@ -38,7 +38,7 @@
     <term><parameter>options</parameter></term>
     <listitem>
      <simpara>
-      Options pour la génération de l'image. Reportez-vous à la page man
+      Options pour la génération de l'image. Se reporter à la page man
       du graphique RRD pour toutes les options possibles. Toutes les options
       (définitions de données, définitions des variables, etc.) sont autorisées.
      </simpara>

--- a/reference/rrd/functions/rrd-restore.xml
+++ b/reference/rrd/functions/rrd-restore.xml
@@ -44,7 +44,7 @@
     <term><parameter>options</parameter></term>
     <listitem>
      <simpara>
-      Tableau d'options pour la restauration. Reportez-vous à la
+      Tableau d'options pour la restauration. Se reporter à la
       page man de la restauration RRD.
      </simpara>
     </listitem>

--- a/reference/rrd/functions/rrd-tune.xml
+++ b/reference/rrd/functions/rrd-tune.xml
@@ -37,7 +37,7 @@
     <listitem>
      <simpara>
       Options avec les propriétés du fichier de la base de données
-      RRD qui doivent être modifiés. Reportez-vous à la page man
+      RRD qui doivent être modifiés. Se reporter à la page man
       correspondante de RRD pour plus de détails.
      </simpara>
     </listitem>

--- a/reference/rrd/functions/rrd-update.xml
+++ b/reference/rrd/functions/rrd-update.xml
@@ -38,7 +38,7 @@
     <listitem>
      <simpara>
       Options pour la mise à jour de la base de données RRD -
-      liste de chaînes. Reportez-vous à la page man correspondante
+      liste de chaînes. Se reporter à la page man correspondante
       pour une liste complète des options.
      </simpara>
     </listitem>

--- a/reference/rrd/functions/rrd-xport.xml
+++ b/reference/rrd/functions/rrd-xport.xml
@@ -29,7 +29,7 @@
     <term><parameter>options</parameter></term>
     <listitem>
      <simpara>
-      Tableau d'options pour l'exportation ; reportez-vous à la
+      Tableau d'options pour l'exportation ; se reporter à la
       page man correspondante.
      </simpara>
     </listitem>

--- a/reference/rrd/rrdcreator/addarchive.xml
+++ b/reference/rrd/rrdcreator/addarchive.xml
@@ -31,7 +31,7 @@
     <listitem>
      <simpara>
       Définition de l'archive RRA. Le format est identique à la définition RRA
-      dans la commande de création RRD. Reportez-vous à la page man
+      dans la commande de création RRD. Se reporter à la page man
       de création RRD pour plus de détails.
      </simpara>
     </listitem>

--- a/reference/rrd/rrdcreator/adddatasource.xml
+++ b/reference/rrd/rrdcreator/adddatasource.xml
@@ -30,7 +30,7 @@
     <listitem>
      <simpara>
       Définition de la source de données (DS). Le format est identique à la
-      définition d'un DS dans la commande de création RRD. Reportez-vous à la
+      définition d'un DS dans la commande de création RRD. Se reporter à la
       page man de la création RRD pour plus de détails.
      </simpara>
     </listitem>

--- a/reference/rrd/rrdgraph/setoptions.xml
+++ b/reference/rrd/rrdgraph/setoptions.xml
@@ -28,7 +28,7 @@
      <simpara>
       Liste les options pour la génération de l'image depuis un fichier
       de base de données RRD. Peut être une liste d'options, ou une liste
-      de chaînes avec des clés pour une meilleure lisibilité. Reportez-vous
+      de chaînes avec des clés pour une meilleure lisibilité. Se reporter
       à la page man du graphique RRD pour une liste des options disponibles.
      </simpara>
     </listitem>

--- a/reference/session/functions/session-create-id.xml
+++ b/reference/session/functions/session-create-id.xml
@@ -94,7 +94,7 @@ function my_session_regenerate_id() {
     // Termine la session
     session_commit();
 
-    // Assurez-vous d'accepter les ID de session définis par l'utilisateur
+    // Il faut s'assurer d'accepter les ID de session définis par l'utilisateur
     // NOTE: Vous devez activer use_strict_mode pour les opérations normales.
     ini_set('session.use_strict_mode', 0);
     // Définir un nouvel ID de session personnalisé
@@ -104,7 +104,7 @@ function my_session_regenerate_id() {
 }
 
 
-// Assurez-vous que use_strict_mode est activé.
+// Il faut s'assurer que use_strict_mode est activé.
 // use_strict_mode est obligatoire pour des raisons de sécurité.
 ini_set('session.use_strict_mode', 1);
 my_session_start();

--- a/reference/session/functions/session-destroy.xml
+++ b/reference/session/functions/session-destroy.xml
@@ -62,7 +62,7 @@
    </para>
    <para>
     Pour éviter ceci, vous devez définir un horodatage à $_SESSION et
-    refuser l'accès à toutes les dates ultérieures. Ou assurez-vous que votre
+    refuser l'accès à toutes les dates ultérieures. Ou il faut s'assurer que votre
     application n'a pas de requêtes simultanées. Ceci s'applique aussi à
     <function>session_regenerate_id</function>.
    </para>

--- a/reference/session/ini.xml
+++ b/reference/session/ini.xml
@@ -289,7 +289,7 @@
       <filename>mod_files.bat</filename>. Notez également que si <literal>N</literal>
       est utilisé et est supérieur à 0, alors la routine automatique gc (garbage collection)
       ne sera pas exécutée ; voir une copie de &php.ini; pour plus d'informations.
-      Également, si vous utilisez <literal>N</literal>, assurez-vous d'entourer
+      Également, si vous utilisez <literal>N</literal>, il faut s'assurer d'entourer
       <literal>session.save_path</literal> de "doubles guillemets" car le séparateur
       (<literal>;</literal>) est également utilisé pour les commentaires dans
       &php.ini;.

--- a/reference/session/security.xml
+++ b/reference/session/security.xml
@@ -214,7 +214,7 @@
      (la fonction <function>session_regenerate_id</function>
      sauvegarde les données de session courantes automatiquement afin de
      sauvegarder les timestamps/etc. dans la session courante.)
-     Assurez-vous que la nouvelle session contient le drapeau d'authentification.
+     Il faut s'assurer que la nouvelle session contient le drapeau d'authentification.
     </para>
     
     <para>
@@ -435,7 +435,7 @@
      <simpara>
       L'activation de la directive
       <link linkend="ini.session.use-strict-mode">session.use_strict_mode</link>
-      est obligatoire pour ce type de configuration. Assurez vous qu'il
+      est obligatoire pour ce type de configuration. Il faut s'assurer qu'il
       est activé. Sinon, la base de données des sessions actives
       peut être compromise.
      </simpara>
@@ -506,7 +506,7 @@
     
     <para>
      La fonction <function>output_add_rewrite_var</function> peut être utilisée pour
-     la protection CSRF. Référez vous aux pages du manuel pour plus de détails.
+     la protection CSRF. Se référer aux pages du manuel pour plus de détails.
     </para>
     
     <note>
@@ -520,7 +520,7 @@
     
     <para>
      La plupart des frameworks d'applications web supporte
-     la protection CSRF. Référez vous au manuel de votre
+     la protection CSRF. Se référer au manuel de votre
      framework d'application web pour plus de détails.
     </para>
     
@@ -716,7 +716,7 @@
      <para>
       Quelques modules de gestion de sauvegarde des sessions n'utilisent pas cette
       fonctionnalité basé sur l'expiration et sur la probabilité ; i.e.
-      memcached, memcache. Référez vous à la documentation de ces gestionnaires
+      memcached, memcache. Se référer à la documentation de ces gestionnaires
       de sauvegarde des sessions pour plus de détails.
      </para>
     </note>

--- a/reference/session/sessionhandler.xml
+++ b/reference/session/sessionhandler.xml
@@ -59,7 +59,7 @@
     Veuillez noter que les méthodes de rappel de cette classe sont destinées à être appelées
     en interne par PHP, et ne sont pas prévues pour être appelées depuis le code de l'espace
     utilisateur. Les valeurs retournées seront utilisées de la même façon en interne par PHP.
-    Pour plus d'informations sur le mécanisme des sessions, référez-vous à la documentation
+    Pour plus d'informations sur le mécanisme des sessions, se référer à la documentation
     sur la fonction <function>session_set_save_handler</function>.
    </para>
   </section>

--- a/reference/session/sessionhandler/close.xml
+++ b/reference/session/sessionhandler/close.xml
@@ -33,7 +33,7 @@
   </para>
   <para>
    Pour plus d'informations sur le fonctionnement de cette méthode et ses attendus,
-   référez-vous à la documentation sur la fonction
+   se référer à la documentation sur la fonction
    <function>SessionHandlerInterface::close</function>.
   </para>
 

--- a/reference/session/sessionhandler/destroy.xml
+++ b/reference/session/sessionhandler/destroy.xml
@@ -29,7 +29,7 @@
    le gestionnaire de cette méthode et donc la fonction interne à PHP.
   </para>
   <para>
-   Pour plus d'informations sur l'attendu de cette méthode, référez-vous à la documentation
+   Pour plus d'informations sur l'attendu de cette méthode, se référer à la documentation
    de la fonction <function>SessionHandlerInterface::destroy</function>.
   </para>
  </refsect1>

--- a/reference/session/sessionhandler/gc.xml
+++ b/reference/session/sessionhandler/gc.xml
@@ -33,7 +33,7 @@
    et filtrée.
   </para>
   <para>
-   Pour plus d'informations sur l'attendu de cette méthode, référez-vous à la documentation
+   Pour plus d'informations sur l'attendu de cette méthode, se référer à la documentation
    sur la fonction <function>SessionHandlerInterface::gc</function>.
   </para>
  </refsect1>

--- a/reference/session/sessionhandler/open.xml
+++ b/reference/session/sessionhandler/open.xml
@@ -32,7 +32,7 @@
    de surcharger, intercepter et/ou filtrer les données.
   </para>
   <para>
-   Pour plus d'informations sur l'attendu de cette méthode, référez-vous à la documentation
+   Pour plus d'informations sur l'attendu de cette méthode, se référer à la documentation
    sur la fonction <function>SessionHandlerInterface::open</function>.
   </para>
  </refsect1>

--- a/reference/session/sessionhandler/read.xml
+++ b/reference/session/sessionhandler/read.xml
@@ -34,7 +34,7 @@
    <parameter>read</parameter>).
   </para>
   <para>
-   Pour plus d'informations sur cette méthode, référez-vous à la documentation
+   Pour plus d'informations sur cette méthode, se référer à la documentation
    sur la fonction <function>SessionHandlerInterface::read</function>.
   </para>
  </refsect1>

--- a/reference/session/sessionhandler/write.xml
+++ b/reference/session/sessionhandler/write.xml
@@ -37,7 +37,7 @@
    <parameter>write</parameter>).
   </para>
   <para>
-   Pour plus d'informations sur l'attendu de cette méthode, référez-vous à la documentation
+   Pour plus d'informations sur l'attendu de cette méthode, se référer à la documentation
    sur la fonction <function>SessionHandlerInterface::write</function>.
   </para>
  </refsect1>

--- a/reference/sockets/errors.xml
+++ b/reference/sockets/errors.xml
@@ -20,7 +20,7 @@
   fonction <function>socket_last_error</function>, au niveau de l'application.
   Vous pouvez appeler <function>socket_strerror</function> avec le code
   d'erreur pour connaître le message d'erreur, humainement lisible.
-  Reportez-vous à leur description pour plus de détails.
+  Se reporter à leur description pour plus de détails.
  </para>
  <note>
   <para>

--- a/reference/sockets/functions/socket-create-listen.xml
+++ b/reference/sockets/functions/socket-create-listen.xml
@@ -47,7 +47,7 @@
        Le paramètre <parameter>backlog</parameter> définit la taille
        maximum de la queue de connexions en attente. 
        <constant>SOMAXCONN</constant> peut être utilisée comme
-       valeur pour le paramètre <parameter>backlog</parameter>. Reportez-vous
+       valeur pour le paramètre <parameter>backlog</parameter>. Se reporter
        à <function>socket_listen</function> pour plus de détails.
       </para>
      </listitem>

--- a/reference/sockets/functions/socket-select.xml
+++ b/reference/sockets/functions/socket-select.xml
@@ -132,7 +132,7 @@ socket_select($r, $w, $e, 0);
   </para>
   <note>
    <para>
-    Assurez-vous bien d'utiliser l'opérateur <literal>===</literal>
+    Il faut s'assurer bien d'utiliser l'opérateur <literal>===</literal>
     lorsque vous vérifiez les erreurs. Étant donné que
     <function>socket_select</function> peut retourner 0, la comparaison
     avec &false; via <literal>==</literal> donnerait &true; :
@@ -184,7 +184,7 @@ if ($num_changed_sockets === false) {
   &reftitle.notes;
   <note>
    <para>
-    Méfiez-vous des implémentations de sockets, qui doivent être manipulées avec
+    Il faut se méfier des implémentations de sockets, qui doivent être manipulées avec
     délicatesse. Quelques règles de base :
     <itemizedlist>
      <listitem>

--- a/reference/sodium/functions/sodium-crypto-stream-xchacha20-xor-ic.xml
+++ b/reference/sodium/functions/sodium-crypto-stream-xchacha20-xor-ic.xml
@@ -25,7 +25,7 @@
   <caution>
    <simpara>
     Ce chiffrement est non authentifié, et ne prévient pas les attaques par texte chiffré choisi.
-    Assurez-vous de combiner le texte chiffré avec un code d'authentification de message,
+    Il faut s'assurer de combiner le texte chiffré avec un code d'authentification de message,
     par exemple avec la fonction <function>sodium_crypto_aead_xchacha20poly1305_ietf_encrypt</function>,
     ou <function>sodium_crypto_auth</function>.
    </simpara>

--- a/reference/sodium/functions/sodium-crypto-stream-xchacha20-xor.xml
+++ b/reference/sodium/functions/sodium-crypto-stream-xchacha20-xor.xml
@@ -23,7 +23,7 @@
   <caution>
    <simpara>
     Ce chiffrement est non authentifié, et ne prévient pas les attaques par texte chiffré choisi.
-    Assurez-vous de combiner le texte chiffré avec un code d'authentification de message,
+    Il faut s'assurer de combiner le texte chiffré avec un code d'authentification de message,
     par exemple avec la fonction <function>sodium_crypto_aead_xchacha20poly1305_ietf_encrypt</function>,
     ou <function>sodium_crypto_auth</function>.
    </simpara>

--- a/reference/solr/setup.xml
+++ b/reference/solr/setup.xml
@@ -49,7 +49,7 @@
     l'option de configuration <option>--enable-solr-debug</option>.
    </para>
    <para>
-    Lors d'une compilation manuelle, assurez-vous d'inclure le support
+    Lors d'une compilation manuelle, il faut s'assurer d'inclure le support
     curl et libxml.
    </para>
   </note>

--- a/reference/sqlsrv/configure.xml
+++ b/reference/sqlsrv/configure.xml
@@ -15,7 +15,7 @@
   <link xlink:href="&url.sqlsrv;">téléchargement de SQLSRV</link>.
  </simpara>
  <simpara>
-  Pour plus d'informations sur les pré-requis SQLSRV, reportez-vous au
+  Pour plus d'informations sur les pré-requis SQLSRV, se reporter au
   chapitre sur les
   <link xlink:href="&url.sqlsrv.system.requirements;">pré-requis du système SQLSRV</link>.
  </simpara>

--- a/reference/sqlsrv/constants.xml
+++ b/reference/sqlsrv/constants.xml
@@ -316,7 +316,7 @@
     <simpara>
      Spécifie une donnée de type flux de PHP. Cette constante fonctionne comme une fonction
      et accepte une constante encodée. Voir les constantes SQLSRV_ENC_*. Pour plus d'informations,
-     repotrez-vous à <link xlink:href="&url.sqlsrv.specify.phptype;">Comment spécifier les types PHP</link>.
+     se reporter à <link xlink:href="&url.sqlsrv.specify.phptype;">Comment spécifier les types PHP</link>.
     </simpara>
    </listitem>
   </varlistentry>
@@ -329,7 +329,7 @@
     <simpara>
      Spécifie une donnée de type chaîne de caractères PHP. Cette constante fonctionne comme une fonction
      et accepte une constante encodée. Voir les constantes SQLSRV_ENC_*. Pour plus d'informations,
-     reportez-vous à <link xlink:href="&url.sqlsrv.specify.phptype;">Comment spécifier les types PHP</link>.
+     se reporter à <link xlink:href="&url.sqlsrv.specify.phptype;">Comment spécifier les types PHP</link>.
     </simpara>
    </listitem>
   </varlistentry>
@@ -342,7 +342,7 @@
     <simpara>
      Spécifie que la donnée est retournée sous la forme d'un flux brute d'octets
      depuis le serveur sans y effectuer un encodage ou une transformation. Pour plus
-     d'informations, reportez-vous à <link xlink:href="&url.sqlsrv.specify.phptype;">Comment spécifier
+     d'informations, se reporter à <link xlink:href="&url.sqlsrv.specify.phptype;">Comment spécifier
      les types PHP</link>.
     </simpara>
    </listitem>
@@ -358,7 +358,7 @@
      spécifiés dans la page de code des paramètres régionaux Windows définis sur le système. Tout
      caractère multioctet ou caractères qui ne correspondent pas à cette page
      de code seront substitués par un point d'interrogation sur un octet (?).
-     C'est l'encodage par défaut. Pour plus d'informations, reportez-vous à
+     C'est l'encodage par défaut. Pour plus d'informations, se reporter à
      <link xlink:href="&url.sqlsrv.specify.phptype;">Comment spécifier les types PHP</link>.
     </simpara>
    </listitem>
@@ -370,7 +370,7 @@
    </term>
    <listitem>
     <simpara>
-     Décrit le type de données bigint SQL Server. Pour plus d'informations, reportez-vous à
+     Décrit le type de données bigint SQL Server. Pour plus d'informations, se reporter à
      <link xlink:href="&url.sqlsrv.specify.sqltype;">Comment spécifier les types SQL</link>.
     </simpara>
    </listitem>
@@ -382,7 +382,7 @@
    </term>
    <listitem>
     <simpara>
-     Décrit le type de données binaire SQL Server. Pour plus d'informations, reportez-vous à
+     Décrit le type de données binaire SQL Server. Pour plus d'informations, se reporter à
      <link xlink:href="&url.sqlsrv.specify.sqltype;">Comment spécifier les types SQL</link>.
     </simpara>
    </listitem>
@@ -394,7 +394,7 @@
    </term>
    <listitem>
     <simpara>
-     Décrit le type de données bit SQL Server. Pour plus d'informations, reportez-vous à
+     Décrit le type de données bit SQL Server. Pour plus d'informations, se reporter à
      <link xlink:href="&url.sqlsrv.specify.sqltype;">Comment spécifier les types SQL</link>.
     </simpara>
    </listitem>
@@ -408,7 +408,7 @@
     <simpara>
      Décrit le type de données caractère SQL Server. Cette constante fonctionne comme
      une fonction et accepte un paramètre indiquant le nombre de caractères. Pour plus
-     d'informations, reportez-vous à
+     d'informations, se reporter à
      <link xlink:href="&url.sqlsrv.specify.sqltype;">Comment spécifier les types SQL</link>.
     </simpara>
    </listitem>
@@ -420,7 +420,7 @@
    </term>
    <listitem>
     <simpara>
-     Décrit le type de données date SQL Server. Pour plus d'informations, reportez-vous à
+     Décrit le type de données date SQL Server. Pour plus d'informations, se reporter à
      <link xlink:href="&url.sqlsrv.specify.sqltype;">Comment spécifier les types SQL</link>.
     </simpara>
    </listitem>
@@ -433,7 +433,7 @@
    <listitem>
     <simpara>
      Décrit le type de données datetime SQL Server. Pour plus d'informations,
-     reportez-vous à
+     se reporter à
      <link xlink:href="&url.sqlsrv.specify.sqltype;">Comment spécifier les types SQL</link>.
     </simpara>
    </listitem>
@@ -445,7 +445,7 @@
    </term>
    <listitem>
     <simpara>
-     Décrit le type de données datetime2 SQL Server. Pour plus d'informations, reportez-vous
+     Décrit le type de données datetime2 SQL Server. Pour plus d'informations, se reporter
      à <link xlink:href="&url.sqlsrv.specify.sqltype;">Comment spécifier les types SQL</link>.
     </simpara>
    </listitem>
@@ -457,7 +457,7 @@
    </term>
    <listitem>
     <simpara>
-     Décrit le type de données datetimeoffset SQL Server. Pour plus d'informations, reportez-vous
+     Décrit le type de données datetimeoffset SQL Server. Pour plus d'informations, se reporter
      à <link xlink:href="&url.sqlsrv.specify.sqltype;">Comment spécifier les types SQL</link>.
     </simpara>
    </listitem>
@@ -471,7 +471,7 @@
     <simpara>
      Décrit le type de données décimal. Cette constante fonctionne comme une fonction
      et accepte 2 paramètres indiquant (dans l'ordre) la précision et l'échelle.
-     Pour plus d'informations, reportez-vous
+     Pour plus d'informations, se reporter
      à <link xlink:href="&url.sqlsrv.specify.sqltype;">Comment spécifier les types SQL</link>.
     </simpara>
    </listitem>
@@ -483,7 +483,7 @@
    </term>
    <listitem>
     <simpara>
-     Décrit le type de données nombre à virgule flottante SQL Server. Pour plus d'informations, reportez-vous
+     Décrit le type de données nombre à virgule flottante SQL Server. Pour plus d'informations, se reporter
      à <link xlink:href="&url.sqlsrv.specify.sqltype;">Comment spécifier les types SQL</link>.
     </simpara>
    </listitem>
@@ -495,7 +495,7 @@
    </term>
    <listitem>
     <simpara>
-     Décrit le type de données image SQL Server. Pour plus d'informations, reportez-vous
+     Décrit le type de données image SQL Server. Pour plus d'informations, se reporter
      à <link xlink:href="&url.sqlsrv.specify.sqltype;">Comment spécifier les types SQL</link>.
     </simpara>
    </listitem>
@@ -507,7 +507,7 @@
    </term>
    <listitem>
     <simpara>
-     Décrit le type de données entier SQL Server. Pour plus d'informations, reportez-vous
+     Décrit le type de données entier SQL Server. Pour plus d'informations, se reporter
      à <link xlink:href="&url.sqlsrv.specify.sqltype;">Comment spécifier les types SQL</link>.
     </simpara>
    </listitem>
@@ -519,7 +519,7 @@
    </term>
    <listitem>
     <simpara>
-     Décrit le type de données monnaie SQL Server. Pour plus d'informations, reportez-vous
+     Décrit le type de données monnaie SQL Server. Pour plus d'informations, se reporter
      à <link xlink:href="&url.sqlsrv.specify.sqltype;">Comment spécifier les types SQL</link>.
     </simpara>
    </listitem>
@@ -533,7 +533,7 @@
     <simpara>
      Décrit le type de données nchar SQL Server. Cette constante fonctionne comme une
      fonction et accepte un seul paramètre indiquant le nombre de caractères.
-     Pour plus d'informations, reportez-vous à
+     Pour plus d'informations, se reporter à
      <link xlink:href="&url.sqlsrv.specify.sqltype;">Comment spécifier les types SQL</link>.
     </simpara>
    </listitem>
@@ -547,7 +547,7 @@
     <simpara>
      Décrit le type de données numérique SQL Server. Cette constante fonctionne comme
      une fonction et accepte 2 paramètres (dans l'ordre), la précision et l'échelle.
-     Pour plus d'informations, reportez-vous à
+     Pour plus d'informations, se reporter à
      <link xlink:href="&url.sqlsrv.specify.sqltype;">Comment spécifier les types SQL</link>.
     </simpara>
    </listitem>
@@ -561,7 +561,7 @@
     <simpara>
      Décrit le type de données nvarchar SQL Server. Cette constante fonctionne comme une
      fonction et accepte un seul paramètre indiquant le nombre de caractères.
-     Pour plus d'informations, reportez-vous à
+     Pour plus d'informations, se reporter à
      <link xlink:href="&url.sqlsrv.specify.sqltype;">Comment spécifier les types SQL</link>.
     </simpara>
    </listitem>
@@ -573,7 +573,7 @@
    </term>
    <listitem>
     <simpara>
-     Décrit le type de données nvarchar(MAX) SQL Server. Pour plus d'informations, reportez-vous
+     Décrit le type de données nvarchar(MAX) SQL Server. Pour plus d'informations, se reporter
      à <link xlink:href="&url.sqlsrv.specify.sqltype;">Comment spécifier les types SQL</link>.
     </simpara>
    </listitem>
@@ -585,7 +585,7 @@
    </term>
    <listitem>
     <simpara>
-     Décrit le type de données ntext SQL Server. Pour plus d'informations, reportez-vous
+     Décrit le type de données ntext SQL Server. Pour plus d'informations, se reporter
      à <link xlink:href="&url.sqlsrv.specify.sqltype;">Comment spécifier les types SQL</link>.
     </simpara>
    </listitem>
@@ -597,7 +597,7 @@
    </term>
    <listitem>
     <simpara>
-     Décrit le type de données réelle SQL Server. Pour plus d'informations, reportez-vous
+     Décrit le type de données réelle SQL Server. Pour plus d'informations, se reporter
      à <link xlink:href="&url.sqlsrv.specify.sqltype;">Comment spécifier les types SQL</link>.
     </simpara>
    </listitem>
@@ -609,7 +609,7 @@
    </term>
    <listitem>
     <simpara>
-     Décrit le type de données smalldatetime SQL Server. Pour plus d'informations, reportez-vous
+     Décrit le type de données smalldatetime SQL Server. Pour plus d'informations, se reporter
      à <link xlink:href="&url.sqlsrv.specify.sqltype;">Comment spécifier les types SQL</link>.
     </simpara>
    </listitem>
@@ -621,7 +621,7 @@
    </term>
    <listitem>
     <simpara>
-     Décrit le type de données smallint SQL Server. Pour plus d'informations, reportez-vous
+     Décrit le type de données smallint SQL Server. Pour plus d'informations, se reporter
      à <link xlink:href="&url.sqlsrv.specify.sqltype;">Comment spécifier les types SQL</link>.
     </simpara>
    </listitem>
@@ -633,7 +633,7 @@
    </term>
    <listitem>
     <simpara>
-     Décrit le type de données smallmoney SQL Server. Pour plus d'informations, reportez-vous
+     Décrit le type de données smallmoney SQL Server. Pour plus d'informations, se reporter
      à <link xlink:href="&url.sqlsrv.specify.sqltype;">Comment spécifier les types SQL</link>.
     </simpara>
    </listitem>
@@ -645,7 +645,7 @@
    </term>
    <listitem>
     <simpara>
-     Décrit le type de données texte SQL Server. Pour plus d'informations, reportez-vous
+     Décrit le type de données texte SQL Server. Pour plus d'informations, se reporter
      à <link xlink:href="&url.sqlsrv.specify.sqltype;">Comment spécifier les types SQL</link>.
     </simpara>
    </listitem>
@@ -657,7 +657,7 @@
    </term>
    <listitem>
     <simpara>
-     Décrit le type de données time SQL Server. Pour plus d'informations, reportez-vous
+     Décrit le type de données time SQL Server. Pour plus d'informations, se reporter
      à <link xlink:href="&url.sqlsrv.specify.sqltype;">Comment spécifier les types SQL</link>.
     </simpara>
    </listitem>
@@ -669,7 +669,7 @@
    </term>
    <listitem>
     <simpara>
-     Décrit le type de données timestamp SQL Server. Pour plus d'informations, reportez-vous
+     Décrit le type de données timestamp SQL Server. Pour plus d'informations, se reporter
      à <link xlink:href="&url.sqlsrv.specify.sqltype;">Comment spécifier les types SQL</link>.
     </simpara>
    </listitem>
@@ -681,7 +681,7 @@
    </term>
    <listitem>
     <simpara>
-     Décrit le type de données tinyint SQL Server. Pour plus d'informations, reportez-vous
+     Décrit le type de données tinyint SQL Server. Pour plus d'informations, se reporter
      à <link xlink:href="&url.sqlsrv.specify.sqltype;">Comment spécifier les types SQL</link>.
     </simpara>
    </listitem>
@@ -693,7 +693,7 @@
    </term>
    <listitem>
     <simpara>
-     Décrit le type de données uniqueidentifier SQL Server. Pour plus d'informations, reportez-vous
+     Décrit le type de données uniqueidentifier SQL Server. Pour plus d'informations, se reporter
      à <link xlink:href="&url.sqlsrv.specify.sqltype;">Comment spécifier les types SQL</link>.
     </simpara>
    </listitem>
@@ -705,7 +705,7 @@
    </term>
    <listitem>
     <simpara>
-     Décrit le type de données UDT SQL Server. Pour plus d'informations, reportez-vous
+     Décrit le type de données UDT SQL Server. Pour plus d'informations, se reporter
      à <link xlink:href="&url.sqlsrv.specify.sqltype;">Comment spécifier les types SQL</link>.
     </simpara>
    </listitem>
@@ -719,7 +719,7 @@
     <simpara>
      Décrit le type de données varbinary SQL Server. Cette constante fonctionne
      comme une fonction et accepte un seul paramètre indiquant le nombre d'octets.
-     Pour plus d'informations, reportez-vous à
+     Pour plus d'informations, se reporter à
      <link xlink:href="&url.sqlsrv.specify.sqltype;">Comment spécifier les types SQL</link>.
     </simpara>
    </listitem>
@@ -731,7 +731,7 @@
    </term>
    <listitem>
     <simpara>
-     Décrit le type de données varbinary(MAX) SQL Server. Pour plus d'informations, reportez-vous
+     Décrit le type de données varbinary(MAX) SQL Server. Pour plus d'informations, se reporter
      à <link xlink:href="&url.sqlsrv.specify.sqltype;">Comment spécifier les types SQL</link>.
     </simpara>
    </listitem>
@@ -745,7 +745,7 @@
     <simpara>
      Décrit le type de données varchar SQL Server. Cette constante fonctionne comme
      une fonction et accepte un seul paramètre indiquant le nombre de caractères.
-     Pour plus d'informations, reportez-vous à
+     Pour plus d'informations, se reporter à
      <link xlink:href="&url.sqlsrv.specify.sqltype;">Comment spécifier les types SQL</link>.
     </simpara>
    </listitem>
@@ -757,7 +757,7 @@
    </term>
    <listitem>
     <simpara>
-     Décrit le type de données varchar(MAX) SQL Server. Pour plus d'informations, reportez-vous
+     Décrit le type de données varchar(MAX) SQL Server. Pour plus d'informations, se reporter
      à <link xlink:href="&url.sqlsrv.specify.sqltype;">Comment spécifier les types SQL</link>.
     </simpara>
    </listitem>
@@ -769,7 +769,7 @@
    </term>
    <listitem>
     <simpara>
-     Décrit le type de données XML SQL Server. Pour plus d'informations, reportez-vous
+     Décrit le type de données XML SQL Server. Pour plus d'informations, se reporter
      à <link xlink:href="&url.sqlsrv.specify.sqltype;">Comment spécifier les types SQL</link>.
     </simpara>
    </listitem>
@@ -852,7 +852,7 @@
    <listitem>
     <simpara>
      Indique un curseur de type "suivant uniquement". Pour plus d'informations,
-     reportez-vous à la section sur
+     se reporter à la section sur
      <link xlink:href="&url.sqlsrv.specify.cursortype;">la spécification d'un type
       de curseur et la sélection de lignes</link>.
     </simpara>
@@ -866,7 +866,7 @@
    <listitem>
     <simpara>
      Indique un curseur de type "statique". Pour plus d'informations,
-     reportez-vous à la section sur
+     se reporter à la section sur
      <link xlink:href="&url.sqlsrv.specify.cursortype;">la spécification d'un type
       de curseur et la sélection de lignes</link>.
     </simpara>
@@ -880,7 +880,7 @@
    <listitem>
     <simpara>
      Indique un curseur de type "dynamique". Pour plus d'informations,
-     reportez-vous à la section sur
+     se reporter à la section sur
      <link xlink:href="&url.sqlsrv.specify.cursortype;">la spécification d'un type
       de curseur et la sélection de lignes</link>.
     </simpara>
@@ -894,7 +894,7 @@
    <listitem>
     <simpara>
      Indique un curseur de type "keyset". Pour plus d'informations,
-     reportez-vous à la section sur
+     se reporter à la section sur
      <link xlink:href="&url.sqlsrv.specify.cursortype;">la spécification d'un type
       de curseur et la sélection de lignes</link>.
     </simpara>
@@ -909,7 +909,7 @@
     <simpara>
      Crée une requête de curseur côté client. Cela vous permet d'accéder aux
      lignes dans n'importe quel ordre. Pour des informations quant à son utilisation,
-     reportez-vous à la section sur la
+     se reporter à la section sur la
     <link xlink:href="&url.sqlsrv.specify.cursortype;">la spécification d'un type
       de curseur et la sélection de lignes</link>.
     </simpara>
@@ -923,7 +923,7 @@
    <listitem>
     <simpara>
      Spécifie la ligne à sélectionner dans un jeu de résultats. Pour plus d'informations,
-     reportez-vous à la section sur
+     se reporter à la section sur
      <link xlink:href="&url.sqlsrv.specify.cursortype;">la spécification d'un type
       de curseur et la sélection de lignes</link>.
     </simpara>
@@ -937,7 +937,7 @@
    <listitem>
     <simpara>
      Spécifie la ligne à sélectionner dans un jeu de résultats. Pour plus d'informations,
-     reportez-vous à la section sur
+     se reporter à la section sur
      <link xlink:href="&url.sqlsrv.specify.cursortype;">la spécification d'un type
       de curseur et la sélection de lignes</link>.
     </simpara>
@@ -951,7 +951,7 @@
    <listitem>
     <simpara>
      Spécifie la ligne à sélectionner dans un jeu de résultats. Pour plus d'informations,
-     reportez-vous à la section sur <link xlink:href="&url.sqlsrv.specify.cursortype;">la
+     se reporter à la section sur <link xlink:href="&url.sqlsrv.specify.cursortype;">la
      spécification d'un type de curseur et la sélection de lignes</link>.
     </simpara>
    </listitem>
@@ -964,7 +964,7 @@
    <listitem>
     <simpara>
      Spécifie la ligne à sélectionner dans un jeu de résultats. Pour plus d'informations,
-     reportez-vous à la section sur <link xlink:href="&url.sqlsrv.specify.cursortype;">la
+     se reporter à la section sur <link xlink:href="&url.sqlsrv.specify.cursortype;">la
      spécification d'un type de curseur et la sélection de lignes</link>.
     </simpara>
    </listitem>
@@ -977,7 +977,7 @@
    <listitem>
     <simpara>
      Spécifie la ligne à sélectionner dans un jeu de résultats. Pour plus d'informations,
-     reportez-vous à la section sur <link xlink:href="&url.sqlsrv.specify.cursortype;">la
+     se reporter à la section sur <link xlink:href="&url.sqlsrv.specify.cursortype;">la
      spécification d'un type de curseur et la sélection de lignes</link>.
     </simpara>
    </listitem>
@@ -990,7 +990,7 @@
    <listitem>
     <simpara>
      Spécifie la ligne à sélectionner dans un jeu de résultats. Pour plus d'informations,
-     reportez-vous à la section sur <link xlink:href="&url.sqlsrv.specify.cursortype;">la
+     se reporter à la section sur <link xlink:href="&url.sqlsrv.specify.cursortype;">la
      spécification d'un type de curseur et la sélection de lignes</link>.
     </simpara>
    </listitem>

--- a/reference/sqlsrv/functions/sqlsrv-begin-transaction.xml
+++ b/reference/sqlsrv/functions/sqlsrv-begin-transaction.xml
@@ -22,7 +22,7 @@
    <function>sqlsrv_commit</function>. Une transaction explicite peut être
    commencée et validée (ou annulée) en utilisant ces fonctions au lieu
    d'exécuter les requêtes SQL qui commencent et valident/annulent les transactions.
-   Pour plus d'informations, reportez-vous aux
+   Pour plus d'informations, se reporter aux
    <link xlink:href="&url.sqlsrv.transaction.handling;">transactions SQLSRV</link>.
   </simpara>
  </refsect1>

--- a/reference/sqlsrv/functions/sqlsrv-commit.xml
+++ b/reference/sqlsrv/functions/sqlsrv-commit.xml
@@ -21,7 +21,7 @@
    <function>sqlsrv_begin_transaction</function>. Les transactions doivent commencer,
    être valider ou être annuler en utilisant ces fonctions au lieu d'utiliser des requêtes
    déclarant le début ou l'annulation d'une transaction. Pour plus d'informations,
-   reportez-vous aux <link xlink:href="&url.sqlsrv.transaction.handling;">transactions SQLSRV</link>.
+   se reporter aux <link xlink:href="&url.sqlsrv.transaction.handling;">transactions SQLSRV</link>.
   </simpara>
  </refsect1>
 

--- a/reference/sqlsrv/functions/sqlsrv-connect.xml
+++ b/reference/sqlsrv/functions/sqlsrv-connect.xml
@@ -43,7 +43,7 @@
       Un tableau associatif spécifiant les options pour la connexion sur le serveur.
       Si les valeurs des clés UID et PWD ne sont pas spécifiées, la connexion
       tentera d'utiliser l'authentification Windows. Pour une liste complète
-      des clés supportées, reportez-vous aux
+      des clés supportées, se reporter aux
       <link xlink:href="&url.sqlsrv.connection.options;">options de connexion SQLSRV</link>.
      </simpara>
     </listitem>
@@ -129,7 +129,7 @@ if( $conn ) {
    de connexion afin d'augmenter les performances. Pour désactiver cette file d'attente
    (i.e. et ainsi, forcer une nouvelle connexion à chaque appel à la fonction), définissez
    l'option "ConnectionPooling" dans le tableau $connectionOptions à 0 (ou &false;).
-   Pour plus d'informations reportez-vous au chapitre sur la
+   Pour plus d'informations se reporter au chapitre sur la
    <link xlink:href="&url.sqlsrv.connection.pooling;">file d'attente de connexions SQLSRV</link>.
   </simpara>
   <simpara>

--- a/reference/sqlsrv/functions/sqlsrv-errors.xml
+++ b/reference/sqlsrv/functions/sqlsrv-errors.xml
@@ -125,7 +125,7 @@ if( $stmt === false ) {
    lors d'un appel à une fonction SQLSRV, la fonction retournera &false;.
    Cependant, les alertes qui correspondent aux SQLSTATE de valeurs
    01000, 01001, 01003, et 01S02 ne seront jamais traitées comme des erreurs.
-   Pour plus d'informations sur la façon de modifier ce comportement, reportez-vous
+   Pour plus d'informations sur la façon de modifier ce comportement, se reporter
    à la documentation sur la fonction <function>sqlsrv_configure</function>
    ainsi que sur la configuration de WarningsReturnAsErrors.
   </simpara>

--- a/reference/sqlsrv/functions/sqlsrv-field-metadata.xml
+++ b/reference/sqlsrv/functions/sqlsrv-field-metadata.xml
@@ -85,7 +85,7 @@
      </tbody>
     </tgroup>
    </table>
-   Pour plus d'informations, reportez-vous à la documentation sur la fonction
+   Pour plus d'informations, se reporter à la documentation sur la fonction
    <link xlink:href="&url.sqlsrv.field.metadata;">sqlsrv_field_metadata</link> de la
    documentation Microsoft SQLSRV.
   </para>

--- a/reference/sqlsrv/functions/sqlsrv-get-field.xml
+++ b/reference/sqlsrv/functions/sqlsrv-get-field.xml
@@ -51,7 +51,7 @@
       Le type de données PHP pour les données du champ retourné. Si ce paramètre
       n'est pas défini, les données du champ seront retournées sous la forme
       d'un type de données PHP par défaut. Pour plus d'informations sur les
-      types de données PHP par défaut, reportez-vous à la section sur
+      types de données PHP par défaut, se reporter à la section sur
       <link xlink:href="&url.sqlsrv.default.phptypes;">les types de données PHP par défaut</link>
       de la documentation Microsoft SQLSRV.
      </simpara>

--- a/reference/sqlsrv/functions/sqlsrv-num-rows.xml
+++ b/reference/sqlsrv/functions/sqlsrv-num-rows.xml
@@ -16,7 +16,7 @@
   <simpara>
    Récupère le nombre de lignes d'un jeu de résultats. Cette fonction
    nécessite que la ressource de requête ait été créée avec un curseur
-   statique ou keyset. Pour plus d'informations, reportez-vous aux fonctions
+   statique ou keyset. Pour plus d'informations, se reporter aux fonctions
    <function>sqlsrv_query</function>, <function>sqlsrv_prepare</function>,
    ou au chapitre
    <link xlink:href="&url.sqlsrv.specify.cursortype;">Spécifier un type de curseur et sélectionner des lignes</link>
@@ -33,7 +33,7 @@
      <simpara>
       La requête depuis laquelle le nombre total de lignes est retourné.
       La ressource de requête doit avoir été créée avec un curseur statique
-      ou keyset. Pour plus d'informations, reportez-vous aux fonctions
+      ou keyset. Pour plus d'informations, se reporter aux fonctions
       <function>sqlsrv_query</function>, <function>sqlsrv_prepare</function>,
       ou au chapitre
       <link xlink:href="&url.sqlsrv.specify.cursortype;">Spécifier un type de curseur et sélectionner des lignes</link>

--- a/reference/sqlsrv/functions/sqlsrv-prepare.xml
+++ b/reference/sqlsrv/functions/sqlsrv-prepare.xml
@@ -123,7 +123,7 @@
          <entry>&true; ou &false; (par défaut, &true;)</entry>
          <entry>Configure le driver pour envoyer les données du flux à l'exécution (&true;),
           ou envoyer les données du flux par morceaux (&false;). Par défaut, la valeur
-          est définie à &true;. Pour plus d'informations, reportez-vous à la fonction
+          est définie à &true;. Pour plus d'informations, se reporter à la fonction
           <function>sqlsrv_send_stream_data</function>.</entry>
         </row>
         <row>

--- a/reference/sqlsrv/functions/sqlsrv-rows-affected.xml
+++ b/reference/sqlsrv/functions/sqlsrv-rows-affected.xml
@@ -17,7 +17,7 @@
   <simpara>
    Retourne le nombre de lignes modifiées par la dernière requête de type
    INSERT, UPDATE, ou DELETE. Pour plus d'informations sur le nombre
-   de lignes retournées par une requête SELECT, reportez-vous à la fonction
+   de lignes retournées par une requête SELECT, se reporter à la fonction
    <function>sqlsrv_num_rows</function>.
   </simpara>
  </refsect1>

--- a/reference/sqlsrv/ini.xml
+++ b/reference/sqlsrv/ini.xml
@@ -8,7 +8,7 @@
  <simpara>
   La table suivante liste les options de configuration disponibles
   pour l'extension. Pour plus d'informations sur ces options,
-  reportez-vous au chapitre sur la
+  se reporter au chapitre sur la
   <link xlink:href="&url.sqlsrv.error.handling;">gestion des erreurs
    et alertes SQLSRV</link>.
  </simpara>

--- a/reference/sqlsrv/setup.xml
+++ b/reference/sqlsrv/setup.xml
@@ -35,7 +35,7 @@
    <link xlink:href="&url.sqlsrv;">téléchargement de SQLSRV</link>.
  </simpara>
   <simpara>
-   Pour plus d'informations sur les pré-requis SQLSRV, reportez-vous au
+   Pour plus d'informations sur les pré-requis SQLSRV, se reporter au
    chapitre sur les
    <link xlink:href="&url.sqlsrv.system.requirements;">pré-requis du système SQLSRV</link>.
   </simpara>

--- a/reference/ssh2/functions/ssh2-publickey-add.xml
+++ b/reference/ssh2/functions/ssh2-publickey-add.xml
@@ -64,7 +64,7 @@
     <listitem>
      <simpara>
       Tableau associatif d'attributs pour assigner à cette clé publique.
-      Référez-vous à ietf-secsh-publickey-subsystem pour une liste des
+      Se référer à ietf-secsh-publickey-subsystem pour une liste des
       attributs supportés. Pour marquer un attribut comme obligatoire,
       précédez son nom par un astérisque. Si le serveur n'est pas capable de
       supporter un attribut marqué comme obligatoire, il abandonnera le

--- a/reference/ssh2/setup.xml
+++ b/reference/ssh2/setup.xml
@@ -12,7 +12,7 @@
    Les bibliothèques
    <link xlink:href="&url.openssl;">OpenSSL</link> et
    <link xlink:href="&url.libssh2;">libssh2</link> sont nécessaires.
-   Assurez-vous que les bibliothèques de développement sont installées ;
+   Il faut s'assurer que les bibliothèques de développement sont installées ;
    typiquement, le nom du paquet est <literal>openssl-dev</literal>.
   </simpara>
   <simpara>

--- a/reference/stream/functions/stream-context-create.xml
+++ b/reference/stream/functions/stream-context-create.xml
@@ -30,7 +30,7 @@
       <para>
        Doit être un tableau associatif, au format
        <literal>$arr['wrapper']['option'] = $value</literal> ou &null;.
-       Référez-vous aux <link linkend="context">options de contexte</link>
+       Se référer aux <link linkend="context">options de contexte</link>
        pour une liste des enveloppes et des options disponibles.
       </para>
       <para>
@@ -44,7 +44,7 @@
       <para>
        Doit être un tableau associatif
        de format <literal>$arr['parameter'] = $value</literal> ou &null;.
-       Référez-vous à la documentation sur les
+       Se référer à la documentation sur les
        <link linkend="context.params">paramètres de contexte</link> pour une liste
        des paramètres de flux standards.
       </para>

--- a/reference/stream/functions/stream-select.xml
+++ b/reference/stream/functions/stream-select.xml
@@ -214,7 +214,7 @@ stream_select($r, $w, $e, 0);
   </note>
   <note>
    <para>
-    Assurez-vous de bien utiliser l'opérateur <literal>===</literal> lorsque vous
+    Il faut s'assurer de bien utiliser l'opérateur <literal>===</literal> lorsque vous
     recherchez des erreurs. Comme <function>stream_select</function> peut retourner
     0, une comparaison effectuée à l'aide de <literal>==</literal>
     l'évaluerait à &true; :

--- a/reference/strings/book.xml
+++ b/reference/strings/book.xml
@@ -17,7 +17,7 @@
   <para>
    Pour plus de détails sur le comportement des chaînes de caractères,
    notamment avec les guillemets simples et doubles, les séquences
-   d'échappement, reportez-vous à la section
+   d'échappement, se reporter à la section
    <link linkend="language.types.string">Chaînes de caractères</link>
    dans la section <link linkend="language.types">Types</link>.
   </para>

--- a/reference/strings/functions/addcslashes.xml
+++ b/reference/strings/functions/addcslashes.xml
@@ -47,7 +47,7 @@
       </para>
       <para>
        Lorsque vous définissez une séquence de caractères
-       dans le paramètre <parameter>characters</parameter>, assurez-vous
+       dans le paramètre <parameter>characters</parameter>, il faut s'assurer
        que vous connaissez bien tous les caractères qui viennent entre
        vos limites d'intervalles.
       <example>

--- a/reference/strings/functions/crypt.xml
+++ b/reference/strings/functions/crypt.xml
@@ -32,7 +32,7 @@
    Cependant, <function>crypt</function> crée un hash faible sans le
    <parameter>salt</parameter>, et lève une erreur <constant>E_NOTICE</constant>
    sans celui-ci.
-   Assurez-vous de spécifier un salt assez solide pour une meilleure sécurité.
+   Il faut s'assurer de spécifier un salt assez solide pour une meilleure sécurité.
   </para>
   <para>
    <function>password_hash</function> utilise un hash fort, génère

--- a/reference/strings/functions/strnatcasecmp.xml
+++ b/reference/strings/functions/strnatcasecmp.xml
@@ -19,7 +19,7 @@
    <function>strnatcasecmp</function> implémente l'algorithme de comparaison
    qui ordonne les chaînes tel qu'un homme le ferait. Cette fonction est
    similaire à la fonction <function>strnatcmp</function>, mais la comparaison
-   n'est pas sensible à la casse. Pour plus de détails, reportez-vous à
+   n'est pas sensible à la casse. Pour plus de détails, se reporter à
    <link xlink:href="&url.strnatcmp;"><literal>Natural Order String
      Comparison</literal></link> de Martin Pool (en anglais).
   </para>

--- a/reference/strings/functions/strnatcmp.xml
+++ b/reference/strings/functions/strnatcmp.xml
@@ -109,7 +109,7 @@ Array
 ]]>
     </screen>
    </example>
-   Pour plus de détails, reportez-vous à
+   Pour plus de détails, se reporter à
    <link xlink:href="&url.strnatcmp;"><literal>Natural Order String
      Comparison</literal></link> de Martin Pool (en anglais).
   </para>

--- a/reference/strings/functions/strstr.xml
+++ b/reference/strings/functions/strstr.xml
@@ -23,7 +23,7 @@
   <note>
    <para>
     <function>strstr</function> est sensible à la casse. Pour une fonctionnalité
-    identique, mais insensible à la casse, reportez-vous à 
+    identique, mais insensible à la casse, se reporter à 
     <function>stristr</function>.
    </para>
   </note>

--- a/reference/strings/reference.xml
+++ b/reference/strings/reference.xml
@@ -10,9 +10,9 @@
   &reftitle.seealso;
   <para>
    Pour des fonctions encore plus puissantes de gestion et manipulation
-   des chaînes, reportez-vous aux
+   des chaînes, se reporter aux
    <link linkend="ref.pcre">expressions régulières Perl</link>.
-   Pour travailler avec les encodages de caractères multioctets, reportez-vous aux
+   Pour travailler avec les encodages de caractères multioctets, se reporter aux
    <link linkend="ref.mbstring">Fonctions sur les chaînes de caractères multioctets</link>.
   </para>
  </partintro>

--- a/reference/svn/functions/svn-auth-set-parameter.xml
+++ b/reference/svn/functions/svn-auth-set-parameter.xml
@@ -19,7 +19,7 @@
    Spécifie le paramètre d'identification <parameter>key</parameter> à
    la valeur <parameter>value</parameter>.
    Pour une liste de clés valides ainsi que leurs significations,
-   reportez-vous à la <link linkend="svn.constants.auth">liste des
+   se reporter à la <link linkend="svn.constants.auth">liste des
     constantes d'identification</link>.
   </simpara>
  </refsect1>


### PR DESCRIPTION
Remplacement des formulations directes (vous/votre/vos) par des tournures impersonnelles dans `reference/` (extensions p à s), conformément à TRADUCTIONS.txt.