### PR TITLE
Add description for UriComparisonMode enum

### DIFF
--- a/reference/uri/uri.uricomparisonmode.xml
+++ b/reference/uri/uri.uricomparisonmode.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 330903cf6a567b885d24d0a468960d1e3b9ae213 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 9e2dd56cb1b2fb3e97eed9b16b4b94ac0dbefadc Maintainer: lacatoire Status: ready -->
 <reference xml:id="enum.uri-uricomparisonmode" role="enum" xmlns="http://docbook.org/ns/docbook">
  <title>L'énumération Uri\UriComparisonMode</title>
  <titleabbrev>Uri\UriComparisonMode</titleabbrev>
@@ -8,6 +8,13 @@
   <section xml:id="enum.uri-uricomparisonmode.intro">
    &reftitle.intro;
    <simpara>
+    Spécifie si le composant <literal>fragment</literal> doit affecter
+    le résultat d'une comparaison d'URI.
+   </simpara>
+   <simpara>
+    Si le fragment est exclu de la comparaison, deux URI seront
+    comparées comme si aucune d'entre elles ne possédait de composant
+    <literal>fragment</literal>.
    </simpara>
   </section>
 


### PR DESCRIPTION
Add introductory description for the UriComparisonMode enum explaining its purpose in URI comparisons.

Fixes #2720