### PR TITLE
Sync enums with EN stubs

### DIFF
--- a/reference/math/roundingmode.xml
+++ b/reference/math/roundingmode.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 15b93836d93f01ea6d90a68cacf04ce0d9fb8eff Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: aeba24a37b237885358909c8d9d50a0a7abe250b Maintainer: Fan2Shrek Status: ready -->
 <!-- Reviewed: yes -->
 <reference xmlns="http://docbook.org/ns/docbook" xml:id="enum.roundingmode" role="enum">
  <title>L'énumération RoundingMode</title>
@@ -84,7 +84,6 @@
       Arrondir à l'entier le plus petit plus grand ou égal.
      </enumitemdescription>
     </enumitem>
-
    </enumsynopsis>
   </section>
  </partintro>

--- a/reference/pcntl/pcntl.qosclass.xml
+++ b/reference/pcntl/pcntl.qosclass.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: fc9cab7d56f91b2fd9b549eaabcbf77f7d66e36f Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: aeba24a37b237885358909c8d9d50a0a7abe250b Maintainer: Fan2Shrek Status: ready -->
 <!-- Reviewed: yes -->
 <reference xmlns="http://docbook.org/ns/docbook" xml:id="enum.pcntl-qosclass" role="enum">
  <title>L'énumération Pcntl\QosClass</title>
@@ -16,37 +16,46 @@
 
   <section xml:id="enum.pcntl-qosclass.synopsis">
    &reftitle.enumsynopsis;
-   <enumsynopsis>
-    <enumname>Pcntl\QosClass</enumname>
+   <packagesynopsis>
+    <package>Pcntl</package>
 
-    <enumitem>
-     <enumidentifier>Background</enumidentifier>
-     <enumitemdescription>
-      Lance le processus après que tous les processus à haute priorité ont terminé.
-     </enumitemdescription>
-    </enumitem>
+    <enumsynopsis>
+     <enumname>QosClass</enumname>
 
-    <enumitem>
-     <enumidentifier>Default</enumidentifier>
-     <enumitemdescription>
-      Lance le processus après tous les processus à haute priorité mais avant les processus à basse priorité.
-     </enumitemdescription>
-    </enumitem>
-
-    <enumitem>
-     <enumidentifier>UserInteractive</enumidentifier>
-     <enumitemdescription>
+     <enumitem>
+      <enumidentifier>UserInteractive</enumidentifier>
+      <enumitemdescription>
       Lance le processus à la priorité la plus élevée.
      </enumitemdescription>
-    </enumitem>
+     </enumitem>
 
-    <enumitem>
-     <enumidentifier>UserInitiated</enumidentifier>
-     <enumitemdescription>
+     <enumitem>
+      <enumidentifier>UserInitiated</enumidentifier>
+      <enumitemdescription>
       Lance le processus à une priorité élevée mais inférieure à UserInteractive.
      </enumitemdescription>
-    </enumitem>
-  </enumsynopsis>
+     </enumitem>
+
+     <enumitem>
+      <enumidentifier>Default</enumidentifier>
+      <enumitemdescription>
+      Lance le processus après tous les processus à haute priorité mais avant les processus à basse priorité.
+     </enumitemdescription>
+     </enumitem>
+
+     <enumitem>
+      <enumidentifier>Utility</enumidentifier>
+      <enumitemdescription>Pcntl\QosClass::Utility description</enumitemdescription>
+     </enumitem>
+
+     <enumitem>
+      <enumidentifier>Background</enumidentifier>
+      <enumitemdescription>
+      Lance le processus après que tous les processus à haute priorité ont terminé.
+     </enumitemdescription>
+     </enumitem>
+    </enumsynopsis>
+   </packagesynopsis>
   </section>
  </partintro>
 </reference>

--- a/reference/random/random.intervalboundary.xml
+++ b/reference/random/random.intervalboundary.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 594f83cb7aff5d87d52426e68691c1fa06963b1d Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: aeba24a37b237885358909c8d9d50a0a7abe250b Maintainer: Fan2Shrek Status: ready -->
 <!-- Reviewed: yes -->
 <reference xmlns="http://docbook.org/ns/docbook" xml:id="enum.random-intervalboundary" role="enum">
  <title>L'énumération Random\IntervalBoundary</title>
