### PR TITLE
[Sync EN] Add caution about underflow in Randomizer::getFloat()

### DIFF
--- a/reference/random/random/randomizer/getfloat.xml
+++ b/reference/random/random/randomizer/getfloat.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: c142be811735a5542c8a2e4c4ed2f81e8cc3acc6 Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: 423a1da63f0d97eb16d42dbb1e3b01ff7c91e498 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="random-randomizer.getfloat" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -343,6 +343,15 @@ Lat: +69.244304 Lng: -53.548951
     pour obtenir les propriétés comportementales souhaitées.
    </para>
   </note>
+  <caution>
+   <para>
+    Le sous-dépassement (underflow) est intentionnellement laissé non géré dans l'algorithme
+    de la section γ. Cela peut entraîner le retour de valeurs incorrectes pour les intervalles
+    dont les limites se trouvent dans la plage sous-normale des nombres à virgule flottante,
+    c'est-à-dire pour des limites dont la valeur absolue est inférieure à environ
+    <literal>2<superscript>-1020</superscript></literal> (environ <literal>8.9e-308</literal>).
+   </para>
+  </caution>
  </refsect1>
 
  <refsect1 role="seealso">


### PR DESCRIPTION
Fixes #2598