### PR TITLE
Fix grammar and spelling in language/ and appendices/ documentation

### DIFF
--- a/appendices/migration81/other-changes.xml
+++ b/appendices/migration81/other-changes.xml
@@ -45,7 +45,7 @@
     Cet ordre est cohérent avec la disposition interne des propriétés dans la structure
     <code>zend_object</code> et répète l'ordre dans
     <code>default_properties_table[]</code> et <code>properties_info_table[]</code>.
-    L'ancien ordre n'était pas documenté et était causé par des détails d'implémentation
+    L'ancien ordre n'était pas documenté et était causé par des détails d'implémentation.
    </para>
   </sect3>
 
@@ -55,7 +55,7 @@
    <para>
     Le drapeau <constant>FILTER_FLAG_ALLOW_OCTAL</constant> du filtre
     <constant>FILTER_VALIDATE_INT</constant>
-    accepté désormais les chaînes octales avec le préfixe octal
+    accepte désormais les chaînes octales avec le préfixe octal
     (<literal>"0o"</literal>/<literal>"0O"</literal>).
    </para>
   </sect3>

--- a/appendices/reserved.xml
+++ b/appendices/reserved.xml
@@ -18,7 +18,7 @@
    Ces mots ont un sens spécial pour PHP. Certains représentent des objets
    ressemblant à des fonctions, d'autres à des constantes, et ainsi de
    suite, mais ils n'en sont pas vraiment : ce sont des structures de langage.
-   Les mots clés suivant ne peuvent pas être utilisés comme nom de constante,
+   Les mots clés suivants ne peuvent pas être utilisés comme nom de constante,
    de classe ou de fonction.
    Ils sont cependant autorisés comme nom de propriété, constante et de
    méthode dans les classes, interfaces, traits sauf le mot clé

