### PR TITLE
Fix ext/uri: getScheme return type and getUsername seealso

### DIFF
--- a/reference/uri/uri/rfc3986/uri/getusername.xml
+++ b/reference/uri/uri/rfc3986/uri/getusername.xml
@@ -55,8 +55,8 @@ user
   &reftitle.seealso;
   <simplelist>
    <member><methodname>Uri\Rfc3986\Uri::getRawUsername</methodname></member>
+   <member><methodname>Uri\Rfc3986\Uri::getRawUserInfo</methodname></member>
    <member><methodname>Uri\Rfc3986\Uri::getUserInfo</methodname></member>
-   <member><methodname>Uri\Rfc3986\Uri::getPassword</methodname></member>
    <member><methodname>Uri\Rfc3986\Uri::withUserInfo</methodname></member>
    <member><methodname>Uri\WhatWg\Url::getUsername</methodname></member>
   </simplelist>

--- a/reference/uri/uri/whatwg/url/getscheme.xml
+++ b/reference/uri/uri/whatwg/url/getscheme.xml
@@ -9,7 +9,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis role="Uri\\WhatWg\\Url">
-   <modifier>public</modifier> <type class="union"><type>string</type><type>null</type></type><methodname>Uri\WhatWg\Url::getScheme</methodname>
+   <modifier>public</modifier> <type>string</type><methodname>Uri\WhatWg\Url::getScheme</methodname>
    <void/>
   </methodsynopsis>
   <simpara>


### PR DESCRIPTION
Fix two issues in the ext/uri translation:

- `Uri\WhatWg\Url::getScheme`: return type was `string|null` instead of `string`
- `Uri\Rfc3986\Uri::getUsername`: seealso referenced `getPassword` instead of `getRawUserInfo`