### PR TITLE
Sync EN: replace <para> with <simpara> in language-snippets (#5522)

### DIFF
--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 330903cf6a567b885d24d0a468960d1e3b9ae213 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 3502ec883a7e65741ac493022d0c03ec10b11607 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <!-- Relecture des Notes, Précautions, Avertissements, Astuces, Divers et Retour le 2018-12-29 par girgias -->
 
@@ -27,16 +27,16 @@ de nombres aléatoires est initialisé automatiquement.</entry></row>'>
 
 <!-- Cautions / Précautions -->
 <!ENTITY caution.cryptographically-insecure '<caution xmlns="http://docbook.org/ns/docbook">
- <para>
+ <simpara>
   Cette fonction ne génère pas de valeurs cryptographiquement sûres, et <emphasis>ne doit pas</emphasis>
   être utilisée à des fins cryptographiques, ou à des fins qui exigent que les valeurs renvoyées soient indéchiffrables.
- </para>
- <para>
+ </simpara>
+ <simpara>
   Si de l&#39;aléatoire cryptographiquement sûre est requis, le <classname>Random\Randomizer</classname> peut être utilisé
   avec le moteur <classname>Random\Engine\Secure</classname>. Pour des cas d&#39;usage simple, les fonctions
   <function>random_int</function> et <function>random_bytes</function> fournissent une <acronym>API</acronym>
    pratique et sûre qui est qui est soutenu par le <acronym>CSPRNG</acronym> du système d&#39;exploitation.
- </para>
+ </simpara>
 </caution>'>
 
 <!ENTITY caution.mt19937-global-state '<caution xmlns="http://docbook.org/ns/docbook">
@@ -53,25 +53,25 @@ de nombres aléatoires est initialisé automatiquement.</entry></row>'>
 </caution>'>
 
 <!ENTITY caution.mt19937-tiny-seed '<caution xmlns="http://docbook.org/ns/docbook">
- <para>
+ <simpara>
   Étant donné que le moteur Mt19937 ("Mersenne Twister") prend un seul entier de 32 bits en tant que
   graine, le nombre de séquences aléatoires possibles est limité à seulement 2<superscript>32</superscript>
-  (par exemple 4 294 967 296), malgré la période énorme de Mt19937 de 2<superscript>19937</superscript>-1.
- </para>
- <para>
+  (soit 4 294 967 296), malgré la période énorme de Mt19937 de 2<superscript>19937</superscript>-1.
+ </simpara>
+ <simpara>
   Quand on se fie à une graine aléatoire implicite ou explicite, les duplications apparaîtront
   beaucoup plus tôt. Les graines dupliquées sont attendues avec une probabilité de 50&#37; après moins de
-  80 000 graines générées aléatoirement selon le problème d anniversaire. Une probabilité de 10&#37;
-  d une graine dupliquée se produit après avoir généré environ 30 000 graines de manière aléatoire.
- </para>
- <para>
+  80 000 graines générées aléatoirement selon le problème d&apos;anniversaire. Une probabilité de 10&#37;
+  d&apos;une graine dupliquée se produit après avoir généré environ 30 000 graines de manière aléatoire.
+ </simpara>
+ <simpara>
   Cela rend Mt19937 inadapté aux applications où les séquences dupliquées ne doivent pas se produire avec
-  plus qu une probabilité négligeable. Si une graine reproductible est requise, à la fois le
-  moteur <classname>Random\Engine\Xoshiro256StarStar</classname> et <classname>Random\Engine\PcgOneseq128XslRr64</classname>
-  supportent des graines beaucoup plus grandes qui sont peu susceptibles de se heurter de manière aléatoire. Si la reproductibilité
-  n&apos;est pas requise, le moteur <classname>Random\Engine\Secure</classname> fournit des données aléatoires cryptographiquement
-  sécurisées.
- </para>
+  plus qu&apos;une probabilité négligeable. Si une graine reproductible est requise, les moteurs
+  <classname>Random\Engine\Xoshiro256StarStar</classname> et <classname>Random\Engine\PcgOneseq128XslRr64</classname>
+  acceptent tous deux des graines beaucoup plus grandes qui ont peu de chances d&apos;entrer en
+  collision aléatoirement. Si la reproductibilité n&apos;est pas requise, le moteur
+  <classname>Random\Engine\Secure</classname> fournit un aléa cryptographiquement sûr.
+ </simpara>
 </caution>'>
 
 <!-- Notes -->
@@ -89,57 +89,57 @@ de nombres aléatoires est initialisé automatiquement.</entry></row>'>
  Une <type>resource</type> de <link linkend="stream.contexts">contexte de flux</link>.
 </simpara></note>'>
 
-<!ENTITY note.exec-bg '<note xmlns="http://docbook.org/ns/docbook"><para>
+<!ENTITY note.exec-bg '<note xmlns="http://docbook.org/ns/docbook"><simpara>
  Si un programme est démarré avec cette fonction et qu&#39;il tourne en arrière plan, la sortie du programme doit
  être redirigée vers un fichier, ou un autre flux de sortie. À défaut, PHP sera bloqué
  jusqu&#39;à la fin de l&#39;exécution du programme.
-</para></note>'>
+</simpara></note>'>
 
-<!ENTITY note.exec-bypass-shell '<note xmlns="http://docbook.org/ns/docbook"><para>
+<!ENTITY note.exec-bypass-shell '<note xmlns="http://docbook.org/ns/docbook"><simpara>
  Sur Windows <function>exec</function> démarrera d&#39;abord cmd.exe pour exécuter la commande.
  Si vous voulez démarrer un programme externe sans exécuter cmd.exe utilisez <function>proc_open</function>
  en définissant l&#39;option <parameter>bypass_shell</parameter>.
-</para></note>'>
+</simpara></note>'>
 
-<!ENTITY note.extractto-windows '<note xmlns="http://docbook.org/ns/docbook"><para>
+<!ENTITY note.extractto-windows '<note xmlns="http://docbook.org/ns/docbook"><simpara>
  Les systèmes de fichiers NTFS Windows ne supportent pas certain caractères dans le noms de fichier,
  à savoir <literal>&lt;|&gt;*?":</literal>.
  Les noms de fichiers avec un point trainant ne sont également pas supporté.
  Contrairement à certains outils d&apos;extraction, cette méthode ne remplace pas ces caractères
  avec un tiret bas, mais échoue à extraire de tel fichiers.
-</para></note>'>
+</simpara></note>'>
 
 <!ENTITY note.func-callback '<note xmlns="http://docbook.org/ns/docbook"><simpara>
  À la place d&#39;un nom de fonction, un tableau contenant une référence d&#39;objet et un nom de méthode peut aussi
  être utilisé.
 </simpara></note>'>
 
-<!ENTITY note.func-callback-exceptions '<note xmlns="http://docbook.org/ns/docbook"><para>
- Notez que les fonctions de rappel enregistrées avec des fonctions comme <function>call_user_func</function> et
+<!ENTITY note.func-callback-exceptions '<note xmlns="http://docbook.org/ns/docbook"><simpara>
+ Il est à noter que les fonctions de rappel enregistrées avec des fonctions comme <function>call_user_func</function> et
  <function>call_user_func_array</function> ne seront pas appelées si une exception n&#39;est pas interceptée alors
  qu&#39;elle a été lancée dans une précédente fonction de rappel.
-</para></note>'>
+</simpara></note>'>
 
-<!ENTITY note.funcbyref '<note xmlns="http://docbook.org/ns/docbook"><para>
+<!ENTITY note.funcbyref '<note xmlns="http://docbook.org/ns/docbook"><simpara>
  Si les arguments sont passés par référence, toutes leurs modifications seront reflétées dans les valeurs
  retournées par cette fonction. À partir de PHP 7, les valeurs courantes seront aussi retournées si les arguments
  sont passés par leur valeur.
-</para></note>'>
+</simpara></note>'>
 
-<!ENTITY note.funcnoparam '<note xmlns="http://docbook.org/ns/docbook"><para>
+<!ENTITY note.funcnoparam '<note xmlns="http://docbook.org/ns/docbook"><simpara>
  Parce que cette fonction dépend de la portée courante pour déterminer les détails des paramètres, ils ne
  peuvent pas être utilisés en tant que paramètre d&apos;une fonction dans les versions de PHP antérieures à 5.3.0.
  Si cette valeur doit être passée, le résultat doit être assigné à une variable et cette variable doit être passée.
-</para></note>'>
+</simpara></note>'>
 
-<!ENTITY note.func-named-params '<note xmlns="http://docbook.org/ns/docbook"><para>
+<!ENTITY note.func-named-params '<note xmlns="http://docbook.org/ns/docbook"><simpara>
  À partir de PHP 8.0.0, la famille de fonction func_*() désigné à être essentiellement
  transparent concernant les arguments nommées, en traitant les arguments comme s&apos;ils
  étaient tous passé de manière positionnelle, et les arguments manquant sont remplacés
  avec leurs valeurs par défaut.
  Cette fonction ignore la collection d&apos;argument variadic nommée inconnue.
  Les arguments nommées qui sont collectionnés sont uniquement accessible à travers le paramètre variadic.
-</para></note>'>
+</simpara></note>'>
 
 <!ENTITY note.line-endings '<note xmlns="http://docbook.org/ns/docbook"><simpara>
  Si PHP ne reconnaît pas correctement les fins de lignes lors de la lecture de fichiers qui ont été créés ou lus sur
@@ -181,67 +181,67 @@ de nombres aléatoires est initialisé automatiquement.</entry></row>'>
  <function>srand</function> ou <function>mt_srand</function>, ceci est fait automatiquement.
 </simpara></note>'>
 
-<!ENTITY note.is-superglobal "<note xmlns='http://docbook.org/ns/docbook'><para>
+<!ENTITY note.is-superglobal "<note xmlns='http://docbook.org/ns/docbook'><simpara>
  Ceci est une 'superglobale', ou variable globale automatique. Cela signifie simplement que cette variable
  est disponible dans tous les contextes du script. Il n'est pas nécessaire de faire <command>global $variable;</command>
  pour y accéder dans les fonctions ou les méthodes.
-</para></note>">
+</simpara></note>">
 
-<!ENTITY note.uses-ob '<note xmlns="http://docbook.org/ns/docbook"><para>
+<!ENTITY note.uses-ob '<note xmlns="http://docbook.org/ns/docbook"><simpara>
  Lorsque le paramètre <parameter>return</parameter> est utilisé, cette fonction utilise la mise en tampon
  (buffer) interne de sortie, il ne peut donc pas être utilisé dans la fonction de rappel de <function>ob_start</function>.
-</para></note>'>
+</simpara></note>'>
 
-<!ENTITY note.uses-ob-php70 '<note xmlns="http://docbook.org/ns/docbook"><para>
+<!ENTITY note.uses-ob-php70 '<note xmlns="http://docbook.org/ns/docbook"><simpara>
  Lorsque le paramètre <parameter>return</parameter> est utilisé, cette fonction
  utilisait la mise en tampon (buffer) interne de sortie antérieur à PHP 7.1.0, et donc ne peut pas être
  utilisé dans la fonction de rappel de <function>ob_start</function>.
-</para></note>'>
+</simpara></note>'>
 
-<!ENTITY note.filesystem-time-res '<note xmlns="http://docbook.org/ns/docbook"><para>
+<!ENTITY note.filesystem-time-res '<note xmlns="http://docbook.org/ns/docbook"><simpara>
  Notez que la précision temporelle peut varier selon le système de fichiers utilisé.
-</para></note>'>
+</simpara></note>'>
 
-<!ENTITY note.uses-autoload '<note xmlns="http://docbook.org/ns/docbook"><para>
+<!ENTITY note.uses-autoload '<note xmlns="http://docbook.org/ns/docbook"><simpara>
  L&#39;usage de cette fonction utilisera tous les <link linkend="language.oop5.autoload">autoloaders</link>
  enregistrés si la classe n&#39;est pas encore connue.
-</para></note>'>
+</simpara></note>'>
 
 <!ENTITY note.network.header.sapi '<note xmlns="http://docbook.org/ns/docbook">
- <para>
+ <simpara>
   Les en-têtes ne seront accessibles et s&#39;afficheront que lorsqu&#39;un SAPI qui les supporte sera utilisé.
- </para>
+ </simpara>
 </note>
 '>
 
 <!ENTITY note.sigchild '<note xmlns="http://docbook.org/ns/docbook">
- <para>
+ <simpara>
   Si PHP a été compilé avec l&#39;option de configuration --enable-sigchild,
   la valeur retournée de cette fonction sera indéfinie.
- </para>
+ </simpara>
 </note>
 '>
 
 <!ENTITY note.sort-unstable '<note xmlns="http://docbook.org/ns/docbook">
- <para>
+ <simpara>
   Si deux membres se comparent comme égaux, ils maintiennent leur ordre original.
   Antérieur à PHP 8.0.0, leur ordre relatif dans le tableau trié n&#39;est pas défini.
- </para>
+ </simpara>
 </note>
 '>
 
 <!ENTITY note.reset-index "<note xmlns='http://docbook.org/ns/docbook'>
- <para>
+ <simpara>
     Réinitialise le pointeur interne du tableau au premier élément.
- </para>
+ </simpara>
 </note>
 ">
 
 <!ENTITY note.resource-migration-8.0-dead-function '<note xmlns="http://docbook.org/ns/docbook">
- <para>
+ <simpara>
   Cette fonction n&apos;a aucun effet. Antérieur à PHP 8.0.0,
   cette fonction était utilisé pour fermer une ressource.
- </para>
+ </simpara>
 </note>
 '>
 
@@ -273,11 +273,11 @@ de nombres aléatoires est initialisé automatiquement.</entry></row>'>
 
 <!-- Warnings / Avertissement -->
 
-<!ENTITY warn.escapeshell '<warning xmlns="http://docbook.org/ns/docbook"><para>
+<!ENTITY warn.escapeshell '<warning xmlns="http://docbook.org/ns/docbook"><simpara>
  Si des données provenant des utilisateurs ont la permission d&apos;être passées à cette fonction, utilisez
  <function>escapeshellarg</function> ou <function>escapeshellcmd</function> pour s&apos;assurer que les utilisateurs
  ne peuvent pas amener le système à exécuter des commandes arbitraires.
-</para></warning>'>
+</simpara></warning>'>
 
 <!ENTITY warn.experimental '<warning xmlns="http://docbook.org/ns/docbook"><simpara>
  Cette extension est <emphasis>EXPERIMENTALE</emphasis>. Le comportement de cette extension, les noms de ses fonctions,
@@ -543,21 +543,21 @@ xmlns="http://docbook.org/ns/docbook"><simpara>
  Note: Yaz 2.0 et supérieur ne souffre plus de ce problème.
 </simpara></warning>'>
 
-<!ENTITY warn.install.cgi '<warning xmlns="http://docbook.org/ns/docbook"><para>
+<!ENTITY warn.install.cgi '<warning xmlns="http://docbook.org/ns/docbook"><simpara>
  Un serveur déployé en mode CGI s&#39;expose à plusieurs vulnérabilités possibles. Veuillez lire notre
  <link linkend="security.cgi-bin">section sur la sécurité en mode CGI</link>
  pour apprendre comment vous protéger contre ces attaques.
-</para></warning>'>
+</simpara></warning>'>
 
 <!ENTITY warn.passwordhashing '<warning xmlns="http://docbook.org/ns/docbook">
-<para>
+<simpara>
  Il n&#39;est pas recommandé d&#39;utiliser cette fonction pour sécuriser les mots de passe, en raison de la nature
  rapide de cet algorithme de hachage. Voir <link linkend="faq.passwords.fasthash">F.A.Q du hachage des
  mots de passe</link> pour plus de détails et les bonnes pratiques.
-</para>
+</simpara>
 </warning>'>
 
-<!ENTITY warn.ssl-non-standard '<warning xmlns="http://docbook.org/ns/docbook"><para>
+<!ENTITY warn.ssl-non-standard '<warning xmlns="http://docbook.org/ns/docbook"><simpara>
  Lorsque SSL est utilisé, le serveur IIS de Microsoft violera le protocole en fermant la connexion sans
  envoyer un indicateur <literal>close_notify</literal>. PHP le reportera en tant que "SSL: Fatal Protocol Error"
  quand vous arrivez à la fin des données. Pour contourner ce le niveau de la directive
@@ -566,7 +566,7 @@ xmlns="http://docbook.org/ns/docbook"><simpara>
  du flux en utilisant <literal>https://</literal> et supprimera l&#39;avertissement.
  Lors de l&#39;utilisation de <function>fsockopen</function> pour créer un socket <literal>ssl://</literal>,
  c&#39;est au développeur de détecter et supprimer l&#39;avertissement.
-</para></warning>'>
+</simpara></warning>'>
 
 <!ENTITY warn.undocumented.class '
 <warning xmlns="http://docbook.org/ns/docbook">
@@ -589,90 +589,90 @@ xmlns="http://docbook.org/ns/docbook"><simpara>
     en/reference/regex/reference.xml for examples of these in action. -->
 
 <!ENTITY warn.deprecated.function.4-1-0.removed.7-0-0.alternatives '
-<para xmlns="http://docbook.org/ns/docbook">
+<simpara xmlns="http://docbook.org/ns/docbook">
  Cette fonction est <emphasis>OBSOLÈTE</emphasis> à partir de PHP 4.1.0 et a été
  <emphasis>SUPPRIMÉE</emphasis> à partir de PHP 7.0.0.
-</para>
-<para xmlns="http://docbook.org/ns/docbook">
+</simpara>
+<simpara xmlns="http://docbook.org/ns/docbook">
  Les alternatives à cette fonction incluent :
-</para>
+</simpara>
 '>
 
 <!ENTITY warn.deprecated.feature.5-3-0.removed.7-0-0.alternatives '
-<para xmlns="http://docbook.org/ns/docbook">
+<simpara xmlns="http://docbook.org/ns/docbook">
  Cette fonctionnalité est <emphasis>OBSOLÈTE</emphasis> à partir de PHP 5.3.0 et a été
  <emphasis>SUPPRIMÉE</emphasis> à partir de PHP 7.0.0.
-</para>
-<para xmlns="http://docbook.org/ns/docbook">
+</simpara>
+<simpara xmlns="http://docbook.org/ns/docbook">
  Les alternatives à cette fonctionnalité incluent :
-</para>
+</simpara>
 '>
 
 <!ENTITY warn.deprecated.function.5-3-0.removed.7-0-0.alternatives '
-<para xmlns="http://docbook.org/ns/docbook">
+<simpara xmlns="http://docbook.org/ns/docbook">
  Cette fonction est <emphasis>OBSOLÈTE</emphasis> à partir de PHP 5.3.0 et a été
  <emphasis>SUPPRIMÉE</emphasis> à partir de PHP 7.0.0.
-</para>
-<para xmlns="http://docbook.org/ns/docbook">
+</simpara>
+<simpara xmlns="http://docbook.org/ns/docbook">
  Les alternatives à cette fonction incluent :
-</para>
+</simpara>
 '>
 
 <!ENTITY warn.deprecated.function.5-5-0.removed.7-0-0.alternatives '
-<para xmlns="http://docbook.org/ns/docbook">
+<simpara xmlns="http://docbook.org/ns/docbook">
  Cette fonction est <emphasis>OBSOLÈTE</emphasis> à partir de PHP 5.5.0 et a été
  <emphasis>SUPPRIMÉE</emphasis> à partir de PHP 7.0.0.
-</para>
-<para xmlns="http://docbook.org/ns/docbook">
+</simpara>
+<simpara xmlns="http://docbook.org/ns/docbook">
  Les alternatives à cette fonction incluent :
-</para>
+</simpara>
 '>
 
 <!ENTITY warn.removed.feature.7-0-0.alternatives '
-<para xmlns="http://docbook.org/ns/docbook">
+<simpara xmlns="http://docbook.org/ns/docbook">
  Cette fonctionnalité a été <emphasis>SUPPRIMÉE</emphasis> à partir de PHP 7.0.0.
-</para>
-<para xmlns="http://docbook.org/ns/docbook">
+</simpara>
+<simpara xmlns="http://docbook.org/ns/docbook">
  Les alternatives à cette fonctionnalité incluent :
-</para>
+</simpara>
 '>
 
 <!ENTITY warn.removed.function.7-0-0.alternatives '
-<para xmlns="http://docbook.org/ns/docbook">
+<simpara xmlns="http://docbook.org/ns/docbook">
  Cette fonction a été <emphasis>SUPPRIMÉE</emphasis> à partir de PHP 7.0.0.
-</para>
-<para xmlns="http://docbook.org/ns/docbook">
+</simpara>
+<simpara xmlns="http://docbook.org/ns/docbook">
  Les alternatives à cette fonction incluent :
-</para>
+</simpara>
 '>
 
 <!ENTITY warn.deprecated.feature.7-1-0.removed.7-2-0.alternatives '
-<para xmlns="http://docbook.org/ns/docbook">
+<simpara xmlns="http://docbook.org/ns/docbook">
  Cette fonctionnalité est <emphasis>OBSOLÈTE</emphasis> à partir de PHP 7.1.0 et a été
  <emphasis>SUPPRIMÉE</emphasis> à partir de PHP 7.2.0.
-</para>
-<para xmlns="http://docbook.org/ns/docbook">
+</simpara>
+<simpara xmlns="http://docbook.org/ns/docbook">
  Les alternatives à cette fonctionnalité incluent :
-</para>
+</simpara>
 '>
 
 <!ENTITY warn.deprecated.function.7-1-0.removed.7-2-0.alternatives '
-<para xmlns="http://docbook.org/ns/docbook">
+<simpara xmlns="http://docbook.org/ns/docbook">
  Cette fonction est <emphasis>OBSOLÈTE</emphasis> à partir de PHP 7.1.0 et a été
  <emphasis>SUPPRIMÉE</emphasis> à partir de PHP 7.2.0.
-</para>
-<para xmlns="http://docbook.org/ns/docbook">
+</simpara>
+<simpara xmlns="http://docbook.org/ns/docbook">
  Les alternatives à cette fonction incluent :
-</para>
+</simpara>
 '>
 
 <!ENTITY warn.deprecated.function-8-1-0.alternatives '<warning
 xmlns="http://docbook.org/ns/docbook"><simpara>Cette fonction
 est <emphasis>OBSOLÈTE</emphasis> à partir de PHP 8.1.0.
 Il est fortement recommandé de les éviter.</simpara></warning>
-<para xmlns="http://docbook.org/ns/docbook">
+<simpara xmlns="http://docbook.org/ns/docbook">
  Les alternatives à cette fonction incluent :
-</para>
+</simpara>
 '>
 
 <!-- Misc / Divers -->
@@ -681,68 +681,68 @@ Il est fortement recommandé de les éviter.</simpara></warning>
 
 <!ENTITY version.trunk.changelog 'Futur'>
 
-<!ENTITY no.function.parameters '<para xmlns="http://docbook.org/ns/docbook">Cette fonction ne contient aucun paramètre.</para>'>
+<!ENTITY no.function.parameters '<simpara xmlns="http://docbook.org/ns/docbook">Cette fonction ne contient aucun paramètre.</simpara>'>
 
-<!ENTITY example.outputs '<para xmlns="http://docbook.org/ns/docbook">L&#39;exemple ci-dessus va afficher :</para>'>
+<!ENTITY example.outputs '<simpara xmlns="http://docbook.org/ns/docbook">L&#39;exemple ci-dessus va afficher :</simpara>'>
 
-<!ENTITY example.outputs.5 '<para xmlns="http://docbook.org/ns/docbook">Résultat de l&#39;exemple ci-dessus en PHP 5 :</para>'>
+<!ENTITY example.outputs.5 '<simpara xmlns="http://docbook.org/ns/docbook">Résultat de l&#39;exemple ci-dessus en PHP 5 :</simpara>'>
 
-<!ENTITY example.outputs.53 '<para xmlns="http://docbook.org/ns/docbook">Résultat de l&#39;exemple ci-dessus en PHP 5.3 :</para>'>
+<!ENTITY example.outputs.53 '<simpara xmlns="http://docbook.org/ns/docbook">Résultat de l&#39;exemple ci-dessus en PHP 5.3 :</simpara>'>
 
-<!ENTITY example.outputs.54 '<para xmlns="http://docbook.org/ns/docbook">Résultat de l&#39;exemple ci-dessus en PHP 5.4 :</para>'>
+<!ENTITY example.outputs.54 '<simpara xmlns="http://docbook.org/ns/docbook">Résultat de l&#39;exemple ci-dessus en PHP 5.4 :</simpara>'>
 
-<!ENTITY example.outputs.55 '<para xmlns="http://docbook.org/ns/docbook">Résultat de l&#39;exemple ci-dessus en PHP 5.5 :</para>'>
+<!ENTITY example.outputs.55 '<simpara xmlns="http://docbook.org/ns/docbook">Résultat de l&#39;exemple ci-dessus en PHP 5.5 :</simpara>'>
 
-<!ENTITY example.outputs.56 '<para xmlns="http://docbook.org/ns/docbook">Résultat de l&#39;exemple ci-dessus en PHP 5.6 :</para>'>
+<!ENTITY example.outputs.56 '<simpara xmlns="http://docbook.org/ns/docbook">Résultat de l&#39;exemple ci-dessus en PHP 5.6 :</simpara>'>
 
-<!ENTITY example.outputs.7 '<para xmlns="http://docbook.org/ns/docbook">Résultat de l&#39;exemple ci-dessus en PHP 7 :</para>'>
+<!ENTITY example.outputs.7 '<simpara xmlns="http://docbook.org/ns/docbook">Résultat de l&#39;exemple ci-dessus en PHP 7 :</simpara>'>
 
-<!ENTITY example.outputs.70 '<para xmlns="http://docbook.org/ns/docbook">Résultat de l&#39;exemple ci-dessus en PHP 7.0 :</para>'>
+<!ENTITY example.outputs.70 '<simpara xmlns="http://docbook.org/ns/docbook">Résultat de l&#39;exemple ci-dessus en PHP 7.0 :</simpara>'>
 
-<!ENTITY example.outputs.71 '<para xmlns="http://docbook.org/ns/docbook">Résultat de l&#39;exemple ci-dessus en PHP 7.1 :</para>'>
+<!ENTITY example.outputs.71 '<simpara xmlns="http://docbook.org/ns/docbook">Résultat de l&#39;exemple ci-dessus en PHP 7.1 :</simpara>'>
 
-<!ENTITY example.outputs.72 '<para xmlns="http://docbook.org/ns/docbook">Résultat de l&#39;exemple ci-dessus en PHP 7.2:</para>'>
+<!ENTITY example.outputs.72 '<simpara xmlns="http://docbook.org/ns/docbook">Résultat de l&#39;exemple ci-dessus en PHP 7.2:</simpara>'>
 
-<!ENTITY example.outputs.73 '<para xmlns="http://docbook.org/ns/docbook">Résultat de l&#39;exemple ci-dessus en PHP 7.3 :</para>'>
+<!ENTITY example.outputs.73 '<simpara xmlns="http://docbook.org/ns/docbook">Résultat de l&#39;exemple ci-dessus en PHP 7.3 :</simpara>'>
 
 
-<!ENTITY example.outputs.8 '<para xmlns="http://docbook.org/ns/docbook">Résultat de l&#39;exemple ci-dessus en PHP 8 :</para>'>
+<!ENTITY example.outputs.8 '<simpara xmlns="http://docbook.org/ns/docbook">Résultat de l&#39;exemple ci-dessus en PHP 8 :</simpara>'>
 
-<!ENTITY example.outputs.8.similar '<para xmlns="http://docbook.org/ns/docbook">Résultat de l&#39;exemple ci-dessus en PHP 8 est similaire à :</para>'>
+<!ENTITY example.outputs.8.similar '<simpara xmlns="http://docbook.org/ns/docbook">Résultat de l&#39;exemple ci-dessus en PHP 8 est similaire à :</simpara>'>
 
-<!ENTITY example.outputs.80 '<para xmlns="http://docbook.org/ns/docbook">Résultat de l&#39;exemple ci-dessus en PHP 8.0 :</para>'>
+<!ENTITY example.outputs.80 '<simpara xmlns="http://docbook.org/ns/docbook">Résultat de l&#39;exemple ci-dessus en PHP 8.0 :</simpara>'>
 
-<!ENTITY example.outputs.81 '<para xmlns="http://docbook.org/ns/docbook">Résultat de l&#39;exemple ci-dessus en PHP 8.1 :</para>'>
+<!ENTITY example.outputs.81 '<simpara xmlns="http://docbook.org/ns/docbook">Résultat de l&#39;exemple ci-dessus en PHP 8.1 :</simpara>'>
 
-<!ENTITY example.outputs.82 '<para xmlns="http://docbook.org/ns/docbook">Résultat de l&#39;exemple ci-dessus en PHP 8.2 :</para>'>
+<!ENTITY example.outputs.82 '<simpara xmlns="http://docbook.org/ns/docbook">Résultat de l&#39;exemple ci-dessus en PHP 8.2 :</simpara>'>
 
-<!ENTITY example.outputs.82.similar '<para xmlns="http://docbook.org/ns/docbook">Résultat de l&#39;exemple ci-dessus en PHP 8.2 est similaire à :</para>'>
+<!ENTITY example.outputs.82.similar '<simpara xmlns="http://docbook.org/ns/docbook">Résultat de l&#39;exemple ci-dessus en PHP 8.2 est similaire à :</simpara>'>
 
-<!ENTITY example.outputs.83 '<para xmlns="http://docbook.org/ns/docbook">Résultat de l&#39;exemple ci-dessus en PHP 8.3 :</para>'>
+<!ENTITY example.outputs.83 '<simpara xmlns="http://docbook.org/ns/docbook">Résultat de l&#39;exemple ci-dessus en PHP 8.3 :</simpara>'>
 
-<!ENTITY example.outputs.83.similar '<para xmlns="http://docbook.org/ns/docbook">Résultat de l&#39;exemple ci-dessus en PHP 8.3 est similaire à :</para>'>
+<!ENTITY example.outputs.83.similar '<simpara xmlns="http://docbook.org/ns/docbook">Résultat de l&#39;exemple ci-dessus en PHP 8.3 est similaire à :</simpara>'>
 
-<!ENTITY example.outputs.84 '<para xmlns="http://docbook.org/ns/docbook">Sortie de l&#39;exemple ci-dessus en PHP 8.4 :</para>'>
+<!ENTITY example.outputs.84 '<simpara xmlns="http://docbook.org/ns/docbook">Sortie de l&#39;exemple ci-dessus en PHP 8.4 :</simpara>'>
 
-<!ENTITY example.outputs.84.similar '<para xmlns="http://docbook.org/ns/docbook">La sortie de l&#39;exemple ci-dessus en PHP 8.4 est similaire à :</para>'>
+<!ENTITY example.outputs.84.similar '<simpara xmlns="http://docbook.org/ns/docbook">La sortie de l&#39;exemple ci-dessus en PHP 8.4 est similaire à :</simpara>'>
 
-<!ENTITY example.outputs.85 '<para xmlns="http://docbook.org/ns/docbook">Sortie de l&#39;exemple ci-dessus en PHP 8.5&nbsp;:</para>'>
+<!ENTITY example.outputs.85 '<simpara xmlns="http://docbook.org/ns/docbook">Sortie de l&#39;exemple ci-dessus en PHP 8.5&nbsp;:</simpara>'>
 
-<!ENTITY example.outputs.85.similar '<para xmlns="http://docbook.org/ns/docbook">La sortie de l&#39;exemple ci-dessus en PHP 8.5 est similaire à :</para>'>
+<!ENTITY example.outputs.85.similar '<simpara xmlns="http://docbook.org/ns/docbook">La sortie de l&#39;exemple ci-dessus en PHP 8.5 est similaire à :</simpara>'>
 
-<!ENTITY example.outputs.32bit '<para xmlns="http://docbook.org/ns/docbook">Résultat de l&#39;exemple ci-dessus sur une machine 32 bits :</para>'>
+<!ENTITY example.outputs.32bit '<simpara xmlns="http://docbook.org/ns/docbook">Résultat de l&#39;exemple ci-dessus sur une machine 32 bits :</simpara>'>
 
-<!ENTITY example.outputs.64bit '<para xmlns="http://docbook.org/ns/docbook">Résultat de l&#39;exemple ci-dessus sur une machine 64 bits :</para>'>
+<!ENTITY example.outputs.64bit '<simpara xmlns="http://docbook.org/ns/docbook">Résultat de l&#39;exemple ci-dessus sur une machine 64 bits :</simpara>'>
 
-<!ENTITY example.outputs.similar '<para xmlns="http://docbook.org/ns/docbook">Résultat de l&#39;exemple ci-dessus est similaire à :</para>'>
+<!ENTITY example.outputs.similar '<simpara xmlns="http://docbook.org/ns/docbook">Résultat de l&#39;exemple ci-dessus est similaire à :</simpara>'>
 
-<!ENTITY examples.outputs '<para xmlns="http://docbook.org/ns/docbook">Les exemples ci-dessus vont afficher :</para>'>
+<!ENTITY examples.outputs '<simpara xmlns="http://docbook.org/ns/docbook">Les exemples ci-dessus vont afficher :</simpara>'>
 
-<!ENTITY examples.outputs.32bit '<para xmlns="http://docbook.org/ns/docbook">Résultat des exemples ci-dessus sur une machine 32 bits :</para>'>
+<!ENTITY examples.outputs.32bit '<simpara xmlns="http://docbook.org/ns/docbook">Résultat des exemples ci-dessus sur une machine 32 bits :</simpara>'>
 
-<!ENTITY examples.outputs.64bit '<para xmlns="http://docbook.org/ns/docbook">Résultat des exemples ci-dessus sur une machine 64 bits :</para>'>
+<!ENTITY examples.outputs.64bit '<simpara xmlns="http://docbook.org/ns/docbook">Résultat des exemples ci-dessus sur une machine 64 bits :</simpara>'>
 
-<!ENTITY examples.outputs.similar '<para xmlns="http://docbook.org/ns/docbook">Les exemples ci-dessus vont afficher quelque chose de similaire à :</para>'>
+<!ENTITY examples.outputs.similar '<simpara xmlns="http://docbook.org/ns/docbook">Les exemples ci-dessus vont afficher quelque chose de similaire à :</simpara>'>
 
 <!ENTITY array.resetspointer '<note xmlns="http://docbook.org/ns/docbook"><simpara>
  Cette fonction remet le pointeur au début du tableau d&#39;entrée (équivalent de <function>reset</function>).
@@ -769,10 +769,10 @@ Il est fortement recommandé de les éviter.</simpara></warning>
 <!ENTITY sort.flags.parameter '<varlistentry xmlns="http://docbook.org/ns/docbook">
  <term><parameter>flags</parameter></term>
  <listitem>
-  <para>
+  <simpara>
    Le deuxième paramètre optionnel <parameter>flags</parameter>
    peut être utilisé pour modifier le comportement de tri en utilisant ces valeurs :
-  </para>
+  </simpara>
   <para>
    Type de drapeaux de tri :
    <itemizedlist>
@@ -813,18 +813,18 @@ Il est fortement recommandé de les éviter.</simpara></warning>
 </varlistentry>
 '>
 
-<!ENTITY sort.callback.description '<para xmlns="http://docbook.org/ns/docbook">
+<!ENTITY sort.callback.description '<simpara xmlns="http://docbook.org/ns/docbook">
 &return.callbacksort;
-</para>
+</simpara>
 &callback.cmp;
 <caution xmlns="http://docbook.org/ns/docbook">
-<para>
+<simpara>
 Retourner des valeurs <emphasis>non-entières</emphasis> à partir de la fonction
 de comparaison, telles que <type>float</type>, entraînera une conversion interne
 de la valeur de retour du rappel en <type>int</type>. Ainsi, des valeurs telles que
 <literal>0.99</literal> et <literal>0.1</literal> seront toutes deux converties en une
 valeur entière de <literal>0</literal>, ce qui comparera de telles valeurs comme égales.
-</para>
+</simpara>
 </caution>'>
 
 <!ENTITY sort.callback.description.presort '<caution xmlns="http://docbook.org/ns/docbook">
@@ -952,7 +952,7 @@ de ce manuel pour une description des <literal xmlns="http://docbook.org/ns/docb
 '>
 
 <!-- FileInfo -->
-<!ENTITY fileinfo.parameters.finfo '<para xmlns="http://docbook.org/ns/docbook">Une instance <classname>finfo</classname>, retourné par <function>finfo_open</function>.</para>'>
+<!ENTITY fileinfo.parameters.finfo '<simpara xmlns="http://docbook.org/ns/docbook">Une instance <classname>finfo</classname>, retourné par <function>finfo_open</function>.</simpara>'>
 <!ENTITY fileinfo.changelog.finfo-object '<row xmlns="http://docbook.org/ns/docbook">
  <entry>8.1.0</entry>
  <entry>
@@ -965,28 +965,28 @@ de ce manuel pour une description des <literal xmlns="http://docbook.org/ns/docb
 <!ENTITY openssl.param.x509 '<varlistentry xmlns="http://docbook.org/ns/docbook">
 <term><parameter>certificate</parameter></term>
 <listitem>
-    <para>
+    <simpara>
         Voir les <link linkend="openssl.certparams">paramètres clés/Certificats</link>
         pour une liste de valeurs valides.
-    </para>
+    </simpara>
 </listitem>
 </varlistentry>'>
 
 <!ENTITY openssl.param.csr '<varlistentry xmlns="http://docbook.org/ns/docbook">
 <term><parameter>csr</parameter></term>
 <listitem>
-    <para>
+    <simpara>
         Voir les <link linkend="openssl.certparams">paramètres CSR</link> pour obtenir une liste des valeurs valides.
-    </para>
+    </simpara>
 </listitem>
 </varlistentry>'>
 
 <!ENTITY openssl.param.key '<varlistentry xmlns="http://docbook.org/ns/docbook">
 <term><parameter>key</parameter></term>
 <listitem>
-    <para>
+    <simpara>
         Voir les <link linkend="openssl.certparams">paramètres clé publique/privé</link> pour obtenir une liste des valeurs valides.
-    </para>
+    </simpara>
 </listitem>
 </varlistentry>'>
 
@@ -1000,23 +1000,23 @@ de ce manuel pour une description des <literal xmlns="http://docbook.org/ns/docb
     si PHP est compilé avec le support Freetype (<option role="configure">--with-freetype-dir=DIR</option>)
 </simpara></note>'>
 
-<!ENTITY note.gd.notrequired '<note xmlns="http://docbook.org/ns/docbook"><para>Cette fonction ne nécessite pas la bibliothèque GD.</para></note>'>
+<!ENTITY note.gd.notrequired '<note xmlns="http://docbook.org/ns/docbook"><simpara>Cette fonction ne nécessite pas la bibliothèque GD.</simpara></note>'>
 
-<!ENTITY note.gd.interpolation '<note xmlns="http://docbook.org/ns/docbook"><para>Cette fonction est affectée par
-    la méthode d&#39;interpolation, définie par la fonction <function>imagesetinterpolation</function>.</para></note>'>
+<!ENTITY note.gd.interpolation '<note xmlns="http://docbook.org/ns/docbook"><simpara>Cette fonction est affectée par
+    la méthode d&#39;interpolation, définie par la fonction <function>imagesetinterpolation</function>.</simpara></note>'>
 
 <!ENTITY gd.image.description '<varlistentry xmlns="http://docbook.org/ns/docbook">
-<term><parameter>image</parameter></term><listitem><para>
+<term><parameter>image</parameter></term><listitem><simpara>
  Un objet <classname>GdImage</classname>, retournée par une des fonctions de
  création d&#39;images, comme <function>imagecreatetruecolor</function>.
-</para></listitem></varlistentry>'>
+</simpara></listitem></varlistentry>'>
 
 <!ENTITY gd.font.description '<varlistentry xmlns="http://docbook.org/ns/docbook">
-<term><parameter>font</parameter></term><listitem><para>
+<term><parameter>font</parameter></term><listitem><simpara>
  Peut être 1, 2, 3, 4, 5 pour les polices internes d&#39;encodage Latin2
  (où les plus grands nombres correspondent aux polices larges) ou une instance
  de <classname>GdFont</classname> retourné par <function>imageloadfont</function>.
-</para></listitem></varlistentry>'>
+</simpara></listitem></varlistentry>'>
 
 <!ENTITY gd.changelog.gdfont-instance '<row xmlns="http://docbook.org/ns/docbook">
  <entry>8.1.0</entry>
@@ -1030,17 +1030,17 @@ de ce manuel pour une description des <literal xmlns="http://docbook.org/ns/docb
 <varlistentry xmlns='http://docbook.org/ns/docbook'>
 <term><parameter>fontfile</parameter></term>
 <listitem>
-    <para>
+    <simpara>
         Le chemin d&apos;accès à la police TrueType que vous souhaitez utiliser.
-    </para>
-    <para>
+    </simpara>
+    <simpara>
         Selon la version de la bibliothèque GD que PHP utilise, <emphasis>quand
         <parameter>fontfile</parameter> ne commence pas par une premier
         <literal>/</literal> alors <literal>.ttf</literal> sera ajouté</emphasis>
         au nom de fichier et la bibliothèque essaiera de rechercher ce nom de
         fichier le long d&apos;un chemin de police défini par la bibliothèque.
-    </para>
-    <para>
+    </simpara>
+    <simpara>
         Lorsque vous utilisez des versions de la bibliothèque GD inférieure à
         2.0.18, un caractère <literal>espace</literal>, plutôt qu&apos;un
         point-virgule, a été utilisé comme séparateur de chemin d&apos;accès pour
@@ -1049,7 +1049,7 @@ de ce manuel pour une description des <literal xmlns="http://docbook.org/ns/docb
         Avertissement: impossible de trouver/ouvrir la police</literal>. Pour
         ces versions affectées, la seule solution consiste à déplacer la police
         vers un chemin qui ne contient pas d&apos;espaces.
-    </para>
+    </simpara>
     <para>
         Dans de nombreux cas où une police réside dans le même répertoire que le
         script en l&apos;utilisant l&apos;astuce suivante permettra d&apos;atténuer les
@@ -1067,10 +1067,10 @@ $font = 'SomeFont';
         </programlisting>
     </para>
     <note>
-        <para>
+        <simpara>
             Notez que <link linkend='ini.open-basedir'>open_basedir</link>
             <emphasis>ne s'applique pas</emphasis> à <parameter>fontfile</parameter>.
-        </para>
+        </simpara>
     </note>
 </listitem>
 </varlistentry>
@@ -1187,35 +1187,35 @@ Ils doivent être considérés <emphasis>obsolète</emphasis>, et devraient seul
 <!-- DBM notes -->
 
 <!ENTITY dbm.dbm-identifier.description '<varlistentry xmlns="http://docbook.org/ns/docbook">
-<term><parameter>dbm_identifier</parameter></term><listitem><para>
+<term><parameter>dbm_identifier</parameter></term><listitem><simpara>
  L&#39;identifiant de lien DBM, retourné par la fonction
  <function>dbmopen</function>.
-</para></listitem></varlistentry>'>
+</simpara></listitem></varlistentry>'>
 
 <!-- JSON notes -->
 
 <!ENTITY json.implementation.superset '
 <note xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
-<para>
+<simpara>
     PHP implémente un sur-ensemble de JSON tel que spécifié dans la
     <link xlink:href="&url.rfc;7159">RFC 7159</link> originale.
-</para>
+</simpara>
 </note>
 '>
 
 <!-- cURL notes -->
 
 <!ENTITY curl.ch.description '<varlistentry xmlns="http://docbook.org/ns/docbook"><term><parameter>handle</parameter>
-</term><listitem><para>Un gestionnaire cURL retourné par
-<function>curl_init</function>.</para></listitem></varlistentry>'>
+</term><listitem><simpara>Un gestionnaire cURL retourné par
+<function>curl_init</function>.</simpara></listitem></varlistentry>'>
 
 <!ENTITY curl.mh.description '<varlistentry xmlns="http://docbook.org/ns/docbook"><term><parameter>multi_handle</parameter>
-</term><listitem><para>Un gestionnaire cURL multiple retourné par
-<function>curl_multi_init</function>.</para></listitem></varlistentry>'>
+</term><listitem><simpara>Un gestionnaire cURL multiple retourné par
+<function>curl_multi_init</function>.</simpara></listitem></varlistentry>'>
 
 <!ENTITY curl.sh.description '<varlistentry xmlns="http://docbook.org/ns/docbook"><term><parameter>share_handle</parameter>
-</term><listitem><para>Un gestionnaire cURL partagé retourné par
-<function>curl_share_init</function>.</para></listitem></varlistentry>'>
+</term><listitem><simpara>Un gestionnaire cURL partagé retourné par
+<function>curl_share_init</function>.</simpara></listitem></varlistentry>'>
 
 <!ENTITY curl.changelog.handle-param '<row xmlns="http://docbook.org/ns/docbook">
  <entry>8.0.0</entry>
@@ -1287,19 +1287,19 @@ Chaque champs est converti en type PHP approprié, sauf :
 <!ENTITY enchant.param.broker '<varlistentry xmlns="http://docbook.org/ns/docbook">
      <term><parameter>broker</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Un courtier Enchant retourné par <function>enchant_broker_init</function>.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>'>
 
 <!ENTITY enchant.param.dictionary '<varlistentry xmlns="http://docbook.org/ns/docbook">
      <term><parameter>dictionary</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Un dictionnaire Enchant retourné par <function>enchant_broker_request_dict</function>
        ou <function>enchant_broker_request_pwl_dict</function>.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>'>
 
@@ -1330,18 +1330,18 @@ Chaque champs est converti en type PHP approprié, sauf :
 </row>'>
 
 <!ENTITY imap.imap-parameter.imap '<varlistentry xmlns="http://docbook.org/ns/docbook">
-<term><parameter>imap</parameter></term><listitem><para>
+<term><parameter>imap</parameter></term><listitem><simpara>
  Une instance de <classname>IMAP\Connection</classname>.
-</para></listitem></varlistentry>'>
+</simpara></listitem></varlistentry>'>
 
 <!-- Deprecated -->
 <!ENTITY imap.imap-stream.description '<varlistentry xmlns="http://docbook.org/ns/docbook">
-<term><parameter>imap</parameter></term><listitem><para>
+<term><parameter>imap</parameter></term><listitem><simpara>
  Un flux IMAP retourné par la fonction <function>imap_open</function>.
-</para></listitem></varlistentry>'>
+</simpara></listitem></varlistentry>'>
 
-<!ENTITY imap.pattern '<para xmlns="http://docbook.org/ns/docbook">Spécifie la position dans la hiérarchie des boîtes
-aux lettres, où il faut commencer à chercher.</para><para xmlns="http://docbook.org/ns/docbook">Il y a deux caractères
+<!ENTITY imap.pattern '<simpara xmlns="http://docbook.org/ns/docbook">Spécifie la position dans la hiérarchie des boîtes
+aux lettres, où il faut commencer à chercher.</simpara><simpara xmlns="http://docbook.org/ns/docbook">Il y a deux caractères
 spéciaux que vous pouvez utiliser dans <parameter>pattern</parameter> :
 &apos;<literal>*</literal>&apos; et &apos;<literal>&#37;</literal>&apos;.
 &apos;<literal>*</literal>&apos; signifie : toutes les boîtes aux lettres. Si vous passez
@@ -1351,7 +1351,7 @@ la liste complète des boîtes aux lettres de la hiérarchie.
 &apos;<literal>&#37;</literal>&apos; passé à <parameter>pattern</parameter> ne retournera
 que les boîtes aux lettres de niveau supérieur; &apos;<literal>~/mail/&#37;</literal>&apos;
 sous <literal>UW_IMAPD</literal> retournera toutes les boîtes aux lettres du
-dossier <filename>~/mail</filename> directory, mais pas leurs enfants.</para>'>
+dossier <filename>~/mail</filename> directory, mais pas leurs enfants.</simpara>'>
 
 <!ENTITY imap.mailboxname.insecure '<warning xmlns="http://docbook.org/ns/docbook"><simpara>
     Passer des données qui ne sont pas digne de confiance à ce paramètre est <emphasis>dangereux</emphasis>, sauf si,
@@ -1360,31 +1360,31 @@ dossier <filename>~/mail</filename> directory, mais pas leurs enfants.</para>'>
 
 <!-- intl notes -->
 
-<!ENTITY intl.parameter.intl-calendar '<para xmlns="http://docbook.org/ns/docbook">Une instance <classname>IntlCalendar</classname>.</para>'>
+<!ENTITY intl.parameter.intl-calendar '<simpara xmlns="http://docbook.org/ns/docbook">Une instance <classname>IntlCalendar</classname>.</simpara>'>
 
-<!ENTITY intl.error.intl-calendar '<para xmlns="http://docbook.org/ns/docbook">
+<!ENTITY intl.error.intl-calendar '<simpara xmlns="http://docbook.org/ns/docbook">
  En cas d&amp;échec &false; est aussi retourné. Pour détecter les conditions d&amp;erreur
  <function>intl_get_error_code</function> doit être utilisé, ou paramétrer Intl pour lancer des
  <link linkend="ini.intl.use-exceptions">exceptions</link>.
-</para>'>
+</simpara>'>
 
-<!ENTITY intl.codepoint.parameter '<para xmlns="http://docbook.org/ns/docbook">La valeur codepoint de type &integer;
+<!ENTITY intl.codepoint.parameter '<simpara xmlns="http://docbook.org/ns/docbook">La valeur codepoint de type &integer;
 (i.e. <literal>0x2603</literal> pour <emphasis>U+2603 SNOWMAN</emphasis>), ou le caractère encodé en UTF-8 de type &string;
-(i.e. <literal>"\u{2603}"</literal>)</para>'>
+(i.e. <literal>"\u{2603}"</literal>)</simpara>'>
 
-<!ENTITY intl.codepoint.return '<para xmlns="http://docbook.org/ns/docbook">Le type retourné sera &integer; tant
+<!ENTITY intl.codepoint.return '<simpara xmlns="http://docbook.org/ns/docbook">Le type retourné sera &integer; tant
 que le codepoint a été passé en une chaîne de type &string; encodée en UTF-8, auquel cas, une &string;
-est retournée. En cas d&#39;échec, retourne &null;.</para>'>
+est retournée. En cas d&#39;échec, retourne &null;.</simpara>'>
 
 <!ENTITY intl.codepoint.example 'Test de différents codepoint'>
 
-<!ENTITY intl.locale-len.return '<para xmlns="http://docbook.org/ns/docbook">
+<!ENTITY intl.locale-len.return '<simpara xmlns="http://docbook.org/ns/docbook">
  Retourne &null; quand la longueur de <parameter>locale</parameter> excède
  <constant>INTL_MAX_LOCALE_LEN</constant>.
-</para>'>
+</simpara>'>
 
-<!ENTITY intl.property.parameter '<para xmlns="http://docbook.org/ns/docbook">La propriété Unicode à chercher (voir la
-constante <literal>IntlChar::PROPERTY_*</literal>).</para>'>
+<!ENTITY intl.property.parameter '<simpara xmlns="http://docbook.org/ns/docbook">La propriété Unicode à chercher (voir la
+constante <literal>IntlChar::PROPERTY_*</literal>).</simpara>'>
 
 <!ENTITY intl.property.example 'Test de différentes propriétés'>
 
