### PR TITLE
[Sync EN] MongoDB: clean up markup (#5517) (suite)

### DIFF
--- a/reference/mongodb/mongodb/driver/monitoring/sdamsubscriber/topologyopening.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/sdamsubscriber/topologyopening.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: a74c03c56bfe3a14a02380a47e33604b1249dde5 Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="mongodb-driver-monitoring-sdamsubscriber.topologyopening" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,10 +13,10 @@
    <modifier>abstract</modifier> <modifier>public</modifier> <type>void</type><methodname>MongoDB\Driver\Monitoring\SDAMSubscriber::topologyOpening</methodname>
    <methodparam><type>MongoDB\Driver\Monitoring\TopologyOpeningEvent</type><parameter>event</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Si un observateur est enregistré, cette méthode est appelée lorsqu'une
    topologie est ouverte.
-  </para>
+  </simpara>
   <note>
    <simpara>
     En raison du comportement du pilote
@@ -34,9 +34,9 @@
    <varlistentry>
     <term><parameter>event</parameter> (<type>MongoDB\Driver\Monitoring\TopologyOpeningEvent</type>)</term>
     <listitem>
-     <para>
+     <simpara>
       Un objet d'événement encapsulant des informations sur la topologie ouverte.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -44,9 +44,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.void;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/serverchangedevent/gethost.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/serverchangedevent/gethost.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: bd6e6603b4614c35d9b63c8d157a98569f2358df Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="mongodb-driver-monitoring-serverchangedevent.gethost" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,9 +22,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Renvoie le nom d'hôte du serveur.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/serverchangedevent/getnewdescription.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/serverchangedevent/getnewdescription.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: bd6e6603b4614c35d9b63c8d157a98569f2358df Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="mongodb-driver-monitoring-serverchangedevent.getnewdescription" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,10 +22,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Renvoie la nouvelle <classname>MongoDB\Driver\ServerDescription</classname>
    du serveur.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/serverchangedevent/getport.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/serverchangedevent/getport.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: bd6e6603b4614c35d9b63c8d157a98569f2358df Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="mongodb-driver-monitoring-serverchangedevent.getport" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,9 +22,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Renvoie le port sur lequel ce serveur écoute.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/serverchangedevent/getpreviousdescription.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/serverchangedevent/getpreviousdescription.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: bd6e6603b4614c35d9b63c8d157a98569f2358df Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="mongodb-driver-monitoring-serverchangedevent.getpreviousdescription" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,10 +22,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Renvoie la <classname>MongoDB\Driver\ServerDescription</classname> précédente
    du serveur.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/serverchangedevent/gettopologyid.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/serverchangedevent/gettopologyid.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: bd6e6603b4614c35d9b63c8d157a98569f2358df Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="mongodb-driver-monitoring-serverchangedevent.gettopologyid" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,9 +22,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Renvoie l'ID de topologie.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/serverclosedevent/gethost.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/serverclosedevent/gethost.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: bd6e6603b4614c35d9b63c8d157a98569f2358df Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="mongodb-driver-monitoring-serverclosedevent.gethost" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,9 +22,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Renvoie le nom d'hôte du serveur.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/serverclosedevent/getport.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/serverclosedevent/getport.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: bd6e6603b4614c35d9b63c8d157a98569f2358df Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="mongodb-driver-monitoring-serverclosedevent.getport" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,9 +22,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Renvoie le port sur lequel ce serveur écoute.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/serverclosedevent/gettopologyid.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/serverclosedevent/gettopologyid.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: bd6e6603b4614c35d9b63c8d157a98569f2358df Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="mongodb-driver-monitoring-serverclosedevent.gettopologyid" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,9 +22,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Renvoie l'ID de topologie.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/serverheartbeatfailedevent/getdurationmicros.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/serverheartbeatfailedevent/getdurationmicros.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: bd6e6603b4614c35d9b63c8d157a98569f2358df Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="mongodb-driver-monitoring-serverheartbeatfailedevent.getdurationmicros" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,10 +13,10 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>int</type><methodname>MongoDB\Driver\Monitoring\ServerHeartbeatFailedEvent::getDurationMicros</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    La durée du signal périodique est une valeur calculée qui inclut le temps
    pour envoyer le message et recevoir la réponse du serveur.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -26,9 +26,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Renvoie la durée du signal périodique en microsecondes.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/serverheartbeatfailedevent/geterror.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/serverheartbeatfailedevent/geterror.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 734bafeaf071b78b15d375f9af583befddd8c2a2 Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="mongodb-driver-monitoring-serverheartbeatfailedevent.geterror" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,10 +22,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Renvoie l'<classname>Exception</classname> associée au signal périodique
    échoué.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/serverheartbeatfailedevent/gethost.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/serverheartbeatfailedevent/gethost.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: bd6e6603b4614c35d9b63c8d157a98569f2358df Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="mongodb-driver-monitoring-serverheartbeatfailedevent.gethost" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,9 +22,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Renvoie le nom d'hôte du serveur.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/serverheartbeatfailedevent/getport.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/serverheartbeatfailedevent/getport.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: bd6e6603b4614c35d9b63c8d157a98569f2358df Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="mongodb-driver-monitoring-serverheartbeatfailedevent.getport" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,9 +22,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Renvoie le port sur lequel ce serveur écoute.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/serverheartbeatfailedevent/isawaited.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/serverheartbeatfailedevent/isawaited.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e9214a2619efc5906fab59cd42fb7404c4dc49a5 Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="mongodb-driver-monitoring-serverheartbeatfailedevent.isawaited" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,11 +13,11 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>bool</type><methodname>MongoDB\Driver\Monitoring\ServerHeartbeatFailedEvent::isAwaited</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Renvoie si le signal périodique a utilisé un protocole de diffusion de flux.
    L'extension n'utilise pas le protocole de diffusion de flux pour la surveillance, donc cette méthode renverra
    toujours &false;.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -27,9 +27,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Renvoie &false;.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/serverheartbeatstartedevent/gethost.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/serverheartbeatstartedevent/gethost.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: bd6e6603b4614c35d9b63c8d157a98569f2358df Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="mongodb-driver-monitoring-serverheartbeatstartedevent.gethost" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,9 +22,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Renvoie le nom d'hôte du serveur.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/serverheartbeatstartedevent/getport.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/serverheartbeatstartedevent/getport.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: bd6e6603b4614c35d9b63c8d157a98569f2358df Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="mongodb-driver-monitoring-serverheartbeatstartedevent.getport" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,9 +22,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Renvoie le port sur lequel ce serveur écoute.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/serverheartbeatstartedevent/isawaited.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/serverheartbeatstartedevent/isawaited.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e9214a2619efc5906fab59cd42fb7404c4dc49a5 Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="mongodb-driver-monitoring-serverheartbeatstartedevent.isawaited" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,11 +13,11 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>bool</type><methodname>MongoDB\Driver\Monitoring\ServerHeartbeatStartedEvent::isAwaited</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Renvoie si le signal périodique a utilisé un protocole de diffusion de flux.
    L'extension n'utilise pas le protocole de diffusion de flux pour la surveillance, donc cette méthode renverra
    toujours &false;.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -27,9 +27,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Renvoie &false;.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/serverheartbeatsucceededevent/getdurationmicros.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/serverheartbeatsucceededevent/getdurationmicros.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: bd6e6603b4614c35d9b63c8d157a98569f2358df Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="mongodb-driver-monitoring-serverheartbeatsucceededevent.getdurationmicros" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,10 +13,10 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>int</type><methodname>MongoDB\Driver\Monitoring\ServerHeartbeatSucceededEvent::getDurationMicros</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    La durée du signal périodique est une valeur calculée qui inclut le temps
    pour envoyer le message et recevoir la réponse du serveur.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -26,9 +26,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Renvoie la durée du signal périodique en microsecondes.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/serverheartbeatsucceededevent/gethost.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/serverheartbeatsucceededevent/gethost.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: bd6e6603b4614c35d9b63c8d157a98569f2358df Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="mongodb-driver-monitoring-serverheartbeatsucceededevent.gethost" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,9 +22,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Renvoie le nom d'hôte du serveur.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/serverheartbeatsucceededevent/getport.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/serverheartbeatsucceededevent/getport.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: bd6e6603b4614c35d9b63c8d157a98569f2358df Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="mongodb-driver-monitoring-serverheartbeatsucceededevent.getport" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,9 +22,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Renvoie le port sur lequel ce serveur écoute.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/serverheartbeatsucceededevent/getreply.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/serverheartbeatsucceededevent/getreply.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: bd6e6603b4614c35d9b63c8d157a98569f2358df Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="mongodb-driver-monitoring-serverheartbeatsucceededevent.getreply" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,11 +13,11 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>object</type><methodname>MongoDB\Driver\Monitoring\ServerHeartbeatSucceededEvent::getReply</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Le document de réponse sera converti de BSON en PHP en utilisant les règles de
    <link linkend="mongodb.persistence.deserialization">désérialisation</link>
    par défaut (par exemple, les documents BSON seront convertis en <type>stdClass</type>).
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -27,10 +27,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Renvoie le document de réponse du heartbeat sous forme d'un objet
    <classname>stdClass</classname>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/serverheartbeatsucceededevent/isawaited.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/serverheartbeatsucceededevent/isawaited.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e9214a2619efc5906fab59cd42fb7404c4dc49a5 Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="mongodb-driver-monitoring-serverheartbeatsucceededevent.isawaited" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,11 +13,11 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>bool</type><methodname>MongoDB\Driver\Monitoring\ServerHeartbeatSucceededEvent::isAwaited</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Renvoie si le signal périodique a utilisé un protocole de diffusion de flux.
    L'extension n'utilise pas le protocole de diffusion de flux pour la surveillance, donc cette méthode renverra
    toujours &false;.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -27,9 +27,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Renvoie &false;.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/serveropeningevent/gethost.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/serveropeningevent/gethost.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: bd6e6603b4614c35d9b63c8d157a98569f2358df Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="mongodb-driver-monitoring-serveropeningevent.gethost" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,9 +22,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Renvoie le nom d'hôte du serveur.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/serveropeningevent/getport.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/serveropeningevent/getport.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: bd6e6603b4614c35d9b63c8d157a98569f2358df Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="mongodb-driver-monitoring-serveropeningevent.getport" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,9 +22,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Renvoie le port sur lequel ce serveur écoute.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/serveropeningevent/gettopologyid.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/serveropeningevent/gettopologyid.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: bd6e6603b4614c35d9b63c8d157a98569f2358df Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="mongodb-driver-monitoring-serveropeningevent.gettopologyid" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,9 +22,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Renvoie l'ID de topologie.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/subscriber.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/subscriber.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes --> 
 <reference xml:id="class.mongodb-driver-monitoring-subscriber" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>L'interface MongoDB\Driver\Monitoring\Subscriber</title>
@@ -10,12 +10,12 @@
 <!-- {{{ MongoDB\Driver\Monitoring\Subscriber intro -->
   <section xml:id="mongodb-driver-monitoring-subscriber.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     L'interface de base pour les observateurs d'événements. Elle est utilisée comme type de paramètre dans les fonctions
     <function>MongoDB\Driver\Monitoring\addSubscriber</function> et
     <function>MongoDB\Driver\Monitoring\removeSubscriber</function> et ne doit
     pas être implémentée directement.
-   </para>
+   </simpara>
   </section>
 <!-- }}} -->
 
@@ -37,10 +37,10 @@
    </classsynopsis>
 <!-- }}} -->
 
