### PR TITLE
Fix grammar and spelling in seaslog/, rnp/, random/, snmp/, oauth/, solr/, sockets/, sodium/, soap/ and rpminfo/ documentation

### DIFF
--- a/reference/oauth/constants.xml
+++ b/reference/oauth/constants.xml
@@ -52,7 +52,7 @@
    </term>
    <listitem>
     <simpara>
-     Cette constante représente l'entête <literal>Authorization</literal>.
+     Cette constante représente l'en-tête <literal>Authorization</literal>.
     </simpara>
    </listitem>
   </varlistentry>
@@ -288,7 +288,7 @@
     <simpara>
      <emphasis>oauth_token</emphasis> n'a pas été acceptée par le prestataire de
      service. La raison est inconnue, mais il se peut que le jeton n'ait jamais
-     été utilisé, a déjà été consommé, a expiré et/ou a été oublié par le
+     été utilisé, ait déjà été consommé, ait expiré et/ou ait été oublié par le
      prestataire de service.
     </simpara>
    </listitem>

--- a/reference/oauth/functions/oauth-urlencode.xml
+++ b/reference/oauth/functions/oauth-urlencode.xml
@@ -26,7 +26,7 @@
     <term><parameter>uri</parameter></term>
     <listitem>
      <simpara>
-      l'URI à encoder.
+      L'URI à encoder.
      </simpara>
     </listitem>
    </varlistentry>

--- a/reference/oauth/oauth/construct.xml
+++ b/reference/oauth/oauth/construct.xml
@@ -56,7 +56,7 @@
      <simpara>
       Ce paramètre optionnel définit la méthode de passage des
       paramètres OAuth au fournisseur de services. Par défaut, c'est
