### PR TITLE
[Sync EN] curl: Update connection timeout default to literal 0

### DIFF
--- a/reference/curl/constants_curl_setopt.xml
+++ b/reference/curl/constants_curl_setopt.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: c9888ac6e5c75d00d50f9c2fd741ae3a82a479ec Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: d7d6dd60085409b295916649e4bd7107742659a2 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
  <variablelist role="constant_list">
   <title><function>curl_setopt</function></title>
@@ -241,7 +241,7 @@
    </term>
    <listitem>
     <para>
-     Le nombre de secondes à attendre lors de la tentative de connexion. Utiliser 0 pour
+     Le nombre de secondes à attendre lors de la tentative de connexion. Utiliser <literal>0</literal> pour
      attendre indéfiniment.
      Cette option accepte toute valeur pouvant être convertie en un <type>int</type> valide.
      Par défaut, la valeur est <literal>300</literal>.


### PR DESCRIPTION
Fixes https://github.com/php/doc-fr/issues/2732

Fix outdated file https://doc.php.net/revcheck.php?p=plain&lang=fr&hbp=c9888ac6e5c75d00d50f9c2fd741ae3a82a479ec&f=reference/curl/constants_curl_setopt.xml&c=off