### PR TITLE
Sync ob-end-clean.xml EN-Revision hash

### DIFF
--- a/reference/outcontrol/functions/ob-end-clean.xml
+++ b/reference/outcontrol/functions/ob-end-clean.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 86b976d5afaf037868174fe5c242e886eb69baa4 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 5778b68049cc01810523b09b028398c70115cd56 Maintainer: yannick Status: ready -->
 <!-- Reviewed: yes -->
 
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.ob-end-clean">


### PR DESCRIPTION
The EN change (`it's` → `its` typo fix from php/doc-en#5449) doesn't affect the FR translation, which already correctly uses `sa valeur de retour`.

Bumping the `EN-Revision` hash only.

Fixes #2693