@@ -1468,32 +1468,32 @@ constante <literal>IntlChar::PROPERTY_*</literal>).</para>'>
 
 <!ENTITY ldap.return-result-array 'Retourne une instance de <classname xmlns="http://docbook.org/ns/docbook">LDAP\Result</classname>, un tableau des instances de <classname xmlns="http://docbook.org/ns/docbook">LDAP\Result</classname>,&return.falseforfailure;.'>
 
-<!ENTITY ldap.return-result-array-info '<para xmlns="http://docbook.org/ns/docbook">Il est également possible d&#39;effectuer des recherches parallèles. Dans ce cas, le premier argument doit être un tableau des
+<!ENTITY ldap.return-result-array-info '<simpara xmlns="http://docbook.org/ns/docbook">Il est également possible d&#39;effectuer des recherches parallèles. Dans ce cas, le premier argument doit être un tableau des
 instances de <classname>LDAP\Connection</classname>, plutôt qu&#39;une seule.
 Si les recherches ne devraient pas utiliser le même nom distingué (DN) de base et filtre, un tableau de DN de base et/ou un tableau de filtre peuvent être passé comme arguments à la place.
 Ces tableaux doivent être de la même taille que le tableau des instances de <classname>LDAP\Connection</classname>,
 
 puisque les premières entrées des tableaux sont utilisées pour une recherche, les secondes pour une autre, et ainsi de suite.