-   <para>
+   <simpara>
     Cette interface n'a pas de méthodes. Son seul but est d'être l'interface de base
     pour tous les observateurs d'événements.
-   </para>
+   </simpara>
 
   </section>
 

--- a/reference/mongodb/mongodb/driver/monitoring/topologychangedevent/getnewdescription.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/topologychangedevent/getnewdescription.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: bd6e6603b4614c35d9b63c8d157a98569f2358df Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="mongodb-driver-monitoring-topologychangedevent.getnewdescription" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,10 +22,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Renvoie la nouvelle <classname>MongoDB\Driver\TopologyDescription</classname>
    pour la topologie.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/topologychangedevent/getpreviousdescription.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/topologychangedevent/getpreviousdescription.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: bd6e6603b4614c35d9b63c8d157a98569f2358df Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="mongodb-driver-monitoring-topologychangedevent.getpreviousdescription" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,10 +22,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Renvoie la description précédente <classname>MongoDB\Driver\TopologyDescription</classname>
    pour la topologie.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/topologychangedevent/gettopologyid.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/topologychangedevent/gettopologyid.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: bd6e6603b4614c35d9b63c8d157a98569f2358df Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="mongodb-driver-monitoring-topologychangedevent.gettopologyid" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,9 +22,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Renvoie l'identifiant de la topologie.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/topologyclosedevent/gettopologyid.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/topologyclosedevent/gettopologyid.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: bd6e6603b4614c35d9b63c8d157a98569f2358df Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="mongodb-driver-monitoring-topologyclosedevent.gettopologyid" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,9 +22,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Renvoie l'identifiant de la topologie.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/monitoring/topologyopeningevent/gettopologyid.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/topologyopeningevent/gettopologyid.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: bd6e6603b4614c35d9b63c8d157a98569f2358df Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="mongodb-driver-monitoring-topologyopeningevent.gettopologyid" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,9 +22,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Renvoie l'identifiant de la topologie.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/readconcern/bsonserialize.xml
+++ b/reference/mongodb/mongodb/driver/readconcern/bsonserialize.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: a5eca06ae7725b4c35eefecbb0d722a3e198ff21 Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="mongodb-driver-readconcern.bsonserialize" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,9 +22,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Renvoie un objet pour la sérialisation du ReadConcern en BSON.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/readconcern/construct.xml
+++ b/reference/mongodb/mongodb/driver/readconcern/construct.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 734bafeaf071b78b15d375f9af583befddd8c2a2 Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="mongodb-driver-readconcern.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,10 +13,10 @@
    <modifier>final</modifier> <modifier>public</modifier> <methodname>MongoDB\Driver\ReadConcern::__construct</methodname>
    <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>level</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Construit un nouvel <classname>MongoDB\Driver\ReadConcern</classname>, qui est
    un objet de valeur immuable.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -25,11 +25,11 @@
    <varlistentry>
     <term><parameter>level</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       Le <link xlink:href="&url.mongodb.docs.readconcern;#read-concern-levels">niveau du read concern</link>.
       Il est possible d'utiliser, mais n'êtes pas limité à, une des
       <link linkend="mongodb-driver-readconcern.constants">constantes de classe</link>.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>

--- a/reference/mongodb/mongodb/driver/readconcern/getlevel.xml
+++ b/reference/mongodb/mongodb/driver/readconcern/getlevel.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 53242ee6628dc1ae6989fe002231fddfd8f005c6 Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="mongodb-driver-readconcern.getlevel" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,9 +22,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Renvoie l'option "level" du ReadConcern.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/readconcern/isdefault.xml
+++ b/reference/mongodb/mongodb/driver/readconcern/isdefault.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 331fbfeac522d4ad00de1e043cc11610d66b88f9 Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="mongodb-driver-readconcern.isdefault" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,19 +13,19 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>bool</type><methodname>MongoDB\Driver\ReadConcern::isDefault</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Renvoie si c'est le read concern par défaut (c'est-à-dire sans
    options spécifiées). Cette méthode est principalement destinée à être utilisée en conjonction avec
    <methodname>MongoDB\Driver\Manager::getReadConcern</methodname> pour déterminer
    si le Manager a été construit sans aucune option de read concern.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Le pilote n'inclura pas de read concern par défaut dans ses opérations de lecture
    (par exemple <methodname>MongoDB\Driver\Manager::executeQuery</methodname>) afin
    de permettre au serveur d'appliquer son propre défaut. Les bibliothèques qui accèdent
    au read concern du Manager pour l'inclure dans leurs propres commandes de lecture
    devraient utiliser cette méthode pour s'assurer que les read concerns par défaut sont laissés non définis.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -35,9 +35,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Renvoie &true; si c'est le read concern par défaut et &false; sinon.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/readpreference/bsonserialize.xml
