### PR TITLE
Fix grammar and spelling in MySQL-related documentation

### DIFF
--- a/reference/mysql/configure.xml
+++ b/reference/mysql/configure.xml
@@ -117,7 +117,7 @@
      Si lorsqu'on démarre le serveur web une erreur similaire à ceci apparaît :
      <literal>"Unable to load dynamic library './php_mysql.dll'"</literal>,
      c'est parce que <filename>php_mysql.dll</filename> et/ou
-     <filename>libmysql.dll</filename> n'ont pû être trouvés par le système.
+     <filename>libmysql.dll</filename> n'ont pu être trouvés par le système.
     </simpara>
    </note>
   </section>

--- a/reference/mysql/constants.xml
+++ b/reference/mysql/constants.xml
@@ -37,7 +37,7 @@
        <entry><constant>MYSQL_CLIENT_SSL</constant></entry>
        <entry>Utilisation du chiffrement SSL. Cette constante n'est disponible
        qu'à partir de la version 4.x et plus récente de la bibliothèque cliente MySQL.
-       La version 3.23.x est fournis avec PHP 4 ainsi qu'avec les binaires 
+       La version 3.23.x est fournie avec PHP 4 ainsi qu'avec les binaires
        pour windows de PHP 5.</entry>
       </row>
      </tbody>

--- a/reference/mysql/functions/mysql-affected-rows.xml
+++ b/reference/mysql/functions/mysql-affected-rows.xml
@@ -60,7 +60,7 @@
   </simpara>
   <simpara>
    La requête REPLACE commence par effacer les enregistrements possédant la même
-   clé primaire et ensuite, insert les nouveaux enregistrements. Cette fonction retourne le
+   clé primaire et ensuite, insère les nouveaux enregistrements. Cette fonction retourne le
    nombre d'enregistrements effacés ainsi que le nombre d'enregistrements insérés.
   </simpara>
   <simpara>
@@ -134,8 +134,8 @@ Lignes modifiées : 10
   <note>
    <title>Transactions</title>
    <simpara>
-    Lors de l'utilisation de des transactions, il faut appeler
-    <function>mysql_affected_rows</function> après le requête INSERT,
+    Lors de l'utilisation des transactions, il faut appeler
+    <function>mysql_affected_rows</function> après la requête INSERT,
     UPDATE ou DELETE et non après le COMMIT.
    </simpara>
   </note>

--- a/reference/mysql/functions/mysql-close.xml
+++ b/reference/mysql/functions/mysql-close.xml
@@ -79,7 +79,7 @@ Connexion réussie
     <function>mysql_close</function> ne fermera pas les connexions
     persistantes créées par <function>mysql_pconnect</function>.
     Pour plus de détails, voir la page du manuel sur les
-    <link linkend="features.persistent-connections">connexions persistentes</link>.
+    <link linkend="features.persistent-connections">connexions persistantes</link>.
    </simpara>
   </note>
  </refsect1>

--- a/reference/mysql/functions/mysql-create-db.xml
+++ b/reference/mysql/functions/mysql-create-db.xml
@@ -57,7 +57,7 @@
  <refsect1 role="examples">
   &reftitle.examples;
   <example>
-   <title>Exemple alternative avec <function>mysql_create_db</function></title>
+   <title>Exemple alternatif avec <function>mysql_create_db</function></title>
    <simpara>
     La fonction <function>mysql_create_db</function> est obsolète. Il
     est préférable d'utiliser la fonction <function>mysql_query</function>,

--- a/reference/mysql/functions/mysql-db-query.xml
+++ b/reference/mysql/functions/mysql-db-query.xml
@@ -114,7 +114,7 @@ mysql_free_result($result);
    <simpara>
     Soyez avertis que cette fonction <emphasis role="strong">ne restaure pas</emphasis>
     la base de données qui était utilisée initialement. En d'autres termes,
-    on ne pouvez utiliser cette fonction pour exécuter
+    on ne peut utiliser cette fonction pour exécuter
     <emphasis>temporairement</emphasis> une requête SQL dans une autre
     base de données, il faudra sélectionner manuellement la bonne
     base à nouveau. Il est fortement recommandé d'utiliser la syntaxe SQL

--- a/reference/mysql/functions/mysql-fetch-array.xml
+++ b/reference/mysql/functions/mysql-fetch-array.xml
@@ -60,11 +60,11 @@
    s'il n'y a plus de lignes. Le type de tableau retourné dépend de la
    définition du paramètre <parameter>result_type</parameter>.
    En utilisant <constant>MYSQL_BOTH</constant> (défaut), l'on
-   récupérerez un tableau contenant des indices associatifs et numériques.
-   En utilisant <constant>MYSQL_ASSOC</constant>, on ne récupérerez que
+   récupérera un tableau contenant des indices associatifs et numériques.
+   En utilisant <constant>MYSQL_ASSOC</constant>, on ne récupérera que
    les indices associatifs (comme le fonctionnement de la fonction
    <function>mysql_fetch_assoc</function>), en utilisant <constant>MYSQL_NUM</constant>,
