### PR TITLE
[Sync EN] quickhash: Specify correct return type and values for set()

### DIFF
--- a/reference/quickhash/quickhashinthash/set.xml
+++ b/reference/quickhash/quickhashinthash/set.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 7ac16ce2e1d9a65f4f10a92f3161d95c9e27f053 Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: 7ac16ce2e1d9a65f4f10a92f3161d95c9e27f053 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="quickhashinthash.set">
  <refnamediv>

--- a/reference/quickhash/quickhashinthash/set.xml
+++ b/reference/quickhash/quickhashinthash/set.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 34c7b33526bef25c40c2ab0dcd8709c8948964c5 Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: 7ac16ce2e1d9a65f4f10a92f3161d95c9e27f053 Maintainer: Fan2Shrek Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="quickhashinthash.set">
  <refnamediv>
@@ -11,7 +11,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier>public</modifier> <type>bool</type><methodname>QuickHashIntHash::set</methodname>
+   <modifier>public</modifier> <type>int</type><methodname>QuickHashIntHash::set</methodname>
    <methodparam><type>int</type><parameter>key</parameter></methodparam>
    <methodparam><type>int</type><parameter>value</parameter></methodparam>
   </methodsynopsis>
@@ -50,7 +50,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   2 si l'entrée a été trouvée et mise à jour, 1 si l'entrée a été nouvellement ajoutée ou 0
+   2 si l'entrée a été nouvellement ajoutée, 1 si l'entrée a été trouvée et mise à jour, ou 0
    s'il y a eu une erreur.
   </simpara>
  </refsect1>
@@ -62,17 +62,17 @@
    <programlisting role="php">
 <![CDATA[
 <?php
-$hash = new QuickHashIntHash( 1024 );
+
+$hash = new QuickHashIntHash(1024);
 
 echo "Set->Add\n";
-var_dump( $hash->get( 46692 ) );
-var_dump( $hash->set( 46692, 16091 ) );
-var_dump( $hash->get( 46692 ) );
+var_dump($hash->get(46692));
+var_dump($hash->set(46692, 16091));
+var_dump($hash->get(46692));
 
-echo "Set->Update\n";
-var_dump( $hash->set( 46692, 29906 ) );
-var_dump( $hash->get( 46692 ) );
-?>
+echo "\n\nSet->Update\n";
+var_dump($hash->set(46692, 29906));
+var_dump($hash->get(46692));
 ]]>
    </programlisting>
    &example.outputs.similar;
@@ -82,6 +82,7 @@ Set->Add
 bool(false)
 int(2)
 int(16091)
+
 Set->Update
 int(1)
 int(29906)


### PR DESCRIPTION
Sync avec doc-en#5215: QuickHashIntHash::set() retourne un int, avec 2 pour un ajout et 1 pour une mise à jour (ordre corrigé). Style du code aligné sur la version EN.

Fixes #2735