+++ b/reference/mongodb/mongodb/driver/readpreference/bsonserialize.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: c64016065c9b97fa1cbbef48a9ed105232b423a8 Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="mongodb-driver-readpreference.bsonserialize" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,9 +22,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Renvoie un objet pour la sérialisation de la ReadPreference en BSON.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/readpreference/gethedge.xml
+++ b/reference/mongodb/mongodb/driver/readpreference/gethedge.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 53242ee6628dc1ae6989fe002231fddfd8f005c6 Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="mongodb-driver-readpreference.gethedge" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,9 +22,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Renvoie l'option "hedge" du ReadPreference.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/readpreference/getmaxstalenessseconds.xml
+++ b/reference/mongodb/mongodb/driver/readpreference/getmaxstalenessseconds.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: c64016065c9b97fa1cbbef48a9ed105232b423a8 Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="mongodb-driver-readpreference.getmaxstalenessseconds" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,12 +22,12 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Renvoie l'option "maxStalenessSeconds" du ReadPreference. Si aucun délai
    maximal n'a été spécifié,
    <constant>MongoDB\Driver\ReadPreference::NO_MAX_STALENESS</constant> sera
    retourné.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/readpreference/getmodestring.xml
+++ b/reference/mongodb/mongodb/driver/readpreference/getmodestring.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: c64016065c9b97fa1cbbef48a9ed105232b423a8 Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="mongodb-driver-readpreference.getmodestring" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,9 +22,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Renvoie l'option "mode" du ReadPreference en tant que chaîne.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/readpreference/gettagsets.xml
+++ b/reference/mongodb/mongodb/driver/readpreference/gettagsets.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: c64016065c9b97fa1cbbef48a9ed105232b423a8 Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="mongodb-driver-readpreference.gettagsets" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,9 +22,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Renvoie l'option "tagSets" de ReadPreference.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/server/construct.xml
+++ b/reference/mongodb/mongodb/driver/server/construct.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: dcfd0933c0adfb15d1efafa5c553b2e57c03d3a0 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="mongodb-driver-server.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -15,13 +15,13 @@
    <modifier>final</modifier> <modifier>private</modifier> <methodname>MongoDB\Driver\Server::__construct</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
     Les objets <classname>MongoDB\Driver\Server</classname> sont créés en interne 
    par <classname>MongoDB\Driver\Manager</classname> lorsqu'une connexion de base de 
    données est établie et peut être retournée par
    <function>MongoDB\Driver\Manager::getServers</function> et
    <function>MongoDB\Driver\Manager::selectServer</function>.
-  </para>
+  </simpara>
 
  </refsect1>
 

--- a/reference/mongodb/mongodb/driver/server/executebulkwritecommand.xml
+++ b/reference/mongodb/mongodb/driver/server/executebulkwritecommand.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 187032b3ea20fa28f1c9f29ba38d06820428f849 Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 
 <refentry xml:id="mongodb-driver-server.executebulkwritecommand" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -15,22 +15,22 @@
    <methodparam><type>MongoDB\Driver\BulkWriteCommand</type><parameter>bulk</parameter></methodparam>
    <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>options</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Exécute une ou plusieurs opérations d'écriture sur le serveur principal en utilisant la
    commande <link xlink:href="&url.mongodb.docs.command;bulkWrite">bulkWrite</link>
    introduite dans MongoDB 8.0.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Une <classname>MongoDB\Driver\BulkWriteCommand</classname> peut être construite
    avec une ou plusieurs opérations d'écriture de types variés (par exemple, des insertions, mises à jour
    et suppressions). Chaque opération d'écriture peut cibler une différente collection.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    La valeur par défaut pour l'option <literal>"writeConcern"</literal> sera
    déduite d'une transaction active (indiquée par l'option
    <literal>"session"</literal> option), suivie de
    <link linkend="mongodb-driver-manager.construct-uri">l'URI de connexion</link>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">

--- a/reference/mongodb/mongodb/driver/server/executereadcommand.xml
+++ b/reference/mongodb/mongodb/driver/server/executereadcommand.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 80693438668530525ea2a78defbfc9bb218c3b1c Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="mongodb-driver-server.executereadcommand" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -15,18 +15,18 @@
    <methodparam><type>MongoDB\Driver\Command</type><parameter>command</parameter></methodparam>
    <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>options</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Exécute la commande sur ce serveur, indépendamment de l'option
    <literal>"readPreference"</literal>.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Cette méthode appliquera une logique spécifique aux commandes de lecture (par exemple
    <link xlink:href="&url.mongodb.docs;reference/command/distinct/">distinct</link>).
    Les valeurs par défaut pour les options <literal>"readPreference"</literal> et
    <literal>"readConcern"</literal> seront déduites d'une transaction active (indiquée par
    l'option <literal>"session"</literal>), suivie de l'
    <link linkend="mongodb-driver-manager.construct-uri">URI de connexion</link>.
-  </para>
+  </simpara>
   &mongodb.note.server.readpreference;
  </refsect1>
 

--- a/reference/mongodb/mongodb/driver/server/gethost.xml
+++ b/reference/mongodb/mongodb/driver/server/gethost.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: c64016065c9b97fa1cbbef48a9ed105232b423a8 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-server.gethost" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -14,9 +14,9 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>string</type><methodname>MongoDB\Driver\Server::getHost</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Retourne le nom d'hôte du serveur.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -26,9 +26,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retourne le nom d'hôte du serveur.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/server/getport.xml
+++ b/reference/mongodb/mongodb/driver/server/getport.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: c64016065c9b97fa1cbbef48a9ed105232b423a8 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-server.getport" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -14,9 +14,9 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>int</type><methodname>MongoDB\Driver\Server::getPort</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Retourne le port sur lequel le serveur écoute.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -26,9 +26,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retourne le port sur lequel le serveur écoute.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/server/getserverdescription.xml
+++ b/reference/mongodb/mongodb/driver/server/getserverdescription.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: bd6e6603b4614c35d9b63c8d157a98569f2358df Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="mongodb-driver-server.getserverdescription" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,11 +13,11 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>MongoDB\Driver\ServerDescription</type><methodname>MongoDB\Driver\Server::getServerDescription</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Renvoie une <classname>MongoDB\Driver\ServerDescription</classname> pour ce
    serveur. C'est un objet de valeur immuable qui décrira le serveur au moment
    où cette méthode est appelée.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -27,10 +27,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Renvoie une <classname>MongoDB\Driver\ServerDescription</classname> pour ce
    serveur.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/server/gettags.xml
+++ b/reference/mongodb/mongodb/driver/server/gettags.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e9366ee458b2900c53a503b1ad97664e1d9a8859 Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="mongodb-driver-server.gettags" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,12 +13,12 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>array</type><methodname>MongoDB\Driver\Server::getTags</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Renvoie un <type>array</type> de
    <link xlink:href="&url.mongodb.glossary;#term-tag">tags</link> utilisés pour
    décrire ce serveur dans un ensemble de réplicas. L'array contiendra zéro ou plusieurs
    paires clé et valeur de type <type>string</type>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -28,10 +28,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Renvoie un <type>array</type> de tags utilisés pour décrire ce serveur dans un
    ensemble de réplicas.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/server/gettype.xml
+++ b/reference/mongodb/mongodb/driver/server/gettype.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: bd6e6603b4614c35d9b63c8d157a98569f2358df Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-server.gettype" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -14,10 +14,10 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>int</type><methodname>MongoDB\Driver\Server::getType</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Retourne un &integer; représentant le type du serveur. La valeur
    correspondra avec une constante <classname>MongoDB\Driver\Server</classname>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -27,9 +27,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retourne un &integer; représentant le type du serveur.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/server/isarbiter.xml
+++ b/reference/mongodb/mongodb/driver/server/isarbiter.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 331fbfeac522d4ad00de1e043cc11610d66b88f9 Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="mongodb-driver-server.isarbiter" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,11 +13,11 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>bool</type><methodname>MongoDB\Driver\Server::isArbiter</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Renvoie si ce serveur est un
    <link xlink:href="&url.mongodb.glossary;#term-arbiter">membre arbitre</link>
    d'un ensemble de réplicas.
