### PR TITLE
[Sync EN] pgsql: Fix function signatures

### DIFF
--- a/reference/pgsql/functions/pg-escape-bytea.xml
+++ b/reference/pgsql/functions/pg-escape-bytea.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: c2eca73ef79ebe78cebb34053e41b565af504c4f Maintainer: yannick Status: ready -->
+<!-- EN-Revision: c43a3cd9b49627b8d42a4b6ad530e10e26ca30dd Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.pg-escape-bytea" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -14,11 +14,11 @@
   <methodsynopsis>
    <type>string</type><methodname>pg_escape_bytea</methodname>
    <methodparam choice="opt"><type>PgSql\Connection</type><parameter>connection</parameter></methodparam>
-   <methodparam><type>string</type><parameter>data</parameter></methodparam>
+   <methodparam><type>string</type><parameter>string</parameter></methodparam>
   </methodsynopsis>
   <para>
    <function>pg_escape_bytea</function> protège les caractères de la
-   chaîne <parameter>data</parameter> avec le mode bytea. La chaîne
+   chaîne <parameter>string</parameter> avec le mode bytea. La chaîne
    protégée est retournée.
   </para>
   <note>
@@ -52,7 +52,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>data</parameter></term>
+     <term><parameter>string</parameter></term>
      <listitem>
       <para>
        Une &string; contenant du texte ou des données binaires qui seront

--- a/reference/pgsql/functions/pg-escape-identifier.xml
+++ b/reference/pgsql/functions/pg-escape-identifier.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e2f2172bf114599926878017ab2dce356956fa9e Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: c43a3cd9b49627b8d42a4b6ad530e10e26ca30dd Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id='function.pg-escape-identifier' xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -12,9 +12,9 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>string</type><methodname>pg_escape_identifier</methodname>
+   <type class="union"><type>string</type><type>false</type></type><methodname>pg_escape_identifier</methodname>
    <methodparam choice="opt"><type>PgSql\Connection</type><parameter>connection</parameter></methodparam>
-   <methodparam><type>string</type><parameter>data</parameter></methodparam>
+   <methodparam><type>string</type><parameter>string</parameter></methodparam>
   </methodsynopsis>
   <para>
    <function>pg_escape_identifier</function> protège un identifiant
@@ -41,7 +41,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>data</parameter></term>
+     <term><parameter>string</parameter></term>
      <listitem>
       <para>
        Une &string; contenant du texte à protéger.
@@ -55,7 +55,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Une &string; contenant les données protégées.
+   Une &string; contenant les données protégées, ou &false; en cas d'erreur.
   </para>
  </refsect1>
 

--- a/reference/pgsql/functions/pg-escape-literal.xml
+++ b/reference/pgsql/functions/pg-escape-literal.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 5f1a92089fa4efe81e9777f87f9ed93f4853898b Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: c43a3cd9b49627b8d42a4b6ad530e10e26ca30dd Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id='function.pg-escape-literal' xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -12,9 +12,9 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>string</type><methodname>pg_escape_literal</methodname>
+   <type class="union"><type>string</type><type>false</type></type><methodname>pg_escape_literal</methodname>
    <methodparam choice="opt"><type>PgSql\Connection</type><parameter>connection</parameter></methodparam>
-   <methodparam><type>string</type><parameter>data</parameter></methodparam>
+   <methodparam><type>string</type><parameter>string</parameter></methodparam>
   </methodsynopsis>
   <para>
    <function>pg_escape_literal</function> protège une requête SQL littérale pour
@@ -40,7 +40,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>data</parameter></term>
+     <term><parameter>string</parameter></term>
      <listitem>
       <para>
        Une &string; contenant du texte à protéger.
@@ -54,7 +54,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Une &string; contenant les données protégées.
+   Une &string; contenant les données protégées, ou &false; en cas d'erreur.
   </para>
  </refsect1>
 

--- a/reference/pgsql/functions/pg-escape-string.xml
+++ b/reference/pgsql/functions/pg-escape-string.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 5f1a92089fa4efe81e9777f87f9ed93f4853898b Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: c43a3cd9b49627b8d42a4b6ad530e10e26ca30dd Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.pg-escape-string" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -14,7 +14,7 @@
   <methodsynopsis>
    <type>string</type><methodname>pg_escape_string</methodname>
    <methodparam choice="opt"><type>PgSql\Connection</type><parameter>connection</parameter></methodparam>
-   <methodparam><type>string</type><parameter>data</parameter></methodparam>
+   <methodparam><type>string</type><parameter>string</parameter></methodparam>
   </methodsynopsis>
   <para>
    <function>pg_escape_string</function> protège une chaîne de caractères
@@ -39,7 +39,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>data</parameter></term>
+     <term><parameter>string</parameter></term>
      <listitem>
       <para>
        Une &string; contenant le texte à échapper.