-   on ne récupérerez que les indices numériques (comme le fonctionnement
+   on ne récupérera que les indices numériques (comme le fonctionnement
    de la fonction <function>mysql_fetch_row</function>).
   </simpara>
   <simpara>

--- a/reference/mysql/functions/mysql-fetch-assoc.xml
+++ b/reference/mysql/functions/mysql-fetch-assoc.xml
@@ -123,7 +123,7 @@ mysql_free_result($result);
    <simpara>
     Une chose importante à noter est que l'utilisation de
     <function>mysql_fetch_assoc</function> n'est <emphasis>pas
-    significativement</emphasis> plus lent que l'utilisation de
+    significativement</emphasis> plus lente que l'utilisation de
     <function>mysql_fetch_row</function>, alors qu'il fournit
     des valeurs significatives ajoutées.
    </simpara>

--- a/reference/mysql/functions/mysql-fetch-field.xml
+++ b/reference/mysql/functions/mysql-fetch-field.xml
@@ -117,7 +117,7 @@
    </listitem>
    <listitem>
     <simpara>
-     <literal>"zerofill"</literal> : 1 si la colonne est complétée par des zéro
+     <literal>"zerofill"</literal> : 1 si la colonne est complétée par des zéros
     </simpara>
    </listitem>
   </itemizedlist>

--- a/reference/mysql/functions/mysql-insert-id.xml
+++ b/reference/mysql/functions/mysql-insert-id.xml
@@ -28,7 +28,7 @@
   </methodsynopsis>
   <simpara>
    Retourne le dernier identifiant généré par un champ de type AUTO_INCREMENT,
-   sur la connexion MySQL courante ou sûr la connexion
+   sur la connexion MySQL courante ou sur la connexion
    spécifiée par <parameter>link_identifier</parameter> (habituellement, une
    requête de type INSERT).
   </simpara>
@@ -79,7 +79,7 @@ printf("Le dernier ID inséré dans est le id %d\n", mysql_insert_id());
     <function>mysql_insert_id</function> convertira le type retourné
     de la fonction native MySQL C API <literal>mysql_insert_id()</literal>
     en un type <literal>long</literal> (nommé <type>int</type> en PHP).
-    Si le colonne AUTO_INCREMENT a une colonne de type BIGINT (64 bits),
+    Si la colonne AUTO_INCREMENT a une colonne de type BIGINT (64 bits),
     la conversion peut résulter en une valeur incorrecte. À la place, utiliser
     la fonction SQL interne à MySQL LAST_INSERT_ID() dans une requête SQL.
     Pour plus d'informations sur les valeurs entières maximales en PHP,
@@ -91,7 +91,7 @@ printf("Le dernier ID inséré dans est le id %d\n", mysql_insert_id());
    <simpara>
     Parce que <function>mysql_insert_id</function> agit sur la dernière requête
     exécutée, il faut s'assurer d'appeler la fonction <function>mysql_insert_id</function>
-    immédiatement après l'exécution de la requête qui a générée la valeur.
+    immédiatement après l'exécution de la requête qui a généré la valeur.
    </simpara>
   </note>
   <note>

--- a/reference/mysql/functions/mysql-pconnect.xml
+++ b/reference/mysql/functions/mysql-pconnect.xml
@@ -135,7 +135,7 @@
   <warning>
    <simpara>
     L'utilisation des connexions persistantes requiert des paramétrages
-    d'Apache et de MySQL pour s'assurer que l'on n'atteindrez pas
+    d'Apache et de MySQL pour s'assurer que l'on n'atteindra pas
     la limite maximale de nombre de connexions simultanées autorisée
     par MySQL.
    </simpara>

--- a/reference/mysql/functions/mysql-select-db.xml
+++ b/reference/mysql/functions/mysql-select-db.xml
@@ -28,7 +28,7 @@
   <simpara>
    Sélectionne une base de données MySQL sur le serveur associé avec le paramètre
    <parameter>link_identifier</parameter>. Chaque appel à la fonction
-   <function>mysql_query</function> sera exécutée sur la base de données active.
+   <function>mysql_query</function> sera exécuté sur la base de données active.
   </simpara>
  </refsect1>
 

--- a/reference/mysql/ini.xml
+++ b/reference/mysql/ini.xml
@@ -242,7 +242,7 @@
   <listitem>
    <simpara>
     Durée maximale d'attente de la réponse d'un serveur, en secondes.
-    Sous Linux, cette durée sert aussi lors de l'échange du premier avec
+    Sous Linux, cette durée sert aussi lors du premier échange avec
     le serveur.
    </simpara>
   </listitem>

--- a/reference/mysql_xdevapi/changelog.xml
+++ b/reference/mysql_xdevapi/changelog.xml
@@ -8,7 +8,7 @@
  <simplesect>
   <title>Historique de changement général de l'extension ext/mysql_xdevapi</title>
   <para>
-   Cette historique de changement référence l'extension ext/mysql_xdevapi.
+   Cet historique de changement référence l'extension ext/mysql_xdevapi.
   </para>
  </simplesect>
 

--- a/reference/mysql_xdevapi/mysql-xdevapi.table.xml
+++ b/reference/mysql_xdevapi/mysql-xdevapi.table.xml
@@ -14,7 +14,7 @@
   <section xml:id="mysql-xdevapi-table.intro">
    &reftitle.intro;
    <para>
-    Fournie un accès à la table à travers des déclarations INSERT/SELECT/UPDATE/DELETE.
+    Fournit un accès à la table à travers des déclarations INSERT/SELECT/UPDATE/DELETE.
    </para>
   </section>
 <!-- }}} -->

