### PR TITLE
Fix grammar and spelling in parallel/ and pthreads/ documentation

### DIFF
--- a/reference/parallel/book.xml
+++ b/reference/parallel/book.xml
@@ -10,7 +10,7 @@
   &reftitle.intro;
   <simpara>
   parallel est une extension de concurrence parallèle pour PHP ≥ 7.2.0.
-  A partir de parallel 1.2.0, PHP ≥ 8.0.0 est requis.
+  À partir de parallel 1.2.0, PHP ≥ 8.0.0 est requis.
   </simpara>
   <simpara>
    Une brève description des concepts de base de parallel suit, des informations plus détaillées peuvent être trouvées dans cette section du manuel.
@@ -80,7 +80,7 @@
    </simpara>
   </simplesect>
   <simplesect>
-   <title>Evénements</title>
+   <title>Événements</title>
    <simpara>
     L'API <classname>parallel\Events</classname> implémente une boucle d'événements (<classname>Traversable</classname>) native, et la méthode <methodname>parallel\Events::poll</methodname>.
     Cela permet au développeur de travailler avec des ensembles de canaux et/ou de futurs.

--- a/reference/parallel/functions/parallel.bootstrap.xml
+++ b/reference/parallel/functions/parallel.bootstrap.xml
@@ -14,7 +14,7 @@
    <methodparam><type>string</type><parameter>file</parameter></methodparam>
   </methodsynopsis>
   <simpara>
-   Utilise le <parameter>file</parameter> fourni pour amorcer tous les exécutions créés pour la planification automatique via <function>parallel\run</function>.
+   Utilise le <parameter>file</parameter> fourni pour amorcer toutes les exécutions créées pour la planification automatique via <function>parallel\run</function>.
   </simpara>
  </refsect1>
 
@@ -25,7 +25,7 @@
     <term><parameter>file</parameter></term>
     <listitem>
      <simpara>
-      Le chemin du fichier pour amorcer tous les exécutions.
+      Le chemin du fichier pour amorcer toutes les exécutions.
      </simpara>
     </listitem>
    </varlistentry>

--- a/reference/parallel/parallel.channel.xml
+++ b/reference/parallel/parallel.channel.xml
@@ -29,7 +29,7 @@
   <section>
     <title>Fermetures sur les canaux</title>
     <simpara>
-     Une fonctionnalité puissante des canaux parallèles est qu'elles permettent l'échange de fermetures entre les tâches (et les runtimes).
+     Une fonctionnalité puissante des canaux parallèles est qu'ils permettent l'échange de fermetures entre les tâches (et les runtimes).
     </simpara>
     <simpara>
      Lorsqu'une fermeture est envoyée sur un canal, la fermeture est tamponnée, cela ne change pas le tampon du canal transmettant la fermeture,
@@ -64,7 +64,7 @@
     </classsynopsisinfo>
 <!-- }}} -->
 
-    <classsynopsisinfo role="comment">Constructeur anonymes</classsynopsisinfo>
+    <classsynopsisinfo role="comment">Constructeur anonyme</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.parallel-channel')/db:refentry/db:refsect1[@audience='anonymous']/descendant::db:methodsynopsis[not(@role='procedural')])">
      <xi:fallback/>
     </xi:include>

--- a/reference/parallel/parallel.events.event.xml
+++ b/reference/parallel/parallel.events.event.xml
@@ -30,7 +30,7 @@
     </classsynopsisinfo>
 <!-- }}} -->
 
-    <classsynopsisinfo role="comment">Doit être un des constantes <classname>Event\Type</classname></classsynopsisinfo>
+    <classsynopsisinfo role="comment">Doit être une des constantes <classname>Event\Type</classname></classsynopsisinfo>
     <fieldsynopsis>
      <modifier>public</modifier>
      <type>int</type>
@@ -51,7 +51,7 @@
      <varname>object</varname>
     </fieldsynopsis>
 
-    <classsynopsisinfo role="comment">Doit être définit les événements de lecture/Erreur</classsynopsisinfo>
+    <classsynopsisinfo role="comment">Doit être défini pour les événements de lecture/Erreur</classsynopsisinfo>
     <fieldsynopsis>
      <modifier>public</modifier>
      <varname>value</varname>

--- a/reference/parallel/parallel.events.input.xml
+++ b/reference/parallel/parallel.events.input.xml
@@ -8,7 +8,7 @@
  <partintro>
 
   <section>
