### PR TITLE
[Sync EN] Add reserved words restrictions for class_alias in PHP 8.5

### DIFF
--- a/appendices/reserved.xml
+++ b/appendices/reserved.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 170b6cda37f29c39b9e08375344c5eb9523b2de3 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: ff9181ea03ac348b2c7ff4ad07896f277cddcb1d Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <appendix xml:id="reserved" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Mots réservés en PHP</title>
@@ -572,6 +572,12 @@
        </entry>
        <entry>
         never (à partir de PHP 8.1)
+       </entry>
+       <entry>
+        array (à partir de PHP 8.5)
+       </entry>
+       <entry>
+        callable (à partir de PHP 8.5)
        </entry>
       </row>
      </tbody>

--- a/reference/classobj/functions/class-alias.xml
+++ b/reference/classobj/functions/class-alias.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: f5a677b8fdc3f7f72f2225f906cac0e466d4558d Maintainer: yannick Status: ready -->
+<!-- EN-Revision: ff9181ea03ac348b2c7ff4ad07896f277cddcb1d Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes Maintainer: pmartin -->
 <refentry xml:id="function.class-alias" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -21,6 +21,9 @@
    par l'utilisateur. L'alias est en tout point
    similaire à la classe originale.
   </para>
+  <simpara>
+   L'alias de classe ne peut pas être l'un des <link linkend="reserved.other-reserved-words">mots réservés</link> de PHP.
+  </simpara>
   <note>
    <simpara>
     À partir de PHP 8.3.0, <function>class_alias</function> prend également en charge


### PR DESCRIPTION
Sync avec doc-en#5059: ajoute array et callable aux mots réservés (PHP 8.5) et précise que class_alias ne peut pas utiliser l'un de ces mots comme alias.

Fixes #2746