--- a/reference/pgsql/functions/pg-execute.xml
+++ b/reference/pgsql/functions/pg-execute.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 5f1a92089fa4efe81e9777f87f9ed93f4853898b Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: c43a3cd9b49627b8d42a4b6ad530e10e26ca30dd Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.pg-execute" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -14,7 +14,7 @@
   <methodsynopsis>
    <type class="union"><type>PgSql\Result</type><type>false</type></type><methodname>pg_execute</methodname>
    <methodparam choice="opt"><type>PgSql\Connection</type><parameter>connection</parameter></methodparam>
-   <methodparam><type>string</type><parameter>stmtname</parameter></methodparam>
+   <methodparam><type>string</type><parameter>statement_name</parameter></methodparam>
    <methodparam><type>array</type><parameter>params</parameter></methodparam>
   </methodsynopsis>
   <para>
@@ -48,7 +48,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>stmtname</parameter></term>
+     <term><parameter>statement_name</parameter></term>
      <listitem>
       <para>
        Le nom de la requête préparée à exécuter. Si une chaîne vide est

--- a/reference/pgsql/functions/pg-lo-export.xml
+++ b/reference/pgsql/functions/pg-lo-export.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: c2eca73ef79ebe78cebb34053e41b565af504c4f Maintainer: dams Status: ready -->
+<!-- EN-Revision: c43a3cd9b49627b8d42a4b6ad530e10e26ca30dd Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.pg-lo-export" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -15,7 +15,7 @@
    <type>bool</type><methodname>pg_lo_export</methodname>
    <methodparam choice="opt"><type>PgSql\Connection</type><parameter>connection</parameter></methodparam>
    <methodparam><type>int</type><parameter>oid</parameter></methodparam>
-   <methodparam><type>string</type><parameter>pathname</parameter></methodparam>
+   <methodparam><type>string</type><parameter>filename</parameter></methodparam>
   </methodsynopsis>
   <para>
    <function>pg_lo_export</function> prend un objet de grande taille de la
@@ -53,7 +53,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>pathname</parameter></term>
+     <term><parameter>filename</parameter></term>
      <listitem>
       <para>
        Le chemin d'accès complet ainsi que le fichier dans lequel il sera

--- a/reference/pgsql/functions/pg-lo-import.xml
+++ b/reference/pgsql/functions/pg-lo-import.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: d0ae617680e58bde494f9d58d9c553e0a6944418 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: c43a3cd9b49627b8d42a4b6ad530e10e26ca30dd Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.pg-lo-import" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -12,10 +12,10 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>int|string|false</type><methodname>pg_lo_import</methodname>
+   <type class="union"><type>int</type><type>string</type><type>false</type></type><methodname>pg_lo_import</methodname>
    <methodparam choice="opt"><type>PgSql\Connection</type><parameter>connection</parameter></methodparam>
-   <methodparam><type>string</type><parameter>pathname</parameter></methodparam>
-   <methodparam choice="opt"><type>mixed</type><parameter>object_id</parameter></methodparam>
+   <methodparam><type>string</type><parameter>filename</parameter></methodparam>
+   <methodparam choice="opt"><type class="union"><type>int</type><type>string</type></type><parameter>oid</parameter></methodparam>
   </methodsynopsis>
   <para>
    <function>pg_lo_import</function> crée un nouvel objet de grande taille
@@ -44,7 +44,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>pathname</parameter></term>
+     <term><parameter>filename</parameter></term>
      <listitem>
       <para>
        Le chemin d'accès complet ainsi que le fichier dans lequel il sera
@@ -53,10 +53,10 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>object_id</parameter></term>
+     <term><parameter>oid</parameter></term>
      <listitem>
       <para>
-       Si le paramètre <parameter>object_id</parameter> est fourni, la fonction
+       Si le paramètre <parameter>oid</parameter> est fourni, la fonction
        essayera de créer un objet large avec cet identifiant, sinon, un
        identifiant d'objet disponible sera assigné par le serveur.
        Ce paramètre dépend d'une fonctionnalité qui est apparue avec PostgreSQL 8.1.

--- a/reference/pgsql/functions/pg-parameter-status.xml
+++ b/reference/pgsql/functions/pg-parameter-status.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 5f1a92089fa4efe81e9777f87f9ed93f4853898b Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: c43a3cd9b49627b8d42a4b6ad530e10e26ca30dd Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.pg-parameter-status" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -12,9 +12,9 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>string</type><methodname>pg_parameter_status</methodname>
+   <type class="union"><type>string</type><type>false</type></type><methodname>pg_parameter_status</methodname>
    <methodparam choice="opt"><type>PgSql\Connection</type><parameter>connection</parameter></methodparam>
-   <methodparam><type>string</type><parameter>param_name</parameter></methodparam>
+   <methodparam><type>string</type><parameter>name</parameter></methodparam>
   </methodsynopsis>
   <para>
    Consulte un paramètre de configuration courant du serveur.
@@ -48,10 +48,10 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>param_name</parameter></term>
+     <term><parameter>name</parameter></term>
      <listitem>
       <para>
