### PR TITLE
[Sync EN] DATE_RFC7231 constant has been deprecated in PHP 8.5

### DIFF
--- a/reference/datetime/datetimeinterface.xml
+++ b/reference/datetime/datetimeinterface.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: a69d8c2c891e70c03c33cbe251a208dd7d185af9 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: e1e7f1f922033c50c2fd2d33fc5e0512f4e76844 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <reference xml:id="class.datetimeinterface" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  
@@ -369,6 +369,13 @@
        </row>
       </thead>
       <tbody>
+       <row>
+        <entry>8.5.0</entry>
+        <entry>
+         Les constantes <constant>DATE_RFC7231</constant> et
+         <constant>DateTimeInterface::RFC7231</constant> ont été rendues obsolètes.
+        </entry>
+       </row>
        <row>
         <entry>8.4.0</entry>
         <entry>


### PR DESCRIPTION
Ajout de l'entree changelog dans datetimeinterface.xml pour signaler l'obsolescence de DATE_RFC7231 et DateTimeInterface::RFC7231 a partir de PHP 8.5.

Fixes #2752