### PR TITLE
Fix: utiliser des guillemets doubles pour \n dans les exemples de code

### DIFF
--- a/language/basic-syntax.xml
+++ b/language/basic-syntax.xml
@@ -35,8 +35,8 @@
 2.  Vous pouvez utiliser la balise courte pour <?= 'écrire ce texte' ?>.
     Est équivalent à <?php echo 'écrire ce texte' ?>.
 
-3.  <? echo 'ce code est entre des balises courtes'; ?>
-    Le code suivant <?= 'du texte' ?> est un raccourci pour <? echo 'du texte' ?> 
+3.  <? echo 'ce code est entre des balises courtes, mais ne fonctionnera '.
+            'que si short_open_tag est activé'; ?>
 ]]>
     </programlisting>
    </example>
@@ -188,12 +188,12 @@ But newline now
     <programlisting role="php">
 <![CDATA[
 <?php
-    echo 'This is a test\n';
+    echo "Ceci est un test\n";
 ?>
 
-<?php echo 'This is a test\n' ?>
+<?php echo "Ceci est un test\n" ?>
 
-<?php echo 'We omitted the last closing tag\n';
+<?php echo "La dernière balise fermante a été omise\n";
 ]]>
     </programlisting>
     </example>
@@ -227,11 +227,11 @@ But newline now
     <programlisting role="php">
 <![CDATA[
 <?php
-    echo 'Ceci est un test\n'; // Ceci est un commentaire sur une seule ligne, style c++
+    echo "Ceci est un test\n"; // Ceci est un commentaire sur une seule ligne, style c++
     /* Ceci est un commentaire sur
        plusieurs lignes */
-    echo 'Ceci est un autre test\n';
-    echo 'Et un test final\n'; # Ceci est un commentaire style shell sur une seule ligne
+    echo "Ceci est un autre test\n";
+    echo "Et un test final\n"; # Ceci est un commentaire style shell sur une seule ligne
 ?>
 ]]>
     </programlisting>


### PR DESCRIPTION
Les exemples utilisaient des guillemets simples avec \n, ce qui affiche littéralement \n au lieu d'un saut de ligne.