### PR TITLE
Fix grammar and spelling in sync/, stream/ and sqlite3/ documentation

### DIFF
--- a/reference/sqlite3/configure.xml
+++ b/reference/sqlite3/configure.xml
@@ -7,7 +7,7 @@
  &reftitle.install;
  <para>
   Le support de SQLite3 est activé par défaut.
-  Il est possible de la désactiver en utilisant l'option 
+  Il est possible de le désactiver en utilisant l'option
   <literal>--without-sqlite3</literal> au moment de la compilation.
  </para>
  <para>

--- a/reference/sqlite3/ini.xml
+++ b/reference/sqlite3/ini.xml
@@ -50,7 +50,7 @@
     </term>
     <listitem>
      <para>
-      Chemin vers le dossier où se trouve les extensions chargeables pour SQLite.
+      Chemin vers le dossier où se trouvent les extensions chargeables pour SQLite.
      </para>
     </listitem>
    </varlistentry>
@@ -62,7 +62,7 @@
     <listitem>
      <para>
       Lorsque le drapeau défensif est activé, les fonctionnalités du langage qui
-      permette à du SQL ordinaire de corrompre délibérément les fichiers de la
+      permettent à du SQL ordinaire de corrompre délibérément les fichiers de la
       base de données sont désactivées. Ceci interdit d'écrire directement dans
       le schéma, les tables d’ombre (telles que les tables de données FTS) ou
       la table virtuelle sqlite_dbpage.

--- a/reference/sqlite3/sqlite3/createcollation.xml
+++ b/reference/sqlite3/sqlite3/createcollation.xml
@@ -39,8 +39,8 @@
       à appliquer comme fonction de rappel, définissant le comportement
       du classement. Elle doit accepter deux arguments et retournera
       la même chose que la fonction <function>strcmp</function>, c'est-à-dire
-      elle doit retourner -1, 1, ou 0 si la première chaîne trie avant,
-      après, ou est équivalent à la seconde.
+      qu'elle doit retourner -1, 1, ou 0 si la première chaîne trie avant,
+      après, ou est équivalente à la seconde.
      </para>
      <para>
       Cette fonction doit être définie comme :

--- a/reference/sqlite3/sqlite3/escapestring.xml
+++ b/reference/sqlite3/sqlite3/escapestring.xml
@@ -55,7 +55,7 @@
    <simpara>
     La fonction <function>addslashes</function> ne doit <emphasis>PAS</emphasis>
     être utilisée pour protéger la chaîne dans les requêtes SQL ; il serait possible de
-     observer d'étranges résultats lorsque l'on récupérerez les données.
+     d'observer d'étranges résultats lorsque l'on récupérera les données.
    </simpara>
   </warning>
  </refsect1>

--- a/reference/sqlite3/sqlite3/setauthorizer.xml
+++ b/reference/sqlite3/sqlite3/setauthorizer.xml
@@ -31,7 +31,7 @@
   </para>
   <para>
    La fonction de rappel de l'autorisateur est appelée avec jusqu'à cinq paramètres. Le premier paramètre est toujours