-  </para>
+  </simpara>
 
  </refsect1>
 
@@ -28,10 +28,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Renvoie &true; si ce serveur est un membre arbitre d'un ensemble de réplicas, et
    &false; sinon.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/server/ishidden.xml
+++ b/reference/mongodb/mongodb/driver/server/ishidden.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 331fbfeac522d4ad00de1e043cc11610d66b88f9 Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="mongodb-driver-server.ishidden" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,11 +13,11 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>bool</type><methodname>MongoDB\Driver\Server::isHidden</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Renvoie si ce serveur est un
    <link xlink:href="&url.mongodb.glossary;#term-hidden-member">membre caché</link>
    d'un ensemble de réplicas.
-  </para>
+  </simpara>
 
  </refsect1>
 
@@ -28,10 +28,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Renvoie &true; si ce serveur est un membre caché d'un ensemble de réplicas, et
    &false; sinon.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/server/ispassive.xml
+++ b/reference/mongodb/mongodb/driver/server/ispassive.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 331fbfeac522d4ad00de1e043cc11610d66b88f9 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="mongodb-driver-server.ispassive" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -15,11 +15,11 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>bool</type><methodname>MongoDB\Driver\Server::isPassive</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Retourne si le serveur est un
    <link xlink:href="&url.mongodb.glossary;#term-passive-member">membre passif</link>
     d'un jeu de réplication (c.-à-d. sa priorité est <literal>0</literal>).
-  </para>
+  </simpara>
 
  </refsect1>
 
@@ -30,10 +30,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retourne &true; si le serveur est un membre passif d'un jeu de réplication,
     et &false; sinon.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/server/isprimary.xml
+++ b/reference/mongodb/mongodb/driver/server/isprimary.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 331fbfeac522d4ad00de1e043cc11610d66b88f9 Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="mongodb-driver-server.isprimary" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,11 +13,11 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>bool</type><methodname>MongoDB\Driver\Server::isPrimary</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Renvoie si ce serveur est un
    <link xlink:href="&url.mongodb.glossary;#term-primary">membre principal</link>
    d'un ensemble de réplicas.
-  </para>
+  </simpara>
 
  </refsect1>
 
@@ -28,10 +28,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Renvoie &true; si ce serveur est un membre principal d'un ensemble de réplicas, et
    &false; sinon.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/server/issecondary.xml
+++ b/reference/mongodb/mongodb/driver/server/issecondary.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 331fbfeac522d4ad00de1e043cc11610d66b88f9 Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="mongodb-driver-server.issecondary" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,11 +13,11 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>bool</type><methodname>MongoDB\Driver\Server::isSecondary</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Renvoie si ce serveur est un
    <link xlink:href="&url.mongodb.glossary;#term-secondary">membre secondaire</link>
    d'un ensemble de réplicas.
-  </para>
+  </simpara>
 
  </refsect1>
 
@@ -28,10 +28,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Renvoie &true; si ce serveur est un membre secondaire d'un ensemble de réplicas, et
    &false; sinon.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/serverapi/bsonserialize.xml
+++ b/reference/mongodb/mongodb/driver/serverapi/bsonserialize.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: eaee72c33fe65d1d4648cd8a30bbec0aeb76c960 Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="mongodb-driver-serverapi.bsonserialize" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,9 +22,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Renvoie un objet pour la sérialisation du ServerApi en BSON.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/serverapi/construct.xml
+++ b/reference/mongodb/mongodb/driver/serverapi/construct.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: a7b808a875840b8850631210ef2190d681b6edfa Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="mongodb-driver-serverapi.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -16,11 +16,11 @@
    <methodparam choice="opt"><type class="union"><type>bool</type><type>null</type></type><parameter>deprecationErrors</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
 
-  <para>
+  <simpara>
    Crée une nouvelle instance de <classname>MongoDB\Driver\ServerApi</classname> utilisée pour
    déclarer une version d'API lors de la création d'un
    <classname>MongoDB\Driver\Manager</classname>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -29,36 +29,36 @@
    <varlistentry xml:id="mongodb-driver-serverapi.construct-version">
     <term><parameter>version</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       Une version d'API de serveur.
-     </para>
-     <para>
+     </simpara>
+     <simpara>
       Les versions d'API prises en charge sont fournies sous forme de constantes
       dans <classname>MongoDB\Driver\ServerApi</classname>. La seule version d'API
       prise en charge est <constant>MongoDB\Driver\ServerApi::V1</constant>.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry xml:id="mongodb-driver-manager.construct-strict">
     <term><parameter>strict</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       Si le paramètre <parameter>strict</parameter> est défini sur &true;, le
       serveur renverra une erreur pour toute commande qui ne fait pas partie de la
       version d'API spécifiée. Si aucune valeur n'est fournie, la valeur par défaut du serveur
       (&false;) est utilisée.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry xml:id="mongodb-driver-manager.construct-deprecationErrors">
     <term><parameter>deprecationErrors</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       Si le paramètre <parameter>deprecationErrors</parameter> est défini sur &true;,
       le serveur renverra une erreur lors de l'utilisation d'une commande qui est obsolète dans
       la version d'API spécifiée. Si aucune valeur n'est fournie, la valeur par défaut du serveur
       (&false;) est utilisée.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>

--- a/reference/mongodb/mongodb/driver/serverdescription/gethelloresponse.xml
+++ b/reference/mongodb/mongodb/driver/serverdescription/gethelloresponse.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: bd6e6603b4614c35d9b63c8d157a98569f2358df Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="mongodb-driver-serverdescription.gethelloresponse" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,21 +13,21 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>array</type><methodname>MongoDB\Driver\ServerDescription::getHelloResponse</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Renvoie un tableau d'informations décrivant le serveur. Ce tableau est dérivé de la réponse
    <link xlink:href="&url.mongodb.docs;reference/command/hello/">hello</link>
    la plus récente (au moment où la
    <classname>MongoDB\Driver\ServerDescription</classname> a été construite) obtenue via
    <link xlink:href="&url.mongodb.sdam;">la surveillance du serveur</link>.
-  </para>
+  </simpara>
   <note>
-   <para>
+   <simpara>
     Lorsque le pilote est connecté à un équilibreur de charge, cette méthode renverra
     un tableau vide car les équilibreurs de charge ne sont pas surveillés. Cela contraste avec
     <function>MongoDB\Driver\Server::getInfo</function>, qui renverrait la réponse du
     <link xlink:href="&url.mongodb.docs;reference/command/hello/">hello</link>
     de la commande de poignée de main de connexion initiale du serveur de base.
-   </para>
+   </simpara>
   </note>
  </refsect1>
 
@@ -38,9 +38,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Renvoie un tableau d'informations décrivant ce serveur.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/serverdescription/gethost.xml
+++ b/reference/mongodb/mongodb/driver/serverdescription/gethost.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: bd6e6603b4614c35d9b63c8d157a98569f2358df Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="mongodb-driver-serverdescription.gethost" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,9 +13,9 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>string</type><methodname>MongoDB\Driver\ServerDescription::getHost</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Renvoie le nom d'hôte de ce serveur.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -25,9 +25,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Renvoie le nom d'hôte de ce serveur.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/serverdescription/getlastupdatetime.xml
+++ b/reference/mongodb/mongodb/driver/serverdescription/getlastupdatetime.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: bd6e6603b4614c35d9b63c8d157a98569f2358df Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="mongodb-driver-serverdescription.getlastupdatetime" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,9 +13,9 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>int</type><methodname>MongoDB\Driver\ServerDescription::getLastUpdateTime</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Renvoie l'heure de la dernière mise à jour du serveur en microsecondes.
-  </para>
+  </simpara>
   <note>
    <simpara>
     La valeur renvoyée est un horodatage monotone, qui commence à un point arbitraire.
