### PR TITLE
Fix typo: RFC 3399 -> RFC 3339 in DateTimeInterface::ATOM

### DIFF
--- a/reference/datetime/datetimeinterface.xml
+++ b/reference/datetime/datetimeinterface.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 6bbb5b9685d27ac9df744702e06525047a163d4b Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: a69d8c2c891e70c03c33cbe251a208dd7d185af9 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <reference xml:id="class.datetimeinterface" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  
@@ -161,7 +161,7 @@
      <listitem>
       <simpara>
        Atom (exemple: 2005-08-15T15:52:01+00:00) ;
-       compatible avec ISO-8601, RFC 3399 et XML Schema
+       compatible avec ISO-8601, RFC 3339 et XML Schema
       </simpara>
      </listitem>
     </varlistentry>


### PR DESCRIPTION
Fixes https://github.com/php/doc-fr/issues/2670