### PR TITLE
Fix mismatched xml:id for T_BOOL_CAST in tokens.xml

### DIFF
--- a/appendices/tokens.xml
+++ b/appendices/tokens.xml
@@ -149,7 +149,7 @@ defined('T_FN') || define('T_FN', 10001);
      <entry>||</entry>
      <entry><link linkend="language.operators.logical">opérateurs logiques</link></entry>
     </row>
-    <row xml:id="constant.t-boolean-cast">
+    <row xml:id="constant.t-bool-cast">
      <entry>
       <constant>T_BOOL_CAST</constant>
       (<type>int</type>)


### PR DESCRIPTION
L'entrée `T_BOOL_CAST` portait `xml:id="constant.t-boolean-cast"` alors que doc-en utilise `constant.t-bool-cast`. Aligne l'ancre côté FR.