### PR TITLE
[Sync EN] Fix collator::setAttribute example

### DIFF
--- a/reference/intl/collator/set-attribute.xml
+++ b/reference/intl/collator/set-attribute.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 1976eae0d815797af97a1e16c5cd90ffc2868395 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 0194deb3cec8d79ae6b13700f3cd031d14597838 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="collator.setattribute" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -77,13 +77,8 @@
     <programlisting role="php">
 <![CDATA[
 <?php
-$coll = collator_create( 'en_CA' );
-$val  = collator_get_attribute( $coll, Collator::NUMERIC_COLLATION );
-if ($val === false) {
-    // Gestion d'erreur.
-} elseif ($val === Collator::ON) {
-    // Quelque chose d'utile
-}
+$coll = collator_create('en_CA');
+collator_set_attribute($coll, Collator::NORMALIZATION_MODE, Collator::ON);
 ?>
 ]]>
     </programlisting>


### PR DESCRIPTION
Remplacement de l'exemple de collator_set_attribute qui appelait en realite collator_get_attribute, par un appel explicite a collator_set_attribute coherent avec la fonction documentee.

Fixes #2749