### PR TITLE
Fix grammar and spelling in event/, ev/ and eio/ documentation

### DIFF
--- a/reference/eio/functions/eio-readdir.xml
+++ b/reference/eio/functions/eio-readdir.xml
@@ -124,7 +124,7 @@
      <simpara>
       Lorsque ce drapeau est spécifié, alors les noms sont retournés dans un
       ordre suivant le statut <literal>stat</literal> de chaque nœud.
-      Pour appliquer la fonction <function>stat</function> a tous
+      Pour appliquer la fonction <function>stat</function> à tous
       les fichiers du dossier, il sera plus rapide d'utiliser ce drapeau.
      </simpara>
     </listitem>

--- a/reference/ev/evtimer.xml
+++ b/reference/ev/evtimer.xml
@@ -11,7 +11,7 @@
    <simpara>
     Les watchers <classname>EvTimer</classname> sont des watchers relativement
     simples qui génèrent un événement après une durée fournie, et, optionnellement,
-    se répète dans un intervalle régulier.
+    se répètent dans un intervalle régulier.
    </simpara>
    <simpara>
     Les minuteurs sont basés sur un temps réel, aussi, si un minuteur enregistre
@@ -25,8 +25,8 @@
     Il est garanti que la fonction de rappel sera appelée uniquement après
     l'expiration du délai maximal d'attente (et non exactement à ce moment précis,
     aussi, sur des systèmes avec une horloge basse résolution, il se peut qu'un
-    petit délai ne soit introduit). Si plusieurs minuteurs deviennent
-    prêts pendant la même itération de boucle, alors celui dont les valeurs
+    petit délai soit introduit). Si plusieurs minuteurs deviennent
+    prêts pendant la même itération de boucle, alors celui dont la valeur
     du délai d'attente maximal sera la plus proche sera invoqué avant l'autre
     ayant une priorité identique mais avec une valeur du délai d'attente plus
     éloignée (mais ceci n'est plus vrai lorsqu'une fonction de rappel appelle

--- a/reference/ev/evwatcher.xml
+++ b/reference/ev/evwatcher.xml
@@ -10,7 +10,7 @@
    &reftitle.intro;
    <simpara>
     La classe <classname>EvWatcher</classname> est une classe de base
-    pour tous les watchers(<classname>EvCheck</classname>, <classname>EvChild</classname>
+    pour tous les watchers (<classname>EvCheck</classname>, <classname>EvChild</classname>
     etc.). Vu que le constructeur de la classe <classname>EvWatcher</classname>
     est <modifier>abstrait</modifier>, on ne peut pas
     (et on ne doit pas) créer des objets EvWatcher directement.
@@ -102,7 +102,7 @@
      <listitem>
       <simpara>
        &integer;
-       Intervalle de <constant>Ev::MINPRI</constant> et <constant>Ev::MAXPRI</constant>.
+       Intervalle entre <constant>Ev::MINPRI</constant> et <constant>Ev::MAXPRI</constant>.
        Les watchers en attente avec une priorité haute seront appelés
        avant les watchers avec une priorité basse, mais la priorité ne peut pas
        faire qu'un watcher ne sera jamais exécuté (sauf pour les watchers

--- a/reference/event/event.persistence.xml
+++ b/reference/event/event.persistence.xml
@@ -3,7 +3,7 @@
 <!-- Reviewed: no -->
 
 <chapter  xml:id="event.persistence" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
- <title>A propos de la persistence des événements</title>
+ <title>À propos de la persistence des événements</title>
  <para>
   Par défaut, dès qu'un événement en attente devient actif (car son descripteur
   de fichier est prêt à être lu ou écrit, ou parce que son délai d'attente
@@ -43,7 +43,7 @@
   <link
  xlink:href="http://www.wangafu.net/~nickm/libevent-book/Ref4_event.html#_about_event_persistence">
   la programmation réseau rapide, portable et non-bloquante avec Libevent ;
-  A propos des événements persistants</link>
+  À propos des événements persistants</link>
  </para>
 </chapter>
 <!-- Keep this comment at the end of the file

--- a/reference/event/event.xml
+++ b/reference/event/event.xml
@@ -109,7 +109,7 @@
      <listitem>
       <para>
        Si l'événement est en attente. Voir la section :
-       <link linkend="event.persistence">A propos de la persistence des événements</link>.
+       <link linkend="event.persistence">À propos de la persistence des événements</link>.
       </para>
      </listitem>
     </varlistentry>
@@ -139,7 +139,7 @@
      <listitem>
       <para>
        Indique que l'événement est persistent. Voir la section :
-       <link linkend="event.persistence">A propos de la persistence des événements</link>.
+       <link linkend="event.persistence">À propos de la persistence des événements</link>.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/event/eventbuffer/write.xml
+++ b/reference/event/eventbuffer/write.xml
@@ -6,7 +6,7 @@
 <refentry xml:id="eventbuffer.write" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>EventBuffer::write</refname>
-  <refpurpose>Ecrit le contenu du buffer dans un fichier ou dans un socket</refpurpose>
+  <refpurpose>Écrit le contenu du buffer dans un fichier ou dans un socket</refpurpose>
  </refnamediv>
  <refsect1 role="description">
   &reftitle.description;
@@ -24,7 +24,7 @@
    </methodparam>
   </methodsynopsis>
   <para>
-   Ecrit le contenu du buffer dans un descripteur de fichier. Le buffer
+   Écrit le contenu du buffer dans un descripteur de fichier. Le buffer
    sera vidé après l'écriture avec succès des derniers octets.
   </para>
  </refsect1>

--- a/reference/event/eventbufferevent.about.callbacks.xml
+++ b/reference/event/eventbufferevent.about.callbacks.xml
@@ -2,7 +2,7 @@
 <!-- EN-Revision: a47dff201e3f65c07f6c84a535951632771cf72d Maintainer: yannick Status: ready -->
 <!-- Reviewed: no -->
 <chapter xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="eventbufferevent.about.callbacks">
- <title>A propos des fonctions de rappel du buffer d'événements</title>
+ <title>À propos des fonctions de rappel du buffer d'événements</title>
  <para>
   Un objet de la classe <classname>EventBufferEvent</classname>
   représente un <emphasis>buffer d'événements</emphasis>.

--- a/reference/event/eventbufferevent.xml
+++ b/reference/event/eventbufferevent.xml
@@ -48,7 +48,7 @@
     lecture, et un buffer d'écriture. Au lieu d'un événement classique,
     qui fournit des fonctions de rappel lorsque le transport sous-jacent
     est prêt à être lu ou écrit, un buffer d'événement appelle ses fonctions
-    de rappel fournis par l'utilisateur lorsqu'il a lu ou écrit suffisamment
+    de rappel fournies par l'utilisateur lorsqu'il a lu ou écrit suffisamment
     de données.
    </para>
   </section>

--- a/reference/event/eventbufferevent/construct.xml
+++ b/reference/event/eventbufferevent/construct.xml
@@ -64,7 +64,7 @@
     </term>
     <listitem>
      <para>
-      Evénement de base qui doit être associé avec le nouveau tampon d'événement.
+      Événement de base qui doit être associé avec le nouveau tampon d'événement.
      </para>
     </listitem>
    </varlistentry>
@@ -99,7 +99,7 @@
      <para>
       Fonction de rappel pour les événements de lecture. Voir aussi
       les <link linkend="eventbufferevent.about.callbacks">fonctions
-      de rappel des tampon d'événement</link>.
+      de rappel des tampons d'événement</link>.
      </para>
     </listitem>
    </varlistentry>
@@ -111,7 +111,7 @@
      <para>
       Fonction de rappel pour les événements d'écriture. Voir aussi les
       <link linkend="eventbufferevent.about.callbacks">fonctions
-      de rappel des tampon d'événement</link>.
+      de rappel des tampons d'événement</link>.
      </para>
     </listitem>
    </varlistentry>
@@ -124,7 +124,7 @@
       Fonction de rappel pour les événements de changement de statut.
       Voir aussi les
       <link linkend="eventbufferevent.about.callbacks">fonctions
-      de rappel des tampon d'événement</link>.
+      de rappel des tampons d'événement</link>.
      </para>
     </listitem>
    </varlistentry>

--- a/reference/event/eventbufferevent/createpair.xml
+++ b/reference/event/eventbufferevent/createpair.xml
@@ -40,7 +40,7 @@
     </term>
     <listitem>
      <para>
-      Evénement de base associé.
+      Événement de base associé.
      </para>
     </listitem>
    </varlistentry>

--- a/reference/event/eventbufferevent/sslfilter.xml
+++ b/reference/event/eventbufferevent/sslfilter.xml
@@ -56,7 +56,7 @@
     </term>
     <listitem>
      <para>
-      Evénement de base associé.
+      Événement de base associé.
      </para>
     </listitem>
    </varlistentry>

--- a/reference/event/eventbufferevent/sslsocket.xml
+++ b/reference/event/eventbufferevent/sslsocket.xml
@@ -49,7 +49,7 @@
     </term>
     <listitem>
      <para>
-      Evénement de base associé.
+      Événement de base associé.
      </para>
     </listitem>
    </varlistentry>

--- a/reference/event/eventconfig/setmaxdispatchinterval.xml
+++ b/reference/event/eventconfig/setmaxdispatchinterval.xml
@@ -5,7 +5,7 @@
 <refentry xml:id="eventconfig.setmaxdispatchinterval" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>EventConfig::setMaxDispatchInterval</refname>
-  <refpurpose>Evite l'inversion des priorités</refpurpose>
+  <refpurpose>Évite l'inversion des priorités</refpurpose>
  </refnamediv>
  <refsect1 role="description">
   &reftitle.description;
@@ -27,7 +27,7 @@
    </methodparam>
   </methodsynopsis>
   <para>
-   Evite l'inversion des priorités en limitant le nombre
+   Évite l'inversion des priorités en limitant le nombre
    de fonctions de rappel d'événements en basse priorité qui peuvent
    être invoquées avant de vérifier la présence d'événements de haute
    priorité.

--- a/reference/event/eventdnsbase/construct.xml
+++ b/reference/event/eventdnsbase/construct.xml
@@ -34,7 +34,7 @@
     </term>
     <listitem>
      <para>
-      Evénement de base.
+      Événement de base.
      </para>
     </listitem>
    </varlistentry>

--- a/reference/event/eventhttp/construct.xml
+++ b/reference/event/eventhttp/construct.xml
@@ -36,7 +36,7 @@
     </term>
     <listitem>
      <para>
-      Evénement de base associé.
+      Événement de base associé.
      </para>
     </listitem>
    </varlistentry>

--- a/reference/event/eventutil/setsocketoption.xml
+++ b/reference/event/eventutil/setsocketoption.xml
@@ -73,7 +73,7 @@
     </term>
     <listitem>
      <para>
-      Nom de l'option (type). A la même signification que le paramètre correspondant
+      Nom de l'option (type). À la même signification que le paramètre correspondant
       de la fonction <function>socket_get_option</function>. Voir aussi les
       <link linkend="eventutil.constants">constantes EventUtil</link>.
      </para>

--- a/reference/event/examples.xml
+++ b/reference/event/examples.xml
@@ -1023,7 +1023,7 @@ PHP, date:
   </screen>
  </example>
  <example>
-  <title>Ecoute d'une connexion en se basant sur un socket de domaine Unix</title>
+  <title>Écoute d'une connexion en se basant sur un socket de domaine Unix</title>
   <programlisting role="php">
 <![CDATA[
 <?php


### PR DESCRIPTION
Fixes grammar, spelling and conjugation errors in event/, ev/ and eio/ extension files.