### PR TITLE
[Sync EN] Clarify with enable_post_data_reading=0 body can also be consumed via request_parse_body() (#5511)

### DIFF
--- a/appendices/ini.core.xml
+++ b/appendices/ini.core.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: ef757b033ba1df823b1ac5176ada439effe4cab4 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 3f8824b246fa5749e627ab5b063a80d2b36940e1 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 
  <section xml:id="ini.core" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -830,9 +830,10 @@ Fatal error: Maximum execution time of 30+2 seconds exceeded (terminated) in Unk
         Le fait de désactiver cette option fera que les
         variables <varname>$_POST</varname> et <varname>$_FILES</varname>
         ne seront <emphasis>pas</emphasis> peuplées.
-        La seule façon de lire les données transmises sera alors
-        d'utiliser le gestionnaire de flux
-        <link linkend="wrappers.php">php://input</link>.
+        Le corps de la requête reste non consommé dans
+        <link linkend="wrappers.php">php://input</link>
+        et peut être lu manuellement ou analysé via
+        <function>request_parse_body</function>.
         Ceci peut être intéressant pour les requêtes via un
         proxy ou pour analyser les données transmises directement
         en mémoire.

--- a/appendices/ini.core.xml
+++ b/appendices/ini.core.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 3f8824b246fa5749e627ab5b063a80d2b36940e1 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 185dda85976e5ed392664db011abda0110726c0d Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 
  <section xml:id="ini.core" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">


### PR DESCRIPTION
Fixes #2761 with typo fixed in https://github.com/php/doc-en/pull/5513