-    <title>Evénements d'entrée</title>
+    <title>Événements d'entrée</title>
     <simpara>
      Un objet d'entrée est un conteneur pour les données que l'objet <classname>parallel\Events</classname> écrira dans
      les objets <classname>parallel\Channel</classname> au fur et à mesure qu'elles deviendront disponibles. Plusieurs boucles d'événements peuvent partager un conteneur d'entrée - parallel ne vérifie pas

--- a/reference/parallel/parallel.future.xml
+++ b/reference/parallel/parallel.future.xml
@@ -87,7 +87,7 @@ parent continues
      <xi:fallback/>
     </xi:include>
 
-    <classsynopsisinfo role="comment">Etats</classsynopsisinfo>
+    <classsynopsisinfo role="comment">États</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.parallel-future')/db:refentry/db:refsect1[@audience='state']/descendant::db:methodsynopsis[not(@role='procedural')])">
      <xi:fallback/>
     </xi:include>

--- a/reference/parallel/parallel.sync.xml
+++ b/reference/parallel/parallel.sync.xml
@@ -9,7 +9,7 @@
   <section>
     <title>Synchronisation de bas niveau</title>
     <simpara>
-     La classe <classname>parallel\Sync</classname> fournit un accès aux primitives de synchronisation de bas niveau, mutex, variables de condition, et permet la mise en oeuvre de sémaphores.
+     La classe <classname>parallel\Sync</classname> fournit un accès aux primitives de synchronisation de bas niveau, mutex, variables de condition, et permet la mise en œuvre de sémaphores.
     </simpara>
 
     <simpara>

--- a/reference/parallel/parallel/events/poll.xml
+++ b/reference/parallel/parallel/events/poll.xml
@@ -24,7 +24,7 @@
     S'il ne reste plus de cibles, &null; sera retourné
    </simpara>
    <simpara>
-    Ceci est un boucle non-bloquante, et si un blocage se produit, &null; sera retourné
+    Ceci est une boucle non-bloquante, et si un blocage se produit, &null; sera retourné
    </simpara>
    <simpara>
     Sinon l'<classname>parallel\Events\Event</classname> retourné décrit l'événement.

--- a/reference/parallel/parallel/events/setblocking.xml
+++ b/reference/parallel/parallel/events/setblocking.xml
@@ -10,7 +10,7 @@
  <refsect1 role="description" audience="behaviour">
   &reftitle.description;
   <simpara>
-   Par défait lorsqu'un événement est interrogé, un blocage se produit (au niveau de PHP) jusqu'à ce que le premier événement puisse être retourné: Définir le mode de blocage à &false; fera
+   Par défaut lorsqu'un événement est interrogé, un blocage se produit (au niveau de PHP) jusqu'à ce que le premier événement puisse être retourné: Définir le mode de blocage à &false; fera
    en sorte que l'interrogation retourne le contrôle si la première cible interrogée n'est pas prête.
   </simpara>
   <simpara>
@@ -18,7 +18,7 @@
    d'être lancée, ce qui peut être extrêmement lent ou gaspilleur si ce qui est vraiment désiré est un comportement non-bloquant.
   </simpara>
   <simpara>
-   Un boucle non-bloquante affecte la valeur de retour de <methodname>parallel\Events::poll</methodname>, de sorte qu'il peut être &null; avant que tous les événements aient été traités.
+   Une boucle non-bloquante affecte la valeur de retour de <methodname>parallel\Events::poll</methodname>, de sorte qu'il peut être &null; avant que tous les événements aient été traités.
   </simpara>
   <methodsynopsis>
    <modifier>public</modifier> <type>void</type><methodname>parallel\Events::setBlocking</methodname>

--- a/reference/parallel/parallel/events/setinput.xml
+++ b/reference/parallel/parallel/events/setinput.xml
@@ -4,7 +4,7 @@
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="parallel-events.setinput">
  <refnamediv>
   <refname>parallel\Events::setInput</refname>
-  <refpurpose>Entré</refpurpose>
+  <refpurpose>Entrée</refpurpose>
  </refnamediv>
 
  <refsect1 role="description" audience="input">

--- a/reference/parallel/parallel/future/cancelled.xml
+++ b/reference/parallel/parallel/future/cancelled.xml
@@ -4,7 +4,7 @@
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="parallel-future.cancelled">
  <refnamediv>
   <refname>parallel\Future::cancelled</refname>