-   donnée, et est un <type>int</type> (code d'action) correspondant à une constante de
+   donné, et est un <type>int</type> (code d'action) correspondant à une constante de
    <literal>SQLite3</literal>. Les autres paramètres ne sont passés que pour certaines actions. Le
    tableau suivant décrit les deuxième et troisième paramètres en fonction de l'action :
    <table>
@@ -92,7 +92,7 @@
    code SQL de niveau supérieur.
   </para>
   <para>
-   Lorsque que la fonction de rappel retourne <constant>SQLite3::OK</constant>, cela signifie que l'opération
+   Lorsque la fonction de rappel retourne <constant>SQLite3::OK</constant>, cela signifie que l'opération
    demandée est acceptée. Lorsque la fonction de rappel retourne <constant>SQLite3::DENY</constant>, l'appel qui a
    déclenché l'autorisateur échouera avec un message d'erreur expliquant que
    l'accès est refusé.
@@ -115,7 +115,7 @@
    désactivée et toutes les lignes sont supprimées individuellement.
   </para>
   <para>
-   Seul un seule autorisateur peut être en place sur une connexion de base de données à la fois. Chaque appel à
+   Seul un seul autorisateur peut être en place sur une connexion de base de données à la fois. Chaque appel à
    <methodname>SQLite3::setAuthorizer</methodname> remplace l'appel précédent. Désactivez l'autorisateur en installant
    un rappel &null;. L'autorisateur est désactivé par défaut.
   </para>
@@ -171,7 +171,7 @@
   <example>
    <title>Exemple de <methodname>SQLite3::setAuthorizer</methodname></title>
    <para>
-     Ceci n'autorise que l'accès en lecture, et seuls certains colonnes de la table
+     Ceci n'autorise que l'accès en lecture, et seules certaines colonnes de la table
      <literal>users</literal> seront retournées. Les autres colonnes seront remplacées par
      &null;.
    </para>

--- a/reference/sqlite3/sqlite3stmt/bindparam.xml
+++ b/reference/sqlite3/sqlite3stmt/bindparam.xml
@@ -23,7 +23,7 @@
     Avant PHP 7.2.14 et 7.3.0, respectivement,
     <methodname>SQLite3Stmt::reset</methodname> doit être appelé après le premier
     appel à <methodname>SQLite3Stmt::execute</methodname> si la valeur liée 
-    devrait être correctement mis à jour lors des appels suivants à
+    devrait être correctement mise à jour lors des appels suivants à
     <methodname>SQLite3Stmt::execute</methodname>.
     Si <methodname>SQLite3Stmt::reset</methodname> n'est pas appelé, les valeurs
     liées ne seront pas modifiées, même si la valeur assignée à la variable passée à
@@ -158,7 +158,7 @@
     <title>Utilisation de <function>SQLite3Stmt::bindParam</function></title>
     <para>
      Cet exemple montre comment une déclaration préparée unique avec un seul
-     paramètre lié peut être utilisé pour insérer plusieurs lignes avec des
+     paramètre lié peut être utilisée pour insérer plusieurs lignes avec des
      valeurs différentes.
     </para>
     <programlisting role="php">

--- a/reference/stream/functions/stream-filter-register.xml
+++ b/reference/stream/functions/stream-filter-register.xml
@@ -40,7 +40,7 @@
       <para>
        Pour créer une classe de filtre, il faut définir une classe qui
        étend la classe <classname>php_user_filter</classname>.
-       Lorsque l'on réalisez des opérations
+       Lorsque l'on réalise des opérations
        de lecture et d'écriture dans le flux auquel le filtre est attaché,
        PHP passera les données à travers le filtre (et tous les autres 
        filtres attachés), de façon à ce que les données soient modifiées 

--- a/reference/stream/functions/stream-select.xml
+++ b/reference/stream/functions/stream-select.xml
@@ -215,7 +215,7 @@ stream_select($r, $w, $e, 0);
   <note>
    <para>
     Il faut s'assurer de bien utiliser l'opérateur <literal>===</literal> lorsque l'on
-    recherchez des erreurs. Comme <function>stream_select</function> peut retourner
+    recherche des erreurs. Comme <function>stream_select</function> peut retourner
     0, une comparaison effectuée à l'aide de <literal>==</literal>
     l'évaluerait à &true; :
     <programlisting role="php">

--- a/reference/stream/functions/stream-socket-client.xml
+++ b/reference/stream/functions/stream-socket-client.xml
@@ -30,7 +30,7 @@
   </para>
   <note>
    <para>
-    Le flux sera par défaut ouvert en mode bloquant. Il est possible du passer
+    Le flux sera par défaut ouvert en mode bloquant. Il est possible de passer
     en mode non bloquant en utilisant la fonction
     <function>stream_set_blocking</function>.
    </para>
@@ -191,7 +191,7 @@ if (!$fp) {
     <title>Utilisation de connexions UDP</title>
     <para>
      Lit la date et l'heure sur un service UDP de type
-     "<literal>daytime</literal>" (port 13) sur son propre machine :
+     "<literal>daytime</literal>" (port 13) sur sa propre machine :
     </para>
     <programlisting role="php">
 <![CDATA[

--- a/reference/stream/functions/stream-socket-server.xml
+++ b/reference/stream/functions/stream-socket-server.xml
@@ -163,7 +163,7 @@ if (!$socket) {
   </para>
   <para>
    L'exemple ci-dessous montre comment lire la date et l'heure
-   sur un service UDP (port 13) sur son propre machine, tel que présenté avec 
+   sur un service UDP (port 13) sur sa propre machine, tel que présenté avec
    la fonction <function>stream_socket_client</function> :
    <note>
     <simpara>

--- a/reference/stream/php_user_filter/filter.xml
+++ b/reference/stream/php_user_filter/filter.xml
@@ -54,7 +54,7 @@
      <para>
       Le paramètre <parameter>consumed</parameter>, qui doit <emphasis>toujours</emphasis>
       être déclaré par référence, doit être incrémenté par la longueur
-      des données filtrés par le filtre. Dans la plupart des cas, cela
+      des données filtrées par le filtre. Dans la plupart des cas, cela
       signifie qu'il faut incrémenter le paramètre <parameter>consumed</parameter>
       par <literal>$bucket-&gt;datalen</literal> pour chaque <literal>$bucket</literal>.
      </para>
@@ -99,8 +99,8 @@
        <entry><constant>PSFS_FEED_ME</constant></entry>
        <entry>
         Le processus de filtrage s'est terminé avec succès, cependant,
-        aucune donnée n'est disponible pour être retourné.
-        Plus de données sont requis depuis le flux ou avant filtrage.
+        aucune donnée n'est disponible pour être retournée.
+        Plus de données sont requises depuis le flux ou avant filtrage.
        </entry>
       </row>
       <row>

--- a/reference/stream/php_user_filter/oncreate.xml
+++ b/reference/stream/php_user_filter/oncreate.xml
@@ -77,7 +77,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Le implémentation de cette méthode doit retourner
+   L'implémentation de cette méthode doit retourner
    &false; si une erreur survient, ou &true; en cas de succès.
   </para>
  </refsect1>

--- a/reference/stream/streamwrapper/stream-write.xml
+++ b/reference/stream/streamwrapper/stream-write.xml
@@ -21,7 +21,7 @@
   <note>
    <para>
     N'oubliez pas de mettre à jour la position courante dans le flux,
-    du nombre d'octets qui ont pu être lu.
+    du nombre d'octets qui ont pu être lus.
    </para>
   </note>
  </refsect1>
@@ -61,7 +61,7 @@
   &userstream.not.implemented.warning;
   <note>
    <para>
-    Si la valeur de retour est plus grand que la taille de 
+    Si la valeur de retour est plus grande que la taille de
     <parameter>data</parameter>, une alerte <constant>E_WARNING</constant> 
     sera émise, et la valeur retournée sera tronquée à sa longueur.
    </para>

--- a/reference/sync/syncevent.xml
+++ b/reference/sync/syncevent.xml
@@ -17,7 +17,7 @@
     Les objets d'événements à la fois automatique et manuelle sont supportés.
    </simpara>
    <simpara>
-    Un objet d'évément, attend, sans mise en file, que les objets soient
+    Un objet d'événement, attend, sans mise en file, que les objets soient
     lancés/définis. Une instance attend sur l'objet d'événement tandis qu'une
     autre lance/définit l'événement. Les objets d'événements sont utiles
     tout au long d'un processus long (c.-à-d. vérifier pour voir si un téléchargement

--- a/reference/sync/syncevent/wait.xml
+++ b/reference/sync/syncevent/wait.xml
@@ -27,7 +27,7 @@
     <listitem>
      <simpara>
       Le nombre de millisecondes à attendre que l'événement ne soit lancé.
-      Une valeur de -1 signifie que l'on attend indéfiniement.
+      Une valeur de -1 signifie que l'on attend indéfiniment.
      </simpara>
     </listitem>
    </varlistentry>

--- a/reference/sync/syncmutex/lock.xml
+++ b/reference/sync/syncmutex/lock.xml
@@ -29,7 +29,7 @@
     <listitem>
      <simpara>
       Le nombre de millisecondes à attendre pour l'obtention du verrou
-      exclusif. Une valeur -1 signifie que l'on attend indéfiniement.
+      exclusif. Une valeur -1 signifie que l'on attend indéfiniment.
      </simpara>
     </listitem>
    </varlistentry>

--- a/reference/sync/syncmutex/unlock.xml
+++ b/reference/sync/syncmutex/unlock.xml
@@ -5,7 +5,7 @@
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="syncmutex.unlock">
  <refnamediv>
   <refname>SyncMutex::unlock</refname>
-  <refpurpose>Déverouille le mutex</refpurpose>
+  <refpurpose>Déverrouille le mutex</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/sync/syncreaderwriter.xml
+++ b/reference/sync/syncreaderwriter.xml
@@ -16,7 +16,7 @@
     Une implémentation cross-plateforme, native des objets lecture-écriture nommés ou non.
    </simpara>
    <simpara>
-    Un objet lecture-écriture autorisent plusieurs lectures, ou une écriture à accéder
+    Un objet lecture-écriture autorise plusieurs lectures, ou une écriture à accéder
     à une ressource. C'est une solution efficace pour gérer les ressources
     où l'accès est originalement en lecture seule mais qu'un accès en écriture est
     occasionnellement nécessaire.

--- a/reference/sync/syncreaderwriter/construct.xml
+++ b/reference/sync/syncreaderwriter/construct.xml
@@ -54,7 +54,7 @@
       <simpara>
        Si l'objet est un objet de lecture/écriture avec l'autounlock à &false;,
        l'objet est verrouillé en lecture ou en écriture, et le script PHP
-       va se terminer avant le déverouillage de l'objet, et donc, l'objet
+       va se terminer avant le déverrouillage de l'objet, et donc, l'objet
        sous-jacent se terminera dans un statut non consistent.
       </simpara>
      </warning>

--- a/reference/sync/syncreaderwriter/readlock.xml
+++ b/reference/sync/syncreaderwriter/readlock.xml
@@ -26,8 +26,8 @@
     <term><parameter>wait</parameter></term>
     <listitem>
      <simpara>
-      Le nombre de millisecondes à attente un verrou. Une valeur de -1 signifie
-      que l'on attend indéfiniement.
+      Le nombre de millisecondes à attendre un verrou. Une valeur de -1 signifie
+      que l'on attend indéfiniment.
      </simpara>
     </listitem>
    </varlistentry>

--- a/reference/sync/syncreaderwriter/writelock.xml
+++ b/reference/sync/syncreaderwriter/writelock.xml
@@ -27,7 +27,7 @@
     <listitem>
      <simpara>
       Le nombre de millisecondes à attendre le verrou. Une valeur de -1 signifie
-      que l'on attend indéfiniement.
+      que l'on attend indéfiniment.
      </simpara>
     </listitem>
    </varlistentry>

--- a/reference/sync/syncsemaphore.xml
+++ b/reference/sync/syncsemaphore.xml
@@ -16,7 +16,7 @@
     Une implémentation cross-plateforme, native des objets Sémaphore nommés ou non.
    </simpara>
    <simpara>
-    Un sémaphore réstreint l'accès à une ressource limitée à un nombre limité
+    Un sémaphore restreint l'accès à une ressource limitée à un nombre limité
     d'instances. Les sémaphores diffèrent des mutexes dans le sens où il permet
     à plus d'une instance à accéder à une ressource en même temps, alors que le mutex
     ne permet qu'une seule instance à la fois.

--- a/reference/sync/syncsemaphore/lock.xml
+++ b/reference/sync/syncsemaphore/lock.xml
@@ -27,8 +27,8 @@
     <term><parameter>wait</parameter></term>
     <listitem>
      <simpara>
-      Le nombre de millisecondes à attendre le sémaphore. Une valuer à -1 signifie que
-      l'on attend indéfiniement.
+      Le nombre de millisecondes à attendre le sémaphore. Une valeur de -1 signifie que
+      l'on attend indéfiniment.
      </simpara>
     </listitem>
    </varlistentry>


### PR DESCRIPTION
Fixes grammar, spelling and conjugation errors in sync/, stream/ and sqlite3/ files.