### PR TITLE
Update EN-Revision hashes for 3 outdated files

### DIFF
--- a/reference/spl/splfileinfo/getfilename.xml
+++ b/reference/spl/splfileinfo/getfilename.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: c9e5015fc6a07fd9479b104ce77b95443f8b1a8b Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 4532dcab5cc997cc75983d403c6be1ee6142b63c Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="splfileinfo.getfilename" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>

--- a/reference/stream/functions/stream-select.xml
+++ b/reference/stream/functions/stream-select.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: dba3c37f8288cb0180ddc5c29b89da9857b27134 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: a758e79c3bf173203550cb78ef07509cf859b212 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="function.stream-select" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>

--- a/security/sessions.xml
+++ b/security/sessions.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 8782bc734072865ade29b8951bc94d98a53750ef Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: c2face03ee1d79647914a73171a64ee1b67b9918 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 
  <chapter xml:id="security.sessions" xmlns="http://docbook.org/ns/docbook">


### PR DESCRIPTION
Update the EN-Revision hashes for 3 files whose translations were already in sync with the English source, but had stale revision hashes:

- `reference/spl/splfileinfo/getfilename.xml` → 4532dcab5cc997cc75983d403c6be1ee6142b63c
- `reference/stream/functions/stream-select.xml` → a758e79c3bf173203550cb78ef07509cf859b212
- `security/sessions.xml` → c2face03ee1d79647914a73171a64ee1b67b9918