### PR TITLE
Fix IntlDateFormatter::PATTERN changelog version: 8.5.0 -> 8.4.0

### DIFF
--- a/reference/intl/dateformatter.xml
+++ b/reference/intl/dateformatter.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 5e36b489fc67bd0b5c424c7d1cd131c2e982bc5c Maintainer: dams Status: ready -->
+<!-- EN-Revision: 1786db6ef5272d6fc9b15147bde2985728284bfd Maintainer: dams Status: ready -->
 <!-- Reviewed: no -->
 <reference xml:id="class.intldateformatter" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>La classe IntlDateFormatter</title>
@@ -131,7 +131,7 @@
      </thead>
      <tbody>
       <row>
-       <entry>8.5.0</entry>
+       <entry>8.4.0</entry>
        <entry>
         Ajout de la constante <constant>IntlDateFormatter::PATTERN</constant>.
        </entry>


### PR DESCRIPTION
Fixes #2630

Sync with php/doc-en#5410.