### PR TITLE
Fix grammar and spelling in openssl/ documentation

### DIFF
--- a/reference/openssl/constants.xml
+++ b/reference/openssl/constants.xml
@@ -313,7 +313,7 @@
        <entry>
         N'enchaîne pas les vérifications des signataires de
         certificats. C'est-à-dire, n'utilise pas les certificats
-        contenu dans le message.
+        contenus dans le message.
        </entry>
       </row>
       <row xml:id="constant.pkcs7-nocerts">
@@ -357,7 +357,7 @@
         Si on annule cette option, le message sera signé de
         manière opaque, ce qui résiste mieux à la traduction
         des relais mail (certains anciens serveurs mail corrompent les
-        messages), mais empêche la lecture par les client emails qui ne
+        messages), mais empêche la lecture par les clients emails qui ne
         connaissent pas S/MIME.
        </entry>
       </row>
@@ -423,8 +423,8 @@
         Normalement le message d'entrée est converti en sa forme "canonique"
         qui en réalité utilise <literal>CR</literal> et <literal>LF</literal>
         comme fin de ligne: tel que requis par la spécification CMS. Quand
-        cette option est présente, aucune translation n'est effectué. Ceci
-        est utile lors de la gestion de données binaire qui peuvent ne pas
+        cette option est présente, aucune translation n'est effectuée. Ceci
+        est utile lors de la gestion de données binaires qui peuvent ne pas
         être en format CMS.
        </entry>
       </row>
@@ -799,7 +799,7 @@
      <simpara>
       Si <constant>OPENSSL_RAW_DATA</constant> est définie dans
       <function>openssl_encrypt</function> ou <function>openssl_decrypt</function>,
-      les données retournées sont retournées tel quel.
+      les données retournées sont retournées telles quelles.
       Quand ceci n'est pas spécifié, les données retournées à l'appeleur sont
       encodées en Base64.
      </simpara>

--- a/reference/openssl/functions/openssl-cipher-key-length.xml
+++ b/reference/openssl/functions/openssl-cipher-key-length.xml
@@ -42,7 +42,7 @@
  <refsect1 role="errors">
   &reftitle.errors;
   <para>
-   Emet une erreur de niveau <constant>E_WARNING</constant> lorsque l'algorithme de chiffrement
+   Émet une erreur de niveau <constant>E_WARNING</constant> lorsque l'algorithme de chiffrement
    est inconnu.
   </para>
  </refsect1>

--- a/reference/openssl/functions/openssl-cms-verify.xml
+++ b/reference/openssl/functions/openssl-cms-verify.xml
@@ -65,7 +65,7 @@
     <term><parameter>untrusted_certificates_filename</parameter></term>
     <listitem>
      <para>
-      A file containing additional intermediate certificates.
+      Un fichier contenant des certificats intermédiaires supplémentaires.
      </para>
     </listitem>
    </varlistentry>

--- a/reference/openssl/functions/openssl-csr-get-subject.xml
+++ b/reference/openssl/functions/openssl-csr-get-subject.xml
@@ -16,7 +16,7 @@
    <methodparam choice="opt"><type>bool</type><parameter>short_names</parameter><initializer>&true;</initializer></methodparam>
   </methodsynopsis>
   <para>
-   <function>openssl_csr_get_subject</function> retournes les informations sur le
+   <function>openssl_csr_get_subject</function> retourne les informations sur le
    nom distinctif du sujet codées dans le <parameter>csr</parameter>,
    y compris les champs commonName (CN), organizationName (O), countryName (C) etc.
   </para>
@@ -31,7 +31,7 @@
      <term><parameter>short_names</parameter></term>
      <listitem>
       <para>
-       <parameter>short_names</parameter> contrôle comment les données sont indexés 
+       <parameter>short_names</parameter> contrôle comment les données sont indexées
        dans le tableau - si <parameter>short_names</parameter> est &true; (par défaut)
        alors les champs seront indexés avec la forme courte du nom, sinon le nom
        complet sera utilisé - par exemple : CN est le nom court de commonName.

--- a/reference/openssl/functions/openssl-get-cipher-methods.xml
+++ b/reference/openssl/functions/openssl-get-cipher-methods.xml
@@ -28,7 +28,7 @@
      <term><parameter>aliases</parameter></term>
      <listitem>
       <para>
