### PR TITLE
[Sync EN] Fix filter_input() return value documentation

### DIFF
--- a/reference/filter/functions/filter-input.xml
+++ b/reference/filter/functions/filter-input.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 627f933cfe6a033dccac32982cd68e7c1b86927f Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: f7e68a1a35d622977d1a1c2155795204243ec3f1 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xml:id="function.filter-input">
  <refnamediv>
@@ -58,11 +58,12 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   En cas de succès retourne la variable filtrée.
-   Si la variable n'est pas définie, &false; est retourné.
-   En cas d'échec &false; est retourné,
-   sauf si le drapeau <constant>FILTER_NULL_ON_FAILURE</constant> est utilisé,
-   dans ce cas là &null; est retourné.
+   Valeur de la variable demandée en cas de succès,
+   &false; si le filtre échoue,
+   ou &null; si la variable <parameter>var_name</parameter> n'est pas définie.
+   Si le drapeau <constant>FILTER_NULL_ON_FAILURE</constant> est utilisé,
+   &false; est retourné si la variable n'est pas définie
+   et &null; si le filtre échoue.
   </simpara>
  </refsect1>
 


### PR DESCRIPTION
Sync avec doc-en#5381: filter_input() retourne null (et non false) quand la variable n'est pas définie, et les valeurs de retour sont inversées avec FILTER_NULL_ON_FAILURE.

Fixes #2737