### PR TITLE
Fix grammar and spelling in session/ and outcontrol/ documentation

### DIFF
--- a/reference/outcontrol/flushing-system-buffers.xml
+++ b/reference/outcontrol/flushing-system-buffers.xml
@@ -31,7 +31,7 @@
     </listitem>
     <listitem>
      <simpara>
-      afficher par des constructions de langage et des fonctions
+      affichées par des constructions de langage et des fonctions
       dont le but explicite est d'afficher des variables ou des chaînes fournies par l'utilisateur telles que
       <function>echo</function>, <function>print</function>,
       <function>printf</function>, <function>var_dump</function>,
@@ -49,7 +49,7 @@
     </listitem>
     <listitem>
      <simpara>
-      afficher par PHP sur une exception non capturée ou une erreur non gérée
+      affichées par PHP sur une exception non capturée ou une erreur non gérée
       (sous réserve des paramètres de
       <link linkend="ini.display-errors">display_errors</link>
       et <link linkend="ini.error-reporting">error_reporting</link>)
@@ -128,7 +128,7 @@
     </listitem>
     <listitem>
      <simpara>
-      d'autre <acronym>SAPI</acronym>s
+      d'autres <acronym>SAPI</acronym>s
       tels que <literal>CLI</literal> et <literal>embed</literal>
       videront la sortie uniquement
      </simpara>

--- a/reference/outcontrol/functions/ob-get-status.xml
+++ b/reference/outcontrol/functions/ob-get-status.xml
@@ -55,7 +55,7 @@
   </para>
   <para>
    <segmentedlist>
-    <title>Éléments retourné par la fonction <function>ob_get_status</function></title>
+    <title>Éléments retournés par la fonction <function>ob_get_status</function></title>
     <segtitle>Clé</segtitle><segtitle>Valeur</segtitle>
     <seglistitem>
      <seg>name</seg>
@@ -100,7 +100,7 @@
     <seglistitem>
      <seg>chunk_size</seg>
      <seg>
-      Taille du fragment en octets. Définit par la fonction <function>ob_start</function>
+      Taille du fragment en octets. Définie par la fonction <function>ob_start</function>
       ou <link linkend="ini.output-buffering">output_buffering</link> s'il est activé
       et sa valeur est définie sur un entier positif
      </seg>

--- a/reference/outcontrol/user-level-output-buffers.xml
+++ b/reference/outcontrol/user-level-output-buffers.xml
@@ -4,8 +4,8 @@
 <chapter xml:id="outcontrol.user-level-output-buffers" xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>Tampons de sortie au niveau utilisateur</title>
  <para>
-  La bufferisation de sortie au niveau utilisateur de PHP peut commencé, manipulé
-  et terminé depuis le code PHP.
+  La bufferisation de sortie au niveau utilisateur de PHP peut être commencée, manipulée
+  et terminée depuis le code PHP.
   Chacun de ces tampons inclut un tampon de sortie
   et une fonction de gestion de sortie associée.
  </para>
@@ -312,7 +312,7 @@
    </simpara>
   </note>
   <para>
-   Si omit ou &null; lors du démarrage du tampon de sortie
+   Si omis ou &null; lors du démarrage du tampon de sortie
    le gestionnaire de sortie interne <literal>"gestionnaire de sortie par défaut"</literal> sera utilisé
    qui retourne le contenu du tampon non modifié lorsqu'il est invoqué.
    Les gestionnaires de sortie peuvent être utilisés pour retourner une version modifiée

--- a/reference/session/examples.xml
+++ b/reference/session/examples.xml
@@ -158,8 +158,8 @@ unset($_SESSION['count']);
    Alternativement, il est possible d'utiliser la constante <constant>SID</constant>
    qui est définie si la session a commencé. Si le client n'envoie pas un cookie de session
    approprié, il aura la forme <literal>session_name=session_id</literal>.
-   Sinon, il vaudra une chaîne vide. Ainsi, il est possible de dans tous les cas
-   l'inclure dans l'URL.
+   Sinon, il vaudra une chaîne vide. Ainsi, il est possible de l'inclure dans tous les cas
+   dans l'URL.
   </para>
   <para>
    L'exemple suivant montre comment enregistrer une variable et comment