-Lors de recherches parallèles, un tableau des instances de <classname>LDAP\Result</classname> est retourné, sauf en cas d&#39;erreur, où la valeur de retour sera &false;.</para>'>
+Lors de recherches parallèles, un tableau des instances de <classname>LDAP\Result</classname> est retourné, sauf en cas d&#39;erreur, où la valeur de retour sera &false;.</simpara>'>
 
 <!-- mbstring notes -->
 
-<!ENTITY note.mbstring.encoding.internal '<note xmlns="http://docbook.org/ns/docbook"><para>L&#39;encodage interne ou l&#39;encodage
+<!ENTITY note.mbstring.encoding.internal '<note xmlns="http://docbook.org/ns/docbook"><simpara>L&#39;encodage interne ou l&#39;encodage
     des caractères spécifié par la fonction <function>mb_regex_encoding</function> sera utilisé
-    comme encodage de caractères pour cette fonction.</para></note>'>
+    comme encodage de caractères pour cette fonction.</simpara></note>'>
 
-<!ENTITY note.mbstring.encoding.current '<note xmlns="http://docbook.org/ns/docbook"><para>L&#39;encodage de caractères
+<!ENTITY note.mbstring.encoding.current '<note xmlns="http://docbook.org/ns/docbook"><simpara>L&#39;encodage de caractères
     spécifié par <function>mb_regex_encoding</function> sera utilisé comme encodage
-    pour cette fonction par défaut.</para></note>'>
+    pour cette fonction par défaut.</simpara></note>'>
 
-<!ENTITY mbstring.encoding.parameter '<para xmlns="http://docbook.org/ns/docbook">Le paramètre <parameter>encoding</parameter>
+<!ENTITY mbstring.encoding.parameter '<simpara xmlns="http://docbook.org/ns/docbook">Le paramètre <parameter>encoding</parameter>
 est l&#39;encodage des caractères. S&#39;il est omis ou &null;, l&#39;encodage de caractères interne
-sera utilisé.</para>'>
+sera utilisé.</simpara>'>
 
-<!ENTITY mbstring.warning.e-modifier '<warning xmlns="http://docbook.org/ns/docbook"><para>N&#39;utilisez jamais l&#39;option <literal>e</literal>
+<!ENTITY mbstring.warning.e-modifier '<warning xmlns="http://docbook.org/ns/docbook"><simpara>N&#39;utilisez jamais l&#39;option <literal>e</literal>
     lorsque vous travaillez avec des données entrantes. Aucune protection automatique n&#39;est appliquée
     (sous la forme de la fonction <function>preg_replace</function>). Si vous omettez cette étape, vous
-    allez certainement crée des failles dans votre application.</para></warning>'>
+    allez certainement crée des failles dans votre application.</simpara></warning>'>
 
 <!ENTITY mbstring.changelog.encoding-nullable '<row xmlns="http://docbook.org/ns/docbook">
  <entry>8.0.0</entry>
@@ -1511,25 +1511,25 @@ sera utilisé.</para>'>
 
 <!-- mcrypt notes -->
 
-<!ENTITY mcrypt.parameter.cipher '<para xmlns="http://docbook.org/ns/docbook">Une constante parmi les constantes
-<constant>MCRYPT_ciphername</constant>, ou le nom de l&#39;algorithme, sous la forme d&#39;une chaîne de caractères.</para>'>
+<!ENTITY mcrypt.parameter.cipher '<simpara xmlns="http://docbook.org/ns/docbook">Une constante parmi les constantes
+<constant>MCRYPT_ciphername</constant>, ou le nom de l&#39;algorithme, sous la forme d&#39;une chaîne de caractères.</simpara>'>
 
-<!ENTITY mcrypt.parameter.iv '<para xmlns="http://docbook.org/ns/docbook">Utilisé pour l&#39;initialisation des modes CBC, CFB, OFB,
+<!ENTITY mcrypt.parameter.iv '<simpara xmlns="http://docbook.org/ns/docbook">Utilisé pour l&#39;initialisation des modes CBC, CFB, OFB,
 ainsi que dans quelques algorithmes du mode STREAM. Si vous ne fournissez pas un IV, alors que cela est nécessaire
-pour l&#39;algorithme, la fonction émettra une alerte et utilisera un IV dont tous les octets vaudront "<literal>\0</literal>".</para>'>
+pour l&#39;algorithme, la fonction émettra une alerte et utilisera un IV dont tous les octets vaudront "<literal>\0</literal>".</simpara>'>
 
-<!ENTITY mcrypt.parameter.iv.strict '<para xmlns="http://docbook.org/ns/docbook">Utilisé pour l&#39;initialisation des modes CBC, CFB, OFB,
-ainsi que dans quelques algorithmes du mode STREAM. Si la taille de l&#39;IV fourni n&#39;est pas supporté par le mode d&#39;opération ou si vous ne fournissez pas d&#39;IV, mais que le mode d&#39;opération en requiert un, la fonction émettra un avertissement et retournera &false;.</para>'>
+<!ENTITY mcrypt.parameter.iv.strict '<simpara xmlns="http://docbook.org/ns/docbook">Utilisé pour l&#39;initialisation des modes CBC, CFB, OFB,
+ainsi que dans quelques algorithmes du mode STREAM. Si la taille de l&#39;IV fourni n&#39;est pas supporté par le mode d&#39;opération ou si vous ne fournissez pas d&#39;IV, mais que le mode d&#39;opération en requiert un, la fonction émettra un avertissement et retournera &false;.</simpara>'>
 
-<!ENTITY mcrypt.parameter.mode '<para xmlns="http://docbook.org/ns/docbook">Une constantes parmi les constantes
-<constant>MCRYPT_MODE_modename</constant>, ou une des chaînes suivantes : "ecb", "cbc", "cfb", "ofb", "nofb" ou "stream".</para>'>
+<!ENTITY mcrypt.parameter.mode '<simpara xmlns="http://docbook.org/ns/docbook">Une constantes parmi les constantes
+<constant>MCRYPT_MODE_modename</constant>, ou une des chaînes suivantes : "ecb", "cbc", "cfb", "ofb", "nofb" ou "stream".</simpara>'>
 
 <!-- MCVE notes -->
 
 <!ENTITY mcve.conn.description '<varlistentry xmlns="http://docbook.org/ns/docbook">
-<term><parameter>conn</parameter></term><listitem><para>
+<term><parameter>conn</parameter></term><listitem><simpara>
  Une ressource MCVE_CONN retournée par la fonction <function>m_initengine</function>.
-</para></listitem></varlistentry>'>
+</simpara></listitem></varlistentry>'>
 
 <!-- memcached notes -->
 
@@ -1559,16 +1559,16 @@ ainsi que dans quelques algorithmes du mode STREAM. Si la taille de l&#39;IV fou
 <!ENTITY memcached.result.getresultcode 'Utilisez <methodname xmlns="http://docbook.org/ns/docbook">Memcached::getResultCode</methodname>
         si nécessaire.'>
 
-<!ENTITY memcached.result.delete-multi '<para xmlns="http://docbook.org/ns/docbook">
+<!ENTITY memcached.result.delete-multi '<simpara xmlns="http://docbook.org/ns/docbook">
    Retourne un tableau indexé par <parameter>keys</parameter>. Chaque élément est
    &true; si la clé correspondante a été supprimée, ou une des constantes
    <constant>Memcached::RES_<replaceable>*</replaceable></constant> si la suppression correspondante a échoué.
-   </para>
-  <para xmlns="http://docbook.org/ns/docbook">
+   </simpara>
+  <simpara xmlns="http://docbook.org/ns/docbook">
    La méthode <methodname>Memcached::getResultCode</methodname> retournera
    le code de résultat pour la dernière opération de suppression éxécuté, c&#39;est à dire,
    l&#39;opération de suppression pour le dernier élément de <parameter>keys</parameter>.
-  </para>
+  </simpara>
 '>
 
 <!-- password notes -->
@@ -1602,9 +1602,9 @@ de mot de passe</link> représentant l&#39;algorithme à utiliser lors du hachag
  </entry>
 </row>'>
 
-<!ENTITY pspell.parameter.pspell-dictionary '<para xmlns="http://docbook.org/ns/docbook">Une instance de <classname>PSpell\Dictionary</classname>.</para>'>
+<!ENTITY pspell.parameter.pspell-dictionary '<simpara xmlns="http://docbook.org/ns/docbook">Une instance de <classname>PSpell\Dictionary</classname>.</simpara>'>
 
-<!ENTITY pspell.parameter.pspell-config '<para xmlns="http://docbook.org/ns/docbook">Une instance de <classname>PSpell\Config</classname>.</para>'>
+<!ENTITY pspell.parameter.pspell-config '<simpara xmlns="http://docbook.org/ns/docbook">Une instance de <classname>PSpell\Config</classname>.</simpara>'>
 
 <!-- RNP -->
 
@@ -1655,13 +1655,13 @@ RNP_LOAD_SAVE_<replaceable>*</replaceable></constant>.'>
 <!ENTITY gearman.parameter.callback '<varlistentry xmlns="http://docbook.org/ns/docbook">
  <term><parameter>callback</parameter></term>
  <listitem>
-  <para>
+  <simpara>
    Une fonction ou méthode à appeler.
    Elle doit retourner une valeur valide <link linkend="gearman.constants">de retour Gearman</link>.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Si aucune instruction de retour n&#39;est présente, la valeur par défaut sera <constant>GEARMAN_SUCCESS</constant>.
-  </para>
+  </simpara>
   <methodsynopsis>
    <type>int</type><methodname><replaceable>callback</replaceable></methodname>
    <methodparam><type>GearmanTask</type><parameter>task</parameter></methodparam>
@@ -1671,17 +1671,17 @@ RNP_LOAD_SAVE_<replaceable>*</replaceable></constant>.'>
    <varlistentry>
     <term><parameter>task</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       La tâche pour laquelle ce callback est appelé.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>context</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       Tout ce qui a été passé à <methodname>GearmanClient::addTask</methodname> (ou méthode équivalente) en tant que <parameter>context</parameter>.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -1689,10 +1689,10 @@ RNP_LOAD_SAVE_<replaceable>*</replaceable></constant>.'>
 </varlistentry>'>
 
 <!ENTITY gearman.note.callback '<note xmlns="http://docbook.org/ns/docbook">
- <para>
+ <simpara>
   Le callback ne sera déclenché que pour les tâches qui sont ajoutées (par exemple en appelant <methodname>GearmanClient::addTask</methodname>)
   après l&#39;appel de cette méthode.
- </para>
+ </simpara>
 </note>'>
 
 <!-- Date and time entities -->
@@ -1739,37 +1739,37 @@ elles peuvent être différentes pour chaque version de la base de données des 
 horaires, et ne doivent donc pas être utilisées. Il est fortement recommandé de les éviter.
 </simpara>'>
 
-<!ENTITY date.timezone.errors.description '<para xmlns="http://docbook.org/ns/docbook">
+<!ENTITY date.timezone.errors.description '<simpara xmlns="http://docbook.org/ns/docbook">
 Chaque appel à une fonction date/heure générera un diagnostic de type
 <constant>E_WARNING</constant> si le fuseau horaire n&#39;est pas valide.
-Voir aussi <function>date_default_timezone_set</function></para>'>
+Voir aussi <function>date_default_timezone_set</function></simpara>'>
 
-<!ENTITY date.timezone.errors.changelog '<row xmlns="http://docbook.org/ns/docbook"><entry>5.1.0</entry><entry><para>
+<!ENTITY date.timezone.errors.changelog '<row xmlns="http://docbook.org/ns/docbook"><entry>5.1.0</entry><entry><simpara>
     Émet un message de type <constant>E_STRICT</constant> et <constant>E_NOTICE</constant>
-    lors d&#39;erreurs de fuseaux horaires.</para></entry></row>'>
+    lors d&#39;erreurs de fuseaux horaires.</simpara></entry></row>'>
 
 <!ENTITY date.timestamp.description '
-<varlistentry xmlns="http://docbook.org/ns/docbook"><term><parameter>timestamp</parameter></term><listitem><para>
+<varlistentry xmlns="http://docbook.org/ns/docbook"><term><parameter>timestamp</parameter></term><listitem><simpara>
     Le paramètre optionnel <parameter>timestamp</parameter> est un timestamp
     Unix de type &integer; qui vaut par défaut l&#39;heure courante locale si
     <parameter>timestamp</parameter> est omis ou &null;. En d&#39;autres
     termes, il vaut par défaut la valeur de la fonction <function>time</function>.
-</para></listitem></varlistentry>'>
+</simpara></listitem></varlistentry>'>
 
 <!ENTITY date.datetime.description '<varlistentry xmlns="http://docbook.org/ns/docbook"><term><parameter>object</parameter></term>
-<listitem><para>Seulement en style procédural : un objet <classname>DateTime</classname>
-    retourné par <function>date_create</function></para></listitem></varlistentry>'>
+<listitem><simpara>Seulement en style procédural : un objet <classname>DateTime</classname>
+    retourné par <function>date_create</function></simpara></listitem></varlistentry>'>
 
 <!ENTITY date.datetime.description.modified '<varlistentry xmlns="http://docbook.org/ns/docbook"><term><parameter>object</parameter></term>
-<listitem><para>Style procédural uniquement : Un objet <classname>DateTime</classname>
+<listitem><simpara>Style procédural uniquement : Un objet <classname>DateTime</classname>
     retourné par la fonction <function>date_create</function>.
-    Cette fonction modifie cet objet.</para></listitem></varlistentry>'>
+    Cette fonction modifie cet objet.</simpara></listitem></varlistentry>'>
 
 <!ENTITY date.datetimezone.description '<varlistentry xmlns="http://docbook.org/ns/docbook">
-<term><parameter>object</parameter></term><listitem><para>
+<term><parameter>object</parameter></term><listitem><simpara>
  Seulement en style procédural : un <classname>DateTimeZone</classname> objet
  retourné par <function>timezone_open</function>
-</para></listitem></varlistentry>'>
+</simpara></listitem></varlistentry>'>
 
 <!ENTITY date.datetime.return.modifiedobjectorfalseforfailure 'Retourne l&#39;objet modifié <classname xmlns="http://docbook.org/ns/docbook">DateTime</classname> pour chainer les méthodes&return.falseforfailure;.'>
 <!ENTITY date.datetime.return.modifiedobject 'Retourne l&#39;objet modifié <classname xmlns="http://docbook.org/ns/docbook">DateTime</classname> pour chainer les méthodes.'>
@@ -1801,15 +1801,15 @@ Voir aussi <function>date_default_timezone_set</function></para>'>
 <!ENTITY dom.node.inserted 'Ce nœud ne sera pas affiché dans le document,
         à moins qu&#39;il ne soit inséré avec <function xmlns="http://docbook.org/ns/docbook">DOMNode::appendChild</function>.'>
 
-<!ENTITY dom.malformederror '<para xmlns="http://docbook.org/ns/docbook">Bien que le HTML mal-formé devrait se charger avec succès, cette fonction peut générer
+<!ENTITY dom.malformederror '<simpara xmlns="http://docbook.org/ns/docbook">Bien que le HTML mal-formé devrait se charger avec succès, cette fonction peut générer
 une alerte de type <constant>E_WARNING</constant> lorsqu&#39;elle rencontre une mauvaise balise.
 <link linkend="function.libxml-use-internal-errors">Les fonctions de gestion des erreurs libxml</link>
-peuvent être utilisées pour gérer ces erreurs.</para>'>
+peuvent être utilisées pour gérer ces erreurs.</simpara>'>
 
-<!ENTITY dom.note.utf8 '<note xmlns="http://docbook.org/ns/docbook"><para>
+<!ENTITY dom.note.utf8 '<note xmlns="http://docbook.org/ns/docbook"><simpara>
  L&apos;extension DOM utilise l&apos;encodage UTF-8. Utilisez <function>mb_convert_encoding</function>,
  <methodname>UConverter::transcode</methodname>, ou <function>iconv</function> pour manipuler d&apos;autres encodages.