--- a/reference/mysql_xdevapi/mysql-xdevapi.tableupdate.xml
+++ b/reference/mysql_xdevapi/mysql-xdevapi.tableupdate.xml
@@ -14,7 +14,7 @@
   <section xml:id="mysql-xdevapi-tableupdate.intro">
    &reftitle.intro;
    <para>
-    Une déclaration pour des opérations de mises à jours sur une Table.
+    Une déclaration pour des opérations de mises à jour sur une Table.
    </para>
   </section>
 <!-- }}} -->

--- a/reference/mysql_xdevapi/mysql_xdevapi/collection/createindex.xml
+++ b/reference/mysql_xdevapi/mysql_xdevapi/collection/createindex.xml
@@ -61,7 +61,7 @@
       </listitem>
       <listitem>
         <para>
-          <code>unique</code>: booléen, (facultatif) true si le champ doit être éxisté dans le document.
+          <code>unique</code>: booléen, (facultatif) true si le champ doit exister dans le document.
           Par défaut à &false;, sauf pour <literal>GEOJSON</literal> où il est par défaut à &true;.
          </para>
        </listitem>

--- a/reference/mysql_xdevapi/mysql_xdevapi/collection/modify.xml
+++ b/reference/mysql_xdevapi/mysql_xdevapi/collection/modify.xml
@@ -42,7 +42,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   SI l'opération n'est pas exécutée, alors la fonction retournera
+   Si l'opération n'est pas exécutée, alors la fonction retournera
    un objet Modify qui peut être utilisé pour ajouter des opérations
    de modification supplémentaires.
   </para>

--- a/reference/mysql_xdevapi/mysql_xdevapi/collection/remove.xml
+++ b/reference/mysql_xdevapi/mysql_xdevapi/collection/remove.xml
@@ -46,7 +46,7 @@
    de suppression supplémentaires.
   </para>
   <para>
-   SI l'opération de suppression est exécutée, alors l'objet retourné contiendra le
+   Si l'opération de suppression est exécutée, alors l'objet retourné contiendra le
    résultat de l'opération.
   </para>
  </refsect1>

--- a/reference/mysql_xdevapi/mysql_xdevapi/collectionfind/lockexclusive.xml
+++ b/reference/mysql_xdevapi/mysql_xdevapi/collectionfind/lockexclusive.xml
@@ -14,7 +14,7 @@
    <methodparam choice="opt"><type>int</type><parameter>lock_waiting_option</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Vérouille le document de manière exclusive.
+   Verrouille le document de manière exclusive.
    Tant que le document est verrouillé,
    d'autres transactions ne peuvent pas mettre à jour le document,
    utiliser <code>SELECT ... LOCK IN SHARE MODE</code>,

--- a/reference/mysql_xdevapi/mysql_xdevapi/collectionfind/lockshared.xml
+++ b/reference/mysql_xdevapi/mysql_xdevapi/collectionfind/lockshared.xml
@@ -17,7 +17,7 @@
    Autorise le partage des documents entre plusieurs transactions qui sont verrouillées en mode partagé.
   </para>
   <para>
-   D'autres sessions peuvent lire les lignes, mais ne peuvent pas les modifier tant que le transaction n'a pas validé.
+   D'autres sessions peuvent lire les lignes, mais ne peuvent pas les modifier tant que la transaction n'a pas validé.
   </para>
   <para>
    Si l'une de ces lignes a été modifiée par une autre transaction qui n'a pas été validée,

--- a/reference/mysql_xdevapi/setup.xml
+++ b/reference/mysql_xdevapi/setup.xml
@@ -92,14 +92,14 @@ pdo_mysql
       <listitem>
         <para>
           Boost; requis, utiliser optionnellement l'option de configuration --with-boost=DIR
-          ou définissez la variable d'environnement MYSQL_XDEVAPI_BOOST_ROOT. Seuls les
+          ou définir la variable d'environnement MYSQL_XDEVAPI_BOOST_ROOT. Seuls les
           fichiers d'en-tête boost sont requis; pas les binaires.
         </para>
       </listitem>
       <listitem>
         <para>
           Google Protocol Buffers (protobuf): requis, utiliser optionnellement l'option de configuration
