### PR TITLE
Sync misc outdated files with doc-en

### DIFF
--- a/appendices/migration85/incompatible.xml
+++ b/appendices/migration85/incompatible.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: f81bbcf9d3ebae72588ecd78c8f7a8a9dabf9f0e Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: f81bbcf9d36c28bf067b5514cffdbc7663357cf3 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <sect1 xml:id="migration85.incompatible" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Changements non rétrocompatibles</title>

--- a/language/predefined/attribute/construct.xml
+++ b/language/predefined/attribute/construct.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 681fd84dbdef6c0f8fe92848677d95a993b66143 Maintainer: pierrick Status: ready -->
+<!-- EN-Revision: 0eb433f1dec35ba1c0daf2d8b30b47f284ad5670 Maintainer: pierrick Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="attribute.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -12,7 +12,7 @@
   &reftitle.description;
   <constructorsynopsis role="Attribute">
    <modifier>public</modifier> <methodname>Attribute::__construct</methodname>
-   <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>Attribute::TARGET_ALL</initializer></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer><constant>Attribute::TARGET_ALL</constant></initializer></methodparam>
   </constructorsynopsis>
   <para>
    Construit une nouvelle instance de <classname>Attribute</classname>.

--- a/language/predefined/attributes/nodiscard.xml
+++ b/language/predefined/attributes/nodiscard.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 02bee41067ab2822cbffcb4b3b2387f79488dffd Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 30bda33771e1c8fa8fc8a5ee7559fd7fa189caa0 Maintainer: lacatoire Status: ready -->
 <reference xml:id="class.nodiscard" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>L'attribut NoDiscard</title>
  <titleabbrev>NoDiscard</titleabbrev>
@@ -39,6 +39,7 @@
 
    <classsynopsis class="class">
     <ooclass>
+     <modifier role="attribute">#[\Attribute]</modifier>
      <modifier>final</modifier>
      <classname>NoDiscard</classname>
     </ooclass>

--- a/language/predefined/exception.xml
+++ b/language/predefined/exception.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 3c4752c0aea6bfdd6795213785e7d7cc07d160ae Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 462d2bcb3fa7e76dd84baadf261146bc62574ca9 Maintainer: yannick Status: ready -->
 <!-- Reviewed: yes Maintainer: yannick -->
 <reference xml:id="class.exception" role="exception" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>Exception</title>

--- a/reference/image/functions/getimagesize.xml
+++ b/reference/image/functions/getimagesize.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 6bb90d24b2b3b2edb36e04b00e6bb10c4e87bbb0 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 6bb90d24b240a0b81e4b203cd8b7ed56bd54033a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://docbook.org/ns/docbook" xml:id="function.getimagesize">
  <refnamediv>

--- a/reference/intl/grapheme/grapheme-str-split.xml
+++ b/reference/intl/grapheme/grapheme-str-split.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 122d5d0969e498bc34f5b5c9f4565ba3bcaf59fc Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 122d5d09692db103ef8e7b2e2fc31583ff3807e2 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="function.grapheme-str-split" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>

--- a/reference/json/functions/json-last-error.xml
+++ b/reference/json/functions/json-last-error.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 058ea1e842d5ff23c5e73b76bb1b84f54bf2d4ec Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 058ea1e8420b9c1b24402af52545e8313428e1d1 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="function.json-last-error" xmlns="http://docbook.org/ns/docbook">

--- a/reference/math/functions/fmod.xml
+++ b/reference/math/functions/fmod.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 54a788ca59cbbfb5b9fbd2dfa3e3d5e0b4740e1a Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 54a788ca59d95ff2b4189406437345a21b489435 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes Maintainer: pmartin -->
 <refentry xml:id="function.fmod" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>

--- a/reference/pdo_mysql/pdo-mysql.xml
+++ b/reference/pdo_mysql/pdo-mysql.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: b2a7a5fab7231fa8634096f111ae0fa0dc60bcfe Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: ae7db14ea8cb8f3041e114f0ef865d86a95f72d6 Maintainer: Fan2Shrek Status: ready -->
 <!-- Reviewed: yes -->
 <reference xml:id="class.pdo-mysql" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>La classe Pdo\Mysql</title>

--- a/reference/pdo_sqlite/pdo-sqlite.xml
+++ b/reference/pdo_sqlite/pdo-sqlite.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 51610360d58ed09bc9d1312f419057c0d1d1a998 Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: ae7db14ea8cb8f3041e114f0ef865d86a95f72d6 Maintainer: Fan2Shrek Status: ready -->
 <!-- Reviewed: yes -->
 <reference xml:id="class.pdo-sqlite" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>La classe Pdo\Sqlite</title>

--- a/reference/random/random/randomizer/getfloat.xml
+++ b/reference/random/random/randomizer/getfloat.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 423a1da63f0d97eb16d42dbb1e3b01ff7c91e498 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 423a1da63f8265c57827234807709232afd274ec Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="random-randomizer.getfloat" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>


### PR DESCRIPTION
Update EN-Revision hashes and sync XML structure for 11 miscellaneous outdated files.

Structural changes:
- `attribute/construct.xml`: wrap `Attribute::TARGET_ALL` in `<constant>` tags
- `nodiscard.xml`: add `<modifier role="attribute">#[\Attribute]</modifier>`

Hash-only updates (cosmetic EN changes like `$Revision` removal):
- `appendices/migration85/incompatible.xml`
- `language/predefined/exception.xml`
- `reference/image/functions/getimagesize.xml`
- `reference/intl/grapheme/grapheme-str-split.xml`
- `reference/json/functions/json-last-error.xml`
- `reference/math/functions/fmod.xml`
- `reference/pdo_mysql/pdo-mysql.xml`
- `reference/pdo_sqlite/pdo-sqlite.xml`
- `reference/random/random/randomizer/getfloat.xml`