### PR TITLE
Expand caution note in parse_url and reference ext/uri

### DIFF
--- a/reference/url/functions/parse-url.xml
+++ b/reference/url/functions/parse-url.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4266e03897e77751a6cf7d15f9556c92124d8df3 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: b3194d54645b22d5f229fcac3b4baf0d7b85ac8d Maintainer: yannick Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.parse-url" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -26,15 +26,30 @@
    <function>parse_url</function> fera de son mieux pour les analyser correctement.
   </para>
   <caution>
-   <para>
-    Cette fonction peut ne pas donner des résultats corrects pour les URLs
-    relatives ou invalides et les résultats peuvent ne pas correspondre au
-    comportement standard des clients HTTP.
-    Si des URLs venant d'entrée utilisateur doivent être analysées,
-    des vérifications supplémentaires sont requises, par exemple en utilisant
-    <function>filter_var</function> avec le filtre
-    <constant>FILTER_VALIDATE_URL</constant>.
-   </para>
+   <simpara>
+    Cette fonction ne suit aucun standard URI ou URL établi.
+    Elle retournera des résultats incorrects ou incohérents pour les URL
+    relatives ou malformées. Même pour des URL valides, le résultat peut
+    différer de celui d'un autre analyseur d'URL, car il existe plusieurs
+    standards différents liés aux URL qui ciblent des cas d'utilisation
+    différents et qui diffèrent dans leurs exigences.
+   </simpara>
+   <simpara>
+    Le traitement d'une URL avec des analyseurs suivant des standards d'URL
+    différents est une source courante de vulnérabilités de sécurité. Par
+    exemple, la validation d'une URL contre une liste de noms d'hôtes
+    autorisés avec l'analyseur A pourrait être inefficace lorsque la
+    récupération réelle de la ressource utilise l'analyseur B qui extrait
+    les noms d'hôtes différemment.
+   </simpara>
+   <simpara>
+    Les classes <classname>Uri\Rfc3986\Uri</classname> et <classname>Uri\WhatWg\Url</classname>
+    suivent strictement les standards RFC 3986 et WHATWG URL respectivement.
+    Il est fortement recommandé d'utiliser ces classes pour tout nouveau code
+    et de migrer les utilisations existantes de la fonction <function>parse_url</function>
+    vers ces classes, à moins que le comportement de <function>parse_url</function>
+    ne doive être préservé pour des raisons de compatibilité.
+   </simpara>
   </caution>
  </refsect1>
 

--- a/reference/url/functions/parse-url.xml
+++ b/reference/url/functions/parse-url.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: b3194d54645b22d5f229fcac3b4baf0d7b85ac8d Maintainer: yannick Status: ready -->
+<!-- EN-Revision: b3194d54645b22d5f229fcac3b4baf0d7b85ac8d Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.parse-url" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>


### PR DESCRIPTION
Expand the caution note in parse_url to better explain the limitations of the function and reference the new Uri\Rfc3986\Uri and Uri\WhatWg\Url classes as recommended alternatives.

Fixes #2718