-          --with-protobuf=DIR ou définissez la variable d'environnement MYSQL_XDEVAPI_PROTOBUF_ROOT.
+          --with-protobuf=DIR ou définir la variable d'environnement MYSQL_XDEVAPI_PROTOBUF_ROOT.
         </para>
         <para>
           Optionnellement utiliser <literal>make protobufs</literal> pour générer les fichiers protobuf (*.pb.cc/.h),

--- a/reference/mysqli/configure.xml
+++ b/reference/mysqli/configure.xml
@@ -21,7 +21,7 @@ xmlns:xlink="http://www.w3.org/1999/xlink">
    Les distributions Linux incluent des versions binaires de PHP qui peuvent
    être installées. Même si ces binaires sont construits avec les extensions
    MySQL, les bibliothèques clientes doivent souvent être installées au
-   moyen d'un paquet additionnel. Voir si c'est le cas pour le distribution.
+   moyen d'un paquet additionnel. Voir si c'est le cas pour la distribution.
   </para>
   
   <para>

--- a/reference/mysqli/mysqli/debug.xml
+++ b/reference/mysqli/mysqli/debug.xml
@@ -130,7 +130,7 @@
       <row>
        <entry>8.0.0</entry>
        <entry>
-        Cette fonction retourne désormais toujours &true;. Auparavant, elle retourne &false; en cas d'échec.
+        Cette fonction retourne désormais toujours &true;. Auparavant, elle retournait &false; en cas d'échec.
        </entry>
       </row>
      </tbody>

--- a/reference/mysqli/mysqli/field-count.xml
+++ b/reference/mysqli/mysqli/field-count.xml
@@ -23,7 +23,7 @@
    sur la connexion spécifiée par le paramètre
    <parameter>mysql</parameter>. Cette fonction peut être utile
    lors de l'utilisation de <function>mysqli_store_result</function>
-   pour déterminer si la requête aurait du retourner un
+   pour déterminer si la requête aurait dû retourner un
    résultat vide ou non, sans en connaître la nature.
   </para>
  </refsect1>

--- a/reference/mysqli/mysqli/get-charset.xml
+++ b/reference/mysqli/mysqli/get-charset.xml
@@ -80,7 +80,7 @@
      <term><parameter>max_length</parameter></term>
      <listitem>
       <para>
-       Longueur maximal de caractères, en octets
+       Longueur maximale de caractères, en octets
       </para>
      </listitem>
     </varlistentry>

--- a/reference/mysqli/mysqli/insert-id.xml
+++ b/reference/mysqli/mysqli/insert-id.xml
@@ -5,7 +5,7 @@
  <refnamediv>
   <refname>mysqli::$insert_id</refname>
   <refname>mysqli_insert_id</refname>
-  <refpurpose>Retourne la valeur généré pour une colonne AUTO_INCREMENT par la dernière requête</refpurpose>
+  <refpurpose>Retourne la valeur générée pour une colonne AUTO_INCREMENT par la dernière requête</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -22,7 +22,7 @@
    <literal>UPDATE</literal> sur une table avec une colonne ayant l'attribut
    <literal>AUTO_INCREMENT</literal>. Dans le cas des requêtes multilignes
    <literal>INSERT</literal>, ceci retourne la première valeur automatiquement
-   généré qui a été inséré avec succès.
+   générée qui a été insérée avec succès.
   </para>
   <para>
    Exécuter une requête <literal>INSERT</literal> ou <literal>UPDATE</literal>
@@ -58,14 +58,14 @@
    pas modifié la valeur de l'<literal>AUTO_INCREMENT</literal>.
   </para>
   <para>
-   Seul les requêtes émises par la connexion courante affecte la valeur de retour.
-   La valeur n'est pas affecté par les requêtes utilisant d'autres connexions
+   Seules les requêtes émises par la connexion courante affectent la valeur de retour.
+   La valeur n'est pas affectée par les requêtes utilisant d'autres connexions
    ou clients.
   </para>
   <note>
    <para>
     Si le nombre est plus grand que la valeur maximale d'un entier,
-    elle sera retourné sous une &string;
+    elle sera retournée sous forme de &string;.
    </para>
   </note>
  </refsect1>

--- a/reference/mysqli/mysqli/options.xml
+++ b/reference/mysqli/mysqli/options.xml
@@ -62,7 +62,7 @@
           </row>
           <row>
            <entry><constant>MYSQLI_OPT_READ_TIMEOUT</constant></entry>
-           <entry>Résultat d'execution durée d'expiration d'une commande en secondes.
+           <entry>Résultat d'exécution durée d'expiration d'une commande en secondes.
             Disponible à partir de PHP 7.2.0.</entry>
           </row>
           <row>

