### PR TITLE
[Sync EN] Clarify persistent connections reuse scope per child process

### DIFF
--- a/features/persistent-connections.xml
+++ b/features/persistent-connections.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: cd8b964b8566801265f0d287db6eb651f93be950 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: ee5ee84013f11aaaf01b09484bc9aa3225379748 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 
 <chapter xml:id="features.persistent-connections" xmlns="http://docbook.org/ns/docbook">
@@ -64,10 +64,9 @@
   un client, elles sont transmises à un fils disponible. Cela signifie
   que si un client fait une deuxième requête, il peut
   être servi par un processus client différent du premier.
-  Les connexions persistantes permettent alors de ne se connecter
-  à une base SQL que la première fois. Lors des connexions
-  ultérieures, les processus fils pourront réutiliser la
-  connexion ouverte précédemment.
+  Une fois qu'une connexion persistante est ouverte, toute requête ultérieure
+  servie par le même processus fils peut réutiliser la connexion déjà établie
+  vers le serveur SQL.
  </simpara>
  <note>
   <para>


### PR DESCRIPTION
Sync avec doc-en#5502: précise que la réutilisation d'une connexion persistante est limitée au même processus fils.

La version FR utilisait déjà des tournures impersonnelles, pas de changement de ton à faire.

Fixes #2741