### PR TITLE
[Sync EN] Document Locale::isRightToLeft (PHP 8.5)

### DIFF
--- a/reference/intl/locale/isrighttoleft.xml
+++ b/reference/intl/locale/isrighttoleft.xml
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: ac2b471bbca22b1b77140cf7c67c979d18a0caec Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+<refentry xml:id="locale.isrighttoleft"
+          xmlns="http://docbook.org/ns/docbook"
+          xmlns:xlink="http://www.w3.org/1999/xlink">
+
+ <refnamediv>
+  <refname>Locale::isRightToLeft</refname>
+  <refpurpose>Vérifie si une locale utilise un système d'écriture de droite à gauche</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Locale">
+   <modifier>public</modifier>
+   <modifier>static</modifier>
+   <type>bool</type>
+   <methodname>Locale::isRightToLeft</methodname>
+   <methodparam choice="opt">
+    <type>string</type><parameter>locale</parameter>
+    <initializer>""</initializer>
+   </methodparam>
+  </methodsynopsis>
+
+  <simpara>
+   Détermine si une locale utilise un système d'écriture de droite à gauche.
+  </simpara>
+
+  <simpara>
+   Cette méthode s'appuie sur la bibliothèque ICU et évalue le script dominant
+   associé à la locale.
+  </simpara>
+
+  <simpara>
+   Si une chaîne vide est fournie, la locale par défaut est utilisée.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>locale</parameter></term>
+    <listitem>
+     <simpara>
+      L'identifiant de la locale. Si vide, la locale par défaut est utilisée.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Retourne &true; si la locale utilise un système d'écriture de droite à
+   gauche, ou &false; sinon.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Ajout de <methodname>Locale::isRightToLeft</methodname>.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Vérifier la direction du texte pour une locale</title>
+   <programlisting>
+<![CDATA[
+var_dump(Locale::isRightToLeft('en-US'));
+var_dump(Locale::isRightToLeft('ar'));
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+bool(false)
+bool(true)
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+</refentry>


### PR DESCRIPTION
Sync avec doc-en#5055: traduction de la nouvelle méthode Locale::isRightToLeft (PHP 8.5) qui détermine si une locale utilise un système d'écriture de droite à gauche.

Fixes #2745