--- a/reference/mysqli/mysqli/reap-async-query.xml
+++ b/reference/mysqli/mysqli/reap-async-query.xml
@@ -42,7 +42,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Retourne &false; en cas d'échec. Pour des requêtes réussites qui produisent
+   Retourne &false; en cas d'échec. Pour des requêtes réussies qui produisent
    un jeu de résultat tel que <literal>SELECT, SHOW, DESCRIBE</literal> ou
    <literal>EXPLAIN</literal>, <function>mysqli_reap_async_query</function>
    retournera un objet <classname>mysqli_result</classname>. Pour les autres types de

--- a/reference/mysqli/mysqli/refresh.xml
+++ b/reference/mysqli/mysqli/refresh.xml
@@ -5,7 +5,7 @@
  <refnamediv>
   <refname>mysqli::refresh</refname>
   <refname>mysqli_refresh</refname>
-  <refpurpose>Rafraîchie</refpurpose>
+  <refpurpose>Rafraîchit</refpurpose>
  </refnamediv>
 
  <refsynopsisdiv>
@@ -28,7 +28,7 @@
    <methodparam><type>int</type><parameter>flags</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Rafraîchie les tables ou les caches, ou ré-initialise
+   Rafraîchit les tables ou les caches, ou ré-initialise
    les informations du serveur de réplication.
   </para>
  </refsect1>

--- a/reference/mysqli/mysqli/release-savepoint.xml
+++ b/reference/mysqli/mysqli/release-savepoint.xml
@@ -5,7 +5,7 @@
  <refnamediv>
   <refname>mysqli::release_savepoint</refname>
   <refname>mysqli_release_savepoint</refname>
-  <refpurpose>Supprime le point de sauvegardé nommé du jeu des points de sauvegarde de la transaction courante</refpurpose>
+  <refpurpose>Supprime le point de sauvegarde nommé du jeu des points de sauvegarde de la transaction courante</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/mysqli/mysqli/thread-safe.xml
+++ b/reference/mysqli/mysqli/thread-safe.xml
@@ -5,7 +5,7 @@
  <refnamediv>
   <refname>mysqli::thread_safe</refname>
   <refname>mysqli_thread_safe</refname>
-  <refpurpose>Indique si le support des threads est activée ou pas</refpurpose>
+  <refpurpose>Indique si le support des threads est activé ou pas</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/mysqli/mysqli_driver/report-mode.xml
+++ b/reference/mysqli/mysqli_driver/report-mode.xml
@@ -29,7 +29,7 @@
   </para>
   <para>
    À partir de PHP 8.1.0, la valeur par défaut est <literal>MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT</literal>.
-   Auparavant, il était <constant>MYSQLI_REPORT_OFF</constant>.
+   Auparavant, elle était <constant>MYSQLI_REPORT_OFF</constant>.
   </para>
  </refsect1>
 

--- a/reference/mysqli/mysqli_result/fetch-column.xml
+++ b/reference/mysqli/mysqli_result/fetch-column.xml
@@ -56,7 +56,7 @@
   <warning>
    <para>
     Il n'y a aucun moyen de retourner une autre colonne de la même ligne si l'on
-    utiliser cette fonction pour récupérer des données.
+    utilise cette fonction pour récupérer des données.
    </para>
   </warning>
  </refsect1>

--- a/reference/mysqli/mysqli_result/fetch-field.xml
+++ b/reference/mysqli/mysqli_result/fetch-field.xml
@@ -5,7 +5,7 @@
  <refnamediv>
   <refname>mysqli_result::fetch_field</refname>
   <refname>mysqli_fetch_field</refname>
-  <refpurpose>Retourne le prochain champs dans le jeu de résultats</refpurpose>
+  <refpurpose>Retourne le prochain champ dans le jeu de résultats</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -41,7 +41,7 @@
   &reftitle.returnvalues;
   <para>
    Retourne un objet qui contient les informations d'un champ ou &false;
-   si aucune information n'est disponible pour ce champs.
+   si aucune information n'est disponible pour ce champ.
   </para>
   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('mysqli-result.fetch-fields')/db:refsect1[@role='returnvalues']/db:table)">
    <xi:fallback/>

--- a/reference/mysqli/mysqli_result/fetch-fields.xml
+++ b/reference/mysqli/mysqli_result/fetch-fields.xml
@@ -98,15 +98,15 @@
      </row>
      <row>
       <entry>charsetnr</entry>
-      <entry>Le numéro du jeu de caractères pour ce champs</entry>
+      <entry>Le numéro du jeu de caractères pour ce champ</entry>
      </row>
      <row>
       <entry>flags</entry>
-      <entry>Un entier représentant le bit-flags pour ce champs</entry>
+      <entry>Un entier représentant le bit-flags pour ce champ</entry>
      </row>
      <row>
       <entry>type</entry>
-      <entry>Le type de données utilisées pour ce champs</entry>
+      <entry>Le type de données utilisées pour ce champ</entry>
      </row>
      <row>
       <entry>decimals</entry>

