### PR TITLE
[Sync EN] Clarify intval() behavior with scientific notation numeric strings

### DIFF
--- a/reference/var/functions/intval.xml
+++ b/reference/var/functions/intval.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: d816a0fad6c458d9515f697cc89e26ca9d8069f5 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 6197a68b1e9bc777323fa0df01adbed4d0c743f4 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.intval" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -97,10 +97,36 @@
   <para>
    Les chaînes de caractères retournent la plupart du temps 0, cela dépend des
    caractères à l'extrême gauche de la chaîne. La règle
-   courante du 
-   <link linkend="language.types.integer.casting">transtypage d'entier</link> 
+   courante du
+   <link linkend="language.types.integer.casting">transtypage d'entier</link>
    s'applique.
   </para>
+  <note>
+   <simpara>
+    Les chaînes numériques utilisant la notation scientifique (contenant la
+    lettre <literal>e</literal> ou <literal>E</literal>) sont d'abord analysées
+    comme des nombres avant d'être converties en entier.
+   </simpara>
+   <simpara>
+    Étant donné que la partie numérique de la chaîne est analysée dans son
+    ensemble, le résultat n'est pas simplement la partie entière de tête. Les
+    exposants importants peuvent en outre déborder jusqu'à
+    <constant>PHP_INT_MAX</constant> :
+   </simpara>
+   <informalexample>
+    <programlisting role="php">
+<![CDATA[
+<?php
+echo intval('42.42e42'); // 9223372036854775807 sur les systèmes 64 bits
+?>
+]]>
+    </programlisting>
+   </informalexample>
+   <simpara>
+    Voir <link linkend="language.types.numeric-strings">Chaînes numériques</link>
+    pour des détails sur l'interprétation de ce type de chaînes.
+   </simpara>
+  </note>
  </refsect1>
  <refsect1 role="changelog">
   &reftitle.changelog;


### PR DESCRIPTION
Ajout d'une note dans intval.xml clarifiant que les chaines numeriques utilisant la notation scientifique (e/E) sont analysees entierement avant la conversion en entier, avec un exemple d'overflow vers PHP_INT_MAX.

Fixes #2750