### PR TITLE
Add IMAGETYPE_AVIF constant to PHP 8.1 migration guide

### DIFF
--- a/appendices/migration81/constants.xml
+++ b/appendices/migration81/constants.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e251b5cfdb995dfac897b7f9ed9aa8194f8dc50f Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: b3e7b16928a4aee2711ea7e27a0a1036d669c74e Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <sect1 xml:id="migration81.constants" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Nouvelles Constantes globales</title>
@@ -143,6 +143,16 @@
    </listitem>
    <listitem>
     <simpara><constant>SODIUM_CRYPTO_CORE_RISTRETTO255_NONREDUCEDSCALARBYTES</constant></simpara>
+   </listitem>
+  </itemizedlist>
+ </sect2>
+
+ <sect2 xml:id="migration81.constants.standard">
+  <title>Standard</title>
+
+  <itemizedlist>
+   <listitem>
+    <simpara><constant>IMAGETYPE_AVIF</constant></simpara>
    </listitem>
   </itemizedlist>
  </sect2>


### PR DESCRIPTION
Fixes #2685