--- a/reference/mysqli/mysqli_result/fetch-object.xml
+++ b/reference/mysqli/mysqli_result/fetch-object.xml
@@ -116,7 +116,7 @@
       <entry>
        <parameter>constructor_args</parameter> accepte désormais
        <literal>[]</literal> pour les constructeurs avec 0 paramètre ;
-       auparavant une exception était lancé.
+       auparavant une exception était lancée.
       </entry>
      </row>
     </tbody>

--- a/reference/mysqli/mysqli_result/lengths.xml
+++ b/reference/mysqli/mysqli_result/lengths.xml
@@ -41,8 +41,8 @@
    aucun caractère null de fin). Retourne &false; si une erreur survient.
   </para>
   <para>
-   <function>mysqli_fetch_lengths</function> n'est valide que pour la ligne courant du
-   jeu de résultats. Elle retourne &false; si l'on l'appelez avant les fonctions
+   <function>mysqli_fetch_lengths</function> n'est valide que pour la ligne courante du
+   jeu de résultats. Elle retourne &false; si l'on l'appelle avant les fonctions
    <function>mysqli_fetch_row</function>, <function>mysqli_fetch_array</function>,
    <function>mysqli_fetch_object</function>
    ou après avoir récupéré toutes les lignes du résultat.

--- a/reference/mysqli/mysqli_stmt/affected-rows.xml
+++ b/reference/mysqli/mysqli_stmt/affected-rows.xml
@@ -5,7 +5,7 @@
  <refnamediv>
   <refname>mysqli_stmt::$affected_rows</refname>
   <refname>mysqli_stmt_affected_rows</refname>
-  <refpurpose>Retourne le nombre total de lignes modifiées, effacées insérées,
+  <refpurpose>Retourne le nombre total de lignes modifiées, effacées, insérées,
    ou correspondant par la dernière requête</refpurpose>
  </refnamediv>
  

--- a/reference/mysqli/mysqli_stmt/bind-result.xml
+++ b/reference/mysqli/mysqli_stmt/bind-result.xml
@@ -78,7 +78,7 @@
      <term><parameter>vars</parameter></term>
      <listitem>
       <para>
-       Variables supplémentaire à lier.
+       Variables supplémentaires à lier.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/mysqli/mysqli_stmt/close.xml
+++ b/reference/mysqli/mysqli_stmt/close.xml
@@ -59,7 +59,7 @@
       <row>
        <entry>8.0.0</entry>
        <entry>
-        Cette fonction retourne désormais toujours &true;. Auparavant, elle retourne &false; en cas d'échec.
+        Cette fonction retourne désormais toujours &true;. Auparavant, elle retournait &false; en cas d'échec.
        </entry>
       </row>
      </tbody>

--- a/reference/mysqli/mysqli_stmt/data-seek.xml
+++ b/reference/mysqli/mysqli_stmt/data-seek.xml
@@ -41,7 +41,7 @@
      <term><parameter>offset</parameter></term>
      <listitem>
       <para>
-       Doit prendre une valeur entre zéro et le nombre total de ligne moins 1
+       Doit prendre une valeur entre zéro et le nombre total de lignes moins 1
        (0..<function>mysqli_stmt_num_rows</function> - 1).
       </para>
      </listitem>

--- a/reference/mysqli/mysqli_stmt/get-result.xml
+++ b/reference/mysqli/mysqli_stmt/get-result.xml
@@ -55,7 +55,7 @@
    Retourne un jeu de résultats pour les requêtes SELECT réussies, ou &false; pour
    d'autres requêtes DML ou en cas d'échec. La fonction <function>mysqli_errno</function>
    peut être utilisée pour distinguer entre ces deux types d'erreurs.
-   Retourne &false; en cas d'échec. Pour des requêtes réussites qui produisent
+   Retourne &false; en cas d'échec. Pour des requêtes réussies qui produisent
    un jeu de résultat tel que <literal>SELECT, SHOW, DESCRIBE</literal> ou
    <literal>EXPLAIN</literal>, <function>mysqli_stmt_get_result</function>
    retournera un objet <classname>mysqli_result</classname>. Pour les autres types de

--- a/reference/mysqli/mysqli_stmt/more-results.xml
+++ b/reference/mysqli/mysqli_stmt/more-results.xml
@@ -42,7 +42,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Retourne &true; s'il y a encore des résultat, &false; sinon.
+   Retourne &true; s'il y a encore des résultats, &false; sinon.
   </para>
  </refsect1>
 

--- a/reference/mysqli/mysqli_stmt/next-result.xml
+++ b/reference/mysqli/mysqli_stmt/next-result.xml
@@ -25,7 +25,7 @@
   </para>
   <note>
    <para>
-    Antérieur PHP 8.1.0, disponible uniquement avec
+    Antérieur à PHP 8.1.0, disponible uniquement avec
     <link xmlns="http://docbook.org/ns/docbook" linkend="book.mysqlnd">mysqlnd</link>.
    </para>
   </note>