-  <refpurpose>Detection d'état</refpurpose>
+  <refpurpose>Détection d'état</refpurpose>
  </refnamediv>
 
  <refsect1 role="description" audience="state">

--- a/reference/parallel/parallel/future/done.xml
+++ b/reference/parallel/parallel/future/done.xml
@@ -4,7 +4,7 @@
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="parallel-future.done">
  <refnamediv>
   <refname>parallel\Future::done</refname>
-  <refpurpose>Detection d'état</refpurpose>
+  <refpurpose>Détection d'état</refpurpose>
  </refnamediv>
 
  <refsect1 role="description" audience="state">

--- a/reference/pthreads/book.xml
+++ b/reference/pthreads/book.xml
@@ -40,7 +40,7 @@
   </warning>
   <simpara>
    La classe <classname>Threaded</classname> constitue la base de la
-   fonctionnalité qui permet à pthreads de fonctionner. Il expose les méthodes
+   fonctionnalité qui permet à pthreads de fonctionner. Elle expose les méthodes
    de synchronisation et quelques interfaces utiles pour le programmeur.
   </simpara>
   <simpara>
@@ -57,7 +57,7 @@
    La classe <classname>Worker</classname> a un état persistant et sera
    disponible à partir de l'appel à <methodname>Thread::start</methodname> (une
    méthode héritée) jusqu'à ce que l'objet soit hors de portée, ou soit
-   explicitement arreté (via <methodname>Worker::shutdown</methodname>). Tout
+   explicitement arrêté (via <methodname>Worker::shutdown</methodname>). Tout
    contexte avec une référence à l'objet Worker peut empiler des tâches sur le
    Worker (via <methodname>Worker::stack</methodname>), où ces tâches seront
    exécutées par le Worker dans un thread séparé. La méthode
@@ -100,8 +100,8 @@
   </simpara>
   <caution>
    <simpara>
-    Tout objet prévu pour être utilisé dans une partie multithreadé du
-    application doit étendre <classname>Threaded</classname>.
+    Tout objet prévu pour être utilisé dans une partie multithreadée de
+    l'application doit étendre <classname>Threaded</classname>.
    </simpara>
   </caution>
   <simpara>
@@ -112,12 +112,12 @@
    les tableaux et les objets qui ne sont pas Threadés, sont stockés sérialisés ; ils peuvent être lus
    et écrits dans l'objet Threadé depuis n'importe quel contexte avec une référence.
    A l'exception des objets Threadés, toute référence utilisée pour définir un membre d'un objet Threadé
-   est séparé de la référence dans l'objet Threadé ; les mêmes données peuvent être lues directement
+   est séparée de la référence dans l'objet Threadé ; les mêmes données peuvent être lues directement
    depuis l'objet Threadé à tout moment par n'importe quel contexte avec une référence vers l'objet Threadé.
   </simpara>
   <simpara>
    Membres statiques : Lorsqu'un nouveau contexte est créé (Thread ou Worker),
-   ils sont généralement copiés, mais les ressources et objects avec un état
+   ils sont généralement copiés, mais les ressources et objets avec un état
    interne sont nullifiés (pour des raisons de sécurité). Ceci permet alors à la fonction une sorte de stockage local
    au niveau du thread. Par exemple, lors du démarrage du contexte, une classe dont les membres statiques
    incluent des informations de connexion vers un serveur de base de données, seules les informations
@@ -133,10 +133,10 @@
   </caution>
   <note>
    <simpara>
-    Ressources : Les extensions et les fonctionnalités qui définissent des ressoures en PHP ne sont pas préparées
+    Ressources : Les extensions et les fonctionnalités qui définissent des ressources en PHP ne sont pas préparées
     pour ce type d'environnement ; pthreads prend des dispositions en matière de ressource à partager entre
     les contextes, cependant, pour la plupart des ressources, elles devront être considérées comme dangereuses.
-    Un soin et une extrème prudence devront être de mise pour partager les ressources entre les contextes.
+    Un soin et une extrême prudence devront être de mise pour partager les ressources entre les contextes.
    </simpara>
   </note>
   <caution>

--- a/reference/pthreads/constants.xml
+++ b/reference/pthreads/constants.xml
@@ -84,7 +84,7 @@
    </term>
    <listitem>
     <simpara>
-     L'héritage inclus l'information de fichier lorsque les nouveaux
+     L'héritage inclut l'information de fichier lorsque les nouveaux
      threads sont démarrés
     </simpara>
    </listitem>
