### PR TITLE
Sync Dom classes: update EN-Revision hash

### DIFF
--- a/reference/dom/dom/dom-attr.xml
+++ b/reference/dom/dom/dom-attr.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 8008e101d6e725ad8050a09a02bbb4492dc2b9fe Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: ae7db14ea8cb8f3041e114f0ef865d86a95f72d6 Maintainer: Fan2Shrek Status: ready -->
 <!-- Reviewed: yes -->
 <reference xml:id="class.dom-attr" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>La classe <classname>Dom\Attr</classname></title>

--- a/reference/dom/dom/dom-cdatasection.xml
+++ b/reference/dom/dom/dom-cdatasection.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 8008e101d6e725ad8050a09a02bbb4492dc2b9fe Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: ae7db14ea8cb8f3041e114f0ef865d86a95f72d6 Maintainer: Fan2Shrek Status: ready -->
 <!-- Reviewed: yes -->
 <reference xml:id="class.dom-cdatasection" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>La classe Dom\CDATASection</title>

--- a/reference/dom/dom/dom-characterdata.xml
+++ b/reference/dom/dom/dom-characterdata.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 8008e101d6e725ad8050a09a02bbb4492dc2b9fe Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: ae7db14ea8cb8f3041e114f0ef865d86a95f72d6 Maintainer: Fan2Shrek Status: ready -->
 <!-- Reviewed: yes -->
 <reference xml:id="class.dom-characterdata" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>La classe Dom\CharacterData</title>

--- a/reference/dom/dom/dom-childnode.xml
+++ b/reference/dom/dom/dom-childnode.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: ef690023bcf92a563a15f5a49bb46acdb59de76a Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: ae7db14ea8cb8f3041e114f0ef865d86a95f72d6 Maintainer: Fan2Shrek Status: ready -->
 <!-- Reviewed: yes -->
 <reference xml:id="class.dom-childnode" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>L'interface Dom\ChildNode</title>

--- a/reference/dom/dom/dom-comment.xml
+++ b/reference/dom/dom/dom-comment.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 8008e101d6e725ad8050a09a02bbb4492dc2b9fe Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: ae7db14ea8cb8f3041e114f0ef865d86a95f72d6 Maintainer: Fan2Shrek Status: ready -->
 <!-- Reviewed: yes -->
 <reference xml:id="class.dom-comment" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>La classe Dom\Comment</title>

--- a/reference/dom/dom/dom-document.xml
+++ b/reference/dom/dom/dom-document.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 8008e101d6e725ad8050a09a02bbb4492dc2b9fe Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: ae7db14ea8cb8f3041e114f0ef865d86a95f72d6 Maintainer: Fan2Shrek Status: ready -->
 <!-- Reviewed: yes -->
 <reference xml:id="class.dom-document" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>La classe Dom\Document</title>

--- a/reference/dom/dom/dom-documentfragment.xml
+++ b/reference/dom/dom/dom-documentfragment.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 8008e101d6e725ad8050a09a02bbb4492dc2b9fe Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: ae7db14ea8cb8f3041e114f0ef865d86a95f72d6 Maintainer: Fan2Shrek Status: ready -->
 <!-- Reviewed: yes -->
 <reference xml:id="class.dom-documentfragment" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>La classe Dom\DocumentFragment</title>

--- a/reference/dom/dom/dom-documenttype.xml
+++ b/reference/dom/dom/dom-documenttype.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 8008e101d6e725ad8050a09a02bbb4492dc2b9fe Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: ae7db14ea8cb8f3041e114f0ef865d86a95f72d6 Maintainer: Fan2Shrek Status: ready -->
 <!-- Reviewed: yes -->
 <reference xml:id="class.dom-documenttype" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>La classe Dom\DocumentType</title>

--- a/reference/dom/dom/dom-dtdnamednodemap.xml
+++ b/reference/dom/dom/dom-dtdnamednodemap.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 8008e101d6e725ad8050a09a02bbb4492dc2b9fe Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: ae7db14ea8cb8f3041e114f0ef865d86a95f72d6 Maintainer: Fan2Shrek Status: ready -->
 <!-- Reviewed: yes -->
 <reference xml:id="class.dom-dtdnamednodemap" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>La classe Dom\DtdNamedNodeMap</title>

