### PR TITLE
Fix grammar and spelling in info/ and intl/ documentation

### DIFF
--- a/reference/info/functions/getrusage.xml
+++ b/reference/info/functions/getrusage.xml
@@ -58,18 +58,18 @@
 <![CDATA[
 <?php
 $dat = getrusage();
-echo $dat["ru_oublock"];       // nombre d'opération de block de sortie
-echo $dat["ru_inblock"];       // nombre d'opération de block d'entrée
-echo $dat["ru_msgsnd"];        // nombre de messages IPC envoyé
-echo $dat["ru_msgrcv"];        // nombre de messages IPC reçu
+echo $dat["ru_oublock"];       // nombre d'opérations de bloc de sortie
+echo $dat["ru_inblock"];       // nombre d'opérations de bloc d'entrée
+echo $dat["ru_msgsnd"];        // nombre de messages IPC envoyés
+echo $dat["ru_msgrcv"];        // nombre de messages IPC reçus
 echo $dat["ru_maxrss"];        // taille maximale du groupe de résidents
 echo $dat["ru_ixrss"];         // taille de la mémoire partagée intégrale
 echo $dat["ru_idrss"];         // taille intégrale des données non partagées
-echo $dat["ru_minflt"];        // nombre de page récupéré (faute de page mineure)
+echo $dat["ru_minflt"];        // nombre de pages récupérées (faute de page mineure)
 echo $dat["ru_majflt"];        // nombre de défauts de page (faute de page majeure)
-echo $dat["ru_nsignals"];      // nombre de signaux reçu
-echo $dat["ru_nvcsw"];         // nombre de changement de contexte volontaire
-echo $dat["ru_nivcsw"];        // nombre de changement de contexte involontaire
+echo $dat["ru_nsignals"];      // nombre de signaux reçus
+echo $dat["ru_nvcsw"];         // nombre de changements de contexte volontaires
+echo $dat["ru_nivcsw"];        // nombre de changements de contexte involontaires
 echo $dat["ru_nswap"];         // taille de la mémoire swap
 echo $dat["ru_utime.tv_usec"]; // temps utilisateur utilisé (en microsecondes)
 echo $dat["ru_utime.tv_sec"];  // temps utilisateur utilisé (en secondes)

--- a/reference/info/functions/php-sapi-name.xml
+++ b/reference/info/functions/php-sapi-name.xml
@@ -60,9 +60,9 @@
 <?php
 $sapi_type = php_sapi_name();
 if (substr($sapi_type, 0, 3) == 'cgi') {
-    echo "Vous utiliser CGI PHP\n";
+    echo "Vous utilisez CGI PHP\n";
 } else {
-    echo "Vous n'utiliser pas CGI PHP\n";
+    echo "Vous n'utilisez pas CGI PHP\n";
 }
 ?>
 ]]>

--- a/reference/intl/intlchar.xml
+++ b/reference/intl/intlchar.xml
@@ -7509,7 +7509,7 @@
        <type>int</type>
       </term>
       <listitem>
-       <para>Bloc des caractères samaritains utilisés dans l'écriture samaritain.</para>
+       <para>Bloc des caractères samaritains utilisés dans l'écriture samaritaine.</para>
       </listitem>
      </varlistentry>
 
@@ -7559,7 +7559,7 @@
        <type>int</type>
       </term>
       <listitem>
-       <para>Bloc des caractères Bamum utilisés dans l'écriture Bamum de la Camaroun.</para>
+       <para>Bloc des caractères Bamum utilisés dans l'écriture Bamum du Cameroun.</para>
       </listitem>
      </varlistentry>
 
@@ -10409,7 +10409,7 @@
        <type>int</type>
       </term>
       <listitem>
-       <para>Catégorie de séparation de lignes : Surrugate.</para>
+       <para>Catégorie de séparation de lignes : Surrogate.</para>
       </listitem>
      </varlistentry>
 

--- a/reference/intl/numberformatter-constants.xml
+++ b/reference/intl/numberformatter-constants.xml
@@ -201,7 +201,7 @@
   <title>Spécificateurs de format de nombre</title>
   <para>
    Ces constantes définissent la méthode d'analyse et de formatage
-   des nombres. Ils doivent être utilisés comme arguments des fonctions
+   des nombres. Elles doivent être utilisées comme arguments des fonctions
    <function>numfmt_format</function> et <function>numfmt_parse</function>.
    <variablelist>
     <varlistentry xml:id="numberformatter.constants.type-default">
@@ -400,7 +400,7 @@
       <type>int</type>
      </term>
      <listitem>
-      <simpara>La largeur de complément pour le formattage d'un nombre.</simpara>
+      <simpara>La largeur de complément pour le formatage d'un nombre.</simpara>
      </listitem>
     </varlistentry>
 


### PR DESCRIPTION
Fixes plural agreements, spelling and conjugation errors in info/ and intl/ files.