### PR TITLE
[Sync EN] Fix exception name in createFromDateString documentation (#5521)

### DIFF
--- a/reference/datetime/dateinterval/createfromdatestring.xml
+++ b/reference/datetime/dateinterval/createfromdatestring.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: c0c9d7721b5a8564a4e27671389a456c1be13e6b Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="dateinterval.createfromdatestring" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -64,7 +64,7 @@
   &reftitle.errors;
   <para>
    API orientée objet uniquement : Si une chaîne Date/Time invalide est passée,
-   <exceptionname>DateMalformedStringException</exceptionname> est levée.
+   <exceptionname>DateMalformedIntervalStringException</exceptionname> est levée.
   </para>
  </refsect1>
 
@@ -83,7 +83,7 @@
       <entry>8.3.0</entry>
       <entry>
        <methodname>DateInterval::createFromDateString</methodname> lance désormais
-       <exceptionname>DateMalformedStringException</exceptionname> si une
+       <exceptionname>DateMalformedIntervalStringException</exceptionname> si une
        chaîne invalide est passée. Auparavant, il retournait &false;,
        et un avertissement était émis.
        <function>date_interval_create_from_date_string</function> n'a pas été


### PR DESCRIPTION
Synchronisation avec php/doc-en@c0c9d772.

Fixes #2774