--- a/reference/dom/dom/dom-element.xml
+++ b/reference/dom/dom/dom-element.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: ebbc5bb97c8c063d31309725c0bb93d21213993b Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: ae7db14ea8cb8f3041e114f0ef865d86a95f72d6 Maintainer: Fan2Shrek Status: ready -->
 <!-- Reviewed: yes -->
 <reference xml:id="class.dom-element" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>La classe Dom\Element</title>

--- a/reference/dom/dom/dom-entity.xml
+++ b/reference/dom/dom/dom-entity.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 8008e101d6e725ad8050a09a02bbb4492dc2b9fe Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: ae7db14ea8cb8f3041e114f0ef865d86a95f72d6 Maintainer: Fan2Shrek Status: ready -->
 <!-- Reviewed: yes -->
 <reference xml:id="class.dom-entity" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>La classe Dom\Entity</title>

--- a/reference/dom/dom/dom-entityreference.xml
+++ b/reference/dom/dom/dom-entityreference.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 8008e101d6e725ad8050a09a02bbb4492dc2b9fe Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: ae7db14ea8cb8f3041e114f0ef865d86a95f72d6 Maintainer: Fan2Shrek Status: ready -->
 <!-- Reviewed: yes -->
 <reference xml:id="class.dom-entityreference" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>La classe Dom\EntityReference</title>

--- a/reference/dom/dom/dom-htmlcollection.xml
+++ b/reference/dom/dom/dom-htmlcollection.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: ebbc5bb97c8c063d31309725c0bb93d21213993b Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: ae7db14ea8cb8f3041e114f0ef865d86a95f72d6 Maintainer: Fan2Shrek Status: ready -->
 <!-- Reviewed: yes -->
 <reference xml:id="class.dom-htmlcollection" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>La classe Dom\HTMLCollection</title>

--- a/reference/dom/dom/dom-htmldocument.xml
+++ b/reference/dom/dom/dom-htmldocument.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: a8b6f4dd3a23875b066d4e47ea4a4977a63e0655 Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: ae7db14ea8cb8f3041e114f0ef865d86a95f72d6 Maintainer: Fan2Shrek Status: ready -->
 <!-- Reviewed: yes -->
 <reference xml:id="class.dom-htmldocument" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>La classe Dom\HTMLDocument</title>

--- a/reference/dom/dom/dom-htmlelement.xml
+++ b/reference/dom/dom/dom-htmlelement.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: ebbc5bb97c8c063d31309725c0bb93d21213993b Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: ae7db14ea8cb8f3041e114f0ef865d86a95f72d6 Maintainer: Fan2Shrek Status: ready -->
 <!-- Reviewed: yes -->
 <reference xml:id="class.dom-htmlelement" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>La classe Dom\HTMLElement</title>

--- a/reference/dom/dom/dom-implementation.xml
+++ b/reference/dom/dom/dom-implementation.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 8008e101d6e725ad8050a09a02bbb4492dc2b9fe Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: ae7db14ea8cb8f3041e114f0ef865d86a95f72d6 Maintainer: Fan2Shrek Status: ready -->
 <!-- Reviewed: yes -->
 <reference xml:id="class.dom-implementation" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>La classe Dom\Implementation</title>

--- a/reference/dom/dom/dom-namednodemap.xml
+++ b/reference/dom/dom/dom-namednodemap.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: ebbc5bb97c8c063d31309725c0bb93d21213993b Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: ae7db14ea8cb8f3041e114f0ef865d86a95f72d6 Maintainer: Fan2Shrek Status: ready -->
 <!-- Reviewed: yes -->
 <reference xml:id="class.dom-namednodemap" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>La classe Dom\NamedNodeMap</title>

--- a/reference/dom/dom/dom-namespaceinfo.xml
+++ b/reference/dom/dom/dom-namespaceinfo.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: bbc649987ac2f21610a8ea643b7a069cdd941f79 Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: ae7db14ea8cb8f3041e114f0ef865d86a95f72d6 Maintainer: Fan2Shrek Status: ready -->
 <!-- Reviewed: yes -->
 <reference xml:id="class.dom-namespaceinfo" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>La classe Dom\NamespaceInfo</title>