-       Passez &true; pour que les alias des méthodes chiffrements
+       Passez &true; pour que les alias des méthodes de chiffrement
        soient inclus dans le tableau retourné.
       </para>
      </listitem>
@@ -43,7 +43,7 @@
    Un <type>array</type> des méthodes de chiffrements disponibles.
    Il est à noter qu'avant OpenSSL 1.1.1, les méthodes de chiffrements
    étaient retournées en majuscule et en minuscule ; à partir d'OpenSSL 1.1.1
-   seul la variante en minuscule est retourné.
+   seule la variante en minuscule est retournée.
   </para>
  </refsect1>
 

--- a/reference/openssl/functions/openssl-get-curve-names.xml
+++ b/reference/openssl/functions/openssl-get-curve-names.xml
@@ -21,11 +21,11 @@
    standardisées / supportées sont <emphasis>prime256v1</emphasis>
    (NIST P-256) et <emphasis>secp384r1</emphasis> (NIST P-384).
    <table>
-    <title>Équivalences approximatives des taille de clés d'AES, RSA, DSA et ECC</title>
+    <title>Équivalences approximatives des tailles de clés d'AES, RSA, DSA et ECC</title>
     <tgroup cols="3">
      <thead>
       <row>
-       <entry>Taille de clé symétriques AES (Bits)</entry>
+       <entry>Taille de clé symétrique AES (Bits)</entry>
        <entry>Taille de clé RSA et DSA (Bits)</entry>
        <entry>Taille de clé ECC (Bits)</entry>
       </row>

--- a/reference/openssl/functions/openssl-open.xml
+++ b/reference/openssl/functions/openssl-open.xml
@@ -144,7 +144,7 @@
 <?php
 
 // On suppose que $sealed, $env_key et $iv contiennent les données scellées,
-// la clé d'enveloppe et IV. Toutes ournies par l'expéditeur.
+// la clé d'enveloppe et IV. Toutes fournies par l'expéditeur.
 
 // Récupérer la clé privée depuis le fichier situé dans private_key.pem
 $pkey = openssl_get_privatekey("file://private_key.pem");

--- a/reference/openssl/functions/openssl-pkcs12-export-to-file.xml
+++ b/reference/openssl/functions/openssl-pkcs12-export-to-file.xml
@@ -43,7 +43,7 @@
       <para>
        Clé privée du fichier <acronym>PKCS</acronym>#12.
        Voir <link linkend="openssl.certparams">paramètres Clé/Certificat</link>
-       pour une liste de valeur valide.
+       pour une liste de valeurs valides.
       </para>
      </listitem>
     </varlistentry>
@@ -72,7 +72,7 @@
           <row>
            <entry><literal>"extracerts"</literal></entry>
            <entry>
-            tableau de certificats supplémentaire ou un certificat unique à inclure
+            tableau de certificats supplémentaires ou un certificat unique à inclure
             dans le fichier <acronym>PKCS</acronym>#12.</entry>
           </row>
           <row>

--- a/reference/openssl/functions/openssl-pkcs7-decrypt.xml
+++ b/reference/openssl/functions/openssl-pkcs7-decrypt.xml
@@ -19,7 +19,7 @@
   </methodsynopsis>
   <para>
    Déchiffre le message S/MIME contenu dans le fichier
-   <parameter>input_filename</parameter>, en utilisant le certificat et la clé privée associé par
+   <parameter>input_filename</parameter>, en utilisant le certificat et la clé privée associés par
    <parameter>certificate</parameter> et <parameter>private_key</parameter>.
   </para>
  </refsect1>

--- a/reference/openssl/functions/openssl-pkcs7-read.xml
+++ b/reference/openssl/functions/openssl-pkcs7-read.xml
@@ -30,7 +30,7 @@
     <term><parameter>data</parameter></term>
     <listitem>
      <para>
-      La chaîne de donnée qui doit être analysé (au format p7b).
+      La chaîne de données qui doit être analysée (au format p7b).
      </para>
     </listitem>
    </varlistentry>

--- a/reference/openssl/functions/openssl-pkcs7-sign.xml
+++ b/reference/openssl/functions/openssl-pkcs7-sign.xml
@@ -54,7 +54,7 @@
       <para>
        Le certificat X.509 utilisé pour signer numériquement <parameter>input_filename</parameter>.
        Voir <link linkend="openssl.certparams">paramètres Clé/Certificat</link>
-       pour une liste de valeur valide.
+       pour une liste de valeurs valides.
       </para>
      </listitem>
     </varlistentry>
