### PR TITLE
SNMP: ajout du changelog PHP 8.5 pour la validation ValueError

### DIFF
--- a/reference/snmp/functions/snmp2-get.xml
+++ b/reference/snmp/functions/snmp2-get.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 40906725410aac6fe8cac4913a557a1784bf04b9 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: dd22c782164c9f8d79f5de8991876d1588a21015 Maintainer: yannick Status: ready -->
 <!-- Reviewed: no -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.snmp2-get">
  <refnamediv>
@@ -76,6 +76,32 @@
    Retourne la valeur de l'objet <acronym>SNMP</acronym>
    en cas de succès, ou &false; si une erreur survient.
   </simpara>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Lance désormais une <exceptionname>ValueError</exceptionname> quand la
+       longueur du nom d'hôte est supérieure ou égale à 128 octets, quand le
+       port est négatif ou supérieur à 65535, ou quand les valeurs du délai
+       d'expiration ou du nombre de tentatives sont inférieures à -1 ou
+       trop grandes.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/snmp/functions/snmp2-get.xml
+++ b/reference/snmp/functions/snmp2-get.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: dd22c782164c9f8d79f5de8991876d1588a21015 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: dd22c782164c9f8d79f5de8991876d1588a21015 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.snmp2-get">
  <refnamediv>

--- a/reference/snmp/functions/snmp2-set.xml
+++ b/reference/snmp/functions/snmp2-set.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 40906725410aac6fe8cac4913a557a1784bf04b9 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: dd22c782164c9f8d79f5de8991876d1588a21015 Maintainer: yannick Status: ready -->
 <!-- Reviewed: no -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.snmp2-set">
  <refnamediv>
@@ -101,6 +101,32 @@
    Si un OID inconnu ou invalide est spécifié, l'alerte émise contiendra
    probablement ceci : "Could not add variable".
   </simpara>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Lance désormais une <exceptionname>ValueError</exceptionname> quand la
+       longueur du nom d'hôte est supérieure ou égale à 128 octets, quand le
+       port est négatif ou supérieur à 65535, ou quand les valeurs du délai
+       d'expiration ou du nombre de tentatives sont inférieures à -1 ou
+       trop grandes.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/snmp/functions/snmp2-set.xml
+++ b/reference/snmp/functions/snmp2-set.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: dd22c782164c9f8d79f5de8991876d1588a21015 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: dd22c782164c9f8d79f5de8991876d1588a21015 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.snmp2-set">
  <refnamediv>

--- a/reference/snmp/functions/snmp3-get.xml
+++ b/reference/snmp/functions/snmp3-get.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: dd22c782164c9f8d79f5de8991876d1588a21015 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: dd22c782164c9f8d79f5de8991876d1588a21015 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.snmp3-get">
  <refnamediv>

--- a/reference/snmp/functions/snmp3-get.xml
+++ b/reference/snmp/functions/snmp3-get.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 40906725410aac6fe8cac4913a557a1784bf04b9 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: dd22c782164c9f8d79f5de8991876d1588a21015 Maintainer: yannick Status: ready -->
 <!-- Reviewed: no -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.snmp3-get">
  <refnamediv>
@@ -135,6 +135,16 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Lance désormais une <exceptionname>ValueError</exceptionname> quand la
+       longueur du nom d'hôte est supérieure ou égale à 128 octets, quand le
+       port est négatif ou supérieur à 65535, ou quand les valeurs du délai
+       d'expiration ou du nombre de tentatives sont inférieures à -1 ou
+       trop grandes.
+      </entry>
+     </row>
      <row>
       <entry>8.1.0</entry>
       <entry>

--- a/reference/snmp/functions/snmp3-set.xml
+++ b/reference/snmp/functions/snmp3-set.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 40906725410aac6fe8cac4913a557a1784bf04b9 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: dd22c782164c9f8d79f5de8991876d1588a21015 Maintainer: yannick Status: ready -->
 <!-- Reviewed: no -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.snmp3-set">
  <refnamediv>
@@ -151,6 +151,32 @@
    est affichée. Si un OID inconnu ou invalide est spécifié, l'alerte sera probablement
    "Could not add variable".
   </simpara>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Lance désormais une <exceptionname>ValueError</exceptionname> quand la
+       longueur du nom d'hôte est supérieure ou égale à 128 octets, quand le
+       port est négatif ou supérieur à 65535, ou quand les valeurs du délai
+       d'expiration ou du nombre de tentatives sont inférieures à -1 ou
+       trop grandes.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/snmp/functions/snmp3-set.xml
+++ b/reference/snmp/functions/snmp3-set.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: dd22c782164c9f8d79f5de8991876d1588a21015 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: dd22c782164c9f8d79f5de8991876d1588a21015 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.snmp3-set">
  <refnamediv>

--- a/reference/snmp/functions/snmpget.xml
+++ b/reference/snmp/functions/snmpget.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: dd22c782164c9f8d79f5de8991876d1588a21015 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: dd22c782164c9f8d79f5de8991876d1588a21015 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.snmpget">
  <refnamediv>

--- a/reference/snmp/functions/snmpget.xml
+++ b/reference/snmp/functions/snmpget.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 40906725410aac6fe8cac4913a557a1784bf04b9 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: dd22c782164c9f8d79f5de8991876d1588a21015 Maintainer: yannick Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.snmpget">
  <refnamediv>
@@ -74,6 +74,32 @@
   <simpara>
    Retourne la valeur de l'objet <acronym>SNMP</acronym> en cas de succès, &false; si une erreur survient.
   </simpara>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Lance désormais une <exceptionname>ValueError</exceptionname> quand la
+       longueur du nom d'hôte est supérieure ou égale à 128 octets, quand le
+       port est négatif ou supérieur à 65535, ou quand les valeurs du délai
+       d'expiration ou du nombre de tentatives sont inférieures à -1 ou
+       trop grandes.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/snmp/functions/snmpset.xml
+++ b/reference/snmp/functions/snmpset.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: dd22c782164c9f8d79f5de8991876d1588a21015 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: dd22c782164c9f8d79f5de8991876d1588a21015 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.snmpset">
  <refnamediv>

--- a/reference/snmp/functions/snmpset.xml
+++ b/reference/snmp/functions/snmpset.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 40906725410aac6fe8cac4913a557a1784bf04b9 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: dd22c782164c9f8d79f5de8991876d1588a21015 Maintainer: yannick Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.snmpset">
  <refnamediv>
@@ -103,6 +103,32 @@
    Si un OID inconnu ou invalide est spécifié, le contenu de l'alerte sera
    probablement "Could not add variable".
   </simpara>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Lance désormais une <exceptionname>ValueError</exceptionname> quand la
+       longueur du nom d'hôte est supérieure ou égale à 128 octets, quand le
+       port est négatif ou supérieur à 65535, ou quand les valeurs du délai
+       d'expiration ou du nombre de tentatives sont inférieures à -1 ou
+       trop grandes.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">


### PR DESCRIPTION
Sync EN de la PR php/doc-en#5533: ajoute l'entrée changelog 8.5.0 pour `snmpget`, `snmpset`, `snmp2_get`, `snmp2_set`, `snmp3_get` et `snmp3_set`, qui lancent désormais une `ValueError` si le nom d'hôte, le port, le timeout ou le retries sortent des bornes attendues.

Fixes #2782