-</para></note>'>
+</simpara></note>'>
 
 <!ENTITY dom.note.modern.utf8 '<note xmlns="http://docbook.org/ns/docbook">
  <simpara>
@@ -1818,10 +1818,10 @@ peuvent être utilisées pour gérer ces erreurs.</para>'>
  </simpara>
 </note>'>
 
-<!ENTITY dom.note.json '<note xmlns="http://docbook.org/ns/docbook"><para>
+<!ENTITY dom.note.json '<note xmlns="http://docbook.org/ns/docbook"><simpara>
  Lors de l&apos;utilisation de <function>json_encode</function> sur un objet
  <classname>DOMDocument</classname> le résultat sera celui d&apos;encoder un objet vide.
-</para></note>'>
+</simpara></note>'>
 <!ENTITY dom.domdocument.html5 '<warning xmlns="http://docbook.org/ns/docbook">
  <simpara>
   Utilisez <classname>Dom\HTMLDocument</classname> pour analyser et traiter le HTML moderne au lieu de <classname>DOMDocument</classname>.
@@ -1874,8 +1874,8 @@ peuvent être utilisées pour gérer ces erreurs.</para>'>
 '>
 
 <!-- Dom Examples -->
-<!ENTITY dom.book.example '<para xmlns="http://docbook.org/ns/docbook">L&#39;exemple suivant
-utilise le fichier <filename>book.xml</filename>, dont le contenu est :</para>
+<!ENTITY dom.book.example '<simpara xmlns="http://docbook.org/ns/docbook">L&#39;exemple suivant
+utilise le fichier <filename>book.xml</filename>, dont le contenu est :</simpara>
 <programlisting role="xml" xmlns="http://docbook.org/ns/docbook">
 <!-- Warning: The CDATA markup here is a little tricky. Please DO NOT BREAK it! -->
 <![CDATA[
@@ -1909,10 +1909,10 @@ utilise le fichier <filename>book.xml</filename>, dont le contenu est :</para>
 ]]></programlisting>'>
 
 <!-- Dom entities -->
-<!ENTITY dom.parameter.options '<para xmlns="http://docbook.org/ns/docbook">
+<!ENTITY dom.parameter.options '<simpara xmlns="http://docbook.org/ns/docbook">
   <link linkend="language.operators.bitwise">Opération de &apos;OU&apos; logique</link>
   des <link linkend="libxml.constants">constantes d&apos;option libxml</link>.
-</para>'>
+</simpara>'>
 
 <!ENTITY dom.parameter.compliant.options '&dom.parameter.options;
  <simpara xmlns="http://docbook.org/ns/docbook">
@@ -1939,11 +1939,11 @@ utilise le fichier <filename>book.xml</filename>, dont le contenu est :</para>
 <!ENTITY dom.parameters.register_node_ns '<varlistentry xmlns="http://docbook.org/ns/docbook">
  <term><parameter>registerNodeNS</parameter></term>
  <listitem>
-  <para>
+  <simpara>
    Indique s&#39;il faut automatiquement enregistrer les préfixes de namespace en vigueur du nœud de contexte dans l&#39;objet <classname>DOMXPath</classname>.
    Cela peut être utilisé pour éviter d&#39;avoir à appeler manuellement <methodname>DOMXPath::registerNamespace</methodname> pour chaque namespace en vigueur.
    En cas de conflit de préfixes de namespace, seul le préfixe de namespace descendant le plus proche est enregistré.
-  </para>
+  </simpara>
  </listitem>
 </varlistentry>'>
 
@@ -1959,32 +1959,32 @@ utilise le fichier <filename>book.xml</filename>, dont le contenu est :</para>
 <!ENTITY dom.errors.hierarchy.parent '<varlistentry xmlns="http://docbook.org/ns/docbook">
  <term><constant>DOM_HIERARCHY_REQUEST_ERR</constant></term>
   <listitem>
-  <para>
+  <simpara>
     Levée si le parent est d&apos;un type qui n&apos;autorise pas les enfants du
     type de l&apos;un des <parameter>nodes</parameter> transmis, ou si le nœud à
     insérer est l&apos;un des ancêtres de ce nœud ou ce nœud lui-même.
-  </para>
+  </simpara>
  </listitem>
 </varlistentry>'>
 
 <!ENTITY dom.errors.hierarchy.self '<varlistentry xmlns="http://docbook.org/ns/docbook">
  <term><constant>DOM_HIERARCHY_REQUEST_ERR</constant></term>
   <listitem>
-  <para>
+  <simpara>
     Levée si ce nœud est d&apos;un type qui n&apos;autorise pas les enfants du
     type de l&apos;un des <parameter>nodes</parameter> transmis, ou si le nœud à
     insérer est l&apos;un des ancêtres de ce nœud ou ce nœud lui-même.
-  </para>
+  </simpara>
  </listitem>
 </varlistentry>'>
 
 <!ENTITY dom.errors.wrong_document '<varlistentry xmlns="http://docbook.org/ns/docbook">
  <term><constant>DOM_WRONG_DOCUMENT_ERR</constant></term>
   <listitem>
-  <para>
+  <simpara>
     Levée si l&apos;un des <parameter>nodes</parameter> transmis a été créé à partir d&apos;un document différent
     de celui qui a créé ce nœud.
-  </para>
+  </simpara>
  </listitem>
 </varlistentry>'>
 
@@ -2033,16 +2033,16 @@ utilise le fichier <filename>book.xml</filename>, dont le contenu est :</para>
  </listitem>'>
 
 <!-- FileSystem entities -->
-<!ENTITY fs.emits.warning.on.failure '<para xmlns="http://docbook.org/ns/docbook">
+<!ENTITY fs.emits.warning.on.failure '<simpara xmlns="http://docbook.org/ns/docbook">
 En cas d&#39;échec, une alerte de type <constant>E_WARNING</constant> sera émise.
-</para>'>
+</simpara>'>
 
-<!ENTITY fs.validfp.all '<para xmlns="http://docbook.org/ns/docbook">Le pointeur de fichier doit être valide et pointer
+<!ENTITY fs.validfp.all '<simpara xmlns="http://docbook.org/ns/docbook">Le pointeur de fichier doit être valide et pointer
 sur un fichier ouvert avec succès par <function>fopen</function> ou
-<function>fsockopen</function> (et pas encore fermé par <function>fclose</function>).</para>'>
+<function>fsockopen</function> (et pas encore fermé par <function>fclose</function>).</simpara>'>
 
-<!ENTITY fs.file.pointer '<para xmlns="http://docbook.org/ns/docbook">Un pointeur de système de fichiers de type &resource;
-qui est habituellement créé en utilisant la fonction <function>fopen</function>.</para>'>
+<!ENTITY fs.file.pointer '<simpara xmlns="http://docbook.org/ns/docbook">Un pointeur de système de fichiers de type &resource;
+qui est habituellement créé en utilisant la fonction <function>fopen</function>.</simpara>'>
 
 <!ENTITY fs.file.32bit '<note xmlns="http://docbook.org/ns/docbook"><simpara>
     Comme le type entier de PHP est signé et que de nombreuses plates-formes
@@ -2051,28 +2051,28 @@ qui est habituellement créé en utilisant la fonction <function>fopen</function
     taille supérieure à 2 Go.
 </simpara></note>'>
 
-<!ENTITY ini.scanner.typed '<para xmlns="http://docbook.org/ns/docbook">
+<!ENTITY ini.scanner.typed '<simpara xmlns="http://docbook.org/ns/docbook">
 À parti de PHP 5.6.1 peut aussi être spécifié comme <constant>INI_SCANNER_TYPED</constant>.
 Dans ce mode les booléens, null et entiers sont préservés tant que possible.
 Les chaines de caractères <literal>"true"</literal>, <literal>"on"</literal> et <literal>"yes"</literal>
 sont converties vers &true;. <literal>"false"</literal>, <literal>"off"</literal>, <literal>"no"</literal>
 et <literal>"none"</literal> sont considérés comme &false;. <literal>"null"</literal> est converti en &null; dans ce mode. De plus toutes les chaines de caractères numériques sont converties en entier si possible.
-</para>'>
+</simpara>'>
 
 <!-- GNUPG -->
-<!ENTITY gnupg.identifier '<para xmlns="http://docbook.org/ns/docbook">L&#39;identifiant gnupg, généré par un appel
+<!ENTITY gnupg.identifier '<simpara xmlns="http://docbook.org/ns/docbook">L&#39;identifiant gnupg, généré par un appel
 à la fonction <function>gnupg_init</function> ou à la fonction
-<classname>gnupg</classname>.</para>'>
+<classname>gnupg</classname>.</simpara>'>
 
-<!ENTITY gnupg.fingerprint '<para xmlns="http://docbook.org/ns/docbook">L&#39;empreinte de la clé.</para>'>
+<!ENTITY gnupg.fingerprint '<simpara xmlns="http://docbook.org/ns/docbook">L&#39;empreinte de la clé.</simpara>'>
 
 <!-- HaruDoc -->
-<!ENTITY haru.error '<para xmlns="http://docbook.org/ns/docbook">Émet une exception <classname>HaruException</classname> en cas d&#39;erreur.</para>'>
+<!ENTITY haru.error '<simpara xmlns="http://docbook.org/ns/docbook">Émet une exception <classname>HaruException</classname> en cas d&#39;erreur.</simpara>'>
 
 <!-- ODBC -->
-<!ENTITY odbc.connection.id '<para xmlns="http://docbook.org/ns/docbook">L&#39;objet de connexion ODBC,
+<!ENTITY odbc.connection.id '<simpara xmlns="http://docbook.org/ns/docbook">L&#39;objet de connexion ODBC,
 voir la documentation de la fonction <function>odbc_connect</function> pour plus
-de détails.</para>'>
+de détails.</simpara>'>
 
 <!ENTITY odbc.result.object 'L’objet de résultat ODBC'>
 
@@ -2160,18 +2160,18 @@ de détails.</para>'>
 <!ENTITY oauth.changelog.error.null 'Avant cette version, &null; était retourné au lieu de &false;.'>
 
 <!-- Oracle -->
-<!ENTITY oci.db "<para xmlns='http://docbook.org/ns/docbook' xmlns:xlink='http://www.w3.org/1999/xlink'>
+<!ENTITY oci.db "<simpara xmlns='http://docbook.org/ns/docbook' xmlns:xlink='http://www.w3.org/1999/xlink'>
 Contient l&#39;instance <literal>Oracle</literal> sur laquelle nous devons nous connecter.
 Ce peut être une <link xlink:href='&url.oracle.oic.connect;'>chaîne de connexion
     rapide</link>, un nom de connexion issue du fichier <filename>tnsnames.ora</filename>,
-ou le nom d&#39;une instance locale Oracle.</para>
-<para xmlns='http://docbook.org/ns/docbook'>Si non spécifié ou &null;, PHP utilise des
+ou le nom d&#39;une instance locale Oracle.</simpara>
+<simpara xmlns='http://docbook.org/ns/docbook'>Si non spécifié ou &null;, PHP utilise des
 variables d&#39;environnement comme <constant>TWO_TASK</constant> (sous Linux)
 ou <constant>LOCAL</constant> (sous Windows)
 et <constant>ORACLE_SID</constant> pour déterminer l&#39;instance
 <literal>Oracle</literal> sur laquelle nous devons nous connecter.
-</para>
-<para xmlns='http://docbook.org/ns/docbook'>
+</simpara>
+<simpara xmlns='http://docbook.org/ns/docbook'>
 Pour utiliser la méthode de connexion rapide, PHP doit être lié avec la bibliothèque
 cliente Oracle 10<emphasis>g</emphasis> ou supérieur. La chaîne de connexion rapide pour Oracle
 10<emphasis>g</emphasis> ou supérieur est de la forme :
@@ -2182,8 +2182,8 @@ cliente Oracle 10<emphasis>g</emphasis> ou supérieur. La chaîne de connexion r
 Les noms des services peuvent être trouvés en exécutant l&#39;utilitaire
 Oracle <literal>lsnrctl status</literal> sur la machine exécutant
 la base de données.
-</para>
-<para xmlns='http://docbook.org/ns/docbook'>
+</simpara>
+<simpara xmlns='http://docbook.org/ns/docbook'>
 Le fichier <filename>tnsnames.ora</filename> peut être dans le chemin
 de recherche d'Oracle Net, qui inclut
 <filename>/your/path/to/instantclient/network/admin</filename>, <filename>$ORACLE_HOME/network/admin</filename>
@@ -2192,25 +2192,25 @@ Une solution alternative serait de définit <literal>TNS_ADMIN</literal>
 afin que le fichier <filename>$TNS_ADMIN/tnsnames.ora</filename> soit lu.
 Assurez-vous que le daemon exécutant le serveur web a accès en lecture à ce
 fichier.
-</para>">
+</simpara>">
 
-<!ENTITY oci.charset "<para xmlns='http://docbook.org/ns/docbook'>Détermine
+<!ENTITY oci.charset "<simpara xmlns='http://docbook.org/ns/docbook'>Détermine
 le jeu de caractères utilisé par la bibliothèque cliente Oracle. Le jeu de
 caractères n'a pas besoin d&#39;être identique à celui utilisé par la base de données.
 S'il ne correspond pas, Oracle ferait de son mieux pour convertir les données
 depuis le jeu de caractères de la base de données. Suivant les jeux de caractères,
 il se peut que le résultat ne soit pas parfait. De plus, cette conversion
 nécessite un peu de temps système.
-</para>
-<para xmlns='http://docbook.org/ns/docbook'>Si non spécifié, la bibliothèque
+</simpara>
+<simpara xmlns='http://docbook.org/ns/docbook'>Si non spécifié, la bibliothèque
 cliente Oracle déterminera un jeu de caractères depuis la variable d&#39;environnement
 <constant>NLS_LANG</constant>.
-</para>
-<para xmlns='http://docbook.org/ns/docbook'>Le fait de passer ce paramètre peut
+</simpara>
+<simpara xmlns='http://docbook.org/ns/docbook'>Le fait de passer ce paramètre peut
 réduire la durée de connexion.
-</para>">
+</simpara>">
 
-<!ENTITY oci.sessionmode '<para xmlns="http://docbook.org/ns/docbook">Ce paramètre
+<!ENTITY oci.sessionmode '<simpara xmlns="http://docbook.org/ns/docbook">Ce paramètre
 est disponible à partir de PHP 5 (PECL OCI8 1.1) et accepte les valeurs suivantes :
 <constant>OCI_DEFAULT</constant>, <constant>OCI_SYSOPER</constant> et
 <constant>OCI_SYSDBA</constant>.
@@ -2220,8 +2220,8 @@ une connexion privilégiée en utilisant des identifiants externes. Les
 connexions privilégiées sont désactivées par défault. Pour les activer, vous
 devez définir l&#39;option <link linkend="ini.oci8.privileged-connect">oci8.privileged_connect</link>
 à <literal>On</literal>.
-</para>
-<para xmlns="http://docbook.org/ns/docbook">
+</simpara>
+<simpara xmlns="http://docbook.org/ns/docbook">
 PHP 5.3 (PECL OCI8 1.3.4) introduisent la valeur de mode
 <constant>OCI_CRED_EXT</constant>. Ce mode demande à Oracle d&#39;utiliser une
 identification externe ou bien issue du système d&#39;exploitation, qui doit être
@@ -2230,65 +2230,65 @@ ne peut être utilisé qu&#39;avec le nom d&#39;utilisateur &quot;/&quot; associ
 mot de passe vide.
 L&#39;option <link linkend="ini.oci8.privileged-connect">oci8.privileged_connect</link>
 peut être définie à <literal>On</literal> ou <literal>Off</literal>.
-</para>
-<para xmlns="http://docbook.org/ns/docbook">
+</simpara>
+<simpara xmlns="http://docbook.org/ns/docbook">
 <constant>OCI_CRED_EXT</constant> peut être combiné avec le mode
 <constant>OCI_SYSOPER</constant> ou le mode
 <constant>OCI_SYSDBA</constant>.
-</para>
-<para xmlns="http://docbook.org/ns/docbook">
+</simpara>
+<simpara xmlns="http://docbook.org/ns/docbook">
 <constant>OCI_CRED_EXT</constant> n&#39;est pas supporté sous Windows pour des
 raisons de sécurité.
-</para>'>
+</simpara>'>
 
-<!ENTITY oci.datatypes '<para xmlns="http://docbook.org/ns/docbook">Pour plus de détails sur le mapping des types de données
+<!ENTITY oci.datatypes '<simpara xmlns="http://docbook.org/ns/docbook">Pour plus de détails sur le mapping des types de données
 effectué par l&#39;extension OCI8, lisez les <link linkend="oci8.datatypes">types de données
-    supportés par le driver</link>.</para>'>
+    supportés par le driver</link>.</simpara>'>
 
-<!ENTITY oci.parameter.connection '<para xmlns="http://docbook.org/ns/docbook">Un identifiant de connexion Oracle,
+<!ENTITY oci.parameter.connection '<simpara xmlns="http://docbook.org/ns/docbook">Un identifiant de connexion Oracle,
 retourné par la fonction <function>oci_connect</function>, <function>oci_pconnect</function>
-ou la fonction <function>oci_new_connect</function>.</para>'>
+ou la fonction <function>oci_new_connect</function>.</simpara>'>
 
 <!ENTITY oci.availability.note.10g '<note xmlns="http://docbook.org/ns/docbook"><title>Requis par la version Oracle</title>
-<para>Cette fonction est disponible si PHP est lié à partir de la version 10<emphasis>g</emphasis>
-    de la bibliothèque de la base de données Oracle .</para></note>'>
+<simpara>Cette fonction est disponible si PHP est lié à partir de la version 10<emphasis>g</emphasis>
+    de la bibliothèque de la base de données Oracle .</simpara></note>'>
 
-<!ENTITY oci.clientinfo.tip '<tip xmlns="http://docbook.org/ns/docbook"><title>Performance</title><para>Avec les anciennes
+<!ENTITY oci.clientinfo.tip '<tip xmlns="http://docbook.org/ns/docbook"><title>Performance</title><simpara>Avec les anciennes
     version OCI8 ou les anciennes bases de données Oracle, l&#39;information quant au client
     peut être défini en utilisant le paquet Oracle <literal>DBMS_APPLICATION_INFO</literal>.
     Ceci est moins efficace que d&#39;utiliser la fonction
-    <function>oci_set_client_info</function>.</para></tip>'>
+    <function>oci_set_client_info</function>.</simpara></tip>'>
 
 <!ENTITY oci.roundtrip.caution '<caution xmlns="http://docbook.org/ns/docbook"><title>Allers-retours</title>
-<para>Quelques fonctions OCI8 nécessitent des allers-retours avec la base de données.
+<simpara>Quelques fonctions OCI8 nécessitent des allers-retours avec la base de données.
     Ces allers-retours peuvent être évités lors de l&#39;utilisation de requêtes dont
     le résultat est mis en cache.
-</para></caution>'>
+</simpara></caution>'>
 
-<!ENTITY oci.use.setprefetch '<para xmlns="http://docbook.org/ns/docbook">Pour les
+<!ENTITY oci.use.setprefetch '<simpara xmlns="http://docbook.org/ns/docbook">Pour les
 requêtes retournant un très grand nombre de lignes, les performances peuvent
 être très grandement accrues en augmentant la valeur de l&#39;option
 <link linkend="ini.oci8.default-prefetch">oci8.default_prefetch</link>
 ou en utilisant la fonction <function>oci_set_prefetch</function>.
-</para>'>
+</simpara>'>
 
-<!ENTITY oci.arg.statement.id "<para xmlns='http://docbook.org/ns/docbook'>Un identifiant de requête OCI8
+<!ENTITY oci.arg.statement.id "<simpara xmlns='http://docbook.org/ns/docbook'>Un identifiant de requête OCI8
 créé par la fonction <function>oci_parse</function> et exécuté par la fonction
 <function>oci_execute</function>, ou un identifiant de requête <literal>REF
-    CURSOR</literal>.</para>">
+    CURSOR</literal>.</simpara>">
 
 <!-- PCNTL Notes -->
-<!ENTITY pcntl.parameter.status '<para xmlns="http://docbook.org/ns/docbook">Le paramètre
+<!ENTITY pcntl.parameter.status '<simpara xmlns="http://docbook.org/ns/docbook">Le paramètre
 <parameter>status</parameter> est le paramètre status passé à un appel
-de <function>pcntl_waitpid</function> ayant réussi.</para>'>
+de <function>pcntl_waitpid</function> ayant réussi.</simpara>'>
 
 <!-- PS Notes -->
-<!ENTITY ps.note.visible '<para xmlns="http://docbook.org/ns/docbook">La note ne sera pas visible si le document est imprimé ou
+<!ENTITY ps.note.visible '<simpara xmlns="http://docbook.org/ns/docbook">La note ne sera pas visible si le document est imprimé ou
 affiché, mais elle sera visible si le document est converti en PDF, soit par
-Acrobat Distiller™, soit par Ghostview.</para>'>
+Acrobat Distiller™, soit par Ghostview.</simpara>'>
 
-<!ENTITY note.open-basedir.func '<note xmlns="http://docbook.org/ns/docbook"><para>Cette fonction est affectée par
-    la directive de configuration <link linkend="ini.open-basedir">open_basedir</link>.</para></note>'>
+<!ENTITY note.open-basedir.func '<note xmlns="http://docbook.org/ns/docbook"><simpara>Cette fonction est affectée par
+    la directive de configuration <link linkend="ini.open-basedir">open_basedir</link>.</simpara></note>'>
 
 <!ENTITY note.language-construct '<note xmlns="http://docbook.org/ns/docbook"><simpara>Comme ceci est une structure
     du langage, et non pas une fonction, il n&#39;est pas possible de l&#39;appeler
@@ -2296,17 +2296,17 @@ Acrobat Distiller™, soit par Ghostview.</para>'>
 </simpara></note>'>
 
 <!-- Common pieces in partintro-sections -->