@@ -32,9 +32,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Renvoie l'heure de la dernière mise à jour du serveur en microsecondes.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/serverdescription/getport.xml
+++ b/reference/mongodb/mongodb/driver/serverdescription/getport.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: bd6e6603b4614c35d9b63c8d157a98569f2358df Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="mongodb-driver-serverdescription.getport" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,9 +13,9 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>int</type><methodname>MongoDB\Driver\ServerDescription::getPort</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Renvoie le port sur lequel ce serveur écoute.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -25,9 +25,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Renvoie le port sur lequel ce serveur écoute.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/serverdescription/getroundtriptime.xml
+++ b/reference/mongodb/mongodb/driver/serverdescription/getroundtriptime.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 734bafeaf071b78b15d375f9af583befddd8c2a2 Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="mongodb-driver-serverdescription.getroundtriptime" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,12 +13,12 @@
    <modifier>final</modifier> <modifier>public</modifier> <type class="union"><type>int</type><type>null</type></type><methodname>MongoDB\Driver\ServerDescription::getRoundTripTime</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Renvoie le temps de trajet aller-retour du serveur en millisecondes. Il s'agit de
    la mesure du client de la durée d'une
    commande
    <link xlink:href="&url.mongodb.docs;reference/command/hello/">hello</link>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -28,9 +28,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Renvoie le temps de trajet aller-retour du serveur en millisecondes.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/serverdescription/gettype.xml
+++ b/reference/mongodb/mongodb/driver/serverdescription/gettype.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: bd6e6603b4614c35d9b63c8d157a98569f2358df Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="mongodb-driver-serverdescription.gettype" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,11 +13,11 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>string</type><methodname>MongoDB\Driver\ServerDescription::getType</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Renvoie une <type>string</type> indiquant le type de ce serveur. La valeur
    sera corrélée à une constante
    <classname>MongoDB\Driver\ServerDescription</classname>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -27,9 +27,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Renvoie un <type>string</type> indiquant le type de ce serveur.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/session.xml
+++ b/reference/mongodb/mongodb/driver/session.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <reference xml:id="class.mongodb-driver-session" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>La classe MongoDB\Driver\Session</title>
@@ -10,12 +10,12 @@
 <!-- {{{ MongoDB\Driver\Session intro -->
   <section xml:id="mongodb-driver-session.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     La classe <classname>MongoDB\Driver\Session</classname> représente une
     session client et est retournée par
     <methodname>MongoDB\Driver\Manager::startSession</methodname>. Les commandes,
     les requêtes et les opérations d'écriture peuvent ensuite être associées à la session.
-   </para>
+   </simpara>
   </section>
 <!-- }}} -->
 
@@ -82,45 +82,45 @@
     <varlistentry xml:id="mongodb-driver-session.constants.transaction-none">
      <term><constant>MongoDB\Driver\Session::TRANSACTION_NONE</constant></term>
      <listitem>
-      <para>
+      <simpara>
        Il n'y a pas de transaction en cours.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="mongodb-driver-session.constants.transaction-starting">
      <term><constant>MongoDB\Driver\Session::TRANSACTION_STARTING</constant></term>
      <listitem>
-      <para>
+      <simpara>
        Une transaction a été démarrée, mais aucune opération n'a été envoyée au serveur.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="mongodb-driver-session.constants.transaction-in-progress">
      <term><constant>MongoDB\Driver\Session::TRANSACTION_IN_PROGRESS</constant></term>
      <listitem>
-      <para>
+      <simpara>
        Une transaction est en cours.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="mongodb-driver-session.constants.transaction-committed">
      <term><constant>MongoDB\Driver\Session::TRANSACTION_COMMITTED</constant></term>
      <listitem>
-      <para>
+      <simpara>
        Une transaction a été validée.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="mongodb-driver-session.constants.transaction-aborted">
      <term><constant>MongoDB\Driver\Session::TRANSACTION_ABORTED</constant></term>
      <listitem>
-      <para>
+      <simpara>
        Une transaction a été annulée.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
 

--- a/reference/mongodb/mongodb/driver/session/aborttransaction.xml
+++ b/reference/mongodb/mongodb/driver/session/aborttransaction.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: f1e951b988e8aafe49b33bdf2f7812740c66c2d2 Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="mongodb-driver-session.aborttransaction" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,11 +13,11 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>void</type><methodname>MongoDB\Driver\Session::abortTransaction</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Termine la transaction multi-document et annule toutes les modifications de données
    effectuées par les opérations dans la transaction. C'est-à-dire que la transaction se termine
    sans enregistrer aucune des modifications apportées par les opérations dans la transaction.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -27,9 +27,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.void;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/session/advanceclustertime.xml
+++ b/reference/mongodb/mongodb/driver/session/advanceclustertime.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 53242ee6628dc1ae6989fe002231fddfd8f005c6 Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="mongodb-driver-session.advanceclustertime" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,17 +13,17 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>void</type><methodname>MongoDB\Driver\Session::advanceClusterTime</methodname>
    <methodparam><type class="union"><type>array</type><type>object</type></type><parameter>clusterTime</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Avance le temps du cluster pour cette session. Si le temps du cluster est inférieur ou égal
    au temps du cluster actuel de la session, cette fonction ne fait rien.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    En utilisant cette méthode en conjonction avec
    <methodname>MongoDB\Driver\Session::advanceOperationTime</methodname> pour copier
    les temps du cluster et des opérations d'une autre session
    il est possible de s'assurer que les opérations dans cette session sont cohérentes
    avec la dernière opération dans l'autre session.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -32,12 +32,12 @@
    <varlistentry>
     <term><parameter>clusterTime</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       Le temps du cluster est un document contenant un horodatage logique et une signature de serveur.
       Typiquement, cette valeur sera obtenue en appelant
       <methodname>MongoDB\Driver\Session::getClusterTime</methodname> sur un autre
       objet de session.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -45,9 +45,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.void;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/session/advanceoperationtime.xml
+++ b/reference/mongodb/mongodb/driver/session/advanceoperationtime.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 0dad2268d5adb19f77270aa2a9515a4bfbca9b22 Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="mongodb-driver-session.advanceoperationtime" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,17 +13,17 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>void</type><methodname>MongoDB\Driver\Session::advanceOperationTime</methodname>
    <methodparam><type>MongoDB\BSON\TimestampInterface</type><parameter>operationTime</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Avance le temps d'opération pour cette session. Si le temps d'opération est inférieur ou égal
    au temps d'opération actuel de la session, cette fonction ne fait rien.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    En utilisant cette méthode en conjonction avec
    <methodname>MongoDB\Driver\Session::advanceClusterTime</methodname> pour copier
    les temps d'opération et de cluster d'une autre session
    il est possible de s'assurer que les opérations dans cette session sont cohérentes
    avec la dernière opération dans l'autre session.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -32,12 +32,12 @@
    <varlistentry>
     <term><parameter>operationTime</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       L'opération est un horodatage logique. Typiquement, cette valeur
       sera obtenue en appelant
       <methodname>MongoDB\Driver\Session::getOperationTime</methodname> sur
       un autre objet de session.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -45,9 +45,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.void;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/session/committransaction.xml
+++ b/reference/mongodb/mongodb/driver/session/committransaction.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 63fc2906221a3cdb9bc086aba6f05ee407d2c13b Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="mongodb-driver-session.committransaction" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,12 +13,12 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>void</type><methodname>MongoDB\Driver\Session::commitTransaction</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Sauvegarde les modifications apportées par les opérations dans la transaction
    multi-document et termine la transaction. Jusqu'à la validation, aucune des
    modifications de données apportées par les opérations dans la transaction
    n'est visible en dehors de la transaction.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -28,9 +28,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.void;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/session/construct.xml
+++ b/reference/mongodb/mongodb/driver/session/construct.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 0dad2268d5adb19f77270aa2a9515a4bfbca9b22 Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="mongodb-driver-session.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,11 +13,11 @@
    <modifier>final</modifier> <modifier>private</modifier> <methodname>MongoDB\Driver\Session::__construct</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Les objets <classname>MongoDB\Driver\Session</classname> sont retournés par
    <methodname>MongoDB\Driver\Manager::startSession</methodname> et ne peuvent pas être
    construits directement.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">

