### PR TITLE
Fix wrong varname for SoapFault::$lang property

### DIFF
--- a/reference/soap/soapfault.xml
+++ b/reference/soap/soapfault.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 5e36b489fc67bd0b5c424c7d1cd131c2e982bc5c Maintainer: yannick Status: ready -->
+<!-- EN-Revision: cdb9b8afa58e676e9c7844a892aa6eca152f916d Maintainer: yannick Status: ready -->
 <!-- Reviewed: yes Maintainer: itanea -->
 <reference xml:id="class.soapfault" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 


### PR DESCRIPTION
The FR file already had the correct varname, only the EN-Revision hash needed updating.

Fixes #2616