-      <constant>OAUTH_AUTH_TYPE_AUTHORIZATION</constant> (dans l'entête
+      <constant>OAUTH_AUTH_TYPE_AUTHORIZATION</constant> (dans l'en-tête
       <literal>Authorization</literal>).
      </simpara>
     </listitem>

--- a/reference/oauth/oauth/fetch.xml
+++ b/reference/oauth/oauth/fetch.xml
@@ -60,7 +60,7 @@
     <term><parameter>http_headers</parameter></term>
     <listitem>
      <simpara>
-      Les entêtes client HTTP (tels que <literal>User-Agent</literal>,
+      Les en-têtes client HTTP (tels que <literal>User-Agent</literal>,
       <literal>Accept</literal>, etc.)
      </simpara>
     </listitem>

--- a/reference/oauth/oauth/setauthtype.xml
+++ b/reference/oauth/oauth/setauthtype.xml
@@ -34,7 +34,7 @@
          <term><constant>OAUTH_AUTH_TYPE_AUTHORIZATION</constant></term>
          <listitem>
          <simpara>
-          Passe les paramètres OAuth dans l'entête HTTP <literal>Authorization</literal>.
+          Passe les paramètres OAuth dans l'en-tête HTTP <literal>Authorization</literal>.
          </simpara>
         </listitem>
        </varlistentry>

--- a/reference/random/functions/mt-getrandmax.xml
+++ b/reference/random/functions/mt-getrandmax.xml
@@ -17,7 +17,7 @@
   <simpara>
    Retourne la plus grande valeur aléatoire possible que peut
    retourner la fonction <function>mt_rand</function> sans argument, ce qui 
-   correspond à la valeur maximum qui peut être utilisé pour son paramètre
+   correspond à la valeur maximum qui peut être utilisée pour son paramètre
    <parameter>max</parameter> sans que le résultat soit élargi (et donc moins 
    aléatoire).
   </simpara>

--- a/reference/random/functions/rand.xml
+++ b/reference/random/functions/rand.xml
@@ -93,7 +93,7 @@
         <function>rand</function> 
         <link linkend="migration72.incompatible.rand-mt_rand-output">a reçu une correction de bogue</link> 
         pour un bug de polarisation modulo. Cela signifie que les séquences 
-        générées dans certain cas spécifiques peuvent différer de PHP 7.1 sur
+        générées dans certains cas spécifiques peuvent différer de PHP 7.1 sur
         les machines 64-bit.
        </entry>
       </row>

--- a/reference/random/functions/random-bytes.xml
+++ b/reference/random/functions/random-bytes.xml
@@ -36,7 +36,7 @@
     <term><parameter>length</parameter></term>
     <listitem>
      <para>
-      La longueur de la &string; aléatoire qui doit être retournée en octets; doit être supérieur ou égal à <literal>1</literal>.
+      La longueur de la &string; aléatoire qui doit être retournée en octets; doit être supérieure ou égale à <literal>1</literal>.
      </para>
     </listitem>
    </varlistentry>

--- a/reference/random/random/engine/pcgoneseq128xslrr64/jump.xml
+++ b/reference/random/random/engine/pcgoneseq128xslrr64/jump.xml
@@ -81,7 +81,7 @@ B: e6d0d5813913a424
    </screen>
   </example>
   <example>
-   <title>>Les méthodes de Randomizer peuvent appeler le moteur plus d'une fois</title>
+   <title>Les méthodes de Randomizer peuvent appeler le moteur plus d'une fois</title>
    <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/random/random/engine/secure/generate.xml
+++ b/reference/random/random/engine/secure/generate.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="random-engine-secure.generate" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Random\Engine\Secure::generate</refname>
-  <refpurpose>Génère des données aléatoires de manière cryptographique sécurisé</refpurpose>
+  <refpurpose>Génère des données aléatoires de manière cryptographique sécurisée</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -14,7 +14,7 @@
    <void/>
   </methodsynopsis>
   <para>
-   Renvoie des données aléatoires de manière cryptographique sécurisé.
+   Renvoie des données aléatoires de manière cryptographique sécurisée.
   </para>
 
   &csprng.sources;
@@ -28,7 +28,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Une chaîne contenant <constant>PHP_INT_SIZE</constant> octets d'aléatoire de manière cryptographique sécurisé.
+   Une chaîne contenant <constant>PHP_INT_SIZE</constant> octets d'aléatoire de manière cryptographique sécurisée.
   </para>
  </refsect1>
 

--- a/reference/random/random/randomizer/nextfloat.xml
+++ b/reference/random/random/randomizer/nextfloat.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="random-randomizer.nextfloat" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Random\Randomizer::nextFloat</refname>
-  <refpurpose>Renvoie un flottant sélectionné de l'interval ouvert à droite [0.0, 1.0)</refpurpose>
+  <refpurpose>Renvoie un flottant sélectionné de l'intervalle ouvert à droite [0.0, 1.0)</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/rnp/examples.xml
+++ b/reference/rnp/examples.xml
@@ -6,10 +6,10 @@
  <section xml:id="rnp.examples-clearsign">
   <title>Texte signé en clair</title>
   <simpara>
-   Cette exemple va signer en clair un texte donné.
+   Cet exemple va signer en clair un texte donné.
   </simpara>
   <example>
-   <title>Exemple RNP signature en claire</title>
+   <title>Exemple RNP signature en clair</title>
    <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/rnp/functions/rnp-key-export-autocrypt.xml
+++ b/reference/rnp/functions/rnp-key-export-autocrypt.xml
@@ -40,7 +40,7 @@
     <term><parameter>key_fp</parameter></term>
     <listitem>
      <simpara>
-      L'empreinte du clé primaire.
+      L'empreinte de la clé primaire.
      </simpara>
     </listitem>
    </varlistentry>
@@ -77,7 +77,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   Les paquets OpenPGP de la clé exportée sur succès&return.falseforfailure;.
+   Les paquets OpenPGP de la clé exportée en cas de succès&return.falseforfailure;.
   </simpara>
  </refsect1>
 

--- a/reference/rnp/functions/rnp-key-export-revocation.xml
+++ b/reference/rnp/functions/rnp-key-export-revocation.xml
@@ -93,7 +93,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   Révocation exportée sur succès&return.falseforfailure;.
+   Révocation exportée en cas de succès&return.falseforfailure;.
   </simpara>
  </refsect1>
 

--- a/reference/rnp/functions/rnp-op-generate-key.xml
+++ b/reference/rnp/functions/rnp-op-generate-key.xml
@@ -142,7 +142,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   L'emptreinte de la clé primaire générée&return.falseforfailure;. Cette empreinte peut être utilisée
+   L'empreinte de la clé primaire générée&return.falseforfailure;. Cette empreinte peut être utilisée
    plus tard pour référencer la clé dans les opérations de signature et de chiffrement. Les données de la clé sont stockées dans le contexte de mémoire
    FFI et peuvent être sauvegardées en utilisant
    <function>rnp_save_keys</function> ou <function>rnp_save_keys_to_path</function>.

--- a/reference/rnp/functions/rnp-op-sign-detached.xml
+++ b/reference/rnp/functions/rnp-op-sign-detached.xml
@@ -98,7 +98,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   Les données de signature(s) détachées sur succès&return.falseforfailure;.
+   Les données de signature détachées en cas de succès&return.falseforfailure;.
   </simpara>
  </refsect1>
 

--- a/reference/rnp/functions/rnp-op-sign.xml
+++ b/reference/rnp/functions/rnp-op-sign.xml
@@ -37,7 +37,7 @@
     <term><parameter>data</parameter></term>
     <listitem>
      <simpara>
-      Data to be signed.
+      Les données à signer.
      </simpara>
     </listitem>
    </varlistentry>
@@ -123,7 +123,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   Les données signées avec la signature(s) intégrée sur succès&return.falseforfailure;.
+   Les données signées avec la ou les signatures intégrées en cas de succès&return.falseforfailure;.
   </simpara>
  </refsect1>
 

--- a/reference/rnp/functions/rnp-op-verify.xml
+++ b/reference/rnp/functions/rnp-op-verify.xml
@@ -36,7 +36,6 @@
     <listitem>
      <simpara>
       Les données signées.
-      Signed data.
      </simpara>
     </listitem>
    </varlistentry>

--- a/reference/rpminfo/constants.xml
+++ b/reference/rpminfo/constants.xml
@@ -549,7 +549,7 @@
    </term>
    <listitem>
     <simpara>
-     Le repertoire des fichiers, avec l'index de la base de données.
+     Le répertoire des fichiers, avec l'index de la base de données.
     </simpara>
    </listitem>
   </varlistentry>
@@ -2472,7 +2472,7 @@
    </term>
    <listitem>
     <simpara>
-     Le repertoire des fichiers, avec l'index de la base de données.
+     Le répertoire des fichiers, avec l'index de la base de données.
     </simpara>
    </listitem>
   </varlistentry>

--- a/reference/rpminfo/functions/rpmexpand.xml
+++ b/reference/rpminfo/functions/rpmexpand.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="function.rpmexpand" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>rpmexpand</refname>
-  <refpurpose>Récupère la valeur étendue d'un macro RPM</refpurpose>
+  <refpurpose>Récupère la valeur étendue d'une macro RPM</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -14,7 +14,7 @@
    <methodparam><type>string</type><parameter>text</parameter></methodparam>
   </methodsynopsis>
   <simpara>
-   Récupère la valeur étendue d'un macro RPM.
+   Récupère la valeur étendue d'une macro RPM.
   </simpara>
  </refsect1>
 

--- a/reference/rpminfo/functions/rpmexpandnumeric.xml
+++ b/reference/rpminfo/functions/rpmexpandnumeric.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="function.rpmexpandnumeric" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>rpmexpandnumeric</refname>
-  <refpurpose>Récupère la valeur numérique d'un macro RPM</refpurpose>
+  <refpurpose>Récupère la valeur numérique d'une macro RPM</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -14,7 +14,7 @@
    <methodparam><type>string</type><parameter>text</parameter></methodparam>
   </methodsynopsis>
   <simpara>
-   Récupère la valeur numérique d'un macro RPM.
+   Récupère la valeur numérique d'une macro RPM.
   </simpara>
  </refsect1>
 

--- a/reference/rpminfo/functions/rpmvercmp.xml
+++ b/reference/rpminfo/functions/rpmvercmp.xml
@@ -44,7 +44,7 @@
     <listitem>
      <para>
       Un opérateur optionnel.
-      Les opérateurs possible sont:
+      Les opérateurs possibles sont :
       <simplelist type="inline">
        <member><literal>&lt;</literal></member>
        <member><literal>lt</literal></member>

--- a/reference/seaslog/examples.xml
+++ b/reference/seaslog/examples.xml
@@ -29,7 +29,7 @@ string(14) "/log/base_test"
  </example>
 
  <example>
-  <title>Obtenir et définit le journal</title>
+  <title>Obtenir et définir le journal</title>
   <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/seaslog/seaslog/critical.xml
+++ b/reference/seaslog/seaslog/critical.xml
@@ -51,7 +51,7 @@
     <term><parameter>logger</parameter></term>
     <listitem>
      <simpara>
-      Le `journal` casé par le troisième paramètre serait utilisé dès maintenant,
+      Le `journal` causé par le troisième paramètre serait utilisé dès maintenant,
       comme un journal temporaire, lorsque la fonction SeasLog::setLogger() est appelée dans le contenu précédent.
       Si `logger` est NULL ou "", SeasLog utilisera le dernier journal défini par <methodname>SeasLog::setLogger</methodname>.
      </simpara>

--- a/reference/seaslog/seaslog/debug.xml
+++ b/reference/seaslog/seaslog/debug.xml
@@ -51,7 +51,7 @@
     <term><parameter>logger</parameter></term>
     <listitem>
      <simpara>
-      Le `journal` casé par le troisième paramètre serait utilisé dès maintenant,
+      Le `journal` causé par le troisième paramètre serait utilisé dès maintenant,
       comme un journal temporaire, lorsque la fonction SeasLog::setLogger() est appelée dans le contenu précédent.
       Si `logger` est NULL ou "", SeasLog utilisera le dernier journal défini par <methodname>SeasLog::setLogger</methodname>.
      </simpara>

--- a/reference/seaslog/seaslog/emergency.xml
+++ b/reference/seaslog/seaslog/emergency.xml
@@ -51,7 +51,7 @@
     <term><parameter>logger</parameter></term>
     <listitem>
      <simpara>
-      Le `journal` casé par le troisième paramètre serait utilisé dès maintenant,
+      Le `journal` causé par le troisième paramètre serait utilisé dès maintenant,
       comme un journal temporaire, lorsque la fonction SeasLog::setLogger() est appelée dans le contenu précédent.
       Si `logger` est NULL ou "", SeasLog utilisera le dernier journal défini par <methodname>SeasLog::setLogger</methodname>.
      </simpara>

--- a/reference/seaslog/seaslog/error.xml
+++ b/reference/seaslog/seaslog/error.xml
@@ -51,7 +51,7 @@
     <term><parameter>logger</parameter></term>
     <listitem>
      <simpara>
-      Le `journal` casé par le troisième paramètre serait utilisé dès maintenant,
+      Le `journal` causé par le troisième paramètre serait utilisé dès maintenant,
       comme un journal temporaire, lorsque la fonction SeasLog::setLogger() est appelée dans le contenu précédent.
       Si `logger` est NULL ou "", SeasLog utilisera le dernier journal défini par <methodname>SeasLog::setLogger</methodname>.
      </simpara>

--- a/reference/seaslog/seaslog/info.xml
+++ b/reference/seaslog/seaslog/info.xml
@@ -51,7 +51,7 @@
     <term><parameter>logger</parameter></term>
     <listitem>
      <simpara>
-      Le `journal` casé par le troisième paramètre serait utilisé dès maintenant,
+      Le `journal` causé par le troisième paramètre serait utilisé dès maintenant,
       comme un journal temporaire, lorsque la fonction SeasLog::setLogger() est appelée dans le contenu précédent.
       Si `logger` est NULL ou "", SeasLog utilisera le dernier journal défini par <methodname>SeasLog::setLogger</methodname>.
      </simpara>

--- a/reference/seaslog/seaslog/log.xml
+++ b/reference/seaslog/seaslog/log.xml
@@ -66,7 +66,7 @@
     <term><parameter>logger</parameter></term>
     <listitem>
      <simpara>
-      Le `journal` casé par le troisième paramètre serait utilisé dès maintenant,
+      Le `journal` causé par le troisième paramètre serait utilisé dès maintenant,
       comme un journal temporaire, lorsque la fonction SeasLog::setLogger() est appelée dans le contenu précédent.
       Si `logger` est NULL ou "", SeasLog utilisera le dernier journal défini par <methodname>SeasLog::setLogger</methodname>.
      </simpara>

--- a/reference/seaslog/seaslog/notice.xml
+++ b/reference/seaslog/seaslog/notice.xml
@@ -51,7 +51,7 @@
     <term><parameter>logger</parameter></term>
     <listitem>
      <simpara>
-      Le `journal` casé par le troisième paramètre serait utilisé dès maintenant,
+      Le `journal` causé par le troisième paramètre serait utilisé dès maintenant,
       comme un journal temporaire, lorsque la fonction SeasLog::setLogger() est appelée dans le contenu précédent.
       Si `logger` est NULL ou "", SeasLog utilisera le dernier journal défini par <methodname>SeasLog::setLogger</methodname>.
      </simpara>

--- a/reference/seaslog/seaslog/warning.xml
+++ b/reference/seaslog/seaslog/warning.xml
@@ -52,7 +52,7 @@
     <term><parameter>logger</parameter></term>
     <listitem>
      <simpara>
-      Le `journal` casé par le troisième paramètre serait utilisé dès maintenant,
+      Le `journal` causé par le troisième paramètre serait utilisé dès maintenant,
       comme un journal temporaire, lorsque la fonction SeasLog::setLogger() est appelée dans le contenu précédent.
       Si `logger` est NULL ou "", SeasLog utilisera le dernier journal défini par <methodname>SeasLog::setLogger</methodname>.
      </simpara>

--- a/reference/snmp/functions/snmp-set-enum-print.xml
+++ b/reference/snmp/functions/snmp-set-enum-print.xml
@@ -18,7 +18,7 @@
   <simpara>
    Cette fonction permet de basculer si snmpwalk/snmpget etc.
    doit automatiquement chercher les valeurs énumérées dans le MIB
-   et les retourne avec leur chaîne humainement lisible.
+   et les retourner avec leur chaîne humainement lisible.
   </simpara>
  </refsect1>
 
@@ -30,7 +30,7 @@
     <listitem>
      <simpara>
       Vu que la valeur est interprétée comme un booléen par
-      la bibliothèque Net-SNMP library, il peut valoir "0" ou "1".
+      la bibliothèque Net-SNMP, il peut valoir "0" ou "1".
      </simpara>
     </listitem>
    </varlistentry>

--- a/reference/snmp/functions/snmp2-real-walk.xml
+++ b/reference/snmp/functions/snmp2-real-walk.xml
@@ -80,7 +80,7 @@
   <simpara>
    Retourne un tableau associatif d'identifiants d'objets
    <acronym>SNMP</acronym> ainsi que leurs valeurs en cas de succès
-   ou &false; une erreur survient.
+   ou &false; si une erreur survient.
    Dans le cas où une erreur survient, une alerte de type
    E_WARNING sera émise.
   </simpara>

--- a/reference/snmp/functions/snmpwalkoid.xml
+++ b/reference/snmp/functions/snmpwalkoid.xml
@@ -19,7 +19,7 @@
 
   <simpara>
    <function>snmpwalkoid</function> est utilisé pour lire tous les
-   identifiant d'objets ainsi que leurs valeurs respectives depuis l'agent SNMP
+   identifiants d'objets ainsi que leurs valeurs respectives depuis l'agent SNMP
    spécifié par <parameter>hostname</parameter>.
   </simpara>
 

--- a/reference/snmp/snmp.xml
+++ b/reference/snmp/snmp.xml
@@ -279,7 +279,7 @@
      <term><varname>info</varname></term>
      <listitem>
       <simpara>
-       Propriété en lecture seul contenant la configuration de l'agent distant : nom d'hôte,
+       Propriété en lecture seule contenant la configuration de l'agent distant : nom d'hôte,
        port, délai d'expiration par défaut, nombre de récupération par défaut</simpara>
      </listitem>
     </varlistentry>

--- a/reference/snmp/snmpexception.xml
+++ b/reference/snmp/snmpexception.xml
@@ -11,7 +11,7 @@
   <section xml:id="snmpexception.intro">
    &reftitle.intro;
    <simpara>
-    Représente une erreur lancée par SNMP. On ne devez
+    Représente une erreur lancée par SNMP. On ne devrait
     pas lancer une exception <classname>SNMPException</classname>
     depuis le code.
     Voir les <link linkend="language.exceptions">exceptions</link>

--- a/reference/soap/soapclient/setlocation.xml
+++ b/reference/soap/soapclient/setlocation.xml
@@ -15,7 +15,7 @@
   </methodsynopsis>
   <para>
    Configure l'URL cible, à laquelle seront envoyées les requêtes SOAP.
-   Ce revient à spécifier l'option <literal>location</literal> lors de 
+   Cela revient à spécifier l'option <literal>location</literal> lors de
    la construction du client <classname>SoapClient</classname>.
   </para>
   <note>

--- a/reference/soap/soapserver/construct.xml
+++ b/reference/soap/soapserver/construct.xml
@@ -63,13 +63,13 @@
       </para>
       <para>
        La dernière option est <literal>features</literal>
-       qui peut être défini à
+       qui peut être définie à
        <constant>SOAP_WAIT_ONE_WAY_CALLS</constant>,
        <constant>SOAP_SINGLE_ELEMENT_ARRAYS</constant>,
        <constant>SOAP_USE_XSI_ARRAY_TYPE</constant>.
       </para>
       <para>
-       L'option <literal>send_errors</literal> peut être défini à &false; pour envoyer
+       L'option <literal>send_errors</literal> peut être définie à &false; pour envoyer
        un message d'erreur générique ("Internal error") au lieu du message d'erreur
        spécifique.
       </para>

--- a/reference/soap/soapserver/fault.xml
+++ b/reference/soap/soapserver/fault.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="soapserver.fault" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>SoapServer::fault</refname>
-  <refpurpose>Emet une erreur <classname>SoapServer</classname></refpurpose>
+  <refpurpose>Émet une erreur <classname>SoapServer</classname></refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/soap/soapserver/getlastresponse.xml
+++ b/reference/soap/soapserver/getlastresponse.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="soapserver.getlastresponse" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>SoapServer::__getLastResponse</refname>
-  <refpurpose>Renvoie la dernière réponse SOPA</refpurpose>
+  <refpurpose>Renvoie la dernière réponse SOAP</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/sockets/constants.xml
+++ b/reference/sockets/constants.xml
@@ -1205,7 +1205,7 @@
    </term>
    <listitem>
     <simpara>
-     Le réseau à annuler la connexion en raison d'une réinitialisation.
+     Le réseau a annulé la connexion en raison d'une réinitialisation.
     </simpara>
    </listitem>
   </varlistentry>
@@ -1282,7 +1282,7 @@
    </term>
    <listitem>
     <simpara>
-     La connexion a expirée.
+     La connexion a expiré.
     </simpara>
    </listitem>
   </varlistentry>
@@ -1548,7 +1548,7 @@
 
  <simpara>
   Les constantes suivantes sont disponibles uniquement sur les
-  plate-formes Unix. Chaque constantes n'est définie que si 
+  plate-formes Unix. Chaque constante n'est définie que si
   leur équivalent est défini au niveau système.
  </simpara>
 
@@ -1714,7 +1714,7 @@
    </term>
    <listitem>
     <simpara>
-     Table de fichier dépassé.
+     Table de fichiers dépassée.
     </simpara>
    </listitem>
   </varlistentry>
@@ -1769,7 +1769,7 @@
    </term>
    <listitem>
     <simpara>
-     Trop de lien.
+     Trop de liens.
     </simpara>
    </listitem>
   </varlistentry>
@@ -1927,7 +1927,7 @@
    </term>
    <listitem>
     <simpara>
-     Echange invalide.
+     Échange invalide.
     </simpara>
    </listitem>
   </varlistentry>
@@ -1949,7 +1949,7 @@
    </term>
    <listitem>
     <simpara>
-     Echange complet.
+     Échange complet.
     </simpara>
    </listitem>
   </varlistentry>

--- a/reference/sockets/functions/socket-close.xml
+++ b/reference/sockets/functions/socket-close.xml
@@ -16,7 +16,7 @@
   </methodsynopsis>
   <para>
    <function>socket_close</function> ferme l'instance <classname>Socket</classname>
-   fournis par <parameter>socket</parameter>.
+   fournie par <parameter>socket</parameter>.
   </para>
  </refsect1>
 

--- a/reference/sockets/functions/socket-create-listen.xml
+++ b/reference/sockets/functions/socket-create-listen.xml
@@ -17,7 +17,7 @@
   </methodsynopsis>
   <para>
    <function>socket_create_listen</function> crée une nouvelle instance
-   de <classname>Socket</classname>, de type <constant>AF_INET</constant>, mis
+   de <classname>Socket</classname>, de type <constant>AF_INET</constant>, mise
    en attente sur <emphasis>toutes</emphasis> les interfaces locales,
    pour le port <parameter>port</parameter>.
   </para>

--- a/reference/sockets/functions/socket-recvfrom.xml
+++ b/reference/sockets/functions/socket-recvfrom.xml
@@ -117,7 +117,7 @@
           <entry><constant>MSG_DONTWAIT</constant></entry>
           <entry>
            Lorsque ce drapeau est défini, la fonction retourne des données
-           même si elle devrait rester bloquer.
+           même si elle devrait rester bloquée.
           </entry>
          </row>
         </tbody>

--- a/reference/sodium/functions/sodium-crypto-aead-chacha20poly1305-decrypt.xml
+++ b/reference/sodium/functions/sodium-crypto-aead-chacha20poly1305-decrypt.xml
@@ -65,7 +65,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   Renvoie le texte en claire en cas de succès, &return.falseforfailure;.
+   Renvoie le texte en clair en cas de succès, &return.falseforfailure;.
   </simpara>
  </refsect1>
 

--- a/reference/sodium/functions/sodium-crypto-aead-chacha20poly1305-ietf-encrypt.xml
+++ b/reference/sodium/functions/sodium-crypto-aead-chacha20poly1305-ietf-encrypt.xml
@@ -20,7 +20,7 @@
    Chiffre puis authentifie avec ChaCha20-Poly1305 (variante IETF).
   </simpara>
   <simpara>
-   Le variant IETF utilise des nonces de 96 bits et des compteurs internes de 32 bits, au lieu de 64 bits pour les deux.
+   La variante IETF utilise des nonces de 96 bits et des compteurs internes de 32 bits, au lieu de 64 bits pour les deux.
   </simpara>
 
  </refsect1>

--- a/reference/sodium/sodiumexception.xml
+++ b/reference/sodium/sodiumexception.xml
@@ -12,7 +12,7 @@
   <section xml:id="sodiumexception.intro">
    &reftitle.intro;
    <simpara>
-    Exception lancé par les fonctions sodium.
+    Exception lancée par les fonctions sodium.
    </simpara>
   </section>
 <!-- }}} -->

