### PR TITLE
CI: ignorer les fichiers versions.xml dans track-en-changes

### DIFF
--- a/.github/scripts/track-en-changes.sh
+++ b/.github/scripts/track-en-changes.sh
@@ -85,6 +85,10 @@ while read -r PR; do
   NEW_LIST=""
 
   while IFS= read -r FILE; do
+    # Skip files that should not be translated (e.g. versions.xml)
+    if [[ "$FILE" == */versions.xml ]]; then
+      continue
+    fi
     if [ -f "$FILE" ]; then
       UPDATE_LIST="${UPDATE_LIST}- \`${FILE}\`"$'\n'
     elif [[ "$FILE" == *.xml ]]; then


### PR DESCRIPTION
Les fichiers `versions.xml` contiennent le commentaire « Do NOT translate » et ne doivent pas apparaître dans les issues de synchronisation.