--- a/reference/mongodb/mongodb/driver/session/endsession.xml
+++ b/reference/mongodb/mongodb/driver/session/endsession.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 69b7314dc644c27289de76afc93684a98428ad05 Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="mongodb-driver-session.endsession" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,11 +13,11 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>void</type><methodname>MongoDB\Driver\Session::endSession</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Cette méthode ferme une session existante. Si une transaction était associée
    à cette session, la transaction sera annulée. Après avoir appelé cette
    méthode, les applications ne doivent pas invoquer d'autres méthodes sur la session.
-  </para>
+  </simpara>
   <note>
    <simpara>
     Les sessions sont également fermées lors du ramassage de miettes. Il ne devrait pas être
@@ -33,9 +33,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.void;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/session/getclustertime.xml
+++ b/reference/mongodb/mongodb/driver/session/getclustertime.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 53242ee6628dc1ae6989fe002231fddfd8f005c6 Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="mongodb-driver-session.getclustertime" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,12 +13,12 @@
    <modifier>final</modifier> <modifier>public</modifier> <type class="union"><type>object</type><type>null</type></type><methodname>MongoDB\Driver\Session::getClusterTime</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Renvoie le temps du cluster pour cette session. Si la session n'a pas été utilisée
    pour une opération et
    <methodname>MongoDB\Driver\Session::advanceClusterTime</methodname> n'a pas
    été appelé, le temps du cluster sera &null;.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -28,10 +28,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Renvoie le temps du cluster pour cette session, ou &null; si la session n'a pas
    de temps du cluster.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/session/getlogicalsessionid.xml
+++ b/reference/mongodb/mongodb/driver/session/getlogicalsessionid.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 0dad2268d5adb19f77270aa2a9515a4bfbca9b22 Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="mongodb-driver-session.getlogicalsessionid" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,10 +13,10 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>object</type><methodname>MongoDB\Driver\Session::getLogicalSessionId</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Renvoie l'identifiant de session logique pour cette session, qui peut être utilisé pour
    identifier les opérations de cette session sur le serveur.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -26,9 +26,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Renvoie l'identifiant de session logique pour cette session.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/session/getoperationtime.xml
+++ b/reference/mongodb/mongodb/driver/session/getoperationtime.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 53242ee6628dc1ae6989fe002231fddfd8f005c6 Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="mongodb-driver-session.getoperationtime" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,12 +13,12 @@
    <modifier>final</modifier> <modifier>public</modifier> <type class="union"><type>MongoDB\BSON\Timestamp</type><type>null</type></type><methodname>MongoDB\Driver\Session::getOperationTime</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Renvoie le temps d'opération pour cette session. Si la session n'a pas été utilisée
    pour une opération et
    <methodname>MongoDB\Driver\Session::advanceOperationTime</methodname> n'a pas
    été appelé, le temps d'opération sera &null;.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -28,10 +28,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Renvoie le temps d'opération pour cette session, ou &null; si la session n'a pas
    de temps d'opération.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/topologydescription/getservers.xml
+++ b/reference/mongodb/mongodb/driver/topologydescription/getservers.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: bd6e6603b4614c35d9b63c8d157a98569f2358df Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="mongodb-driver-topologydescription.getservers" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,10 +13,10 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>array</type><methodname>MongoDB\Driver\TopologyDescription::getServers</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Renvoie un tableau d'objets <classname>MongoDB\Driver\ServerDescription</classname>
    correspondant aux serveurs connus dans la topologie.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -26,10 +26,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Renvoie un tableau d'objets <classname>MongoDB\Driver\ServerDescription</classname>
    correspondant aux serveurs connus dans la topologie.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/topologydescription/gettype.xml
+++ b/reference/mongodb/mongodb/driver/topologydescription/gettype.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: bd6e6603b4614c35d9b63c8d157a98569f2358df Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="mongodb-driver-topologydescription.gettype" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,11 +13,11 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>string</type><methodname>MongoDB\Driver\TopologyDescription::getType</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Renvoie un <type>string</type> dénotant le type de cette topologie. La valeur
    sera corrélée avec une constante de
    <classname>MongoDB\Driver\TopologyDescription</classname>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -27,9 +27,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Renvoie un <type>string</type> dénotant le type de cette topologie.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/topologydescription/hasreadableserver.xml
+++ b/reference/mongodb/mongodb/driver/topologydescription/hasreadableserver.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: bd6e6603b4614c35d9b63c8d157a98569f2358df Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="mongodb-driver-topologydescription.hasreadableserver" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,11 +13,11 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>bool</type><methodname>MongoDB\Driver\TopologyDescription::hasReadableServer</methodname>
    <methodparam choice="opt"><type class="union"><type>MongoDB\Driver\ReadPreference</type><type>null</type></type><parameter>readPreference</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Renvoie si la topologie a un serveur lisible ou, si
    <parameter>readPreference</parameter> est spécifié, un serveur correspondant à
    la préférence de lecture spécifiée.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -27,11 +27,11 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Renvoie si la topologie a un serveur lisible ou, si
    <parameter>readPreference</parameter> est spécifié, un serveur correspondant à
    la préférence de lecture spécifiée.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/topologydescription/haswritableserver.xml
+++ b/reference/mongodb/mongodb/driver/topologydescription/haswritableserver.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: bd6e6603b4614c35d9b63c8d157a98569f2358df Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="mongodb-driver-topologydescription.haswritableserver" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,9 +13,9 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>bool</type><methodname>MongoDB\Driver\TopologyDescription::hasWritableServer</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Retourne si la topologie dispose d'un serveur en écriture.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -25,9 +25,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retourne si la topologie dispose d'un serveur en écriture.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/writeconcern/bsonserialize.xml
+++ b/reference/mongodb/mongodb/driver/writeconcern/bsonserialize.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: a5eca06ae7725b4c35eefecbb0d722a3e198ff21 Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="mongodb-driver-writeconcern.bsonserialize" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,9 +22,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Renvoie un objet pour la sérialisation du WriteConcern en BSON.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/writeconcern/getjournal.xml
+++ b/reference/mongodb/mongodb/driver/writeconcern/getjournal.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 86e6094e86b84a51d00ab217ac50ce8dde33d82a Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="mongodb-driver-writeconcern.getjournal" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,9 +22,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Renvoie l'option "journal" du WriteConcern.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/writeconcern/getw.xml
+++ b/reference/mongodb/mongodb/driver/writeconcern/getw.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 86e6094e86b84a51d00ab217ac50ce8dde33d82a Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="mongodb-driver-writeconcern.getw" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,9 +22,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Renvoie l'option "w" du WriteConcern.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/writeconcernerror/getcode.xml
+++ b/reference/mongodb/mongodb/driver/writeconcernerror/getcode.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9a03654d101176d0073a32683ef791bc20bc1425 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="mongodb-driver-writeconcernerror.getcode" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -14,9 +14,9 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>int</type><methodname>MongoDB\Driver\WriteConcernError::getCode</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
 
-  </para>
+  </simpara>
 
  </refsect1>
 
@@ -27,9 +27,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retourne le code d'erreur de WriteConcernError
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/writeconcernerror/getinfo.xml
+++ b/reference/mongodb/mongodb/driver/writeconcernerror/getinfo.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9a03654d101176d0073a32683ef791bc20bc1425 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="mongodb-driver-writeconcernerror.getinfo" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -14,9 +14,9 @@
    <modifier>final</modifier> <modifier>public</modifier> <type class="union"><type>object</type><type>null</type></type><methodname>MongoDB\Driver\WriteConcernError::getInfo</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
 
-  </para>
+  </simpara>
 
  </refsect1>
 
@@ -27,10 +27,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
     Retourne le document de métadonnées pour WriteConcernError, ou &null;
    si aucune métadonnée n'est disponible.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/writeconcernerror/getmessage.xml
+++ b/reference/mongodb/mongodb/driver/writeconcernerror/getmessage.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9a03654d101176d0073a32683ef791bc20bc1425 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="mongodb-driver-writeconcernerror.getmessage" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -14,9 +14,9 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>string</type><methodname>MongoDB\Driver\WriteConcernError::getMessage</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
 
-  </para>
+  </simpara>
 
  </refsect1>
 