-<!ENTITY no.config '<para xmlns="http://docbook.org/ns/docbook">Cette extension ne définit aucune directive de
-configuration.</para>'>
-<!ENTITY no.resource '<para xmlns="http://docbook.org/ns/docbook">Cette extension ne définit aucune ressource.</para>'>
-<!ENTITY no.constants '<para xmlns="http://docbook.org/ns/docbook">Cette extension ne définit aucune constante.</para>'>
-<!ENTITY no.requirement '<para xmlns="http://docbook.org/ns/docbook">Aucune bibliothèque externe n&#39;est nécessaire pour compiler cette extension.</para>'>
-<!ENTITY no.install '<para xmlns="http://docbook.org/ns/docbook">Il n&#39;y pas d&#39;installation nécessaire pour
-utiliser ces fonctions, elles font parties du cœur de PHP.</para>'>
+<!ENTITY no.config '<simpara xmlns="http://docbook.org/ns/docbook">Cette extension ne définit aucune directive de
+configuration.</simpara>'>
+<!ENTITY no.resource '<simpara xmlns="http://docbook.org/ns/docbook">Cette extension ne définit aucune ressource.</simpara>'>
+<!ENTITY no.constants '<simpara xmlns="http://docbook.org/ns/docbook">Cette extension ne définit aucune constante.</simpara>'>
+<!ENTITY no.requirement '<simpara xmlns="http://docbook.org/ns/docbook">Aucune bibliothèque externe n&#39;est nécessaire pour compiler cette extension.</simpara>'>
+<!ENTITY no.install '<simpara xmlns="http://docbook.org/ns/docbook">Il n&#39;y pas d&#39;installation nécessaire pour
+utiliser ces fonctions, elles font parties du cœur de PHP.</simpara>'>
 
 <!-- Used in every chapter that has directive descriptions -->
-<!ENTITY ini.descriptions.title '<para xmlns="http://docbook.org/ns/docbook">Voici un éclaircissement sur
-l&#39;utilisation des directives de configuration.</para>'>
+<!ENTITY ini.descriptions.title '<simpara xmlns="http://docbook.org/ns/docbook">Voici un éclaircissement sur
+l&#39;utilisation des directives de configuration.</simpara>'>
 
 <!-- Common pieces for reference part BEGIN-->
 
@@ -2348,14 +2348,14 @@ pilote, si votre code peut fonctionner sur des pilotes multiples.</simpara>'>
 
 <!-- PDO errors -->
 
-<!ENTITY pdo.errors '<para xmlns="http://docbook.org/ns/docbook">
+<!ENTITY pdo.errors '<simpara xmlns="http://docbook.org/ns/docbook">
 Émet une erreur de niveau <constant>E_WARNING</constant> si l&#39;attribut <constant>PDO::ATTR_ERRMODE</constant> est défini
 à <constant>PDO::ERRMODE_WARNING</constant>.
-</para>
-<para xmlns="http://docbook.org/ns/docbook">
+</simpara>
+<simpara xmlns="http://docbook.org/ns/docbook">
 Lève une exception <classname>PDOException</classname> si l&#39;attribut <constant>PDO::ATTR_ERRMODE</constant> est défini
 à <constant>PDO::ERRMODE_EXCEPTION</constant>.
-</para>'>
+</simpara>'>
 
 <!-- PECL entities -->
 <!ENTITY pecl.moved 'Cette extension &link.pecl; n&#39;est pas intégrée à PHP.'>
@@ -2403,11 +2403,11 @@ des extensions PECL</link>. D&#39;autres informations comme les notes sur les no
 
 <!-- PGSQL entities -->
 
-<!ENTITY pgsql.parameter.connection '<para xmlns="http://docbook.org/ns/docbook">Une instance <classname>PgSql\Connection</classname>.</para>'>
+<!ENTITY pgsql.parameter.connection '<simpara xmlns="http://docbook.org/ns/docbook">Une instance <classname>PgSql\Connection</classname>.</simpara>'>
 
 <!ENTITY pgsql.parameter.connection-with-unspecified-default '<para xmlns="http://docbook.org/ns/docbook">
  Une instance <classname>PgSql\Connection</classname>.
- Quand <parameter>connection</parameter> est pas spécifié, la connexion par défaut est utilisé.
+ Quand <parameter>connection</parameter> n&apos;est pas spécifiée, la connexion par défaut est utilisée.
  La connexion par défaut est la dernière connexion faite par
  <function>pg_connect</function> ou <function>pg_pconnect</function>
  <warning><simpara>À partir de PHP 8.1.0, utiliser la connexion par défaut est obsolète.</simpara></warning>
@@ -2415,26 +2415,26 @@ des extensions PECL</link>. D&#39;autres informations comme les notes sur les no
 
 <!ENTITY pgsql.parameter.connection-with-nullable-default '<para xmlns="http://docbook.org/ns/docbook">
  Une instance <classname>PgSql\Connection</classname>.
- Quand <parameter>connection</parameter> est &null;, la connexion par défaut est utilisé.
+ Quand <parameter>connection</parameter> est &null;, la connexion par défaut est utilisée.
  La connexion par défaut est la dernière connexion faite par
  <function>pg_connect</function> ou <function>pg_pconnect</function>
  <warning><simpara>À partir de PHP 8.1.0, utiliser la connexion par défaut est obsolète.</simpara></warning>
  </para>'>
 
-<!ENTITY pgsql.parameter.result '<para xmlns="http://docbook.org/ns/docbook">
+<!ENTITY pgsql.parameter.result '<simpara xmlns="http://docbook.org/ns/docbook">
  Une instance <classname>PgSql\Result</classname>, retourné par <function>pg_query</function>,
  <function>pg_query_params</function>, ou <function>pg_execute</function> (entre autres).
-</para>'>
+</simpara>'>
 
-<!ENTITY pgsql.parameter.lob '<para xmlns="http://docbook.org/ns/docbook">Une instance <classname>PgSql\Lob</classname>, retourné par <function>pg_lo_open</function>.</para>'>
+<!ENTITY pgsql.parameter.lob '<simpara xmlns="http://docbook.org/ns/docbook">Une instance <classname>PgSql\Lob</classname>, retourné par <function>pg_lo_open</function>.</simpara>'>
 
-<!ENTITY pgsql.parameter.mode '<para xmlns="http://docbook.org/ns/docbook">
+<!ENTITY pgsql.parameter.mode '<simpara xmlns="http://docbook.org/ns/docbook">
 Un paramètre optionnel qui contrôle la façon dont le <type>array</type> retourné est indexé.
 <parameter>mode</parameter> est une constante qui peut prendre les valeurs suivantes :
 <constant>PGSQL_ASSOC</constant>, <constant>PGSQL_NUM</constant> et <constant>PGSQL_BOTH</constant>.
 En utilisant <constant>PGSQL_NUM</constant>, la fonction retournera un tableau avec des indices numériques,
 en utilisant <constant>PGSQL_ASSOC</constant>, elle retournera seulement des indices associatifs
-tandis que <constant>PGSQL_BOTH</constant> retournera à la fois des indices numériques et associatifs.</para>'>
+tandis que <constant>PGSQL_BOTH</constant> retournera à la fois des indices numériques et associatifs.</simpara>'>
 
 <!ENTITY pgsql.changelog.connection-object '<row xmlns="http://docbook.org/ns/docbook">
  <entry>8.1.0</entry>
@@ -2480,16 +2480,16 @@ de bibliothèque supplémentaire pour disposer de ces fonctions.</simpara>'>
 <!ENTITY sqlsafemode '<link xmlns="http://docbook.org/ns/docbook" linkend="ini.sql.safe-mode">safe mode SQL</link>'>
 
 <!-- CTYPE Notes -->
-<!ENTITY note.ctype.parameter.integer '<note xmlns="http://docbook.org/ns/docbook"><para>
+<!ENTITY note.ctype.parameter.integer '<note xmlns="http://docbook.org/ns/docbook"><simpara>
     Si un entier dans l&#39;intervalle -128 et 255 inclus est fourni, il sera interprété comme
     la valeur ASCII d&#39;un seul caractère (les valeurs négatives se verront ajouter 256 afin d&#39;autoriser
     les caractères dans l&#39;intervalle ASCII étendue). Tout autre entier sera interprété comme
-    une chaîne de caractères contenant les décimales de l&#39;entier.</para></note>'>
+    une chaîne de caractères contenant les décimales de l&#39;entier.</simpara></note>'>
 
-<!ENTITY note.ctype.parameter.non-string "<warning xmlns='http://docbook.org/ns/docbook'><para>
+<!ENTITY note.ctype.parameter.non-string "<warning xmlns='http://docbook.org/ns/docbook'><simpara>
 À partir de PHP 8.1.0, passer un argument différent d'une chaîne est obsolète.
 À l&#39;avenir, l#39;argument sera interprété comme une chaîne de caractères au lieu d'un point de code ASCII.
-Selon le comportement souhaité, l&#39;argument doit être transtypé en &string; ou un appel explicite à <function>chr</function> doit être effectué.</para></warning>">
+Selon le comportement souhaité, l&#39;argument doit être transtypé en &string; ou un appel explicite à <function>chr</function> doit être effectué.</simpara></warning>">
 
 <!ENTITY ctype.result.empty-string 'Lorsque appelé avec une chaîne vide, le résultat sera toujours &false;.'>
 
@@ -2501,68 +2501,68 @@ Selon le comportement souhaité, l&#39;argument doit être transtypé en &string
   <classname>FTP\Connection</classname> ; auparavant, une &resource; était attendu.
  </entry>
 </row>'>
-<!ENTITY ftp.parameter.ftp '<para xmlns="http://docbook.org/ns/docbook">Une instance de <classname>FTP\Connection</classname>.</para>'>
+<!ENTITY ftp.parameter.ftp '<simpara xmlns="http://docbook.org/ns/docbook">Une instance de <classname>FTP\Connection</classname>.</simpara>'>
 
 <!-- GMP Notes -->
 <!ENTITY gmp.return 'Un objet <classname xmlns="http://docbook.org/ns/docbook">GMP</classname>.'>
