### PR TITLE
Fix PGSQL_TRACE_SUPPRESS_TIMESTAMPS version: 8.3.0 → 8.4.20

### DIFF
--- a/reference/pgsql/constants.xml
+++ b/reference/pgsql/constants.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 3c6c95fcfd7d9eaa603df40327693ea8dff89d53 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: f5419b6eddbbb69317b0b3e6d752532ee2ed0b2a Maintainer: yannick Status: ready -->
 <!-- Reviewed: yes -->
 
 <appendix xml:id="pgsql.constants" xmlns="http://docbook.org/ns/docbook">
@@ -971,7 +971,7 @@
     <simpara>
      À utiliser avec <function>pg_trace</function>,
      l'horodatage n'est pas inclus dans les messages de trace.
-     Disponible à partir de PHP 8.3.0.
+     Disponible à partir de PHP 8.4.20.
     </simpara>
    </listitem>
 </varlistentry>


### PR DESCRIPTION
Fixes #2666