@@ -64,7 +64,7 @@
       <para>
        <parameter>private_key</parameter> est la clé privée correspondant à <parameter>certificate</parameter>.
        Voir <link linkend="openssl.certparams">paramètres Clé Publique/Privée</link>
-       pour une liste de valeur valide.
+       pour une liste de valeurs valides.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/openssl/functions/openssl-pkcs7-verify.xml
+++ b/reference/openssl/functions/openssl-pkcs7-verify.xml
@@ -65,7 +65,7 @@
       <para>
        Si le paramètre <parameter>ca_info</parameter> est spécifié, il doit
        contenir les informations sur les tiers de certificats de confiance
-       utilisé lors de la vérification. Voir
+       utilisés lors de la vérification. Voir
        <link linkend="openssl.cert.verification">vérification des certificats</link>
        pour plus de détails.
       </para>
@@ -86,7 +86,7 @@
      <listitem>
       <para>
        Il est possible de spécifier un nom de fichier avec le paramètre
-       <parameter>content</parameter> qui peut être remplit avec les données vérifiées,
+       <parameter>content</parameter> qui peut être rempli avec les données vérifiées,
        mais avec les informations de signature.
       </para>
      </listitem>

--- a/reference/openssl/functions/openssl-pkey-derive.xml
+++ b/reference/openssl/functions/openssl-pkey-derive.xml
@@ -65,7 +65,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Le secret dérivé sur succès&return.falseforfailure;.
+   Le secret dérivé en cas de succès&return.falseforfailure;.
   </para>
  </refsect1>
 

--- a/reference/openssl/functions/openssl-pkey-export-to-file.xml
+++ b/reference/openssl/functions/openssl-pkey-export-to-file.xml
@@ -59,7 +59,7 @@
       <para>
        <parameter>options</parameter> peut être utilisé pour calibrer le processus
        d'exportation en spécifiant ou remplaçant les options du fichier
-       de configuration d'OpenSSl. Voir <function>openssl_csr_new</function> 
+       de configuration d'OpenSSL. Voir <function>openssl_csr_new</function>
        pour plus d'informations sur <parameter>options</parameter>.
       </para>
      </listitem>

--- a/reference/openssl/functions/openssl-pkey-export.xml
+++ b/reference/openssl/functions/openssl-pkey-export.xml
@@ -57,7 +57,7 @@
       <para>
        <parameter>options</parameter> peut être utilisé pour calibrer le processus
        d'exportation en spécifiant ou remplaçant les options du fichier
-       de configuration d'OpenSSl. Voir <function>openssl_csr_new</function> 
+       de configuration d'OpenSSL. Voir <function>openssl_csr_new</function>
        pour plus d'informations sur <parameter>options</parameter>.
       </para>
      </listitem>

--- a/reference/openssl/functions/openssl-pkey-get-details.xml
+++ b/reference/openssl/functions/openssl-pkey-get-details.xml
@@ -78,7 +78,7 @@
         </row>
         <row>
          <entry><literal>"e"</literal></entry>
-         <entry>exposant publique</entry>
+         <entry>exposant public</entry>
         </row>
         <row>
          <entry><literal>"d"</literal></entry>
@@ -128,7 +128,7 @@
         </row>
         <row>
          <entry><literal>"q"</literal></entry>