--- a/reference/solr/solrclient/commit.xml
+++ b/reference/solr/solrclient/commit.xml
@@ -37,7 +37,7 @@
       <para>
        Un commit "soft" est plus rapide sachant qu'il ne modifie que l'index,
        et ne synchronise pas les fichiers d'index, ni n'écrit de nouveaux descripteurs
-       d'index. Si le JVM crash ou s'il y a un perte d'énergie, les modificiations
+       d'index. Si le JVM crash ou s'il y a une perte d'énergie, les modifications
        qui sont survenues après le dernier commit "hard" seront perdues.
        Les collections de recherche, qui ont des besoins proches du temps réel
        (qui nécessitent donc que les modifications soient rapidement visibles)
@@ -115,7 +115,7 @@
        <entry>PECL solr 0.9.2</entry>
        <entry>
         Signature : SolrClient::commit ([ int $maxSegments = 1 [, bool $waitFlush = true [, bool $waitSearcher = true ]]] ). 
-        $waitFlush : bloc tant que les modifications de l'index ne sont pas écrites sur le disque.
+        $waitFlush : bloque tant que les modifications de l'index ne sont pas écrites sur le disque.
        </entry>
       </row>
      </tbody>

--- a/reference/solr/solrclient/optimize.xml
+++ b/reference/solr/solrclient/optimize.xml
@@ -70,7 +70,7 @@
   &reftitle.errors;
   <para>
    Lance une exception <classname>SolrClientException</classname> si le client