@@ -27,9 +27,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Renvoie le message d'erreur du WriteConcernError
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/writeerror/getcode.xml
+++ b/reference/mongodb/mongodb/driver/writeerror/getcode.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: ad2e71299d249c84ab5a0420aeb548e66f699a13 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="mongodb-driver-writeerror.getcode" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -15,9 +15,9 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>int</type><methodname>MongoDB\Driver\WriteError::getCode</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
 
-  </para>
+  </simpara>
 
  </refsect1>
 
@@ -28,9 +28,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retourne le code d'erreur de WriteError
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/writeerror/getindex.xml
+++ b/reference/mongodb/mongodb/driver/writeerror/getindex.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: ad2e71299d249c84ab5a0420aeb548e66f699a13 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="mongodb-driver-writeerror.getindex" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -15,9 +15,9 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>int</type><methodname>MongoDB\Driver\WriteError::getIndex</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
 
-  </para>
+  </simpara>
 
  </refsect1>
 
@@ -28,10 +28,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retourne l'index de l'opération d'écriture (à partir de 
    <classname>MongoDBDriverBulkWrite</classname>) correspondant à ce WriteError.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/writeerror/getinfo.xml
+++ b/reference/mongodb/mongodb/driver/writeerror/getinfo.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 53242ee6628dc1ae6989fe002231fddfd8f005c6 Maintainer: girgias Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 
 <refentry xml:id="mongodb-driver-writeerror.getinfo" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -15,9 +15,9 @@
    <modifier>final</modifier> <modifier>public</modifier> <type class="union"><type>object</type><type>null</type></type><methodname>MongoDB\Driver\WriteError::getInfo</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
 
-  </para>
+  </simpara>
 
  </refsect1>
 
@@ -28,10 +28,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retourne le document de métadonnées pour WriteError, ou &null; s'il
    n'y a pas de métadonnées disponibles.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/writeerror/getmessage.xml
+++ b/reference/mongodb/mongodb/driver/writeerror/getmessage.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 697b3c9468124f58cc13901057bec0b813f6197f Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="mongodb-driver-writeerror.getmessage" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -15,9 +15,9 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>string</type><methodname>MongoDB\Driver\WriteError::getMessage</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
 
-  </para>
+  </simpara>
 
  </refsect1>
 
@@ -28,9 +28,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Renvoie le message d'erreur du WriteError.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/writeresult/getserver.xml
+++ b/reference/mongodb/mongodb/driver/writeresult/getserver.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: c64016065c9b97fa1cbbef48a9ed105232b423a8 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="mongodb-driver-writeresult.getserver" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -15,9 +15,9 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>MongoDB\Driver\Server</type><methodname>MongoDB\Driver\WriteResult::getServer</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Retourne le <classname>MongoDB\Driver\Server</classname> associé à ce résultat d'écriture. Il s'agit du serveur qui a exécuté le <classname>MongoDB\Driver\BulkWrite</classname>.
-  </para>
+  </simpara>
 
  </refsect1>
 
@@ -28,9 +28,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retourne le <classname>MongoDB\Driver\Server</classname> associé à ce résultat d'écriture.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/writeresult/getupsertedids.xml
+++ b/reference/mongodb/mongodb/driver/writeresult/getupsertedids.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 2c423ff085531b5a614c7b10c2d8cf957cdda808 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="mongodb-driver-writeresult.getupsertedids" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -15,9 +15,9 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>array</type><methodname>MongoDB\Driver\WriteResult::getUpsertedIds</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
 
-  </para>
+  </simpara>
 
  </refsect1>
 
@@ -28,9 +28,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retourne un tableau d'identificateurs (par exemple la valeur du champ <literal> "_id"</literal>) pour les documents upserted. Les clés de tableau correspondent à l'index de l'opération d'écriture (à partir de <classname>MongoDBDriverBulkWrite</classname>) responsable du upsert.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/writeresult/getwriteconcernerror.xml
+++ b/reference/mongodb/mongodb/driver/writeresult/getwriteconcernerror.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9a03654d101176d0073a32683ef791bc20bc1425 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="mongodb-driver-writeresult.getwriteconcernerror" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -14,9 +14,9 @@
    <modifier>final</modifier> <modifier>public</modifier> <type class="union"><type>MongoDB\Driver\WriteConcernError</type><type>null</type></type><methodname>MongoDB\Driver\WriteResult::getWriteConcernError</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
 
-  </para>
+  </simpara>
 
  </refsect1>
 
@@ -27,9 +27,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retourne un <classname>MongoDBDriverWriteConcernError</classname> si une erreur de préoccupation d'écriture a été rencontrée pendant l'opération d'écriture, et &null; sinon.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/writeresult/getwriteerrors.xml
+++ b/reference/mongodb/mongodb/driver/writeresult/getwriteerrors.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 61f9e84aa71378ccf3958a6c20d3a8017392562c Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="mongodb-driver-writeresult.getwriteerrors" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -15,9 +15,9 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>array</type><methodname>MongoDB\Driver\WriteResult::getWriteErrors</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
 
-  </para>
+  </simpara>
 
  </refsect1>
 
@@ -28,11 +28,11 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retourne un tableau d'objets <classname>MongoDBDriverWriteError</classname> 
    pour toutes les erreurs d'écriture rencontrées pendant l'opération 
    d'écriture. Le tableau sera vide si aucune erreur d'écriture n'est survenue.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/writeresult/isacknowledged.xml
+++ b/reference/mongodb/mongodb/driver/writeresult/isacknowledged.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9a03654d101176d0073a32683ef791bc20bc1425 Maintainer: girgias Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="mongodb-driver-writeresult.isacknowledged" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -14,10 +14,10 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>bool</type><methodname>MongoDB\Driver\WriteResult::isAcknowledged</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Si l'écriture a été reconnue, d'autres champs de comptage seront disponibles
    pour l'objet <classname>MongoDB\Driver\WriteResult</classname>.
-  </para>
+  </simpara>
 
  </refsect1>
 
@@ -28,9 +28,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retourne &true; si l'écriture a été reconnue, et &false; sinon.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/setup.xml
+++ b/reference/mongodb/setup.xml
@@ -1,24 +1,24 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 6536bde9ac873428828d7c62cc8d0d04b1a24267 Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <chapter xml:id="mongodb.setup" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.setup;
 
  <section xml:id="mongodb.requirements">
   &reftitle.required;
-  <para>
+  <simpara>
    Depuis la version 1.21.0, l'extension nécessite PHP 8.1 ou supérieur. Les
    versions précédentes de l'extension permettent la compatibilité avec les anciennes versions de PHP.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    L'extension nécessite
    <link xlink:href="&url.mongodb.libbson;">libbson</link> et
    <link xlink:href="&url.mongodb.libmongoc;">libmongoc</link>, et utilisera
    les versions incluses par défaut. Les bibliothèques système peuvent également
    être utilisées, comme discuté dans la documentation
    <link linkend="mongodb.installation.manual">d'installation manuelle</link>.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    L'extension, via libmongoc, dépend optionnellement d'une bibliothèque TLS
    (par exemple OpenSSL) et l'utilisera si elle est disponible. Si le processus
    de construction ne parvient pas à trouver une bibliothèque TLS, les
@@ -28,11 +28,11 @@
    tous deux installés. Le processus de détection et de configuration des
    bibliothèques TLS est discuté plus en détail dans la documentation
    <link linkend="mongodb.installation.manual">d'installation manuelle</link>.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    <link xlink:href="&url.cyrus;">Cyrus SASL</link> est une dépendance optionnelle
     pour prendre en charge l'authentification Kerberos et sera utilisée si elle est disponible.
-  </para>
+  </simpara>
   <note>
    <simpara>
     A cause de problèmes potentiels de représentation des entiers 64 bits sur des
@@ -50,9 +50,9 @@
 <!--
  <section xml:id="mongodb.resources">
   &reftitle.resources;
-  <para>
+  <simpara>
 
-  </para>
+  </simpara>
  </section>
 -->
 

--- a/reference/mongodb/tutorial.xml
+++ b/reference/mongodb/tutorial.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 3e871fe7eab38f9b0398569c57a1dd0c21e69652 Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
  <chapter xml:id="mongodb.tutorial" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
   <title>Tutoriels</title>