--- a/reference/mysqli/mysqli_stmt/reset.xml
+++ b/reference/mysqli/mysqli_stmt/reset.xml
@@ -29,7 +29,7 @@
    annule les jeux de résultats non mis en buffer mais aussi les erreurs courantes.
    Par contre, les jeux de résultats stockés ou liés ne sont pas annulés.
    Les jeux de résultats stockés sont effacés lors de l'exécution de la
-   requête préparée (ou lorsuq'on les ferme).
+   requête préparée (ou lorsqu'on les ferme).
   </para>
   <para>
    Pour préparer de nouveau une requête, utiliser la fonction

--- a/reference/mysqli/mysqli_stmt/result-metadata.xml
+++ b/reference/mysqli/mysqli_stmt/result-metadata.xml
@@ -23,7 +23,7 @@
   <para>
    Si une commande a été préparée par <function>mysqli_prepare</function>,
    et qu'elle produira un résultat, <function>mysqli_stmt_result_metadata</function> 
-   retourne l'objet de résultat qui sera utilisée pour lire les métadonnées,
+   retourne l'objet de résultat qui sera utilisé pour lire les métadonnées,
    comme le nombre de champs et les informations de colonnes.
   </para>
   <simpara>

--- a/reference/mysqli/mysqli_stmt/store-result.xml
+++ b/reference/mysqli/mysqli_stmt/store-result.xml
@@ -21,8 +21,8 @@
    <methodparam><type>mysqli_stmt</type><parameter>statement</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Cette fonction devrait être appelé pour les requêtes qui produisent
-   produire un jeu de résultats (p. ex. <literal>SELECT, SHOW, DESCRIBE, EXPLAIN</literal>)
+   Cette fonction devrait être appelée pour les requêtes qui produisent
+   un jeu de résultats (p. ex. <literal>SELECT, SHOW, DESCRIBE, EXPLAIN</literal>)
    seulement si le jeu de résultats complet doit être mis en tampon par PHP.
    Chaque appel successif à <function>mysqli_stmt_fetch</function> retourne
    les données mises en tampon.

--- a/reference/mysqli/mysqli_warning/next.xml
+++ b/reference/mysqli/mysqli_warning/next.xml
@@ -18,7 +18,7 @@
   </para>
   <para>
    Une fois que l'avertissement a été défini au prochain avertissement,
-   de nouvelle valeurs pour les propriétés de <literal>message</literal>,
+   de nouvelles valeurs pour les propriétés de <literal>message</literal>,
    <literal>sqlstate</literal> et <literal>errno</literal> de
    <classname>mysqli_warning</classname> sont disponibles.
   </para>

--- a/reference/mysqli/quickstart.xml
+++ b/reference/mysqli/quickstart.xml
@@ -984,7 +984,7 @@ array(2) {
    Une telle séparation est souvent considérée comme la seule fonctionnalité
    pour se protéger des injections SQL, mais le même degré de sécurité peut
    être atteint avec les requêtes non-préparées, si toutes les valeurs sont
-   correctement formatées. À noter : qu'un formattage correct n'est pas la même
+   correctement formatées. À noter : qu'un formatage correct n'est pas la même
    chose qu'un échappement et nécessite plus de logique qu'un simple échappement.
    Aussi, les requêtes préparées sont simplement une méthode plus simple
    et moins prompte aux erreurs concernant cette approche sécuritaire.
@@ -1214,7 +1214,7 @@ array(3) {
    de préparation des requêtes pour récupérer les résultats depuis la même procédure
    stockée que celle ci-dessous. Les interfaces de requête préparée et non préparée
    sont similaires. Veuillez noter que toutes les versions du serveur MySQL ne
-   supporte pas la préparation des requêtes SQL <literal>CALL</literal>.
+   supportent pas la préparation des requêtes SQL <literal>CALL</literal>.
   </para>
   <para>
    <example>

--- a/reference/mysqli/setup.xml
+++ b/reference/mysqli/setup.xml
@@ -22,7 +22,7 @@
    Si PHP est utilisé antérieur à sa version 7.1.16, ou PHP 7.2 antérieur à 7.2.4,
    le plugin de mot de passe doit être défini à
    <emphasis>mysql_native_password</emphasis> pour MySQL 8 Server car sinon des erreurs
-   similaire à <emphasis>The server requested authentication method unknown to the
+   similaires à <emphasis>The server requested authentication method unknown to the
    client [caching_sha2_password]</emphasis> peuvent apparaître même si
    <emphasis>caching_sha2_password</emphasis> n'est pas utilisé.
   </para>

--- a/reference/mysqli/summary.xml
+++ b/reference/mysqli/summary.xml
@@ -706,7 +706,7 @@
  <note>
   <para>
    Les alias sont fournis pour assurer la compatibilité ascendante.
-   Ne les utiliser pas dans de nouveaux projets.
+   Ne pas les utiliser dans de nouveaux projets.
   </para>
  </note>
 

--- a/reference/mysqlinfo/set.xml
+++ b/reference/mysqlinfo/set.xml
@@ -154,7 +154,7 @@
     Typiquement, une extension expose une API au programmeur PHP, lui
     permettant quelques facilités lors de la programmation. Cependant,
     quelques extensions qui utilisent le framework d'extension PHP
-    n'expose aucune API au programmeur PHP.
+    n'exposent aucune API au programmeur PHP.
    </simpara>
 
    <simpara>

--- a/reference/mysqlnd/config.xml
+++ b/reference/mysqlnd/config.xml
@@ -106,7 +106,7 @@
    <listitem>
     <simpara>
      Active la collecte de différentes statistiques du client auxquelles l'on
-     pouvez accéder via <function>mysqli_get_client_stats</function>,
+     peut accéder via <function>mysqli_get_client_stats</function>,
      <function>mysqli_get_connection_stats</function>,
      et qui sont aussi décrites
      dans la section <literal>mysqlnd</literal> de la sortie de la fonction
@@ -173,7 +173,7 @@
       <listitem>
        <simpara>
         d - Active la sortie depuis les macros DBUG_&lt;N&gt; pour l'état actuel.
-        Peut être suivi d'une liste de mots-clés qui selectionnent la sortie seulement
+        Peut être suivi d'une liste de mots-clés qui sélectionnent la sortie seulement
         pour les macros DBUG avec ce mot-clé (filtre). Une liste vide de mot-clé
         sélectionnera tout.
        </simpara>
@@ -293,7 +293,7 @@ d:t:x:O,/tmp/mysqlnd.trace
     <listitem>
      <simpara>
       <literal>mysqlnd</literal> et la MySQL Client Library,
-      <literal>libmysqlclient</literal> utilise des API réseau différentes.
+      <literal>libmysqlclient</literal> utilisent des API réseau différentes.
       <literal>mysqlnd</literal> utilise les flux PHP, alors que
       <literal>libmysqlclient</literal> utilise sa propre implémentation basée sur
       le système. PHP, par défaut, utilise un timeout en lecture de 60s. Ceci
@@ -388,11 +388,11 @@ d:t:x:O,/tmp/mysqlnd.trace
       Fichier contenant la clé publique RSA sur serveur MySQL.
      </simpara>
      <simpara>
-      Les clients peuvent soit ommettre de définir une clé publique RSA et spécifier
+      Les clients peuvent soit omettre de définir une clé publique RSA et spécifier
       la clé via la directive de configuration PHP, ou bien, définir la clé
       au moment de l'exécution en utilisant la fonction <function>mysqli_options</function>.
       Si aucun fichier de clé publique RSA n'est fourni par le client, alors la clé
-      sera échangé conformément à la procédure du plugin d'authentification standard
+      sera échangée conformément à la procédure du plugin d'authentification standard
       SHA-256.
      </simpara>
     </listitem>

--- a/reference/mysqlnd/plugin.xml
+++ b/reference/mysqlnd/plugin.xml
@@ -1411,7 +1411,7 @@ mysqlnd_plugin_set_conn_proxy(new proxy());
   <simpara>
    Comme résultat d'un sous-classement, il est possible de
    redéfinir uniquement les méthodes sélectionnées, et l'on
-   pouvez choisir d'avoir des actions "pre" ou "post".
+   peut choisir d'avoir des actions "pre" ou "post".
   </simpara>
   <simpara>
    <emphasis role="bold">Construction d'une classe : mysqlnd_plugin_connection::connect()</emphasis>

--- a/reference/mysqlnd/stats.xml
+++ b/reference/mysqlnd/stats.xml
@@ -771,7 +771,7 @@ $res->close();
      <simpara>
       Le nombre total de colonnes de type
       <literal>MYSQL_TYPE_NULL</literal>
-      récupères à partir d'une requête normale (protocole texte MySQL).
+      récupérées à partir d'une requête normale (protocole texte MySQL).
      </simpara>
     </listitem>
    </varlistentry>
@@ -1491,7 +1491,7 @@ $link->real_connect(/* ... */);
     <term><literal>com_daemon</literal></term>
     <listitem>
      <simpara>
-      LE nombre total de tentatives d'envoi d'une certaine commande
+      Le nombre total de tentatives d'envoi d'une certaine commande
       <literal>COM_*</literal> de PHP à MySQL.
      </simpara>
      <simpara>
@@ -1517,7 +1517,7 @@ $link->real_connect(/* ... */);
        </listitem>
        <listitem>
         <simpara>
-         Calcule le nombre moyen d'exécutions de commandes préparées
+         Calculer le nombre moyen d'exécutions de commandes préparées
          en comparant <literal>COM_EXECUTE</literal> avec
          <literal>COM_PREPARE</literal>
         </simpara>


### PR DESCRIPTION
Fix grammar and spelling in MySQL-related documentation