-   a échoué, ou s'il y a eu une problème avec la connexion.
+   a échoué, ou s'il y a eu un problème avec la connexion.
   </para>
   <para>
    Lance une exception <classname>SolrServerException</classname> si le serveur

--- a/reference/solr/solrclient/ping.xml
+++ b/reference/solr/solrclient/ping.xml
@@ -39,7 +39,7 @@
   &reftitle.errors;
   <para>
    Lance une exception <classname>SolrClientException</classname> si le
-   client a échoué, ou s'il y a eu une problème avec la connexion.
+   client a échoué, ou s'il y a eu un problème avec la connexion.
   </para>
   <para>
    Lance une exception <classname>SolrServerException</classname> si le

--- a/reference/solr/solrserverexception.xml
+++ b/reference/solr/solrserverexception.xml
@@ -14,7 +14,7 @@
   <section xml:id="solrserverexception.intro">
    &reftitle.intro;
    <para>
-    Une exception est émise lorsque ce produit une erreur dans le
+    Une exception est émise lorsque se produit une erreur dans le
     serveur Solr.
    </para>
   </section>


### PR DESCRIPTION
Fix grammar and spelling in seaslog/, rnp/, random/, snmp/, oauth/, solr/, sockets/, sodium/, soap/ and rpminfo/ documentation