--- a/language/namespaces.xml
+++ b/language/namespaces.xml
@@ -999,7 +999,7 @@ if (is_array('hi')) { // affiche "n'est pas un tableau"
       fait référence à une fonction ou une constante, et que le code est en
       dehors du namespace global, le nom est résolu par l'exécution.
       Supposons que le code est dans le namespace
-      <literal>A\B</literal>, voici comme un appel à la fonction <literal>foo()</literal> est résolu :
+      <literal>A\B</literal>, voici comment un appel à la fonction <literal>foo()</literal> est résolu :
      </simpara>
 
      <orderedlist>
@@ -1301,7 +1301,7 @@ $a = \INI_ALL; // $a reçoit la valeur de la constante "INI_ALL"
   <sect2 xml:id="language.namespaces.faq.qualified">
    <title>Comment est-ce qu'un nom tel que <literal>mon\nom</literal> est résolu ?</title>
    <para>
-    Les noms qui contiennent un antislash mais ne commencent par un
+    Les noms qui contiennent un antislash mais ne commencent pas par un
     antislash, comme <literal>mon\nom</literal> peuvent être résolus de deux manières
     différentes.
    </para>

--- a/language/oop5/changelog.xml
+++ b/language/oop5/changelog.xml
@@ -54,7 +54,7 @@
       <entry>7.4.0</entry>
       <entry>
        Ajout : Support limité pour la covariance du type de retour et
-       contravariance pour le type d'argument. Support complet de variance est
+       contravariance pour le type d'argument. Le support complet de variance est
        uniquement disponible si l'autochargement est utilisé. À l'intérieur
        d'un fichier unique seules les références non-cycliques de type sont
        possibles.

--- a/language/oop5/decon.xml
+++ b/language/oop5/decon.xml
@@ -147,7 +147,7 @@ class Point {
      Quand un argument de constructeur inclut un modificateur, PHP l'interprétera
      comme une propriété d'objet et un argument du constructeur, et assigne la valeur de l'argument
      à la propriété. Le corps du constructeur peut être alors vide ou peut contenir d'autres
-     déclarations. Toutes déclarations additionnelles seront exécutées après que la valeur de
+     déclarations. Toutes les déclarations additionnelles seront exécutées après que la valeur de
      l'argument a été assignée à sa propriété correspondante.
     </para>
     <para>
@@ -165,7 +165,7 @@ class Point {
     </note>
     <note>
      <para>
-      Les propriétés d'objet ne peuvent être typés <type>callable</type> à cause des ambiguïtés du moteur
+      Les propriétés d'objet ne peuvent être typées <type>callable</type> à cause des ambiguïtés du moteur
       que ceci introduirait. Ainsi, les arguments promus, ne peuvent pas non plus être typés
       <type>callable</type>. Cependant, toute autre
       <link linkend="language.types.declarations">déclaration de type</link> est permise.

--- a/language/oop5/final.xml
+++ b/language/oop5/final.xml
@@ -5,7 +5,7 @@
   <title>Mot-clé "final"</title>
   <para>
    Le mot-clé <literal>final</literal> empêche les classes enfants de redéfinir
-   une méthode, une propriété ou constante en préfixant la définition avec
+   une méthode, une propriété ou une constante en préfixant la définition avec
    <literal>final</literal>. Si la classe elle-même est
    définie comme finale, elle ne pourra pas être étendue.
   </para>

--- a/language/oop5/inheritance.xml
+++ b/language/oop5/inheritance.xml
@@ -29,7 +29,7 @@
   À partir de PHP 8.0.0, l'unique restriction de méthode privée qui est imposée
   est <literal>private final</literal> sur les constructeurs, car c'est une
   manière courante pour "désactiver" le constructeur lors de l'utilisation
-  de méthodes factory statique à la place.
+  de méthodes factory statiques à la place.
  </para>
  <para>
   La <link linkend="language.oop5.visibility">visibilité</link>

--- a/language/oop5/lazy-objects.xml
+++ b/language/oop5/lazy-objects.xml
@@ -452,7 +452,7 @@ var_dump($post->id);
   </simpara>
 
   <simpara>
-   Pour les objets proxis, le proxy et son instance réelle sont clonés, et
+   Pour les objets proxys, le proxy et son instance réelle sont clonés, et
    le clone du proxy est retourné.
    La méthode <link linkend="object.clone"><literal>__clone</literal></link> est
    appelée sur l'instance réelle, pas sur le proxy.

--- a/language/oop5/visibility.xml
+++ b/language/oop5/visibility.xml
@@ -10,7 +10,7 @@
    <literal>private</literal>.
    Les éléments déclarés comme publics sont accessibles partout.
    L'accès aux éléments protégés est limité à la classe elle-même, ainsi
-   qu'aux classes qui en héritent et parente.
+   qu'aux classes qui en héritent et à la classe parente.
    L'accès aux éléments privés est uniquement réservé à la classe qui les a définis.
   </para>
   

--- a/language/operators/comparison.xml
+++ b/language/operators/comparison.xml
@@ -424,9 +424,9 @@ if (empty($_POST['action'])) {
    <para>
     Il est recommandé de ne pas "empiler" les expressions ternaires.
     Le comportement de PHP lors de l'utilisation de plusieurs opérateurs
-    ternaire qui ne sont pas entre parenthèses en une unique expression est
+    ternaires qui ne sont pas entre parenthèses en une unique expression est
     non évident comparé à d'autres langages.
-    En effet antérieur à PHP 8.0.0, l'expression ternaire était évaluée
+    En effet, antérieur à PHP 8.0.0, l'expression ternaire était évaluée
     gauche-associatif, au lieu de droite-associatif comme la plupart des
     autres langages de programmations.
     Dépendre de la gauche associativité est obsolète à partir de PHP 7.4.0.
@@ -520,7 +520,7 @@ if (isset($_POST['action'])) {
    <para>
     L'opérateur de fusion null a une précédence faible. Ceci signifie que le mélanger
     avec d'autres opérateurs (tels que la concaténation de chaînes ou les opérateurs
-    arithmétiques) des parenthèses seront requis.
+    arithmétiques) des parenthèses seront requises.
    </para>
    <programlisting role="php">
 <![CDATA[

--- a/language/operators/precedence.xml
+++ b/language/operators/precedence.xml
@@ -476,7 +476,7 @@ x moins un est égal à 3, en tout cas j'espère
       <entry>
        Dépendre de la gauche-associativité de l'opérateur ternaire (<literal>? :</literal>),
        c.-à-d. l'imbrication de plusieurs opérateurs ternaires qui ne sont pas
-       entre parenthèse, est obsolète.
+       entre parenthèses, est obsolète.
       </entry>
      </row>
     </tbody>

--- a/language/types/array.xml
+++ b/language/types/array.xml
@@ -847,7 +847,7 @@ echo $foo[bar];
    <warning>
     <simpara>
      La solution de recours qui considère une constante non-définie comme une
-     chaîne de caractères nu est une erreur de niveau <constant>E_NOTICE</constant>.
+     chaîne de caractères nue est une erreur de niveau <constant>E_NOTICE</constant>.
      Ceci est obsolète à partir de PHP 7.2.0, et émet une erreur de niveau
      <constant>E_WARNING</constant>.
      À partir de PHP 8.0.0, ceci a été retiré et lance une exception
@@ -1062,7 +1062,7 @@ $error_descriptions[8] = "This is just an informal notice";
   <para>
    Pour tous les types &integer;, &float;, &string;, &boolean; et &resource;,
    le fait de convertir une valeur en un tableau résulte en un tableau contenant
-   un seul élément dont l'indexe vaut zéro et la valeur, une valeur scalaire convertie.
+   un seul élément dont l'index vaut zéro et la valeur, une valeur scalaire convertie.
    En d'autres termes, <code>(array) $scalarValue</code> est exactement la
    même chose que <literal>array($scalarValue)</literal>.
   </para>
@@ -1212,7 +1212,7 @@ var_dump($arr1, $arr2, $arr3, $arr4, $arr5, $arr6);
    et les clés numériques sont renumérotées :
 
    <example>
-    <title>Déballage de tableau avec clé dupliqué</title>
+    <title>Déballage de tableau avec clé dupliquée</title>
     <programlisting role="php">
 <![CDATA[
 <?php

--- a/language/types/declarations.xml
+++ b/language/types/declarations.xml
@@ -693,7 +693,7 @@ class User {
     actif, et non aux fonctions déclarées dans ce fichier. Si un fichier dont
     le typage strict n'est pas activé effectue un appel à une fonction qui a
     été définie dans un fichier dont le type strict est actif, la préférence de
-    l'appelant (mode coercitif) sera respecté et la valeur sera forcée.
+    l'appelant (mode coercitif) sera respectée et la valeur sera forcée.
    </para>
   </note>
 

--- a/language/types/integer.xml
+++ b/language/types/integer.xml
@@ -130,7 +130,7 @@ var_dump(PHP_INT_MAX + 1);       // 32-bit system: float(2147483648)
   <title>Division d'entier</title>
   
   <para>
-   Il n'y a pas d'opérateur de division d'&integer; en PHP, pour accomplir ceci
+   Il n'y a pas d'opérateur de division d'&integer; en PHP, pour accomplir ceci,
    utiliser la fonction <function>intdiv</function>.
    <literal>1/2</literal> produit le &float; (<literal>0.5</literal>).
    La valeur peut être transtypée en un &integer; pour l'arrondir vers zéro, ou

--- a/language/types/type-juggling.xml
+++ b/language/types/type-juggling.xml
@@ -65,7 +65,7 @@
    comme des <type>float</type>s, et le résultat sera un <type>float</type>.
    Sinon, les opérandes sont interprétés comme des <type>int</type>s,
    et le résultat sera aussi un <type>int</type>.
-   À partir de PHP 8.0.0, si un des opérandes ne peut être interprété une
+   À partir de PHP 8.0.0, si un des opérandes ne peut être interprété, une
    <classname>TypeError</classname> est lancée.
   </simpara>
  </sect2>
@@ -287,7 +287,7 @@ true  --> 1           // bool compatible avec int
 
   <simpara>
    Le casting de type convertit la valeur en un type donné en écrivant le type
-   entre parenthèse avant la valeur à convertir.
+   entre parenthèses avant la valeur à convertir.
   </simpara>
 
   <example>

--- a/language/wrappers/http.xml
+++ b/language/wrappers/http.xml
@@ -149,7 +149,7 @@ foreach ($meta_data['wrapper_data'] as $response) {
   </note>
   <simpara>
    Les connexions HTTP sont en lecture seule ; l'écriture de données
-   ou la copie de fichier vers une ressource HTTP ne sont pas supportés.
+   ou la copie de fichier vers une ressource HTTP ne sont pas supportées.
   </simpara>
   <simpara>
    L'envoi de requêtes <emphasis>POST</emphasis> et <emphasis>PUT</emphasis>,

--- a/language/wrappers/php.xml
+++ b/language/wrappers/php.xml
@@ -156,7 +156,7 @@
        </row>
        <row>
         <entry>
-         <literal>&lt;liste de filtre à appliquer à la fois lors de la lecture et de l'écriture&gt;</literal>
+         <literal>&lt;liste de filtres à appliquer à la fois lors de la lecture et de l'écriture&gt;</literal>
         </entry>
         <entry>
          Tous les filtres fournis sans être préfixés par <literal>read=</literal>


### PR DESCRIPTION
Fixes grammar, spelling and conjugation errors in language/ and appendices/ files.