@@ -7,10 +7,10 @@
 
   <info xml:id="mongodb.tutorial.intro">
    <abstract>
-    <para>
+    <simpara>
      Dans cette section, on trouvera plusieurs tutoriels sur l'utilisation du
      pilote MongoDB pour PHP.
-    </para>
+    </simpara>
    </abstract>
   </info>
 

--- a/reference/mongodb/tutorial/apm.xml
+++ b/reference/mongodb/tutorial/apm.xml
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 3e871fe7eab38f9b0398569c57a1dd0c21e69652 Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <section xml:id="mongodb.tutorial.apm" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Surveillance de la performance de l'application (Application Performance Monitoring - APM)</title>
 
- <para>
+ <simpara>
   L'extension contient une API d'observations événements, qui permet aux applications de
   surveiller les commandes et les activités internes liées à la
   <link xlink:href="&url.mongodb.sdam;">Spécification de découverte et de surveillance du serveur</link>.
   Ce tutoriel démontrera la surveillance des commandes en utilisant l'interface
   <classname>MongoDB\Driver\Monitoring\CommandSubscriber</classname>.
- </para>
+ </simpara>
 
- <para>
+ <simpara>
   L'interface
   <classname>MongoDB\Driver\Monitoring\CommandSubscriber</classname>
   définit trois méthodes: <literal>commandStarted</literal>,
@@ -21,19 +21,19 @@
   d'une classe spécifique pour l'événement respectif. Par exemple, l'argument
   <parameter>$event</parameter> de <literal>commandSucceeded</literal>
   est un objet <classname>MongoDB\Driver\Monitoring\CommandSucceededEvent</classname>.
- </para>
+ </simpara>
 
- <para>
+ <simpara>
   Dans ce tutoriel, nous allons implémenter un observateur qui crée une liste de tous
   les profils de requête et le temps moyen qu'ils ont pris.
- </para>
+ </simpara>
 
  <section>
   <title>Structure des classes d'observations</title>
 
-  <para>
+  <simpara>
    Nous commençons par le cadre de notre observateur:
-  </para>
+  </simpara>
 
   <programlisting role="php">
 <![CDATA[
@@ -62,13 +62,13 @@ class QueryTimeCollector implements \MongoDB\Driver\Monitoring\CommandSubscriber
  <section>
   <title>Enregistrement de l'observateur</title>
 
-  <para>
+  <simpara>
    Une fois qu'un objet observateur est instancié, il doit être enregistré avec le
    système de surveillance de l'extension. Cela se fait en appelant
    <methodname>MongoDB\Driver\Monitoring\addSubscriber</methodname> ou
    <methodname>MongoDB\Driver\Manager::addSubscriber</methodname> pour enregistrer
    l'observateur globalement ou avec un Manager spécifique, respectivement.
-  </para>
+  </simpara>
 
   <programlisting role="php">
 <![CDATA[
@@ -84,28 +84,28 @@ class QueryTimeCollector implements \MongoDB\Driver\Monitoring\CommandSubscriber
  <section>
   <title>Implémenter la logique</title>
 
-  <para>
+  <simpara>
    Avec l'objet enregistré, la seule chose qui reste est d'implémenter la logique
    dans la classe observatrice. Pour corréler les deux événements qui composent une
    commande exécutée avec succès (commandStarted et commandSucceeded), chaque
    objet d'événement expose un champ <literal>requestId</literal>.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Pour enregistrer le temps moyen par forme de requête, nous allons commencer par vérifier
    une commande <literal>find</literal> dans l'événement commandStarted. Nous allons ensuite
    ajouter un élément à la propriété <literal>pendingCommands</literal> indexé par son
    <literal>requestId</literal> et avec sa valeur représentant la forme de requête.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Si nous recevons un événement commandSucceeded correspondant avec le même
    <literal>requestId</literal>, nous ajoutons la durée de l'événement (depuis
    <literal>durationMicros</literal>) au temps total et incrémentons le
    compteur d'opérations.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Si un événement commandFailed correspondant est rencontré, nous supprimons
    simplement l'entrée de la propriété <literal>pendingCommands</literal>.
-  </para>
+  </simpara>
 
   <programlisting role="php">
 <![CDATA[

--- a/reference/mongodb/tutorial/library.xml
+++ b/reference/mongodb/tutorial/library.xml
@@ -1,28 +1,28 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 3e871fe7eab38f9b0398569c57a1dd0c21e69652 Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <section xml:id="mongodb.tutorial.library" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Utiliser la bibliothèque PHP pour MongoDB (PHPLIB)</title>
 
- <para>
+ <simpara>
   Après la configuration initiale de l'extension, nous allons continuer à expliquer comment démarrer
   avec la bibliothèque utilisateur correspondante pour écrire notre premier projet.
- </para>
+ </simpara>
 
  <section>
   <title>Installer la bibliothèque PHP avec Composer</title>
 
-  <para>
+  <simpara>
    La dernière chose que nous devons installer pour commencer l'application
    elle-même est la bibliothèque PHP.
-  </para>
+  </simpara>
 
-  <para>
+  <simpara>
    La bibliothèque doit être installée avec
    <link xlink:href="&url.mongodb.composer;">Composer</link>, un gestionnaire de
    paquets pour PHP. Les instructions pour installer Composer sur différentes
    plateformes peuvent être trouvées sur son site web.
-   </para>
+   </simpara>
 
    <para>
     Installer la bibliothèque en exécutant:
@@ -50,11 +50,11 @@ Generating autoload files
     </programlisting>
    </para>
 
-   <para>
+   <simpara>
     Composer va créer plusieurs fichiers: <code>composer.json</code>,
     <code>composer.lock</code>, et un répertoire <code>vendor</code> qui
     contiendra la bibliothèque et toutes les autres dépendances que le projet pourrait nécessiter.
-   </para>
+   </simpara>
   </section>
 
   <section>
@@ -74,7 +74,7 @@ require 'vendor/autoload.php';
     </programlisting>
    </para>
 
-   <para>
+   <simpara>
     Avec cela fait, il est maintenant possible d'utiliser n'importe quelle
     fonctionnalité comme décrit dans la
     <link xlink:href="&url.mongodb.library.docs;">documentation de la bibliothèque</link>.
@@ -112,7 +112,7 @@ echo "Inserted with Object ID '{$result->getInsertedId()}'";
     </programlisting>
    </para>
 
-   <para>
+   <simpara>
     Comme le document inséré ne contenait pas de champ <code>_id</code>, l'extension
     va générer un <classname>MongoDB\BSON\ObjectId</classname> pour que le serveur
     l'utilise comme <code>_id</code>. Cette valeur est également disponible pour

--- a/reference/mongodb/tutorial/library.xml
+++ b/reference/mongodb/tutorial/library.xml
@@ -78,7 +78,7 @@ require 'vendor/autoload.php';
     Avec cela fait, il est maintenant possible d'utiliser n'importe quelle
     fonctionnalité comme décrit dans la
     <link xlink:href="&url.mongodb.library.docs;">documentation de la bibliothèque</link>.
-   </para>
+   </simpara>
 
    <para>
     Si on a utilisé des pilotes MongoDB dans d'autres langages, l'API de la
@@ -117,7 +117,7 @@ echo "Inserted with Object ID '{$result->getInsertedId()}'";
     va générer un <classname>MongoDB\BSON\ObjectId</classname> pour que le serveur
     l'utilise comme <code>_id</code>. Cette valeur est également disponible pour
     l'appelant via l'objet de résultat retourné par la méthode <code>insertOne</code>.
-   </para>
+   </simpara>
 
    <para>
     Après l'insertion, il est possible d'interroger les données qu'on vient d'insérer.


### PR DESCRIPTION
Suite de #2769 : applique le sweep `<para>`→`<simpara>` (php/doc-en#5517) sur 94 fichiers mongodb restés outdated.

Scope limité aux fichiers où le diff EN se réduit à ce sweep markup. Les ~30 autres fichiers outdated mongodb dont le diff inclut aussi des changements structurels feront l'objet de PRs de sync séparées.