-<!ENTITY gmp.parameter '<para xmlns="http://docbook.org/ns/docbook">
+<!ENTITY gmp.parameter '<simpara xmlns="http://docbook.org/ns/docbook">
  Un objet <classname>GMP</classname>, un &integer;,
  ou un &string; qui peut être interprété comme un nombre suivant la même logique
  que si la chaîne était utilisée dans <function>gmp_init</function> avec détection automatique de la base (c&#39;est-à-dire lorsque <parameter>base</parameter> est égal à 0).
-</para>'>
+</simpara>'>
 
 <!-- MySQLi Notes -->
 <!ENTITY mysqli.result.description '<varlistentry xmlns="http://docbook.org/ns/docbook">
-<term><parameter>result</parameter></term><listitem><para>
+<term><parameter>result</parameter></term><listitem><simpara>
  Style procédural uniquement : Un objet <classname>mysqli_result</classname>
  retourné par <function>mysqli_query</function>,
  <function>mysqli_store_result</function>, <function>mysqli_use_result</function>,
  ou <function>mysqli_stmt_get_result</function>.
-</para></listitem></varlistentry>'>
+</simpara></listitem></varlistentry>'>
 
 <!ENTITY mysqli.link.description '<varlistentry xmlns="http://docbook.org/ns/docbook">
-<term><parameter>mysql</parameter></term><listitem><para>
+<term><parameter>mysql</parameter></term><listitem><simpara>
  Seulement en style procédural : Un objet <classname>mysqli</classname>
  retourné par la fonction <function>mysqli_connect</function> ou <function>mysqli_init</function>.
-</para></listitem></varlistentry>'>
+</simpara></listitem></varlistentry>'>
 
 <!ENTITY mysqli.stmt.description '<varlistentry xmlns="http://docbook.org/ns/docbook">
-<term><parameter>statement</parameter></term><listitem><para>
+<term><parameter>statement</parameter></term><listitem><simpara>
  Style procédural uniquement : Un objet <classname>mysqli_stmt</classname>
  retourné par la fonction <function>mysqli_stmt_init</function>.
-</para></listitem></varlistentry>'>
+</simpara></listitem></varlistentry>'>
 
 <!ENTITY mysqli.available.mysqlnd 'Disponible uniquement avec <link xmlns="http://docbook.org/ns/docbook"
                                                                     linkend="book.mysqlnd">mysqlnd</link>.'>
 
 <!ENTITY mysqli.charset.note '<note xmlns="http://docbook.org/ns/docbook">
-<para>MySQLnd s&#39;occupe toujours du jeu de caractères par défaut du serveur. Celui-ci est envoyé durant la négociation de la
-    connexion ou l&#39;authentification.</para><para>Libmysqlclient utilise le jeu de caractères par défaut de
+<simpara>MySQLnd s&#39;occupe toujours du jeu de caractères par défaut du serveur. Celui-ci est envoyé durant la négociation de la
+    connexion ou l&#39;authentification.</simpara><simpara>Libmysqlclient utilise le jeu de caractères par défaut de
     <filename>my.cnf</filename> ou via par un appel à <function>mysqli_options</function> avant
-    <function>mysqli_real_connect</function>, mais après <function>mysqli_init</function>.</para></note>'>
+    <function>mysqli_real_connect</function>, mais après <function>mysqli_init</function>.</simpara></note>'>
 
-<!ENTITY mysqli.integer.overflow.as.string.note '<note xmlns="http://docbook.org/ns/docbook"><para>
+<!ENTITY mysqli.integer.overflow.as.string.note '<note xmlns="http://docbook.org/ns/docbook"><simpara>
  Si le nombre de ligne est supérieur à <constant>PHP_INT_MAX</constant>, le nombre sera retourné en tant que &string;.
-</para></note>'>
+</simpara></note>'>
 
 <!ENTITY mysqli.sqlinjection.warning '<warning xmlns="http://docbook.org/ns/docbook">
  <title>Avertissement de Sécurité : injection SQL</title>
- <para>Si la requête contiens des variables d&apos;entrées alors des
+ <simpara>Si la requête contiens des variables d&apos;entrées alors des
  <link linkend="mysqli.quickstart.prepared-statements">déclarations préparées paramétrisées</link>
  devrait être utilisé à la place. Alternativement, les données doivent être correctement
  formatées et toutes les chaînes de caractères doivent être échappées en utilisant la fonction
- <function>mysqli_real_escape_string</function>.</para>
+ <function>mysqli_real_escape_string</function>.</simpara>
 </warning>'>
 
-<!ENTITY mysqli.conditionalexception '<para xmlns="http://docbook.org/ns/docbook">
+<!ENTITY mysqli.conditionalexception '<simpara xmlns="http://docbook.org/ns/docbook">
 Si le rapport d&#39;erreurs mysqli est activé (<constant>MYSQLI_REPORT_ERROR</constant>) et que l&#39;opération demandée échoue,
 un avertissement est généré. Si, en plus, le mode est défini sur <constant>MYSQLI_REPORT_STRICT</constant>,
-une <classname>mysqli_sql_exception</classname> est lancée à la place.</para>'>
+une <classname>mysqli_sql_exception</classname> est lancée à la place.</simpara>'>
 
 <!-- Notes for PCRE -->
-<!ENTITY pcre.pattern.warning '<para xmlns="http://docbook.org/ns/docbook">
+<!ENTITY pcre.pattern.warning '<simpara xmlns="http://docbook.org/ns/docbook">
 Si le masque regex passé ne compile pas à une regex valide, une <constant>E_WARNING</constant> est émise.
-</para>'>
+</simpara>'>
 
 <!-- Notes for SAPI/Apache -->
 <!ENTITY apache.req.module '<simpara xmlns="http://docbook.org/ns/docbook">Cette fonction
@@ -2570,9 +2570,9 @@ est supportée lorsque PHP est installé comme module d&#39;Apache.
 </simpara>'>
 
 <!-- Notes for SAPI/FPM -->
-<!ENTITY fpm.intro "<para xmlns='http://docbook.org/ns/docbook'>FPM (FastCGI Process Manager, gestionnaire de processus FastCGI)
+<!ENTITY fpm.intro "<simpara xmlns='http://docbook.org/ns/docbook'>FPM (FastCGI Process Manager, gestionnaire de processus FastCGI)
 est une alternative à l&#39;implémentation PHP FastCGI avec des fonctionnalités supplémentaires utiles pour les sites très fortement chargés.
-</para>">
+</simpara>">
 
 <!-- SimpleXML Notes -->
 <!ENTITY simplexml.iteration '<note xmlns="http://docbook.org/ns/docbook"><simpara>SimpleXML ajoute des propriétés
@@ -2581,27 +2581,27 @@ est une alternative à l&#39;implémentation PHP FastCGI avec des fonctionnalit�
     objets.</simpara></note>'>
 
 <!-- SQLite Notes -->
-<!ENTITY sqlite.case-fold '<para xmlns="http://docbook.org/ns/docbook">Les noms de colonnes retournés par
+<!ENTITY sqlite.case-fold '<simpara xmlns="http://docbook.org/ns/docbook">Les noms de colonnes retournés par
 <constant>SQLITE_ASSOC</constant> et <constant>SQLITE_BOTH</constant>
 suivent les règles concernant la case définie par l&#39;option de configuration
-<link linkend="ini.sqlite.assoc-case">sqlite.assoc_case</link>.</para>'>
+<link linkend="ini.sqlite.assoc-case">sqlite.assoc_case</link>.</simpara>'>
 
-<!ENTITY sqlite.decode-bin '<para xmlns="http://docbook.org/ns/docbook">Lorsque <parameter>decode_binary</parameter>
+<!ENTITY sqlite.decode-bin '<simpara xmlns="http://docbook.org/ns/docbook">Lorsque <parameter>decode_binary</parameter>
 vaut &true; (par défaut), PHP va décoder les données binaires, si elles ont été
 codées avec la fonction <function>sqlite_escape_string</function>.
 Vous allez généralement laisser cette valeur à sa valeur par défaut,
 à moins que vous ne travailliez avec des bases opérées par d&#39;autres
-applications.</para>'>
+applications.</simpara>'>
 
-<!ENTITY sqlite.no-unbuffered '<note xmlns="http://docbook.org/ns/docbook"><para>Cette fonction ne fonctionnera pas sur des
-    résultats non tamponné.</para></note>'>
+<!ENTITY sqlite.no-unbuffered '<note xmlns="http://docbook.org/ns/docbook"><simpara>Cette fonction ne fonctionnera pas sur des
+    résultats non tamponné.</simpara></note>'>
 
 <!ENTITY sqlite.param-compat '<note xmlns="http://docbook.org/ns/docbook"><simpara>Deux syntaxes alternatives sont
     supportées pour assurer la compatibilité avec les autres bases de données
     (telles que MySQL) : la forme recommandée est la première, où le paramètre
     <parameter>dbhandle</parameter> est le premier dans la fonction.</simpara></note>'>
 
-<!ENTITY sqlite.result-type '<para xmlns="http://docbook.org/ns/docbook">Le paramètre optionnel
+<!ENTITY sqlite.result-type '<simpara xmlns="http://docbook.org/ns/docbook">Le paramètre optionnel
 <parameter>result_type</parameter> accepte une constante et détermine comment
 le tableau retourné doit être indexé. L&#39;utilisation de
 <constant>SQLITE_ASSOC</constant> retournera uniquement un tableau associatif
@@ -2609,7 +2609,7 @@ le tableau retourné doit être indexé. L&#39;utilisation de
 tableau indexé numériquement (numéro ordinal des champs).
 <constant>SQLITE_BOTH</constant> retournera des indices numériques et associatifs.
 <constant>SQLITE_BOTH</constant> est la valeur par défaut pour cette
-fonction.</para>'>
+fonction.</simpara>'>
 
 <!-- Database Notes -->
 <!ENTITY database.field-case '<note xmlns="http://docbook.org/ns/docbook"><simpara>Les noms des champs retournés par
@@ -2621,7 +2621,7 @@ fonction.</para>'>
 <!-- MySQL Notes -->
 <!-- The mysql.*.description entities are used in the parameters refsect1 -->
 <!ENTITY mysql.linkid.description '<varlistentry xmlns="http://docbook.org/ns/docbook">
-<term><parameter>link_identifier</parameter></term><listitem><para>
+<term><parameter>link_identifier</parameter></term><listitem><simpara>
  La connexion MySQL.
  S&#39;il n&#39;est pas spécifié, la dernière connexion ouverte avec la fonction
  <function>mysql_connect</function> sera utilisée. Si une telle connexion
@@ -2629,79 +2629,79 @@ fonction.</para>'>
  si la fonction <function>mysql_connect</function> avait été appelée sans argument.
  Si aucune connexion n&#39;est trouvée ou établie, une alerte de niveau
  <constant>E_WARNING</constant> sera générée.
-</para></listitem></varlistentry>'>
+</simpara></listitem></varlistentry>'>
 
 <!ENTITY mysql.linkid-noreopen.description '<varlistentry xmlns="http://docbook.org/ns/docbook">
-<term><parameter>link_identifier</parameter></term><listitem><para>
+<term><parameter>link_identifier</parameter></term><listitem><simpara>
  La connexion MySQL.
  Si l&#39;identifiant du lien n&#39;est pas spécifié, la dernière connexion
  ouverte avec la fonction <function>mysql_connect</function> sera utilisée.
  Si aucune connexion n&#39;est trouvée ou établie, une alerte de niveau
  <constant>E_WARNING</constant> sera générée.
-</para></listitem></varlistentry>'>
+</simpara></listitem></varlistentry>'>
 
 <!ENTITY mysql.result.description '<varlistentry xmlns="http://docbook.org/ns/docbook">
-<term><parameter>result</parameter></term><listitem><para>
+<term><parameter>result</parameter></term><listitem><simpara>
  La &resource; de résultat qui vient d&#39;être évaluée.
  Ce résultat vient de l&#39;appel à la fonction <function>mysql_query</function>.
-</para></listitem></varlistentry>'>
+</simpara></listitem></varlistentry>'>
 
 <!ENTITY mysql.field-offset.req.description '<varlistentry xmlns="http://docbook.org/ns/docbook">
-<term><parameter>field_offset</parameter></term><listitem><para>
+<term><parameter>field_offset</parameter></term><listitem><simpara>
  La position numérique du champ.
  <parameter>field_offset</parameter> commence à <literal>0</literal>.
  Si <parameter>field_offset</parameter> n&#39;existe pas, une alerte de niveau
  <constant>E_WARNING</constant> sera générée.
-</para></listitem></varlistentry>'>
+</simpara></listitem></varlistentry>'>
 
-<!ENTITY mysql.alternative.note '<para xmlns="http://docbook.org/ns/docbook">Cette extension
+<!ENTITY mysql.alternative.note '<simpara xmlns="http://docbook.org/ns/docbook">Cette extension
 était obsolète en PHP 5.5.0, et a été supprimée en PHP 7.0.0. À la place, vous pouvez
 utiliser l&#39;extension <link linkend="book.mysqli">MySQLi</link> ou l&#39;extension
 <link linkend="ref.pdo-mysql">PDO_MySQL</link>. Voir aussi
 <link linkend="mysqlinfo.api.choosing">MySQL : choisir une API</link> du guide.
-Alternatives à cette fonction :</para>'>
+Alternatives à cette fonction :</simpara>'>
 
-<!ENTITY mysql.alternative.note.4-3-0 '<para xmlns="http://docbook.org/ns/docbook">Cette fonction était obsolète
+<!ENTITY mysql.alternative.note.4-3-0 '<simpara xmlns="http://docbook.org/ns/docbook">Cette fonction était obsolète
 en PHP 4.3.0, et la totalité de <link linkend="book.mysql">l&#39;extension original MySQL</link> a été supprimée en PHP 7.0.0.
 À la place, vous pouvez utiliser soit l&#39;extension <link linkend="book.mysqli">MySQLi</link>, soit l&#39;extension
 <link linkend="ref.pdo-mysql">PDO_MySQL</link>. Voir aussi <link linkend="mysqlinfo.api.choosing">MySQL : choisir
-une API</link> du guide. Alternatives à cette fonction :</para>'>
+une API</link> du guide. Alternatives à cette fonction :</simpara>'>
 
-<!ENTITY mysql.alternative.note.5-3-0 '<para xmlns="http://docbook.org/ns/docbook">Cette fonction était obsolète
+<!ENTITY mysql.alternative.note.5-3-0 '<simpara xmlns="http://docbook.org/ns/docbook">Cette fonction était obsolète
 en PHP 5.3.0, et la totalité de <link linkend="book.mysql">l&#39;extension original MySQL</link> a été supprimée en PHP 7.0.0.
 À la place, vous pouvez utiliser soit l&#39;extension <link linkend="book.mysqli">MySQLi</link>, soit l&#39;extension
 <link linkend="ref.pdo-mysql">PDO_MySQL</link>. Voir aussi <link linkend="mysqlinfo.api.choosing">MySQL : choisir
 une API</link> du guide.
-Alternatives à cette fonction :</para>'>
+Alternatives à cette fonction :</simpara>'>
 
-<!ENTITY mysql.alternative.note.5-4-0 '<para xmlns="http://docbook.org/ns/docbook">Cette fonction était obsolète
+<!ENTITY mysql.alternative.note.5-4-0 '<simpara xmlns="http://docbook.org/ns/docbook">Cette fonction était obsolète
 en PHP 5.4.0, et la totalité de <link linkend="book.mysql">l&#39;extension original MySQL</link> a été supprimée en PHP 7.0.0.
 À la place, vous pouvez utiliser soit l&#39;extension <link linkend="book.mysqli">MySQLi</link>, soit l&#39;extension
 <link linkend="ref.pdo-mysql">PDO_MySQL</link>. Voir aussi <link linkend="mysqlinfo.api.choosing">MySQL : choisir
-    une API</link> du guide. Alternatives à cette fonction :</para>'>
+    une API</link> du guide. Alternatives à cette fonction :</simpara>'>
 
-<!ENTITY mysql.alternative.note.5-5-0 '<para xmlns="http://docbook.org/ns/docbook">Cette fonction était obsolète
+<!ENTITY mysql.alternative.note.5-5-0 '<simpara xmlns="http://docbook.org/ns/docbook">Cette fonction était obsolète
 en PHP 5.5.0, et la totalité de <link linkend="book.mysql">l&#39;extension original MySQL</link> a été supprimée en PHP 7.0.0.
 À la place, vous pouvez utiliser soit l&#39;extension <link linkend="book.mysqli">MySQLi</link>, soit l&#39;extension
 <link linkend="ref.pdo-mysql">PDO_MySQL</link>. Voir aussi <link linkend="mysqlinfo.api.choosing">MySQL : choisir
-    une API</link> du guide. Alternatives à cette fonction :</para>'>
+    une API</link> du guide. Alternatives à cette fonction :</simpara>'>
 
-<!ENTITY mysql.close.connections.result.sets '<para xmlns="http://docbook.org/ns/docbook">
+<!ENTITY mysql.close.connections.result.sets '<simpara xmlns="http://docbook.org/ns/docbook">
 Les connexions et les jeux de résultats ouverts de façon non persistantes sont automatiquement
 détruits lorsqu&#39;un script PHP termine son exécution. Aussi, le fait de fermer une connexion
 et libérer les résultats étant optionnel, le fait de le faire explicitement est néanmoins vivement
 recommandé. Ceci va retourner les ressources immédiatement à PHP et à MySQL, ce qui va améliorer les
 performance. Pour plus d&#39;informations, référez-vous à la
-<link linkend="language.types.resource.self-destruct">libération des ressources</link></para>'>
+<link linkend="language.types.resource.self-destruct">libération des ressources</link></simpara>'>
 
 <!-- Xattr entities -->
-<!ENTITY xattr.namespace '<para xmlns="http://docbook.org/ns/docbook">Les attributs étendus ont deux espaces de noms
+<!ENTITY xattr.namespace '<simpara xmlns="http://docbook.org/ns/docbook">Les attributs étendus ont deux espaces de noms
 différents : <literal>user</literal> et <literal>root</literal>. L&#39;espace de noms
 <literal>user</literal> est disponible pour tous les utilisateurs tandis que l&#39;espace de
 noms <literal>root</literal> n&#39;est disponible que pour les utilisateurs ayant les privilèges
 <literal>root</literal>. xattr opère sur l&#39;espace de noms <literal>user</literal> par
 défaut, mais vous pouvez changer cela en utilisant l&#39;argument
-<parameter>flags</parameter>.</para>'>
+<parameter>flags</parameter>.</simpara>'>
 
 <!-- Notes for IPv6 -->
 <!ENTITY ipv6.brackets '<note xmlns="http://docbook.org/ns/docbook"><simpara>Lors de la spécification d&#39;adresses
@@ -2712,13 +2712,13 @@ défaut, mais vous pouvez changer cela en utilisant l&#39;argument
 <!-- Notes for tidy -->
 <!ENTITY tidy.object 'L&#39;objet <classname xmlns="http://docbook.org/ns/docbook">Tidy</classname>'>
 
-<!ENTITY tidy.conf-enc '<para xmlns="http://docbook.org/ns/docbook">Le paramètre <parameter>config</parameter> peut
+<!ENTITY tidy.conf-enc '<simpara xmlns="http://docbook.org/ns/docbook">Le paramètre <parameter>config</parameter> peut
 prendre la forme d&#39;un tableau ou d&#39;une chaîne de caractères. Sous forme
 de chaîne, il représente le nom du fichier de configuration et sinon, c&#39;est
 un tableau avec les options de configuration. Lisez <link xmlns:xlink="http://www.w3.org/1999/xlink"
                                                           xlink:href="&url.tidy.conf;">&url.tidy.conf;</link> pour en savoir plus sur chaque
-option.</para>
-<para>Le paramètre <parameter>encoding</parameter> spécifie le jeu de caractères
+option.</simpara>
+<simpara>Le paramètre <parameter>encoding</parameter> spécifie le jeu de caractères
 utilisé pour les documents en entrées et sorties. Les valeurs possibles de
 <parameter>encoding</parameter> sont :
 <literal>ascii</literal>, <literal>latin0</literal>, <literal>latin1</literal>,
@@ -2726,23 +2726,23 @@ utilisé pour les documents en entrées et sorties. Les valeurs possibles de
 <literal>mac</literal>, <literal>win1252</literal>, <literal>ibm858</literal>,
 <literal>utf16</literal>, <literal>utf16le</literal>,
 <literal>utf16be</literal>, <literal>big5</literal> et
-<literal>shiftjis</literal>.</para>'>
+<literal>shiftjis</literal>.</simpara>'>
 
 <!-- Snippets for the installation section -->
-<!ENTITY warn.apache2.compat '<warning xmlns="http://docbook.org/ns/docbook"><para>Nous ne recommandons pas
+<!ENTITY warn.apache2.compat '<warning xmlns="http://docbook.org/ns/docbook"><simpara>Nous ne recommandons pas
     l&#39;utilisation de PHP dans un environnement threadé MPM, avec Apache 2.
     Utilisez le mode prefork MPM, qui est le MPM par défaut pour Apache 2.0 et 2.2.
     Pour savoir pourquoi, lisez
     l&#39;entrée de la FAQ correspondante à l&#39;<link linkend="faq.installation.apache2">utilisation
-        d&#39;Apache 2 dans un environnement threadé MPM</link>.</para></warning>'>
+        d&#39;Apache 2 dans un environnement threadé MPM</link>.</simpara></warning>'>
 <!ENTITY warn.install.third-party-support '<warning xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
- <para>
+ <simpara>
   Les versions provenant de tiers sont considérées comme non officielles et ne
   sont pas directement prises en charge par le projet PHP. Tout bogue rencontré
   doit être signalé au fournisseur de ces versions non officielles, sauf s&apos;il peut
   être reproduit à l&apos;aide des versions provenant de <link xlink:href="&url.php.downloads;">
   la zone de téléchargement officielle</link>.
- </para>
+ </simpara>
 </warning>'>
 
 <!ENTITY note.apache.slashes '<note xmlns="http://docbook.org/ns/docbook"><simpara>Souvenez-vous que lorsque vous ajoutez
@@ -2755,14 +2755,14 @@ utilisé pour les documents en entrées et sorties. Les valeurs possibles de
 <!-- Snippets and titles for the contributors section -->
 <!ENTITY Credit.Authors.and.Contributors 'Auteurs et Contributeurs'>
 
-<!ENTITY Credit.Introduction '<para xmlns="http://docbook.org/ns/docbook">Nous mettons en avant les personnes les
+<!ENTITY Credit.Introduction '<simpara xmlns="http://docbook.org/ns/docbook">Nous mettons en avant les personnes les
 plus actives dans la préface du manuel mais il y a bien plus de contributeurs
 qui nous aident actuellement dans notre travail ou qui ont fournis une aide
 précieuse au projet dans le passé. Il y a beaucoup d&#39;inconnus qui nous ont
 aidés à travers leurs notes concernant les pages du manuel qui sont
 continuellement incluses dans le manuel, travail dont nous sommes très
 reconnaissants. La liste fournie ci-dessous est classée par ordre
-alphabétique.</para>'>
+alphabétique.</simpara>'>
 
 <!ENTITY Credit.Authors.and.Editors 'Auteurs et Éditeurs'>
 
@@ -2805,12 +2805,12 @@ alphabétique.</para>'>
 
 <!-- XMLWriter Notes -->
 <!ENTITY xmlwriter.xmlwriter.description '<varlistentry xmlns="http://docbook.org/ns/docbook">
-<term><parameter>writer</parameter></term><listitem><para>
+<term><parameter>writer</parameter></term><listitem><simpara>
  Uniquement pour les appels procéduraux.
  L&#39;instance <classname>XMLWriter</classname> qui est modifiée.
  Cet objet provient d&#39;un appel à <function>xmlwriter_open_uri</function>
  ou <function>xmlwriter_open_memory</function>.
-</para></listitem></varlistentry>'>
+</simpara></listitem></varlistentry>'>
 
 <!ENTITY xmlwriter.changelog.writer-param '<row xmlns="http://docbook.org/ns/docbook">
  <entry>8.0.0</entry>
@@ -2821,12 +2821,12 @@ alphabétique.</para>'>
 </row>'>
 
 <!-- SOAP notes -->
-<!ENTITY soap.wsdl.mode.only "<note xmlns='http://docbook.org/ns/docbook'><para>Cette fonction n'est disponible qu&#39;en mode WSDL.</para></note>">
+<!ENTITY soap.wsdl.mode.only "<note xmlns='http://docbook.org/ns/docbook'><simpara>Cette fonction n'est disponible qu&#39;en mode WSDL.</simpara></note>">
 
 <!-- Stomp notes -->
-<!ENTITY stomp.param.link "<varlistentry xmlns='http://docbook.org/ns/docbook'><term><parameter>link</parameter></term><listitem><para>Style procédural uniquement : L&#39;identifiant stomp retourné par la fonction<function>stomp_connect</function>.</para></listitem></varlistentry>">
-<!ENTITY stomp.param.headers "<varlistentry xmlns='http://docbook.org/ns/docbook'><term><parameter>headers</parameter></term><listitem><para>Tableau associatif contenant les en-têtes additionnels (exemple : receipt).</para></listitem></varlistentry>">
-<!ENTITY stomp.note.transaction "<note xmlns='http://docbook.org/ns/docbook'><para>Un en-tête de transaction peut être spécifié, indiquant que la confirmation des messages doit faire partie de la transaction.</para></note>">
+<!ENTITY stomp.param.link "<varlistentry xmlns='http://docbook.org/ns/docbook'><term><parameter>link</parameter></term><listitem><simpara>Style procédural uniquement : L&#39;identifiant stomp retourné par la fonction<function>stomp_connect</function>.</simpara></listitem></varlistentry>">
+<!ENTITY stomp.param.headers "<varlistentry xmlns='http://docbook.org/ns/docbook'><term><parameter>headers</parameter></term><listitem><simpara>Tableau associatif contenant les en-têtes additionnels (exemple : receipt).</simpara></listitem></varlistentry>">
+<!ENTITY stomp.note.transaction "<note xmlns='http://docbook.org/ns/docbook'><simpara>Un en-tête de transaction peut être spécifié, indiquant que la confirmation des messages doit faire partie de la transaction.</simpara></note>">
 <!ENTITY stomp.note.sync "<tip xmlns='http://docbook.org/ns/docbook'><simpara>Stomp est, par nature, asynchrone. Une communication synchrone peut être implémentée en ajoutant un en-tête <literal>receipt</literal>. Ceci fera que les méthodes ne retourneront rien tant que le message de confirmation n&#39;aura pas été reçu ou tant que le délai d&#39;attente ne sera pas atteint.</simpara></tip>">
 
 <!-- SVN notes -->
@@ -2839,15 +2839,15 @@ alphabétique.</para>'>
 <!ENTITY svn.referto.type 'Référez-vous aux <link xmlns="http://docbook.org/ns/docbook" linkend="svn.constants.type">constantes de type</link> pour les valeurs possibles.'>
 
 <!-- FANN notes -->
-<!ENTITY fann.ann.description '<para xmlns="http://docbook.org/ns/docbook">Ressource de réseau de neurones.</para>'>
-<!ENTITY fann.train.description '<para xmlns="http://docbook.org/ns/docbook">Ressource de données d&#39;entrainement du réseau de neurones.</para>'>
-<!ENTITY fann.errdat.description '<para xmlns="http://docbook.org/ns/docbook">Soit une ressource de réseau de neurones, soit une ressource de données d&#39;entrainement d&#39;un réseau de neurones.</para>'>
-<!ENTITY fann.return.void '<para xmlns="http://docbook.org/ns/docbook">Aucune valeur retournée.</para>'>
-<!ENTITY fann.return.bool '<para xmlns="http://docbook.org/ns/docbook">Retourne &true; en cas de succès, &false; sinon.</para>'>
-<!ENTITY fann.return.ann '<para xmlns="http://docbook.org/ns/docbook">Retourne une ressource de réseau de neurones en cas de succès, ou &false; si une erreur survient.</para>'>
-<!ENTITY fann.return.train '<para xmlns="http://docbook.org/ns/docbook">Retourne une ressource de données d&#39;entrainement en cas de succès, ou &false; si une erreur survient.</para>'>
-<!ENTITY fann.note.function.fann-2.2 '<note xmlns="http://docbook.org/ns/docbook"><para>Cette fonction est maintenant disponible si l&#39;extension fann a été compilée
-avec libfann &gt;= 2.2.</para></note>'>
+<!ENTITY fann.ann.description '<simpara xmlns="http://docbook.org/ns/docbook">Ressource de réseau de neurones.</simpara>'>
+<!ENTITY fann.train.description '<simpara xmlns="http://docbook.org/ns/docbook">Ressource de données d&#39;entrainement du réseau de neurones.</simpara>'>
+<!ENTITY fann.errdat.description '<simpara xmlns="http://docbook.org/ns/docbook">Soit une ressource de réseau de neurones, soit une ressource de données d&#39;entrainement d&#39;un réseau de neurones.</simpara>'>
+<!ENTITY fann.return.void '<simpara xmlns="http://docbook.org/ns/docbook">Aucune valeur retournée.</simpara>'>
+<!ENTITY fann.return.bool '<simpara xmlns="http://docbook.org/ns/docbook">Retourne &true; en cas de succès, &false; sinon.</simpara>'>
+<!ENTITY fann.return.ann '<simpara xmlns="http://docbook.org/ns/docbook">Retourne une ressource de réseau de neurones en cas de succès, ou &false; si une erreur survient.</simpara>'>
+<!ENTITY fann.return.train '<simpara xmlns="http://docbook.org/ns/docbook">Retourne une ressource de données d&#39;entrainement en cas de succès, ou &false; si une erreur survient.</simpara>'>
+<!ENTITY fann.note.function.fann-2.2 '<note xmlns="http://docbook.org/ns/docbook"><simpara>Cette fonction est maintenant disponible si l&#39;extension fann a été compilée
+avec libfann &gt;= 2.2.</simpara></note>'>
 
 <!-- Imagick generic return types -->
 <!ENTITY imagick.return.success 'Retourne &true; en cas de succès.'>
@@ -2915,37 +2915,37 @@ avec libfann &gt;= 2.2.</para></note>'>
     concernant l&#39;installation</link> pour plus d&#39;informations.
 </simpara>
 </note>'>
-<!ENTITY note.openssl.param-notext '<para xmlns="http://docbook.org/ns/docbook">
+<!ENTITY note.openssl.param-notext '<simpara xmlns="http://docbook.org/ns/docbook">
 Le paramètre optionnel <parameter>notext</parameter> affecte le niveau verbeux de l&#39;affichage ;
 s&#39;il vaut &false;, des informations humainement lisibles seront ajoutées dans l&#39;affichage.
 Par défaut, le paramètre <parameter>notext</parameter> vaut &true;.
-</para>'>
+</simpara>'>
 
 <!-- COM/Dotnet -->
 <!ENTITY com.variant-arith '<note xmlns="http://docbook.org/ns/docbook">
-<para>
+<simpara>
     Comme pour toutes les fonctions arithmétiques, les paramètres pour cette fonction
     peuvent être soit un type PHP natif (entier, chaîne de caractères, nombre à virgule flottante,
     booléen ou &null;), ou une instance de la classe COM, VARIANT ou DOTNET. Les types PHP natifs
     seront convertis en VARIANT en utilisant les mêmes règles que celles trouvées dans le
     constructeur de la classe <xref linkend="class.variant"/>. Les objets COM et DOTNET
     auront la valeur de leur propriété par défaut récupérée et utilisée en tant que valeur VARIANT.
-</para>
-<para>
+</simpara>
+<simpara>
     Les fonctions arithmétiques VARIANT sont interfacées sur les fonctions de la bibliothèque
     COM équivalentes ; pour plus d&#39;informations sur ces fonctions, veuillez consulter
     la bibliothèque MSDN. Les fonctions PHP sont nommées de façon légèrement différentes :
     par exemple, <function>variant_add</function>, en PHP, correspond à
     <literal>VarAdd()</literal> dans la documentation MSDN.
-</para>
+</simpara>
 </note>
 '>
 
 <!-- phar -->
-<!ENTITY phar.write '<note xmlns="http://docbook.org/ns/docbook"><para>Cette
+<!ENTITY phar.write '<note xmlns="http://docbook.org/ns/docbook"><simpara>Cette
     méthode nécessite que la variable de configuration INI <literal>phar.readonly</literal>
     soit définie à &zero; pour fonctionner avec les objets <classname>Phar</classname>.
-    Sinon, une exception <classname>PharException</classname> sera lançée.</para></note>'>
+    Sinon, une exception <classname>PharException</classname> sera lançée.</simpara></note>'>
 
 <!ENTITY phar.note.performance '<note xmlns="http://docbook.org/ns/docbook">
  <simpara>
@@ -2966,30 +2966,30 @@ Par défaut, le paramètre <parameter>notext</parameter> vaut &true;.
 </note>'>
 
 <!-- XML -->
-<!ENTITY libxml.required '<para xmlns="http://docbook.org/ns/docbook">
+<!ENTITY libxml.required '<simpara xmlns="http://docbook.org/ns/docbook">
  Cette extension requière l&#39;extension PHP <link linkend="book.libxml">libxml</link>.
  Ceci signifie passer l&#39;option de configuration
  <option role="configure">--with-libxml</option>, ou antérieur à PHP 7.4
  l&#39;option de configuration <option role="configure">--enable-libxml</option>,
  bien que ceci est accomplie implicitement car libxml est activé par défaut.
-</para>'>
+</simpara>'>
 
 <!-- XMLReader -->
-<!ENTITY xmlreader.libxml20620.note '<caution xmlns="http://docbook.org/ns/docbook"><para>Cette fonction n&#39;est disponible que
-    si PHP est compilé à l&#39;aide de la librarie libxml 20620 ou ultérieure.</para></caution>'>
+<!ENTITY xmlreader.libxml20620.note '<caution xmlns="http://docbook.org/ns/docbook"><simpara>Cette fonction n&#39;est disponible que
+    si PHP est compilé à l&#39;aide de la librarie libxml 20620 ou ultérieure.</simpara></caution>'>
 
 <!-- inotify -->
 <!ENTITY inotify.instance.description 'Ressource returnée par
 <function xmlns="http://docbook.org/ns/docbook">inotify_init</function>'>
 
 <!-- User streams -->
-<!ENTITY userstream.not.implemented.warning '<para xmlns="http://docbook.org/ns/docbook">Émet une alerte
+<!ENTITY userstream.not.implemented.warning '<simpara xmlns="http://docbook.org/ns/docbook">Émet une alerte
 <constant>E_WARNING</constant> si l&#39;appel à cette méthode échoue
-(i.e. pas implémenté).</para>'>
+(i.e. pas implémenté).</simpara>'>
 
-<!ENTITY userstream.updates.context '<note xmlns="http://docbook.org/ns/docbook"><para>La propriété
+<!ENTITY userstream.updates.context '<note xmlns="http://docbook.org/ns/docbook"><simpara>La propriété
     <varname linkend="streamwrapper.props.context">streamWrapper::$context</varname>
-    est mise à jour si un contexte valide est passé à la fonction.</para></note>'>
+    est mise à jour si un contexte valide est passé à la fonction.</simpara></note>'>
 
 <!ENTITY stream.bucket.param '<parameter>bucket</parameter> attend désormais une instance de <classname>StreamBucket</classname> ; auparavant, une <classname>stdClass</classname> était attendue.'>
 <!ENTITY stream.bucket.return 'Cette fonction retourne désormais une instance de <classname>StreamBucket</classname> ; auparavant, une <classname>stdClass</classname> était retournée.'>
@@ -3015,27 +3015,27 @@ Par défaut, le paramètre <parameter>notext</parameter> vaut &true;.
 <!ENTITY reflection.getattributes.param.name '<varlistentry xmlns="http://docbook.org/ns/docbook">
 <term><parameter>name</parameter></term>
 <listitem>
- <para>
+ <simpara>
   Filtrer les résultats pour inclure uniquement les instances
   de <classname>ReflectionAttribute</classname> pour les attributs correspondant à ce nom de classe.
- </para>
+ </simpara>
 </listitem>
 </varlistentry>'>
 
 <!ENTITY reflection.getattributes.param.flags '<varlistentry xmlns="http://docbook.org/ns/docbook">
 <term><parameter>flags</parameter></term>
 <listitem>
- <para>
+ <simpara>
   Flags pour déterminer comment filtrer les résultats, si <parameter>name</parameter> est fourni.
- </para>
- <para>
+ </simpara>
+ <simpara>
   La valeur par défaut est <literal>0</literal> qui ne renverra que les résultats
   pour les attributs qui sont de la classe <parameter>name</parameter>.
- </para>
- <para>
+ </simpara>
+ <simpara>
   La seule autre option disponible est d&#39;utiliser <constant>ReflectionAttribute::IS_INSTANCEOF</constant>,
   qui utilisera plutôt <literal>instanceof</literal> pour le filtrage.
- </para>
+ </simpara>
 </listitem>
 </varlistentry>'>
 
@@ -3048,10 +3048,10 @@ Par défaut, le paramètre <parameter>notext</parameter> vaut &true;.
 <!ENTITY win32service.noerror.false.error 'retournait <constant xmlns="http://docbook.org/ns/docbook">WIN32_NO_ERROR</constant> on success&win32service.false.error;'>
 
 <!-- SNMP -->
-<!ENTITY snmp.set.type.values '<para xmlns="http://docbook.org/ns/docbook">
+<!ENTITY snmp.set.type.values '<simpara xmlns="http://docbook.org/ns/docbook">
 Le <acronym>MIB</acronym> définit le type de chaque identifiant d&#39;objets. Il doit
 être spécifié sous la forme d&#39;un simple caractère depuis la liste suivante.
-</para>
+</simpara>
 <table xmlns="http://docbook.org/ns/docbook">
 <title>types</title>
 <tgroup cols="2">
@@ -3070,11 +3070,11 @@ Le <acronym>MIB</acronym> définit le type de chaque identifiant d&#39;objets. I
     </tbody>
 </tgroup>
 </table>
-<para xmlns="http://docbook.org/ns/docbook">
+<simpara xmlns="http://docbook.org/ns/docbook">
 Si la constante <constant>OPAQUE_SPECIAL_TYPES</constant> a été définie lors
 de la compilation de la bibliothèque <acronym>SNMP</acronym>, les caractères suivants
 seront également disponibles :
-</para>
+</simpara>
 <table xmlns="http://docbook.org/ns/docbook">
 <title>types</title>
 <tgroup cols="2">
@@ -3087,22 +3087,22 @@ seront également disponibles :
 </tgroup>
 </table>
 '>
-<!ENTITY snmp.set.type.values.asn.mapping '<para xmlns="http://docbook.org/ns/docbook">
+<!ENTITY snmp.set.type.values.asn.mapping '<simpara xmlns="http://docbook.org/ns/docbook">
 La plupart de ces valeurs utilise le type ASN.1 correspondant. &apos;s&apos;, &apos;x&apos;, &apos;d&apos; et &apos;b&apos;
 sont toutes des façons différentes de spécifier la valeur OCTET STRING et le type non-signé
 &apos;u&apos; est également utilisé pour gérer les valeurs Gauge32.
-</para>
+</simpara>
 '>
-<!ENTITY snmp.set.type.values.equal.note '<para xmlns="http://docbook.org/ns/docbook">
+<!ENTITY snmp.set.type.values.equal.note '<simpara xmlns="http://docbook.org/ns/docbook">
 Si les fichiers MIB sont chargés dans l&#39;arbre MIB avec "snmp_read_mib" ou en les spécifiant
 dans la configuration de libsnmp, &apos;=&apos; pourra être utilisé comme paramètre
 de type pour tous les identifiants d&#39;objets, vu que le type peut automatiquement être lu depuis le MIB.
-</para>
+</simpara>
 '>
-<!ENTITY snmp.set.type.values.bitset.note '<para xmlns="http://docbook.org/ns/docbook">
+<!ENTITY snmp.set.type.values.bitset.note '<simpara xmlns="http://docbook.org/ns/docbook">
 Notez qu&#39;il y a 2 façons de définir une variable de type BITS like i.e.
 "SYNTAX    BITS {telnet(0), ftp(1), http(2), icmp(3), snmp(4), ssh(5), https(6)}":
-</para>
+</simpara>
 <itemizedlist xmlns="http://docbook.org/ns/docbook">
 <listitem>
     <simpara>
@@ -3117,13 +3117,13 @@ Notez qu&#39;il y a 2 façons de définir une variable de type BITS like i.e.
     </simpara>
 </listitem>
 </itemizedlist>
-<para xmlns="http://docbook.org/ns/docbook">
+<simpara xmlns="http://docbook.org/ns/docbook">
 Reportez-vous à la section sur les exemples pour plus de détails.
-</para>
+</simpara>
 '>
 <!ENTITY snmp.methods.exceptions_enable.refsect '<refsect1 role="errors" xmlns="http://docbook.org/ns/docbook">
 &reftitle.errors;
-<para>
+<simpara>
     Cette méthode ne lance aucune exception par défaut.
     Pour activer l&#39;émission d&#39;exceptions SNMPException lorsque
     des erreurs de la bibliothèque surviennent,
@@ -3131,7 +3131,7 @@ Reportez-vous à la section sur les exemples pour plus de détails.
     doit être défini à la valeur correspondante. Voir les <link linkend="snmp.props.exceptions-enabled">
     explications sur <parameter>SNMP::$exceptions_enabled</parameter></link>
     pour plus de détails.
-</para>
+</simpara>
 </refsect1>
 '>
 
@@ -3145,23 +3145,23 @@ void callback(mixed $data, int $result[, resource $req]);
 <variablelist xmlns="http://docbook.org/ns/docbook">
     <varlistentry xmlns="http://docbook.org/ns/docbook">
         <term><parameter>data</parameter></term>
-        <listitem><para>représente les données personnalisées passées à la requête.</para></listitem>
+        <listitem><simpara>représente les données personnalisées passées à la requête.</simpara></listitem>
     </varlistentry>
     <varlistentry xmlns="http://docbook.org/ns/docbook">
         <term><parameter>result</parameter></term>
-        <listitem><para>représente la valeur résultante spécifique à la requête ; basiquement,
-            la valeur retournée par l&#39;appel système correspondant.</para></listitem>
+        <listitem><simpara>représente la valeur résultante spécifique à la requête ; basiquement,
+            la valeur retournée par l&#39;appel système correspondant.</simpara></listitem>
     </varlistentry>
     <varlistentry xmlns="http://docbook.org/ns/docbook">
         <term><parameter>req</parameter></term>
-        <listitem><para>est la ressource optionnelle de la requête qui peut être
-            utilisée avec les fonctions comme <function>eio_get_last_error</function>.</para></listitem>
+        <listitem><simpara>est la ressource optionnelle de la requête qui peut être
+            utilisée avec les fonctions comme <function>eio_get_last_error</function>.</simpara></listitem>
     </varlistentry>
 </variablelist>
 </para>
 '>
 
-<!ENTITY eio.request.pri.values '<para
+<!ENTITY eio.request.pri.values '<simpara
 xmlns="http://docbook.org/ns/docbook">La priorité de la requête : <constant
         xmlns="http://docbook.org/ns/docbook">EIO_PRI_DEFAULT</constant>, <constant
         xmlns="http://docbook.org/ns/docbook">EIO_PRI_MIN</constant>, <constant
@@ -3169,7 +3169,7 @@ xmlns="http://docbook.org/ns/docbook">La priorité de la requête : <constant
 Si &null; est passé, le paramètre <parameter
         xmlns="http://docbook.org/ns/docbook">pri</parameter>, en interne, est défini à
 <constant xmlns="http://docbook.org/ns/docbook">EIO_PRI_DEFAULT</constant>.
-</para>
+</simpara>
 '>
 
 <!ENTITY eio.warn.relpath '<warning
@@ -3242,10 +3242,10 @@ xmlns="http://docbook.org/ns/docbook"><simpara xmlns="http://docbook.org/ns/docb
     <row xmlns="http://docbook.org/ns/docbook">
         <entry>PECL mongodb 2.0.0</entry>
         <entry>
-            <para>
+            <simpara>
                 Cette classe n’implémente plus l&#39;interface
                 <interfacename>Serializable</interfacename>.
-            </para>
+            </simpara>
         </entry>
     </row>
 '>
@@ -3276,10 +3276,10 @@ xmlns="http://docbook.org/ns/docbook"><simpara xmlns="http://docbook.org/ns/docb
     <row xmlns="http://docbook.org/ns/docbook">
         <entry>PECL mongodb 2.0.0</entry>
         <entry>
-            <para>
+            <simpara>
                 Cette méthode déclenche désormais une exception lorsqu&#39;elle est appelée
                 pour une écriture non reconnue, au lieu de retourner &null;.
-            </para>
+            </simpara>
         </entry>
     </row>
 '>
@@ -3289,15 +3289,15 @@ xmlns="http://docbook.org/ns/docbook"><simpara xmlns="http://docbook.org/ns/docb
 <entry>collation</entry>
 <entry><type class="union"><type>array</type><type>object</type></type></entry>
 <entry>
-    <para>
+    <simpara>
         <link xlink:href="&url.mongodb.docs.collation;" xmlns:xlink="http://www.w3.org/1999/xlink">Collation</link> permet aux utilisateurs de spécifier des règles spécifiques au langage pour la comparaison des chaînes, par exemple, des règles pour les majuscules ou les accents. Lors de la spécification d&#39;une collation, le champ <literal>"locale"</literal> est obligatoire ; tous les autres champs de la collation sont optionnels. Pour la description de ces champs, reportez-vous au <link xlink:href="&url.mongodb.docs.collation;#collation-document" xmlns:xlink="http://www.w3.org/1999/xlink">document Collation</link>.
-    </para>
-    <para>
+    </simpara>
+    <simpara>
         Si la collation n&#39;est pas spécifiée mais que la collection a une collation par défaut, l&#39;opération utilisera la collation spécifiée pour la collection. Si aucune collation n&#39;est spécifiée pour la collection ou pour l&#39;opération, MongoDB utilisera le binaire simple de comparaison utilisé dans les versions précédentes pour les comparaisons des chaînes.
-    </para>
-    <para>
+    </simpara>
+    <simpara>
         Cette option est disponible en MongoDB 3.4+ et une exception sera émise au moment de l&#39;exécution si elle est spécifiée dans une version antérieure.
-    </para>
+    </simpara>
 </entry>
 </row>
 '>
@@ -3307,12 +3307,12 @@ xmlns="http://docbook.org/ns/docbook"><simpara xmlns="http://docbook.org/ns/docb
   <entry>let</entry>
   <entry><type class="union"><type>array</type><type>object</type></type></entry>
   <entry>
-   <para>
+   <simpara>
     Dictionnaire des noms et des valeurs des paramètres. Les valeurs doivent être des constantes ou des expressions fermées qui ne font pas référence aux champs du document. Les paramètres peuvent ensuite être accédés en tant que variables dans un contexte d&#39;expression agrégée (par exemple <literal>$$var</literal>).
-   </para>
-   <para>
+   </simpara>
+   <simpara>
     Cette option est disponible dans MongoDB 5.0+ et entraînera une exception au moment de l&#39;exécution si elle est spécifiée pour une version antérieure du serveur.
-   </para>
+   </simpara>
   </entry>
  </row>
 '>
@@ -3336,22 +3336,22 @@ xmlns="http://docbook.org/ns/docbook"><simpara xmlns="http://docbook.org/ns/docb
           <entry>kmsProviders</entry>
           <entry>&array;</entry>
           <entry>
-           <para>
+           <simpara>
             Un document contenant la configuration d&apos;un ou plusieurs
             fournisseurs KMS, qui sont utilisés pour chiffrer les clés de données.
             Les fournisseurs supporté sont <literal>"aws"</literal>,
             <literal>"azure"</literal>, <literal>"gcp"</literal> et
             <literal>"local"</literal>, et au moins un doit être spécifié.
-           </para>
-           <para>
+           </simpara>
+           <simpara>
             Si un document vide est spécifié pour <literal>"aws"</literal>,
             <literal>"azure"</literal>, ou <literal>"gcp"</literal>, le pilote
             tentera de configurer le fournisseur en utilisant
             <link xlink:href="&url.mongodb.specs;/blob/master/source/client-side-encryption/client-side-encryption.rst#automatic-credentials">Automatic Credentials</link>.
-           </para>
-           <para>
+           </simpara>
+           <simpara>
             Le format pour <literal>"aws"</literal> est le suivant :
-           </para>
+           </simpara>
            <programlisting role="javascript">
 <![CDATA[
 aws: {
@@ -3361,9 +3361,9 @@ aws: {
 }
 ]]>
            </programlisting>
-           <para>
+           <simpara>
             Le format pour <literal>"azure"</literal> est le suivant :
-           </para>
+           </simpara>
            <programlisting role="javascript">
 <![CDATA[
 azure: {
@@ -3375,9 +3375,9 @@ azure: {
 }
 ]]>
            </programlisting>
-           <para>
+           <simpara>
             Le format pour <literal>"gcp"</literal> est le suivant :
-           </para>
+           </simpara>
            <programlisting role="javascript">
 <![CDATA[
 gcp: {
@@ -3388,9 +3388,9 @@ gcp: {
 }
 ]]>
            </programlisting>
-           <para>
+           <simpara>
             Le format pour <literal>"kmip"</literal> est le suivant :
-           </para>
+           </simpara>
            <programlisting role="javascript">
 <![CDATA[
 kmip: {
@@ -3398,9 +3398,9 @@ kmip: {
 }
 ]]>
            </programlisting>
-           <para>
+           <simpara>
             Le format pour <literal>"local"</literal> est le suivant :
-           </para>
+           </simpara>
            <programlisting role="javascript">
 <![CDATA[
 local: {
@@ -3560,14 +3560,14 @@ local: {
   <entry>tlsOptions</entry>
   <entry><type>array</type></entry>
   <entry>
-   <para>
+   <simpara>
     Un document contenant la configuration TLS d&apos;un ou plusieurs
     fournisseurs KMS.
     Les fournisseurs supporté sont <literal>"aws"</literal>,
     <literal>"azure"</literal>, <literal>"gcp"</literal> et
     <literal>"kmip"</literal>.
     Tous les fournisseurs supportent les options suivantes :
-   </para>
+   </simpara>
    <programlisting role="javascript">
 <![CDATA[
 <provider>: {
@@ -3587,14 +3587,14 @@ local: {
  <entry>maxCommitTimeMS</entry>
  <entry>integer</entry>
  <entry>
-  <para>
+  <simpara>
    Le temps maximum en millisecondes pour permettre à une seule commande
    <literal>commitTransaction</literal> de s&#39;exécuter.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Si spécifié, <literal>maxCommitTimeMS</literal> doit être un entier
    32 bits signé supérieur ou égal à zéro.
-  </para>
+  </simpara>
  </entry>
 </row>
 '>
@@ -3603,14 +3603,14 @@ local: {
 <entry>readConcern</entry>
 <entry><classname>MongoDB\Driver\ReadConcern</classname></entry>
 <entry>
-    <para>
+    <simpara>
         Une préoccupation de lecture à appliquer à l&#39;opération.
-    </para>
-    <para>
+    </simpara>
+    <simpara>
         Cette option est disponible dans MongoDB 3.2+ et se traduira par
         une exception au moment de l&#39;exécution si elle est spécifiée pour
         une version plus ancienne du serveur.
-    </para>
+    </simpara>
 </entry>
 </row>
 '>
@@ -3619,10 +3619,10 @@ local: {
 <entry>readPreference</entry>
 <entry><classname>MongoDB\Driver\ReadPreference</classname></entry>
 <entry>
-    <para>
+    <simpara>
         Une préférence de lecture à utiliser pour sélectionner un serveur
         pour l&#39;opération.
-    </para>
+    </simpara>
 </entry>
 </row>
 '>
@@ -3631,22 +3631,22 @@ local: {
 <entry>session</entry>
 <entry><classname>MongoDB\Driver\Session</classname></entry>
 <entry>
-    <para>
+    <simpara>
         Une session à associer à l&#39;opération.
-    </para>
+    </simpara>
 </entry>
 </row>
 '>
 <!ENTITY mongodb.option.transactionReadWriteConcern '
 <warning xmlns="http://docbook.org/ns/docbook">
-<para>
+<simpara>
     Si vous utilisez une <literal>"session"</literal> qui a une transaction
     en cours, vous ne pouvez pas spécifier l&#39;option <literal>"readConcern"</literal>
     ou <literal>"writeConcern"</literal>. Tenter de faire ceci lancera une exception
     <classname>MongoDB\Driver\Exception\InvalidArgumentException</classname>.
     À la place vous devriez définir ces options quand vous créez la transaction avec
     <methodname>MongoDB\Driver\Session::startTransaction</methodname>.
-</para>
+</simpara>
 </warning>
 '>
 <!ENTITY mongodb.option.writeConcern '
@@ -3654,9 +3654,9 @@ local: {
 <entry>writeConcern</entry>
 <entry><classname>MongoDB\Driver\WriteConcern</classname></entry>
 <entry>
-    <para>
+    <simpara>
         Une préoccupation d&#39;écriture à appliquer à l&#39;opération.
-    </para>
+    </simpara>
 </entry>
 </row>
 '>
@@ -3664,9 +3664,9 @@ local: {
 <varlistentry xmlns="http://docbook.org/ns/docbook">
 <term><parameter>namespace</parameter> (<type>string</type>)</term>
 <listitem>
-    <para>
+    <simpara>
         Un espace de noms totalement qualifié (e.g. <literal>"databaseName.collectionName"</literal>)
-    </para>
+    </simpara>
 </listitem>
 </varlistentry>
 '>
@@ -3674,9 +3674,9 @@ local: {
 <varlistentry xmlns="http://docbook.org/ns/docbook">
 <term><parameter>db</parameter> (<type>string</type>)</term>
 <listitem>
-    <para>
+    <simpara>
         Le nom de la base de données sur laquelle la commande sera exécutée.
-    </para>
+    </simpara>
 </listitem>
 </varlistentry>
 '>
@@ -3684,9 +3684,9 @@ local: {
 <varlistentry xmlns="http://docbook.org/ns/docbook">
 <term><parameter>bulk</parameter> (<classname>MongoDB\Driver\BulkWrite</classname>)</term>
 <listitem>
-    <para>
+    <simpara>
         Écriture(s) à exécuter.
-    </para>
+    </simpara>
 </listitem>
 </varlistentry>
 '>
@@ -3694,9 +3694,9 @@ local: {
    <varlistentry xmlns="http://docbook.org/ns/docbook">
     <term><parameter>bulk</parameter> (<classname>MongoDB\Driver\BulkWriteCommand</classname>)</term>
     <listitem>
-     <para>
+     <simpara>
       Écriture(s) à exécuter.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
 '>
@@ -3704,9 +3704,9 @@ local: {
 <varlistentry xmlns="http://docbook.org/ns/docbook">
 <term><parameter>command</parameter> (<classname>MongoDB\Driver\Command</classname>)</term>
 <listitem>
-    <para>
+    <simpara>
         La commande à exécuter.
-    </para>
+    </simpara>
 </listitem>
 </varlistentry>
 '>
@@ -3734,10 +3734,10 @@ local: {
                 <type>string</type>
               </entry>
               <entry>
-                <para>
+                <simpara>
                   L&apos;algorithme de chiffrement à utiliser. Cette option est requise. Spécifiez l&apos;une des constantes suivantes de
                   <link linkend="mongodb-driver-clientencryption.constants">ClientEncryption</link> :
-                </para>
+                </simpara>
                 <simplelist>
                   <member>
                     <constant>MongoDB\Driver\ClientEncryption::AEAD_AES_256_CBC_HMAC_SHA_512_DETERMINISTIC</constant>
@@ -3763,15 +3763,15 @@ local: {
                 <type>int</type>
               </entry>
               <entry>
-                <para>
+                <simpara>
                   Le facteur de contention pour évaluer les requêtes avec des charges utiles chiffrées indexées.
-                </para>
-                <para>
+                </simpara>
+                <simpara>
                   Cette option s&apos;applique uniquement et ne peut être spécifiée que lorsque
                   <literal>algorithm</literal> est
                   <constant>MongoDB\Driver\ClientEncryption::ALGORITHM_INDEXED</constant> ou
                   <constant>MongoDB\Driver\ClientEncryption::ALGORITHM_RANGE</constant>.
-                </para>
+                </simpara>
               </entry>
             </row>
             <row>
@@ -3780,10 +3780,10 @@ local: {
                 <type>string</type>
               </entry>
               <entry>
-                <para>
+                <simpara>
                   Identifie un document de collection de coffre à clés par <literal>keyAltName</literal>. Cette option est mutuellement exclusive
                   avec <literal>keyId</literal> et l&apos;une des deux est requise.
-                </para>
+                </simpara>
               </entry>
             </row>
             <row>
@@ -3792,10 +3792,10 @@ local: {
                 <classname>MongoDB\BSON\Binary</classname>
               </entry>
               <entry>
-                <para>
+                <simpara>
                   Identifie une clé de données par <literal>_id</literal>. La valeur est un UUID (sous-type binaire 4). Cette option est mutuellement
                   exclusive avec <literal>keyAltName</literal> et l&apos;une des deux est requise.
-                </para>
+                </simpara>
               </entry>
             </row>
             <row>
@@ -3804,10 +3804,10 @@ local: {
                 <type>string</type>
               </entry>
               <entry>
-                <para>
+                <simpara>
                   Le type de requête pour évaluer les requêtes avec des charges utiles chiffrées indexées. Spécifiez l&apos;une des constantes suivantes de
                   <link linkend="mongodb-driver-clientencryption.constants">ClientEncryption</link> :
-                </para>
+                </simpara>
                 <simplelist>
                   <member>
                     <constant>MongoDB\Driver\ClientEncryption::QUERY_TYPE_EQUALITY</constant>
@@ -3816,12 +3816,12 @@ local: {
                     <constant>MongoDB\Driver\ClientEncryption::QUERY_TYPE_RANGE</constant>
                   </member>
                 </simplelist>
-                <para>
+                <simpara>
                   Cette option s&apos;applique uniquement et ne peut être spécifiée que lorsque
                   <literal>algorithm</literal> est
                   <constant>MongoDB\Driver\ClientEncryption::ALGORITHM_INDEXED</constant> ou
                   <constant>MongoDB\Driver\ClientEncryption::ALGORITHM_RANGE</constant>.
-                </para>
+                </simpara>
               </entry>
             </row>
             <row>
@@ -3830,11 +3830,11 @@ local: {
                 <type>array</type>
               </entry>
               <entry>
-                <para>
+                <simpara>
                   Options d&apos;index pour un champ de chiffrement interrogeable prenant en charge les requêtes "range". Les options ci-dessous doivent correspondre
                   aux valeurs définies dans <literal>encryptedFields</literal> de la collection cible. Pour les types de champ BSON double et decimal128,
                   <literal>min</literal>, <literal>max</literal> et <literal>precision</literal> doivent être tous définis ou tous non définis.
-                </para>
+                </simpara>
                 <para>
                   <table>
                     <title>Options d&apos;index de plage</title>
@@ -3901,9 +3901,9 @@ local: {
 <varlistentry xmlns="http://docbook.org/ns/docbook">
 <term><parameter>query</parameter> (<classname>MongoDB\Driver\Query</classname>)</term>
 <listitem>
-    <para>
+    <simpara>
         La requête à exécuter.
-    </para>
+    </simpara>
 </listitem>
 </varlistentry>
 '>
@@ -3911,9 +3911,9 @@ local: {
 <varlistentry xmlns="http://docbook.org/ns/docbook">
 <term><parameter>typeMap</parameter> (<type>array</type>)</term>
 <listitem>
-    <para>
+    <simpara>
         <link linkend="mongodb.persistence.typemaps">Configuration du type de carte</link>.
-    </para>
+    </simpara>
 </listitem>
 </varlistentry>
 '>
@@ -3921,10 +3921,10 @@ local: {
 <varlistentry xmlns="http://docbook.org/ns/docbook">
 <term><parameter>filter</parameter> (<type class="union"><type>array</type><type>object</type></type>)</term>
 <listitem>
-    <para>
+    <simpara>
         L&#39;<link xlink:href="&url.mongodb.docs;tutorial/query-documents/" xmlns:xlink="http://www.w3.org/1999/xlink">attribut de la requête</link>.
         Un attribut vide va faire correspondre tous les documents de la collection.
-    </para>
+    </simpara>
     <note>
         <simpara>
             Lors de l&#39;évaluation des critères de requête, MongoDB compare les type et les valeurs en fonction de leur propre <link xlink:href="&url.mongodb.docs;reference/bson-type-comparison-order/" xmlns:xlink="http://www.w3.org/1999/xlink">règles de comparaison pour les types BSON</link>, qui diffère des règles de <link linkend="types.comparisons">comparaison</link> et de <link linkend="language.types.type-juggling">manipulation des type</link> de PHP. Lors de  la correspondance d&#39;un type BSON spcécial, les critères de requête doivent utiliser la <link linkend="mongodb.bson">classe BSON</link> (ex. : utiliser <classname>MongoDB\BSON\ObjectId</classname> pour correspondre à un <link xlink:href="&url.mongodb.docs.objectid;" xmlns:xlink="http://www.w3.org/1999/xlink">ObjectId</link>).
@@ -3933,9 +3933,9 @@ local: {
 </listitem>
 </varlistentry>
 '>
-<!ENTITY mongodb.returns.cursor '<para xmlns="http://docbook.org/ns/docbook">Retourne un <classname>MongoDB\Driver\Cursor</classname> en cas de succès.</para>'>
-<!ENTITY mongodb.returns.writeresult '<para xmlns="http://docbook.org/ns/docbook">Retourne un <classname>MongoDB\Driver\WriteResult</classname> en cas de succès.</para>'>
-<!ENTITY mongodb.returns.bulkwritecommandresult '<para xmlns="http://docbook.org/ns/docbook">Retourne un <classname>MongoDB\Driver\BulkWriteCommandResult</classname> en cas de succès.</para>'>
+<!ENTITY mongodb.returns.cursor '<simpara xmlns="http://docbook.org/ns/docbook">Retourne un <classname>MongoDB\Driver\Cursor</classname> en cas de succès.</simpara>'>
+<!ENTITY mongodb.returns.writeresult '<simpara xmlns="http://docbook.org/ns/docbook">Retourne un <classname>MongoDB\Driver\WriteResult</classname> en cas de succès.</simpara>'>
+<!ENTITY mongodb.returns.bulkwritecommandresult '<simpara xmlns="http://docbook.org/ns/docbook">Retourne un <classname>MongoDB\Driver\BulkWriteCommandResult</classname> en cas de succès.</simpara>'>
 <!ENTITY mongodb.throws.std '&mongodb.throws.authentication;&mongodb.throws.connection;'>
 <!ENTITY mongodb.throws.session-unacknowledged '<member xmlns="http://docbook.org/ns/docbook">Lance une exception <classname>MongoDB\Driver\Exception\InvalidArgumentException</classname> si l&#39;option <literal>"session"</literal> est utilisée conjointement avec une préoccupation d&#39;écriture non reconnu.</member>'>
 <!ENTITY mongodb.throws.bulkwritecommandexception '<member xmlns="http://docbook.org/ns/docbook">Lance une exception <classname>MongoDB\Driver\Exception\BulkWriteCommandException</classname> lors d&#39;une erreur d&#39;écriture (par exemple, échec de commande, erreur d&#39;écriture ou d&#39;écriture préoccupante)</member>'> 
@@ -4037,35 +4037,35 @@ local: {
 '>
 
 <!-- Radius -->
-<!ENTITY radius.request.required '<note xmlns="http://docbook.org/ns/docbook"><para>Une requête doit être créée via la fonction <function>radius_create_request</function> avant que cette fonction puisse être appelée.</para></note>'>
-<!ENTITY radius.parameter.attribute-type '<varlistentry xmlns="http://docbook.org/ns/docbook"><term><parameter>type</parameter></term><listitem><para>Le type d&#39;attribut.</para></listitem></varlistentry>'>
-<!ENTITY radius.parameter.handle '<varlistentry xmlns="http://docbook.org/ns/docbook"><term><parameter>radius_handle</parameter></term><listitem><para>La ressource RADIUS.</para></listitem></varlistentry>'>
-<!ENTITY radius.parameter.options '<varlistentry xmlns="http://docbook.org/ns/docbook"><term><parameter>options</parameter></term><listitem><para>Un masqe d&#39;options d&#39;attribut. Les options disponibles incluent <link linkend="constant.radius-option-tagged"><constant>RADIUS_OPTION_TAGGED</constant></link> et <link linkend="constant.radius-option-salt"><constant>RADIUS_OPTION_SALT</constant></link>.</para></listitem></varlistentry>'>
-<!ENTITY radius.parameter.tag '<varlistentry xmlns="http://docbook.org/ns/docbook"><term><parameter>tag</parameter></term><listitem><para>L&#39;attribut tag. Ce paramètre est ignoré tant que l&#39;option <link linkend="constant.radius-option-tagged"><constant>RADIUS_OPTION_TAGGED</constant></link> est défini.</para></listitem></varlistentry>'>
-<!ENTITY radius.parameter.vendor '<varlistentry xmlns="http://docbook.org/ns/docbook"><term><parameter>vendor</parameter></term><listitem><para>L&#39;identifiant du vendeur.</para></listitem></varlistentry>'>
+<!ENTITY radius.request.required '<note xmlns="http://docbook.org/ns/docbook"><simpara>Une requête doit être créée via la fonction <function>radius_create_request</function> avant que cette fonction puisse être appelée.</simpara></note>'>
+<!ENTITY radius.parameter.attribute-type '<varlistentry xmlns="http://docbook.org/ns/docbook"><term><parameter>type</parameter></term><listitem><simpara>Le type d&#39;attribut.</simpara></listitem></varlistentry>'>
+<!ENTITY radius.parameter.handle '<varlistentry xmlns="http://docbook.org/ns/docbook"><term><parameter>radius_handle</parameter></term><listitem><simpara>La ressource RADIUS.</simpara></listitem></varlistentry>'>
+<!ENTITY radius.parameter.options '<varlistentry xmlns="http://docbook.org/ns/docbook"><term><parameter>options</parameter></term><listitem><simpara>Un masqe d&#39;options d&#39;attribut. Les options disponibles incluent <link linkend="constant.radius-option-tagged"><constant>RADIUS_OPTION_TAGGED</constant></link> et <link linkend="constant.radius-option-salt"><constant>RADIUS_OPTION_SALT</constant></link>.</simpara></listitem></varlistentry>'>
+<!ENTITY radius.parameter.tag '<varlistentry xmlns="http://docbook.org/ns/docbook"><term><parameter>tag</parameter></term><listitem><simpara>L&#39;attribut tag. Ce paramètre est ignoré tant que l&#39;option <link linkend="constant.radius-option-tagged"><constant>RADIUS_OPTION_TAGGED</constant></link> est défini.</simpara></listitem></varlistentry>'>
+<!ENTITY radius.parameter.vendor '<varlistentry xmlns="http://docbook.org/ns/docbook"><term><parameter>vendor</parameter></term><listitem><simpara>L&#39;identifiant du vendeur.</simpara></listitem></varlistentry>'>
 
 <!-- posix snippets -->
 <!ENTITY posix.parameter.fd '<varlistentry xmlns="http://docbook.org/ns/docbook">
 <term><parameter>file_descriptor</parameter></term>
 <listitem>
- <para>
+ <simpara>
   Le descripteur de fichier, qui doit être soit une ressource
   de fichier, soit un entier. Un entier est supposé être un descripteur
   de fichier qui peut être passé directement à l&#39;appel système
   sous-jacent.
- </para>
+ </simpara>
 </listitem>
 </varlistentry>'>
 
 <!ENTITY posix.rlimits '
-<para xmlns="http://docbook.org/ns/docbook">
+<simpara xmlns="http://docbook.org/ns/docbook">
 Chaque ressource a une limite soft et hard d&#39;associées. La limite
 soft correspond à la valeur que le noyau force pour la ressource
 correspondante. La limite hard agit comme un plafond de la limite soft.
 Un processus non privilégié ne peut que définir sa limite soft en une
 valeur comprise entre 0 et la limite hard, ce qui ne fera qu&#39;abaisser
 sa limite hard.
-</para>
+</simpara>
 '>
 
 <!-- strings snippets -->
@@ -4268,42 +4268,42 @@ sa limite hard.
 '>
 
 <!ENTITY strings.parameter.encoding '
-<para xmlns="http://docbook.org/ns/docbook">
+<simpara xmlns="http://docbook.org/ns/docbook">
 Un argument optionnel définissant l&#39;encodage utilisé lors
 de la conversion des caractères.
-</para>
+</simpara>
 
-<para xmlns="http://docbook.org/ns/docbook">
+<simpara xmlns="http://docbook.org/ns/docbook">
 Si omis, la valeur par défaut du paramètre <parameter>encoding</parameter>
 est la valeur de l&#39;option de configuration
 <link linkend="ini.default-charset">default_charset</link>.
-</para>
+</simpara>
 
-<para xmlns="http://docbook.org/ns/docbook">
+<simpara xmlns="http://docbook.org/ns/docbook">
 Malgré le fait que cet argument soit techniquement optionnel, vous
 êtes vivement encouragé à spécifier la valeur correcte pour votre code
 si l&#39;option de configuration
 <link linkend="ini.default-charset">default_charset</link>
 a été définie de façon incorrecte pour l&#39;entrée fournie.
-</para>
+</simpara>
 '>
 
 <!ENTITY strings.parameter.format '
 <varlistentry xmlns="http://docbook.org/ns/docbook">
  <term><parameter>format</parameter></term>
  <listitem>
-  <para>
+  <simpara>
    La chaîne de format est composé de zéro ou plusieurs directives :
    des caractères ordinaires (à l&#39;exception de <literal>&#37;</literal>)
    qui sont copiés directement dans le résultat et des
    <emphasis>spécifications de conversion</emphasis>,
    chacun ayant pour résultat de récupérer ses propres paramètre.
-  </para>
+  </simpara>
 
-  <para>
+  <simpara>
    Une spécification de conversion qui suit ce prototype :
    <literal>&#37;[argnum$][flags][width][.precision]specifier</literal>.
-  </para>
+  </simpara>
 
   <formalpara>
    <title>Argnum</title>
@@ -4490,18 +4490,18 @@ a été définie de façon incorrecte pour l&#39;entrée fournie.
       <row>
        <entry><literal>g</literal></entry>
        <entry>
-        <para>
+        <simpara>
          Format général.
-        </para>
-        <para>
+        </simpara>
+        <simpara>
          Soit P égal à la précision si différent de 0, 6 si la précision
          est omit ou 1 si la précision est zéro.
          Alors, si la conversion avec le style E aurait comme exposant X :
-        </para>
-        <para>
+        </simpara>
+        <simpara>
          Si P > X ≥ −4, la conversion est avec style f et précision P − (X + 1).
          Sinon, la conversion est avec le style e et précision P - 1.
-        </para>
+        </simpara>
        </entry>
       </row>
       <row>
@@ -4565,17 +4565,17 @@ a été définie de façon incorrecte pour l&#39;entrée fournie.
   </para>
 
   <warning>
-   <para>
+   <simpara>
     Le spécificateur de type <literal>c</literal> ignore l&apos;alignement et la taille.
-   </para>
+   </simpara>
   </warning>
 
   <warning>
-   <para>
+   <simpara>
     Le fait de tenter d&apos;utiliser une combinaison d&apos;une chaîne
     et de spécificateurs avec des jeux de caractères qui nécessitent
     plus d&apos;un octet par caractères donnera un résultat inattendu.
-   </para>
+   </simpara>
   </warning>
 
   <para>
@@ -4665,14 +4665,14 @@ a été définie de façon incorrecte pour l&#39;entrée fournie.
 '>
 
 <!ENTITY strings.parameter.needle.non-string '
- <para xmlns="http://docbook.org/ns/docbook">
+ <simpara xmlns="http://docbook.org/ns/docbook">
   Antérieur à PHP 8.0.0, si <parameter>needle</parameter> n&#39;est pas une chaîne de caractères,
   elle est convertie en un entier et appliqué en tant que valeur ordinal d&#39;un caractère.
   Ce comportement est obsolète à partir de PHP 7.3.0, et se fier à celui-ci
   est fortement déconseillé. En fonction du comportement attendu,
   <parameter>needle</parameter> doit être transtypé explicitement en une chaîne de caractère,
   ou un appel explicite à <function>chr</function> doit être exécuté.
- </para>
+ </simpara>
 '>
 
 <!ENTITY strings.changelog.needle-empty '<row xmlns="http://docbook.org/ns/docbook">
@@ -4811,22 +4811,22 @@ a été définie de façon incorrecte pour l&#39;entrée fournie.
   </informaltable>
 '>
 <!ENTITY strings.errors.sprintf '
-  <para xmlns="http://docbook.org/ns/docbook">
+  <simpara xmlns="http://docbook.org/ns/docbook">
 À partir de PHP 8.0.0, une <classname>ValueError</classname> est lancée si le nombre d&apos;arguments est nul.
 Antérieur à PHP 8.0.0, un <constant>E_WARNING</constant> était émis à la place.
-</para>
-<para xmlns="http://docbook.org/ns/docbook">
+</simpara>
+<simpara xmlns="http://docbook.org/ns/docbook">
 À partir de PHP 8.0.0, une <classname>ValueError</classname> est lancée si <literal>[width]</literal> est inférieur à zéro ou supérieur à <constant>PHP_INT_MAX</constant>.
 Antérieur à PHP 8.0.0, un <constant>E_WARNING</constant> était émis à la place.
-</para>
-<para xmlns="http://docbook.org/ns/docbook">
+</simpara>
+<simpara xmlns="http://docbook.org/ns/docbook">
 À partir de PHP 8.0.0, une <classname>ValueError</classname> est lancée si <literal>[precision]</literal> est inférieur à zéro ou supérieur à <constant>PHP_INT_MAX</constant>.
 Antérieur à PHP 8.0.0, un <constant>E_WARNING</constant> était émis à la place.
-</para>
-<para xmlns="http://docbook.org/ns/docbook">
+</simpara>
+<simpara xmlns="http://docbook.org/ns/docbook">
 À partir de PHP 8.0.0, une <classname>ArgumentCountError</classname> est lancée lorsque moins d&apos;arguments sont donnés que requis.
 Antérieur à PHP 8.0.0, &false; était retourné et un <constant>E_WARNING</constant> était émis à la place.
-</para>
+</simpara>
 '>
 
 <!ENTITY strings.comparison.return '
@@ -4847,73 +4847,73 @@ Antérieur à PHP 8.0.0, &false; était retourné et un <constant>E_WARNING</con
 <varlistentry xmlns="http://docbook.org/ns/docbook">
 <term><parameter>filter</parameter></term>
 <listitem>
-    <para>
+    <simpara>
      Le filtre à appliquer.  
      Peut être un filtre de validation en utilisant l&apos;une des constantes  
      <constant>FILTER_VALIDATE_<replaceable>*</replaceable></constant>, un filtre de  
      nettoyage en utilisant l&apos;une des constantes  
      <constant>FILTER_SANITIZE_<replaceable>*</replaceable></constant> ou <constant>FILTER_UNSAFE_RAW</constant>,  
      ou encore un filtre personnalisé en utilisant <constant>FILTER_CALLBACK</constant>.
-    </para>
-    <para>
+    </simpara>
+    <simpara>
      La valeur par défaut est <constant>FILTER_DEFAULT</constant>,  
      qui est un alias de <constant>FILTER_UNSAFE_RAW</constant>.
-    </para>
+    </simpara>
 </listitem>
 </varlistentry>
 '>
 
 <!-- csprng snippets -->
 <!ENTITY csprng.sources '
-<para xmlns="http://docbook.org/ns/docbook">
+<simpara xmlns="http://docbook.org/ns/docbook">
 Les sources de hasard par ordre de priorité sont les suivantes :
-</para>
+</simpara>
 <itemizedlist xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
 <listitem>
-  <para>
+  <simpara>
    Linux: <link xlink:href="&url.csprng.get-random-2;">getrandom()</link>, <filename>/dev/urandom</filename>
-  </para>
+  </simpara>
 </listitem>
 <listitem>
-   <para>
+   <simpara>
    FreeBSD &gt;= 12 (PHP &gt;= 7.3): <link xlink:href="&url.csprng.get-random-2;">getrandom()</link>, <filename>/dev/urandom</filename>
-  </para>
+  </simpara>
  </listitem>
  <listitem>
-  <para>
+  <simpara>
    Windows (PHP &gt;= 7.2): <link xlink:href="&url.csprng.cng-api;">CNG-API</link>
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Windows: <link xlink:href="&url.csprng.crypt-gen-random;">CryptGenRandom</link>
-  </para>
+  </simpara>
  </listitem>
  <listitem>
-  <para>
+  <simpara>
    macOS (PHP &gt;= 8.2; &gt;= 8.1.9; &gt;= 8.0.22 si CCRandomGenerateBytes est disponible au moment de la compilation): CCRandomGenerateBytes()
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    macOS (PHP &gt;= 8.1; &gt;= 8.0.2): arc4random_buf(), <filename>/dev/urandom</filename>
-  </para>
+  </simpara>
  </listitem>
  <listitem>
-  <para>
+  <simpara>
    NetBSD &gt;= 7 (PHP &gt;= 7.1; &gt;= 7.0.1): arc4random_buf(), <filename>/dev/urandom</filename>
-  </para>
+  </simpara>
  </listitem>
  <listitem>
-  <para>
+  <simpara>
    OpenBSD &gt;= 5.5 (PHP &gt;= 7.1; &gt;= 7.0.1): arc4random_buf(), <filename>/dev/urandom</filename>
-  </para>
+  </simpara>
  </listitem>
  <listitem>
-  <para>
+  <simpara>
    DragonflyBSD (PHP &gt;= 8.1): <link xlink:href="&url.csprng.get-random-2;">getrandom()</link>, <filename>/dev/urandom</filename>
-  </para>
+  </simpara>
  </listitem>
  <listitem>
-  <para>
+  <simpara>
    Solaris (PHP &gt;= 8.1): <link xlink:href="&url.csprng.get-random-2;">getrandom()</link>, <filename>/dev/urandom</filename>
-  </para>
+  </simpara>
 </listitem>
 <listitem>
     <simpara>
@@ -4981,9 +4981,9 @@ xmlns="http://docbook.org/ns/docbook"><simpara>Cette fonction a été
 <!ENTITY xml.parser.param '<varlistentry xmlns="http://docbook.org/ns/docbook">
  <term><parameter>parser</parameter></term>
  <listitem>
-  <para>
+  <simpara>
    Le parseur XML.
-  </para>
+  </simpara>
  </listitem>
 </varlistentry>'>
 
@@ -4996,10 +4996,10 @@ xmlns="http://docbook.org/ns/docbook"><simpara>Cette fonction a été
   </simpara>
  </warning>
 </para>
-<para xmlns="http://docbook.org/ns/docbook">
+<simpara xmlns="http://docbook.org/ns/docbook">
  Si <parameter>handler</parameter> est un <type>callable</type>,
  l&#39;appelable est défini comme le gestionnaire.
-</para>
+</simpara>
 <para xmlns="http://docbook.org/ns/docbook">
  Si <parameter>handler</parameter> est une <type>string</type>,
  il peut s&#39;agir du nom d&#39;une méthode d&#39;un objet défini avec
@@ -5041,23 +5041,23 @@ xmlns="http://docbook.org/ns/docbook"><simpara>Cette fonction a été
 
 <!-- Migration Guide snippets -->
 <!ENTITY migration56.openssl.peer-verification '
-<para xmlns="http://docbook.org/ns/docbook">
+<simpara xmlns="http://docbook.org/ns/docbook">
     Tous les flux clients cryptés activent désormais la vérification par paire par défaut.
     Par défaut, ceci va utiliser le CA OpenSSL par défaut pour vérifier la paire
     de certificat. Dans la plupart des cas, aucune modification n&#39;a besoin d&#39;être faite
     pour communiquer avec des serveurs et des certificats SSL valides, sachant que les
     distributeurs configurent généralement OpenSSL pour utiliser les CA connus.
-</para>
+</simpara>
 
-<para xmlns="http://docbook.org/ns/docbook">
+<simpara xmlns="http://docbook.org/ns/docbook">
     Le CA par défaut peut être écrasé sur une base globale en utilisant les
     options de configuration openssl.cafile ou openssl.capath, ou via une requête
     basique en utilisant les options de contexte
     <link linkend="context.ssl.cafile"><parameter>cafile</parameter></link> ou
     <link linkend="context.ssl.capath"><parameter>capath</parameter></link>.
-</para>
+</simpara>
 
-<para xmlns="http://docbook.org/ns/docbook">
+<simpara xmlns="http://docbook.org/ns/docbook">
     Bien que ce ne soit pas conseillé en général, il est possible de désactiver la
     vérification de certificats par paire pour une requête en définissant l&#39;option
     de contexte <link linkend="context.ssl.verify-peer"><parameter>verify_peer</parameter></link>
@@ -5065,7 +5065,7 @@ xmlns="http://docbook.org/ns/docbook"><simpara>Cette fonction a été
     l&#39;option de contexte
     <link linkend="context.ssl.verify-peer-name"><parameter>verify_peer_name</parameter></link>
     à &false;.
-</para>
+</simpara>
 '>
 
 <!--


### PR DESCRIPTION
Sync depuis https://github.com/php/doc-en/pull/5522 : remplacement structurel de `<para>` par `<simpara>` dans les entités concernées de `language-snippets.ent`, miroir de l'upstream.

Petites corrections françaises au passage (apostrophes, accords féminins sur `connexion`, `Notez que` -> `Il est à noter que` per TRADUCTIONS.txt, et reformulation légère du dernier paragraphe de `caution.mt19937-tiny-seed`).

Fixes #2785