### PR TITLE
stream_select: Fix explanation of the microseconds behavior

### DIFF
--- a/reference/stream/functions/stream-select.xml
+++ b/reference/stream/functions/stream-select.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: a123b24db5b3e42841179fea13cd508418fc45c7 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: dba3c37f8288cb0180ddc5c29b89da9857b27134 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="function.stream-select" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -81,11 +81,12 @@
        microsecondes. Le paramètre <parameter>timeout</parameter>
        représente la limite supérieure du temps que 
        <function>stream_select</function> doit attendre avant de
-       se terminer. Si <parameter>seconds</parameter> et 
-       <parameter>microseconds</parameter> sont tous les deux définis
-       à <literal>0</literal>, <function>stream_select</function> n'attendra 
+       se terminer. Si <parameter>seconds</parameter> est défini
+       à <literal>0</literal> et <parameter>microseconds</parameter>
+       vaut <literal>0</literal> ou &null;,
+       <function>stream_select</function> n'attendra
        pas de données - à la place, elle se terminera immédiatement,
-       indiquant le statut courant du flux. 
+       indiquant le statut courant du flux.
       </para>
       <para>
        Si <parameter>seconds</parameter> vaut &null;, 


### PR DESCRIPTION
Fixes https://github.com/php/doc-fr/issues/2673