--- a/reference/dom/dom/dom-node.xml
+++ b/reference/dom/dom/dom-node.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: ebbc5bb97c8c063d31309725c0bb93d21213993b Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: ae7db14ea8cb8f3041e114f0ef865d86a95f72d6 Maintainer: Fan2Shrek Status: ready -->
 <!-- Reviewed: yes -->
 <reference xml:id="class.dom-node" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>La classe Dom\Node</title>

--- a/reference/dom/dom/dom-nodelist.xml
+++ b/reference/dom/dom/dom-nodelist.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 8008e101d6e725ad8050a09a02bbb4492dc2b9fe Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: ae7db14ea8cb8f3041e114f0ef865d86a95f72d6 Maintainer: Fan2Shrek Status: ready -->
 <!-- Reviewed: yes -->
 <reference xml:id="class.dom-nodelist" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>La classe <classname>Dom\NodeList</classname></title>

--- a/reference/dom/dom/dom-notation.xml
+++ b/reference/dom/dom/dom-notation.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 8008e101d6e725ad8050a09a02bbb4492dc2b9fe Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: ae7db14ea8cb8f3041e114f0ef865d86a95f72d6 Maintainer: Fan2Shrek Status: ready -->
 <!-- Reviewed: yes -->
 <reference xml:id="class.dom-notation" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>La classe Dom\Notation</title>

--- a/reference/dom/dom/dom-parentnode.xml
+++ b/reference/dom/dom/dom-parentnode.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e64de8beed5f6e44e02cd36b907fba7aa38f1c84 Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: ae7db14ea8cb8f3041e114f0ef865d86a95f72d6 Maintainer: Fan2Shrek Status: ready -->
 <!-- Reviewed: yes -->
 <reference xml:id="class.dom-parentnode" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>L'interface Dom\ParentNode</title>

--- a/reference/dom/dom/dom-processinginstruction.xml
+++ b/reference/dom/dom/dom-processinginstruction.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 8008e101d6e725ad8050a09a02bbb4492dc2b9fe Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: ae7db14ea8cb8f3041e114f0ef865d86a95f72d6 Maintainer: Fan2Shrek Status: ready -->
 <!-- Reviewed: yes -->
 <reference xml:id="class.dom-processinginstruction" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>La classe Dom\ProcessingInstruction</title>

--- a/reference/dom/dom/dom-text.xml
+++ b/reference/dom/dom/dom-text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 8008e101d6e725ad8050a09a02bbb4492dc2b9fe Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: ae7db14ea8cb8f3041e114f0ef865d86a95f72d6 Maintainer: Fan2Shrek Status: ready -->
 <!-- Reviewed: yes -->
 <reference xml:id="class.dom-text" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>La classe Dom\Text</title>

--- a/reference/dom/dom/dom-tokenlist.xml
+++ b/reference/dom/dom/dom-tokenlist.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: ffd2ef754b37526c0b96e94859d57ce06acfbf41 Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: ae7db14ea8cb8f3041e114f0ef865d86a95f72d6 Maintainer: Fan2Shrek Status: ready -->
 <!-- Reviewed: yes -->
 <reference xml:id="class.dom-tokenlist" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>La classe Dom\TokenList</title>

--- a/reference/dom/dom/dom-xmldocument.xml
+++ b/reference/dom/dom/dom-xmldocument.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 5ddcf0969ce5f8f57fb169521a0b86a231c42b1c Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: ae7db14ea8cb8f3041e114f0ef865d86a95f72d6 Maintainer: Fan2Shrek Status: ready -->
 <!-- Reviewed: yes -->
 <reference xml:id="class.dom-xmldocument" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>La classe Dom\XMLDocument</title>

--- a/reference/dom/dom/dom-xpath.xml
+++ b/reference/dom/dom/dom-xpath.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 8008e101d6e725ad8050a09a02bbb4492dc2b9fe Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: ae7db14ea8cb8f3041e114f0ef865d86a95f72d6 Maintainer: Fan2Shrek Status: ready -->
 <!-- Reviewed: yes -->
 <reference xml:id="class.dom-xpath" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>La classe Dom\XPath</title>


### PR DESCRIPTION
Update EN-Revision hash for 27 Dom class files (cosmetic change in doc-en: removal of $Revision$ tag).