-         <entry>160-bit nombre sous-prime, q | p-1 (publique</entry>
+         <entry>160-bit nombre sous-prime, q | p-1 (public)</entry>
         </row>
         <row>
          <entry><literal>"g"</literal></entry>
@@ -136,7 +136,7 @@
         </row>
         <row>
          <entry><literal>"priv_key"</literal></entry>
-         <entry>clé privé x</entry>
+         <entry>clé privée x</entry>
         </row>
         <row>
          <entry><literal>"pub_key"</literal></entry>

--- a/reference/openssl/functions/openssl-pkey-get-private.xml
+++ b/reference/openssl/functions/openssl-pkey-get-private.xml
@@ -64,7 +64,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Retourne une instance de <classname>OpenSSLAsymmetricKey</classname> cas de succès, ou
+   Retourne une instance de <classname>OpenSSLAsymmetricKey</classname> en cas de succès, ou
    &false; si une erreur survient.
   </para>
  </refsect1>

--- a/reference/openssl/functions/openssl-private-decrypt.xml
+++ b/reference/openssl/functions/openssl-private-decrypt.xml
@@ -26,7 +26,7 @@
   </para>
   <para>
    Il est possible d'utiliser cette fonction, par exemple pour déchiffrer des données 
-   qui ne sont censées être disponibles que pour l'on.
+   qui ne sont censées être disponibles que pour soi.
   </para>
  </refsect1>
 

--- a/reference/openssl/functions/openssl-private-encrypt.xml
+++ b/reference/openssl/functions/openssl-private-encrypt.xml
@@ -53,7 +53,7 @@
      <listitem>
       <para>
        <parameter>private_key</parameter> doit être la clé privée correspondant
-       à la clé publique qui sera utilisée pour décrypter les données.
+       à la clé publique qui sera utilisée pour déchiffrer les données.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/openssl/functions/openssl-public-encrypt.xml
+++ b/reference/openssl/functions/openssl-public-encrypt.xml
@@ -56,7 +56,7 @@
      <listitem>
       <para>
        <parameter>public_key</parameter> doit être la clé publique correspondant
-       à la clé privée qui sera utilisée pour décrypter les données.
+       à la clé privée qui sera utilisée pour déchiffrer les données.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/openssl/functions/openssl-seal.xml
+++ b/reference/openssl/functions/openssl-seal.xml
@@ -129,7 +129,7 @@
       <entry>8.0.0</entry>
       <entry>
        <parameter>public_key</parameter> accepte désormais un &array;
-       d'instance de <classname>OpenSSLAsymmetricKey</classname> ;
+       d'instances de <classname>OpenSSLAsymmetricKey</classname> ;
        auparavant, un &array; de &resource;s de type <literal>OpenSSL key</literal>
        était acceptée.
       </entry>

--- a/reference/openssl/functions/openssl-spki-export-challenge.xml
+++ b/reference/openssl/functions/openssl-spki-export-challenge.xml
@@ -70,7 +70,7 @@ $challenge = openssl_spki_export_challenge(preg_replace('/SPKAC=/', '', $spkac))
   <example xml:id="openssl_spki_export_challenge.example.keygen">
    <title>Exemple avec <function>openssl_spki_export_challenge</function> depuis &lt;keygen&gt;</title>
    <para>
-    Extrait le challenge associé issue d'un élément &lt;keygen&gt;
+    Extrait le challenge associé issu d'un élément &lt;keygen&gt;
    </para>
    <programlisting role="php">
 <![CDATA[

--- a/reference/openssl/functions/openssl-spki-new.xml
+++ b/reference/openssl/functions/openssl-spki-new.xml
@@ -31,7 +31,7 @@
       <para>
        <parameter>private_key</parameter> doit être une clé privée
        qui a été précédemment générée par la fonction
-       <function>openssl_pkey_new</function> (ou sinon, obtenu depuis
+       <function>openssl_pkey_new</function> (ou sinon, obtenue depuis
        une fonction de la famille openssl_pkey). La portion
        publique de la clé sera utilisée pour signer le <acronym>CSR</acronym>.
       </para>
@@ -68,7 +68,7 @@
   &reftitle.errors;
   <para>
    Émet une alerte de niveau <constant>E_WARNING</constant> si
-   un algorithme avec une signature non connue est passée via le
+   un algorithme avec une signature non connue est passé via le
    paramètre <parameter>digest_algo</parameter>.
   </para>
  </refsect1>

--- a/reference/openssl/functions/openssl-verify.xml
+++ b/reference/openssl/functions/openssl-verify.xml
@@ -52,7 +52,7 @@
      <term><parameter>public_key</parameter></term>
      <listitem>
       <para>
-       <classname>OpenSSLAsymmetricKey</classname> - une clé, retourné par la fonction
+       <classname>OpenSSLAsymmetricKey</classname> - une clé, retournée par la fonction
        <function>openssl_get_publickey</function>
       </para>
       <para>

--- a/reference/openssl/functions/openssl-x509-parse.xml
+++ b/reference/openssl/functions/openssl-x509-parse.xml
@@ -34,7 +34,7 @@
      <listitem>
       <para>
        Certificat X509. Voir <link linkend="openssl.certparams">paramètre de
-       Clé/Certificat</link> pour une list de valeur valide.
+       Clé/Certificat</link> pour une liste de valeurs valides.
       </para>
      </listitem>
     </varlistentry>


### PR DESCRIPTION
Fix grammar and spelling in openssl/ documentation