@@ -217,7 +217,7 @@ if (empty($_SESSION['count'])) {
    Pour implémenter un stockage en base de données, ou toute autre méthode,
    on aura besoin de la fonction <function>session_set_save_handler</function> pour
    paramétrer ses propres fonctions de stockage.
-   Un gestionnaires de session peut être crée en utilisant l'interface
+   Un gestionnaire de session peut être créé en utilisant l'interface
    <classname>SessionHandlerInterface</classname> ou en étendant les
    gestionnaires internes de PHP en héritant de la classe
    <classname>SessionHandler</classname>.

--- a/reference/session/functions/session-create-id.xml
+++ b/reference/session/functions/session-create-id.xml
@@ -41,9 +41,9 @@
       <listitem>
        <para>
         Si <parameter>prefix</parameter> est spécifié, le nouvel ID de session
-        est préfixé par <parameter>prefix</parameter>. Pas tous
-        les caractères sont autorisés dans l'ID de session. Les caractères
-        parmi <literal>[a-z A-Z 0-9]</literal> sont autorisés. Longueur maximale est de 256 caractères.
+        est préfixé par <parameter>prefix</parameter>. Tous
+        les caractères ne sont pas autorisés dans l'ID de session. Les caractères
+        parmi <literal>[a-z A-Z 0-9]</literal> sont autorisés. La longueur maximale est de 256 caractères.
        </para> 
       </listitem>
      </varlistentry>

--- a/reference/session/functions/session-destroy.xml
+++ b/reference/session/functions/session-destroy.xml
@@ -39,7 +39,7 @@
   </para>
   <para>
    Quand <link linkend="ini.session.use-strict-mode">session.use_strict_mode</link>
-   est activé. Il n'est pas nécessaire d'effacer le cookies d'ID de session
+   est activé. Il n'est pas nécessaire d'effacer le cookie d'ID de session
    obsolète car le module de session n'accepte pas les cookies d'ID de sessions
    quand il n'y a pas de données associées à cet ID de session et définira un
    nouvel cookie d'ID de session.
@@ -58,7 +58,7 @@
     vide, mais la suppression immédiate de session peut provoquer un cookie
     d'ID de session vide à cause d'une condition de concurrence côté client 
     (navigateur). Ceci provoquera la création de beaucoup d'ID de session
-    inutile par le client.
+    inutiles par le client.
    </para>
    <para>
     Pour éviter ceci, il faut définir un horodatage à $_SESSION et

--- a/reference/session/functions/session-module-name.xml
+++ b/reference/session/functions/session-module-name.xml
@@ -68,7 +68,7 @@
      <row>
       <entry>7.2.0</entry>
       <entry>
-       Il est désormais explicitement interdit de définir le nom du mode en tant que
+       Il est désormais explicitement interdit de définir le nom du module en tant que
        <literal>"user"</literal>. Auparavant, ceci était silencieusement ignoré.
       </entry>
      </row>

--- a/reference/session/ini.xml
+++ b/reference/session/ini.xml
@@ -851,7 +851,7 @@
       <literal>session.sid_bits_per_character</literal> permet de spécifier le
       nombre de bits dans le caractère codé dans l'ID de session. Les valeurs
       possibles sont
-      '4' (0-9, a-f), '5' (0-9, a-v), and '6' (0-9, a-z, A-Z, "-", ",").
+      '4' (0-9, a-f), '5' (0-9, a-v), et '6' (0-9, a-z, A-Z, "-", ",").
      </simpara>
      <simpara>
       La valeur par défaut est 4. Plus de bits aboutit à un ID de session plus
@@ -992,7 +992,7 @@
      <simpara>
       Définit le nombre de fois où les informations de progression de téléchargement
       doivent être mises à jour. Peut être défini en octets (c.-à-d. "mettre à jour
-      les informations de progression de téléchargement tous les 100 octets),
+      les informations de progression de téléchargement tous les 100 octets"),
       ou en pourcentage (c.-à-d. "mettre à jour les informations de progression de
       téléchargement tous les 1% de réception du poids total du fichier").
      </simpara>
@@ -1023,7 +1023,7 @@
     <listitem>
      <simpara>
       <literal>session.lazy_write</literal>, quand défini à 1, cela signifie que
-      la donnée de session ne sera réécrite uniquement si celle-ci change. Par
+      la donnée de session ne sera réécrite que si celle-ci change. Par
       défaut 1, activé.
      </simpara>
     </listitem>

--- a/reference/session/security.xml
+++ b/reference/session/security.xml
@@ -259,7 +259,7 @@
     <simpara>
      La suppression soudaine d'une session active produit des effets de bords
      indésirables. Les sessions peuvent disparaître lorsqu'il y a des connexions
-     concurentes sur l'application web et/ou lorsque le réseau est instable.
+     concurrentes sur l'application web et/ou lorsque le réseau est instable.
     </simpara>
     <simpara>
      Les accès potentiellement malicieux sont indétectables avec la suppression

--- a/reference/session/sessionhandler/destroy.xml
+++ b/reference/session/sessionhandler/destroy.xml
@@ -20,7 +20,7 @@
    <function>session_decode</function> échoue.
   </para>
   <para>
-   Cette méthode se substitut au gestionnaire interne de sauvegarde de PHP défini via l'option
+   Cette méthode se substitue au gestionnaire interne de sauvegarde de PHP défini via l'option
    de configuration <link linkend="ini.session.save-handler">session.save_handler</link> qui a été
    définie avant celui défini via la fonction <function>session_set_save_handler</function>.
   </para>

--- a/reference/session/sessionhandler/write.xml
+++ b/reference/session/sessionhandler/write.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="sessionhandler.write" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>SessionHandler::write</refname>
-  <refpurpose>Ecrit des données dans la session</refpurpose>
+  <refpurpose>Écrit des données dans la session</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/session/sessionhandlerinterface/gc.xml
+++ b/reference/session/sessionhandlerinterface/gc.xml
@@ -28,7 +28,7 @@
     <term><parameter>max_lifetime</parameter></term>
     <listitem>
      <para>
-      Les sessions qui n'ont pas été mit à jour durant les <parameter>max_lifetime</parameter> dernières secondes seront supprimées.
+      Les sessions qui n'ont pas été mises à jour durant les <parameter>max_lifetime</parameter> dernières secondes seront supprimées.
      </para>
     </listitem>
    </varlistentry>

--- a/reference/session/sessionhandlerinterface/read.xml
+++ b/reference/session/sessionhandlerinterface/read.xml
@@ -56,7 +56,7 @@
   <para>
    Retourne les données lues encodées.
    Si rien n'est lu &false; doit être retourné.
-   Il est à noter que cette valeur est destiné aux processus internes à PHP.
+   Il est à noter que cette valeur est destinée aux processus internes à PHP.
   </para>
  </refsect1>
  

--- a/reference/session/sessionhandlerinterface/write.xml
+++ b/reference/session/sessionhandlerinterface/write.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="sessionhandlerinterface.write" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>SessionHandlerInterface::write</refname>
-  <refpurpose>Ecrit les données de session</refpurpose>
+  <refpurpose>Écrit les données de session</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -27,7 +27,7 @@
    <link linkend="ini.session.serialize-handler">session.serialize_handler</link>.
   </para>
   <para>
-   Cette méthode est normalement appelée par PHP après que les tampons de sortie ont été fermé
+   Cette méthode est normalement appelée par PHP après que les tampons de sortie ont été fermés
    sauf si <function>session_write_close</function> est explicitement appelé.
   </para>
  </refsect1>
@@ -49,7 +49,7 @@
      <para>
       Les données de session encodées. Ces données sont le résultat de l'encodage interne par PHP de la superglobale <varname>$_SESSION</varname>
       à une chaîne sérialisée et le passer en tant que ce paramètre.
-      Veuillez noter que les sessions utilise une méthode de sérialisation alternative.
+      Veuillez noter que les sessions utilisent une méthode de sérialisation alternative.
      </para>
     </listitem>
    </varlistentry>

--- a/reference/session/upload-progress.xml
+++ b/reference/session/upload-progress.xml
@@ -44,7 +44,7 @@ var_dump($_SESSION[$key]);
   en définissant la clé <literal>$_SESSION[$key]["cancel_upload"]</literal> à la valeur
   &true;. Lors du téléversement de plusieurs fichiers dans la même
   requête, cette action n'annulera que le fichier actuellement en cours de téléchargement,
-  ainsi que ceux en attente de téléversement mais n'annulera pas les téléversement
+  ainsi que ceux en attente de téléversement mais n'annulera pas les téléversements
   terminés avec succès. Lorsqu'un téléversement est annulé en utilisant cette méthode,
   la clé <literal>error</literal> du tableau <varname>$_FILES</varname> sera définie à
   <constant>UPLOAD_ERR_EXTENSION</constant>.
@@ -55,7 +55,7 @@ var_dump($_SESSION[$key]);
   et
   <link linkend="ini.session.upload-progress.min-freq">session.upload_progress.min_freq</link>
   contrôlent la fréquence de mise à jour des informations de progression de téléversement.
-  Avec une configuration raisonnable de ces 2 options, la surcoût en terme
+  Avec une configuration raisonnable de ces 2 options, le surcoût en terme
   de charge est quasi nul.
  </para>
  <para>
@@ -117,13 +117,13 @@ $_SESSION["upload_progress_123"] = array(
   <para>
    La mise en mémoire tampon de la requête du serveur web doit être désactivée
    pour la bonne marche de cette fonctionnalité, sinon PHP ne verra le fichier
-   qu'une fois qu'il sera totalement téléversé. Les serveurs tel que Nginx
+   qu'une fois qu'il sera totalement téléversé. Les serveurs tels que Nginx
    sont connus pour mettre en mémoire tampon des grosses requêtes.
   </para>
  </warning>
  <caution>
   <para>
-   Les informations de la progression du téléversement sont écrite en session avant
+   Les informations de la progression du téléversement sont écrites en session avant
    qu'un script soit exécuté. Par conséquent, changer le nom de session grâce à
    <function>ini_set</function> ou <function>session_name</function> donnera une
    session sans les informations de progression du téléversement.


### PR DESCRIPTION
Fix grammar and spelling in session/ and outcontrol/ documentation