### PR TITLE
Sync with EN documentation (debug_backtrace, php/doc-en@86a4b30f)

### DIFF
--- a/reference/errorfunc/functions/debug-backtrace.xml
+++ b/reference/errorfunc/functions/debug-backtrace.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: a124543dd3f6b1e5567b07420d23899e582514dc Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 86a4b30f22f16793d60adbce234d3786b9f3500e Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="function.debug-backtrace" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -77,7 +77,7 @@
             <row>
              <entry><code>debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS)</code></entry>
              <entry morerows="1" valign="middle">
-              Omet l'index <literal>"object"</literal> <emphasis>et</emphasis> l'index <literal>"args"</literal>.
+              Omet <emphasis>à la fois</emphasis> l'index <literal>"object"</literal> <emphasis>et</emphasis> l'index <literal>"args"</literal>.
              </entry>
             </row>
             <row>


### PR DESCRIPTION
Fixes #2788