@@ -109,7 +109,7 @@
    <listitem>
     <simpara>
      Autorise les nouveaux threads à envoyer les en-têtes à la sortie
-     standart (normalement non autorisé)
+     standard (normalement non autorisé)
     </simpara>
    </listitem>
   </varlistentry>

--- a/reference/pthreads/pool/collect.xml
+++ b/reference/pthreads/pool/collect.xml
@@ -15,7 +15,7 @@
    <methodparam choice="opt"><type>Callable</type><parameter>collector</parameter></methodparam>
   </methodsynopsis>
   <simpara>
-   Permet au pool de collecter des références déterminées pour être collectée
+   Permet au pool de collecter des références déterminées pour être collectées
    par le collecteur donné optionnellement.
   </simpara>
  </refsect1>

--- a/reference/pthreads/pool/submitTo.xml
+++ b/reference/pthreads/pool/submitTo.xml
@@ -17,7 +17,7 @@
   </methodsynopsis>
   <simpara>
    Soumet la tâche au worker spécifié dans le Pool. Les travailleurs sont
-   indexés à partir de 0, et n'existera que si le pool a besoin de les créer
+   indexés à partir de 0, et n'existeront que si le pool a besoin de les créer
    (puisque les threads sont générés paresseusement).
   </simpara>
  </refsect1>

--- a/reference/pthreads/setup.xml
+++ b/reference/pthreads/setup.xml
@@ -8,7 +8,7 @@
  <section xml:id="pthreads.requirements">
   &reftitle.required;
   <simpara>
-   Pthreads requièrt une construction de PHP avec ZTS activé
+   Pthreads requiert une construction de PHP avec ZTS activé
    (<option role="configure">--enable-zts</option>, ou sur les systèmes non-Windows antérieurs à PHP 8.0.0,
    <option role="configure">--enable-maintainer-zts</option>).
   </simpara>
@@ -28,7 +28,7 @@
  <section xml:id="pthreads.installation">
   &reftitle.install;
   <simpara>
-   Les versions de pthreads sont hébergés par PECL et les sources sur
+   Les versions de pthreads sont hébergées par PECL et les sources sur
     <link xlink:href="&url.git.hub;krakjoe/pthreads">github</link>.
    La procédure d'installation la plus simple est la procédure PECL standard :
    <link xlink:href="&url.pecl.package;pthreads">&url.pecl.package;pthreads</link>.

--- a/reference/pthreads/thread/getcurrentthread.xml
+++ b/reference/pthreads/thread/getcurrentthread.xml
@@ -15,7 +15,7 @@
    <void/>
   </methodsynopsis>
   <simpara>
-   Retourne un référence du thread actuellement en cours d'exécution
+   Retourne une référence du thread actuellement en cours d'exécution
   </simpara>
 
  </refsect1>

--- a/reference/pthreads/threaded/extend.xml
+++ b/reference/pthreads/threaded/extend.xml
@@ -15,7 +15,7 @@
    <methodparam><type>string</type><parameter>class</parameter></methodparam>
   </methodsynopsis>
   <simpara>
-   Rend la classe standart sécurisée au nivau du thread pendant l'exécution.
+   Rend la classe standard sécurisée au niveau du thread pendant l'exécution.
   </simpara>
  </refsect1>
 

--- a/reference/pthreads/threaded/run.xml
+++ b/reference/pthreads/threaded/run.xml
@@ -15,8 +15,8 @@
    <void/>
   </methodsynopsis>
   <simpara>
-   Le développeur doit toujours implément la méthode run pour les objets
-   qui doivent être exécuté.
+   Le développeur doit toujours implémenter la méthode run pour les objets
+   qui doivent être exécutés.
   </simpara>
  </refsect1>
 

--- a/reference/pthreads/worker.xml
+++ b/reference/pthreads/worker.xml
@@ -18,7 +18,7 @@
    </simpara>
    <simpara>
     Quand un Worker est démarré, la méthode <methodname>run</methodname> sera
-    exécuté, mais le <classname>Thread</classname> ne
+    exécutée, mais le <classname>Thread</classname> ne
     s'arrêtera pas tant qu'une des conditions suivantes n'est pas atteinte :
    </simpara>
    <itemizedlist>


### PR DESCRIPTION
Fix grammar and spelling in parallel/ and pthreads/ documentation