@@ -18,44 +18,47 @@
   <section xml:id="enum.random-intervalboundary.synopsis">
    &reftitle.enumsynopsis;
 
-   <enumsynopsis>
-    <enumname>Random\IntervalBoundary</enumname>
+   <packagesynopsis>
+    <package>Random</package>
 
-    <enumitem>
-     <enumidentifier>ClosedOpen</enumidentifier>
-     <enumitemdescription>
+    <enumsynopsis>
+     <enumname>IntervalBoundary</enumname>
+
+     <enumitem>
+      <enumidentifier>ClosedOpen</enumidentifier>
+      <enumitemdescription>
       Un intervalle fermé à droite.
       La limite inférieure est incluse dans l'intervalle,
       la limite supérieure ne l'est pas.
      </enumitemdescription>
-    </enumitem>
+     </enumitem>
 
-    <enumitem>
-     <enumidentifier>ClosedClosed</enumidentifier>
-     <enumitemdescription>
+     <enumitem>
+      <enumidentifier>ClosedClosed</enumidentifier>
+      <enumitemdescription>
       Un intervalle fermé.
       Les deux valeurs limites sont incluses dans l'intervalle.
      </enumitemdescription>
-    </enumitem>
+     </enumitem>
 
-    <enumitem>
-     <enumidentifier>OpenClosed</enumidentifier>
-     <enumitemdescription>
+     <enumitem>
+      <enumidentifier>OpenClosed</enumidentifier>
+      <enumitemdescription>
       Un intervalle fermé à gauche.
       La limite supérieure est incluse dans l'intervalle,
       la limite inférieure ne l'est pas.
      </enumitemdescription>
-    </enumitem>
+     </enumitem>
 
-    <enumitem>
-     <enumidentifier>OpenOpen</enumidentifier>
-     <enumitemdescription>
+     <enumitem>
+      <enumidentifier>OpenOpen</enumidentifier>
+      <enumitemdescription>
       Un intervalle ouvert.
       Aucune des valeurs limites n'est incluse dans l'intervalle.
      </enumitemdescription>
-    </enumitem>
-
-   </enumsynopsis>
+     </enumitem>
+    </enumsynopsis>
+   </packagesynopsis>
   </section>
  </partintro>
 </reference>

--- a/reference/reflection/propertyhooktype.xml
+++ b/reference/reflection/propertyhooktype.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 0cc604f2db478345bff5ade4e191111d5cbfbd90 Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: aeba24a37b237885358909c8d9d50a0a7abe250b Maintainer: Fan2Shrek Status: ready -->
 <!-- Reviewed: yes -->
 <reference xmlns="http://docbook.org/ns/docbook" xml:id="enum.propertyhooktype" role="enum">
  <title>L'énumération PropertyHookType</title>
@@ -22,6 +22,7 @@
 
     <enumitem>
      <enumidentifier>Get</enumidentifier>
+     <enumvalue>'get'</enumvalue>
      <enumitemdescription>
       Indique un hook <literal>get</literal>.
      </enumitemdescription>
@@ -29,6 +30,7 @@
 
     <enumitem>
      <enumidentifier>Set</enumidentifier>
+     <enumvalue>'set'</enumvalue>
      <enumitemdescription>
       Indique un hook <literal>set</literal>.
      </enumitemdescription>


### PR DESCRIPTION
Syncs the following enum documentation files with php/doc-en#5443:

- `reference/math/roundingmode.xml` — remove extra blank line before closing tag
- `reference/pcntl/pcntl.qosclass.xml` — add `<packagesynopsis>`, reorder items (UserInteractive, UserInitiated, Default, Utility, Background), add new `Utility` case
- `reference/random/random.intervalboundary.xml` — add `<packagesynopsis>` wrapper
- `reference/reflection/propertyhooktype.xml` — add `<enumvalue>` for Get and Set cases

Fixes #2698