### PR TITLE
CI: add QA scripts (extensions.xml, section-order)

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -39,5 +39,10 @@ jobs:
           path: "doc-base"
           repository: "php/doc-base"
 
+      - name: "Quality Assurance scripts"
+        run: |
+          php8.1 doc-base/scripts/qa/extensions.xml.php --check
+          php8.1 doc-base/scripts/qa/section-order.php
+
       - name: "Build documentation for ${{ matrix.language }}"
         run: "php8.1 doc-base/configure.php --disable-libxml-check --enable-xml-details --redirect-stderr-to-stdout --with-lang=${{ matrix.language }}"


### PR DESCRIPTION
Ajout des scripts QA de doc-base avant le build :

- `extensions.xml.php --check` : vérifie la cohérence de `appendices/extensions.xml`
- `section-order.php` : vérifie l'ordre des sections DocBook dans `en/reference/`

Déjà utilisé par :
- [doc-en](https://github.com/php/doc-en/blob/master/.github/workflows/integrate.yaml)
- [doc-es](https://github.com/php/doc-es/blob/master/.github/workflows/integrate.yaml)
- [doc-zh](https://github.com/php/doc-zh/blob/master/.github/workflows/integrate.yaml)
- [doc-pt_BR](https://github.com/php/doc-pt_BR/blob/master/.github/workflows/build.yaml) (extensions.xml uniquement)