### PR TITLE
[Sync EN] Add ValueError for empty filename in getimagesize()

### DIFF
--- a/reference/image/functions/getimagesize.xml
+++ b/reference/image/functions/getimagesize.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: f8d1e172bd6d11986f0dfeb11756b90c039a39bc Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 6bb90d24b2b3b2edb36e04b00e6bb10c4e87bbb0 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://docbook.org/ns/docbook" xml:id="function.getimagesize">
  <refnamediv>
@@ -192,6 +192,10 @@ if ($size && $fp) {
    <function>getimagesize</function> générera une erreur de niveau
    <constant>E_NOTICE</constant>.
   </para>
+  <para>
+   À partir de PHP 8.0.0, une <exceptionname>ValueError</exceptionname> est lancée
+   si <parameter>filename</parameter> est vide.
+  </para>
  </refsect1>
  <refsect1 role="changelog">
   &reftitle.changelog;
@@ -211,6 +215,14 @@ if ($size && $fp) {
         Retourne les dimensions actuelles de l'image, bits et chaînes des images AVIF;
         précédemment, les dimensions étaient reportées en tant que <literal>0x0</literal>,
         et bits et chaînes n'étaient pas reportées du tout.
+       </entry>
+      </row>
+      <row>
+       <entry>8.0.0</entry>
+       <entry>
+        Une <exceptionname>ValueError</exceptionname> est désormais lancée si
+        <parameter>filename</parameter> est vide ; précédemment un
+        <constant>E_WARNING</constant> était émis et la fonction retournait &false;.
        </entry>
       </row>
       <row>


### PR DESCRIPTION
Fixes #2597