### PR TITLE
Add description for UrlValidationErrorType enum

### DIFF
--- a/reference/uri/uri.whatwg.urlvalidationerrortype.xml
+++ b/reference/uri/uri.whatwg.urlvalidationerrortype.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 330903cf6a567b885d24d0a468960d1e3b9ae213 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 66d06b9c7c95ead73080ea7f0ac25dd11a052f71 Maintainer: lacatoire Status: ready -->
 <reference xml:id="enum.uri-whatwg-urlvalidationerrortype" role="enum" xmlns="http://docbook.org/ns/docbook">
  <title>L'énumération Uri\WhatWg\UrlValidationErrorType</title>
  <titleabbrev>Uri\WhatWg\UrlValidationErrorType</titleabbrev>
@@ -8,6 +8,7 @@
   <section xml:id="enum.uri-whatwg-urlvalidationerrortype.intro">
    &reftitle.intro;
    <simpara>
+    Les erreurs de validation possibles définies dans le <link xlink:href="&url.url.whatwg-url;">standard WHATWG URL</link>.
    </simpara>
   </section>
 


### PR DESCRIPTION
Add introductory description for the UrlValidationErrorType enum referencing the WHATWG URL Standard.

Fixes #2719