### PR TITLE
Fix typo mongodb driver manager option

### DIFF
--- a/reference/mongodb/mongodb/driver/manager/construct.xml
+++ b/reference/mongodb/mongodb/driver/manager/construct.xml
@@ -341,7 +341,7 @@ mongodb://[username:password@]host1[:port1][,host2[:port2],...[,hostN[:portN]]][
           <entry><type>bool</type></entry>
           <entry>
            <para>
-            Spécife si le pilote doit automatiquement réessayer
+            Spécifie si le pilote doit automatiquement réessayer
             certaines opérations de lecture qui échouent en raison d'erreurs réseau transitoires
             ou d'élections d'ensemble de réplicas. Cette fonctionnalité nécessite MongoDB 3.6+.
             Par défaut à &true;.


### PR DESCRIPTION
https://www.php.net/manual/fr/mongodb-driver-manager.construct.php

<img width="1312" height="525" alt="image" src="https://github.com/user-attachments/assets/a99e9ff8-77ad-4708-a4ef-c17fd85763aa" />