-       Les valeurs possibles de <parameter>param_name</parameter> sont
+       Les valeurs possibles de <parameter>name</parameter> sont
        <literal>server_version</literal>, <literal>server_encoding</literal>,
        <literal>client_encoding</literal>, <literal>is_superuser</literal>,
        <literal>session_authorization</literal>, <literal>DateStyle</literal>,
@@ -68,7 +68,7 @@
   &reftitle.returnvalues;
   <para>
    Une chaîne contenant la valeur du paramètre, &false; en cas d'échec ou
-   du paramètre <parameter>param_name</parameter> invalide.
+   du paramètre <parameter>name</parameter> invalide.
   </para>
  </refsect1>
 

--- a/reference/pgsql/functions/pg-prepare.xml
+++ b/reference/pgsql/functions/pg-prepare.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 5f1a92089fa4efe81e9777f87f9ed93f4853898b Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: c43a3cd9b49627b8d42a4b6ad530e10e26ca30dd Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.pg-prepare" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -15,7 +15,7 @@
   <methodsynopsis>
    <type class="union"><type>PgSql\Result</type><type>false</type></type><methodname>pg_prepare</methodname>
    <methodparam choice="opt"><type>PgSql\Connection</type><parameter>connection</parameter></methodparam>
-   <methodparam><type>string</type><parameter>stmtname</parameter></methodparam>
+   <methodparam><type>string</type><parameter>statement_name</parameter></methodparam>
    <methodparam><type>string</type><parameter>query</parameter></methodparam>
   </methodsynopsis>
   <para>
@@ -28,9 +28,9 @@
   </para>
   <para>
    La fonction crée une requête préparée nommée
-   <parameter>stmtname</parameter> à partir de la chaîne
+   <parameter>statement_name</parameter> à partir de la chaîne
    <parameter>query</parameter>, celle-ci ne doit contenir qu'une seule commande
-   SQL. <parameter>stmtname</parameter> peut être <literal>""</literal> pour créer une
+   SQL. <parameter>statement_name</parameter> peut être <literal>""</literal> pour créer une
    requête qui n'est pas nommée. Dans ce cas, les requêtes qui existaient et
    qui se trouvaient sans noms sont automatiquement remplacées; autrement, il y
    aura une erreur si le nom de la requête est déjà défini dans la session
@@ -60,7 +60,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>stmtname</parameter></term>
+     <term><parameter>statement_name</parameter></term>
      <listitem>
       <para>
        Le nom à donner à la requête préparée. Il doit être unique à chaque

--- a/reference/pgsql/functions/pg-put-line.xml
+++ b/reference/pgsql/functions/pg-put-line.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: c2eca73ef79ebe78cebb34053e41b565af504c4f Maintainer: jsgoupil Status: ready -->
+<!-- EN-Revision: c43a3cd9b49627b8d42a4b6ad530e10e26ca30dd Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.pg-put-line" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -14,7 +14,7 @@
   <methodsynopsis>
    <type>bool</type><methodname>pg_put_line</methodname>
    <methodparam choice="opt"><type>PgSql\Connection</type><parameter>connection</parameter></methodparam>
-   <methodparam><type>string</type><parameter>data</parameter></methodparam>
+   <methodparam><type>string</type><parameter>query</parameter></methodparam>
   </methodsynopsis>
   <para>
    <function>pg_put_line</function> envoie une chaîne (terminée
@@ -59,7 +59,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>data</parameter></term>
+     <term><parameter>query</parameter></term>
      <listitem>
       <para>
        Une ligne de texte à envoyer directement au serveur PostgreSQL. Un

--- a/reference/pgsql/functions/pg-set-error-verbosity.xml
+++ b/reference/pgsql/functions/pg-set-error-verbosity.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: c2eca73ef79ebe78cebb34053e41b565af504c4f Maintainer: jsgoupil Status: ready -->
+<!-- EN-Revision: c43a3cd9b49627b8d42a4b6ad530e10e26ca30dd Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.pg-set-error-verbosity" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -13,7 +13,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>int</type><methodname>pg_set_error_verbosity</methodname>
+   <type class="union"><type>int</type><type>false</type></type><methodname>pg_set_error_verbosity</methodname>
    <methodparam choice="opt"><type>PgSql\Connection</type><parameter>connection</parameter></methodparam>
    <methodparam><type>int</type><parameter>verbosity</parameter></methodparam>
   </methodsynopsis>
@@ -68,7 +68,7 @@
    Le degré de message d'erreur précédent :
    <constant>PGSQL_ERRORS_TERSE</constant>,
    <constant>PGSQL_ERRORS_DEFAULT</constant>
-   ou <constant>PGSQL_ERRORS_VERBOSE</constant>.
+   ou <constant>PGSQL_ERRORS_VERBOSE</constant>, ou &false; en cas d'erreur.
   </para>
  </refsect1>
 


### PR DESCRIPTION
Mise a jour des 11 fichiers pgsql pour refleter les signatures corrigees dans doc-en : types de retour union (string|false, int|false) et renommage des parametres pour correspondre aux stubs php-src.

Fixes #2751