### PR TITLE
[Sync EN] request_parse_body: Clarify behavior when body already consumed

### DIFF
--- a/reference/network/functions/request-parse-body.xml
+++ b/reference/network/functions/request-parse-body.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4bf789e981af0836c41daa16e57ef86c21497faa Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: c78af136d0497e16230218083ce43448f1864272 Maintainer: Fan2Shrek Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="function.request-parse-body" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -39,8 +39,12 @@
 
   <caution>
    <simpara>
+    Le corps de la requête ne peut être consommé qu'une seule fois.
     <function>request_parse_body</function> consomme le corps de la requête sans
     le mettre en mémoire tampon dans le flux <literal>php://input</literal>.
+    Inversement, si le corps a déjà été lu (par exemple via
+    <literal>php://input</literal>), <function>request_parse_body</function>
+    retournera des données vides.
    </simpara>
   </caution>
  </refsect1>


### PR DESCRIPTION
Sync avec doc-en#5504: précise que le corps de la requête ne peut être consommé qu'une fois et que request_parse_body() retourne des données vides si le corps a déjà été lu.

Fixes #2742