### PR TITLE
[Sync EN] Fix PDO method names in migration 8.5

### DIFF
--- a/appendices/migration85/incompatible.xml
+++ b/appendices/migration85/incompatible.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: ec01a42be50e84f192c0b19fc6e9cf40a0f7ac31 Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: f81bbcf9d3ebae72588ecd78c8f7a8a9dabf9f0e Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <sect1 xml:id="migration85.incompatible" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Changements non rétrocompatibles</title>
@@ -334,9 +334,9 @@
 
   <simpara>
    Essayer d'appeler <methodname>PDOStatement::setFetchMode</methodname> pendant
-   un appel à <methodname>PDO::fetch</methodname>,
-   <methodname>PDO::fetchObject</methodname>,
-   <methodname>PDO::fetchAll</methodname>, par exemple en utilisant des astuces telles que
+   un appel à <methodname>PDOStatement::fetch</methodname>,
+   <methodname>PDOStatement::fetchObject</methodname>,
+   <methodname>PDOStatement::fetchAll</methodname>, par exemple en utilisant des astuces telles que
    passer l'objet statement comme argument de constructeur lors de la récupération dans un
    objet, lèvera désormais une <exceptionname>Error</exceptionname>.
   </simpara>


### PR DESCRIPTION
Fixes #2599