### PR TITLE
Fix out-of-date EN-Revision in language-snippets.ent

### DIFF
--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: d6dc2be3c5c70e4a1c3d13f788643ea232747c19 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 330903cf6a567b885d24d0a468960d1e3b9ae213 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <!-- Relecture des Notes, Précautions, Avertissements, Astuces, Divers et Retour le 2018-12-29 par girgias -->
 


### PR DESCRIPTION
The `git-hash` was not updated when modifications were made in https://github.com/php/doc-fr/pull/2714.

See https://doc.php.net/revcheck.php?p=plain&lang=fr&hbp=d6dc2be3c5c70e4a1c3d13f788643ea232747c19&f=./language-snippets.ent&c=on