### PR TITLE
Sync EN: issues #2700, #2701, #2702

### DIFF
--- a/language/predefined/attributes/allowdynamicproperties.xml
+++ b/language/predefined/attributes/allowdynamicproperties.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 77325b622f91355b118e8f3bc9ff940e8201f55d Maintainer: pierrick Status: ready -->
+<!-- EN-Revision: be3574f52a050f3dd9aa6ca9dffc19b0484c250a Maintainer: pierrick Status: ready -->
 <!-- Reviewed: no -->
 <reference xml:id="class.allowdynamicproperties" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>La classe AllowDynamicProperties</title>
@@ -9,10 +9,18 @@
 
   <section xml:id="allowdynamicproperties.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     Cet attribut est utilisé pour marquer les classes qui autorisent les
     <link linkend="language.oop5.properties.dynamic-properties">propriétés dynamiques</link>.
-   </para>
+   </simpara>
+   <note>
+    <simpara>
+     Bien que les attributs eux-mêmes ne soient pas hérités, l'effet de l'attribut
+     <literal>AllowDynamicProperties</literal> <emphasis>l'est</emphasis>.
+     Les classes enfants d'une classe marquée avec cet attribut autoriseront également
+     les propriétés dynamiques, même si elles ne déclarent pas explicitement l'attribut.
+    </simpara>
+   </note>
   </section>
 
   <section xml:id="allowdynamicproperties.synopsis">
@@ -35,12 +43,13 @@
 
   <section>
    &reftitle.examples;
-   <para>
+   <simpara>
     Les propriétés dynamiques sont obsolètes à partir de PHP 8.2.0,
     donc les utiliser sans marquer la classe avec cet attribut émettra
     un avis d'obsolescence.
-   </para>
-   <informalexample>
+   </simpara>
+   <example>
+    <title>AllowDynamicProperties avec une propriété inexistante</title>
     <programlisting role="php">
 <![CDATA[
 <?php
@@ -63,12 +72,39 @@ $o2->nonExistingProp = true;
 Deprecated: Creation of dynamic property DefaultBehaviour::$nonExistingProp is deprecated in file on line 10
 ]]>
     </screen>
-   </informalexample>
+   </example>
+   <example>
+    <title>AllowDynamicProperties avec une propriété inexistante dans une classe héritée</title>
+    <programlisting role="php">
+     <![CDATA[
+<?php
+class DefaultBehaviour { }
+
+#[\AllowDynamicProperties]
+class ClassAllowsDynamicProperties { }
+
+class InheritedClassAllowsDynamicProperties extends ClassAllowsDynamicProperties { }
+
+$o1 = new DefaultBehaviour();
+$o2 = new InheritedClassAllowsDynamicProperties();
+
+$o1->nonExistingProp = true;
+$o2->nonExistingProp = true;
+?>
+]]>
+    </programlisting>
+    &example.outputs.82;
+    <screen>
+     <![CDATA[
+Deprecated: Creation of dynamic property DefaultBehaviour::$nonExistingProp is deprecated in file on line 12
+]]>
+    </screen>
+   </example>
   </section>
 
   <section xml:id="allowdynamicproperties.seealso">
    &reftitle.seealso;
-   <para><link linkend="language.attributes">Aperçu des attributs</link></para>
+   <simpara><link linkend="language.attributes">Aperçu des attributs</link></simpara>
   </section>
 
  </partintro>

--- a/language/types/boolean.xml
+++ b/language/types/boolean.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: f90b26b377a61c76c0f64028e47553e550411d08 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: fee54c7c435a1664a7a8b0e7b7de7cec4a084c45 Maintainer: yannick Status: ready -->
 <!-- Reviewed: yes Maintainer: mikaelkael -->
 
 <sect1 xml:id="language.types.boolean">
@@ -117,7 +117,9 @@ if ($show_separators) {
     <simpara>
      les objets internes qui surchargent leur comportement de casting en booléen.
      Par exemple : les <link linkend="ref.simplexml">objets SimpleXML</link> créés à
-     partir d'éléments vides sans attributs.
+     partir d'éléments vides sans attributs, ou les objets
+     <classname>GMP</classname> représentant la valeur
+     <literal>0</literal>.
     </simpara>
    </listitem>
   </itemizedlist>

--- a/language/types/string.xml
+++ b/language/types/string.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 2832df2e1bd7daa1ec29ffb167dce1c9feb8cc6b Maintainer: yannick Status: ready -->
+<!-- EN-Revision: ddc2a2d0966f746b67292b6c0987ef288747e409 Maintainer: yannick Status: ready -->
 <!-- Reviewed: no Maintainer: girgias -->
 <sect1 xml:id="language.types.string">
  <title>Chaînes</title>
@@ -921,10 +921,13 @@ $arr = [
 ];
 
 // Ne fonctionnera pas, affiche : This is { fantastic}
-echo "Ceci est { $great}";
+echo "Ceci est { $great}" . PHP_EOL;
 
 // Fonctionne, affiche : This is fantastic
-echo "Ceci est {$great}";
+echo "Ceci est {$great}" . PHP_EOL;
+
+// Pour afficher des accolades dans la sortie :
+echo "Ceci est {{$great}}" . PHP_EOL;
 
 class Square {
     public $width;
@@ -935,29 +938,29 @@ class Square {
 $square = new Square(5);
 
 // Fonctionne
-echo "Ce carré mesure {$square->width}00 centimètres de large.";
+echo "Ce carré mesure {$square->width}00 centimètres de large." . PHP_EOL;
 
 // Fonctionne, les clés entre guillemets ne fonctionnent qu'avec la syntaxe des accolades
-echo "Cela fonctionne : {$arr['key']}";
+echo "Cela fonctionne : {$arr['key']}" . PHP_EOL;
 
 // Fonctionne
-echo "Cela fonctionne : {$arr[3][2]}";
+echo "Cela fonctionne : {$arr[3][2]}" . PHP_EOL;
 
-echo "Cela fonctionne : {$arr[DATA_KEY]}";
+echo "Cela fonctionne : {$arr[DATA_KEY]}" . PHP_EOL;
 
 // Lors de l'utilisation de tableaux multidimensionnels, utilisez toujours des accolades autour des tableaux
 // lorsqu'ils sont à l'intérieur de chaînes
-echo "Cela fonctionne : {$arr['foo'][2]}";
+echo "Cela fonctionne : {$arr['foo'][2]}" . PHP_EOL;
 
-echo "Cela fonctionne : {$obj->values[3]->name}";
+echo "Cela fonctionne : {$obj->values[3]->name}" . PHP_EOL;
 
-echo "Cela fonctionne : {$obj->$staticProp}";
+echo "Cela fonctionne : {$obj->$staticProp}" . PHP_EOL;
 
 // Ne fonctionnera pas, affiche : C:\directory\{fantastic}.txt
-echo "C:\directory\{$great}.txt";
+echo "C:\directory\{$great}.txt" . PHP_EOL;
 
 // Fonctionne, affiche : C:\directory\fantastic.txt
-echo "C:\\directory\\{$great}.txt";
+echo "C:\\directory\\{$great}.txt" . PHP_EOL;
 ?>
 ]]>
      </programlisting>


### PR DESCRIPTION
## Summary

- **#2700**: Add curly brace escaping example in `language/types/string.xml`
- **#2701**: Add inherited class example to `AllowDynamicProperties`
- **#2702**: Add GMP as example of internal object overloading bool cast in `language/types/boolean.xml`

Fixes #2700
Fixes #2701
Fixes #2702