### PR TITLE
[Sync EN] ext/zip: Change <para> to <simpara> (#5536)

### DIFF
--- a/reference/zip/book.xml
+++ b/reference/zip/book.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: aebf045bfb7f4f2350db5e1e908cf290be334075 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 
 <book xml:id="book.zip" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -10,10 +10,10 @@
  <!-- {{{ preface -->
  <preface xml:id="intro.zip">
   &reftitle.intro;
-  <para>
+  <simpara>
    Cette extension offre la possibilité de lire et d'écrire des archives
    compressées ZIP, et d'accéder aux fichiers et dossiers s'y trouvant.
-  </para>
+  </simpara>
  </preface>
  <!-- }}} -->
 

--- a/reference/zip/configure.xml
+++ b/reference/zip/configure.xml
@@ -1,46 +1,46 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 7747acdc55fe497b9e920d6edcbe70c71e03ea30 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <section xml:id="zip.installation" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.install;
 
  <section xml:id="zip.installation.linux">
   <title>Systèmes Linux</title>
-  <para>
+  <simpara>
    Pour utiliser ces fonctions, PHP doit être compilé avec le support ZIP
    en utilisant l'option de configuration <option role="configure">--with-zip</option>.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Avant PHP 7.4.0, libzip était inclus avec PHP,
    et pour compiler l'extension, il fallait utiliser l'option de
    configuration <option role="configure">--enable-zip</option>.
    À partir de PHP 7.3.0, il était déconseillé de construire avec la version incluse de libzip, mais cela restait possible en utilisant l'option de configuration <option role="configure">--without-libzip</option>.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Une option de configuration
    <option role="configure">--with-libzip=DIR</option>
    a été ajoutée pour utiliser une installation système de libzip.
    La version 0.11 de libzip est requise, avec la recommandation d'utiliser la version 0.11.2 ou ultérieure.
-  </para>
+  </simpara>
  </section>
 
  <section xml:id="zip.installation.new.windows">
   <title>Windows</title>
-  <para>
+  <simpara>
    À partir de PHP 8.2.0, la DLL <filename>php_zip.dll</filename> doit être
    <link linkend="install.pecl.windows.loading">activée</link> dans
    &php.ini;.
    Précédemment, cette extension était intégrée.
-  </para>
+  </simpara>
  </section>
 
  <section xml:id="zip.pecl.installation">
   <title>Installation via PECL</title>
-  <para>
+  <simpara>
    &pecl.info;
    <link xlink:href="&url.pecl.package;zip">&url.pecl.package;zip</link>.
-  </para>
+  </simpara>
  </section>
 
 </section>

--- a/reference/zip/constants.xml
+++ b/reference/zip/constants.xml
@@ -1,20 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 8afee82662753fe5ed0c3b8003b14118f00547ef Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no Maintainer: yannick -->
 
 <appendix xml:id="zip.constants" xmlns="http://docbook.org/ns/docbook">
  &reftitle.constants;
  &extension.constants;
 
-  <para>
+  <simpara>
    <classname>ZipArchive</classname> utilise des constantes de classe.
    Il existe différents types de constantes, dont les principaux sont les suivants :
    Les drapeaux globaux (préfixés par <literal>AFL_</literal>),
    les options (préfixées par <literal>FL_</literal>),
    les erreurs (préfixées par <literal>ER_</literal>)
    ou les modes (sans préfixe).
-  </para>
+  </simpara>
 
  <variablelist xml:id="ziparchive.constants.mode">
   <title>Modes d'ouverture de l'archive</title>

--- a/reference/zip/examples.xml
+++ b/reference/zip/examples.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: bac24fafb415f56925732ef41ec7b2326ded3d8e Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes Maintainer: yannick -->
 
 <chapter xml:id="zip.examples" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -80,12 +80,12 @@ print_r($odt_meta);
 ]]>
   </programlisting>
  </example>
- <para>
+ <simpara>
   Cet exemple utilise l'ancienne API (PHP 4) ; il ouvre une archive
   ZIP, lit chaque fichier de l'archive et affiche son contenu.
   L'archive <filename>test2.zip</filename> utilisée dans cet exemple
   est une des archives de test, se trouvant dans les sources de ZZIPlib.
- </para>
+ </simpara>
  <example>
   <title>Exemple d'utilisation de Zip</title>
   <programlisting role="php">

--- a/reference/zip/functions/zip-close.xml
+++ b/reference/zip/functions/zip-close.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 9b1673cf114a1e10c4563ab9223cb56aed552b89 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="function.zip-close" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -19,9 +19,9 @@
    <type>void</type><methodname>zip_close</methodname>
    <methodparam><type>resource</type><parameter>zip</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    <function>zip_close</function> ferme l'archive ZIP donnée.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -30,9 +30,9 @@
     <varlistentry>
      <term><parameter>zip</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Un fichier ZIP précédemment ouvert avec la fonction <function>zip_open</function>.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -40,9 +40,9 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.void;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">

--- a/reference/zip/functions/zip-entry-close.xml
+++ b/reference/zip/functions/zip-entry-close.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 9b1673cf114a1e10c4563ab9223cb56aed552b89 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="function.zip-entry-close" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -19,9 +19,9 @@
    <type>bool</type><methodname>zip_entry_close</methodname>
    <methodparam><type>resource</type><parameter>zip_entry</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    <function>zip_entry_close</function> ferme un dossier d'archive donné.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -30,10 +30,10 @@
     <varlistentry>
      <term><parameter>zip_entry</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Un dossier d'archive précédemment ouvert avec la fonction
        <function>zip_entry_open</function>.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -41,9 +41,9 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">

--- a/reference/zip/functions/zip-entry-compressedsize.xml
+++ b/reference/zip/functions/zip-entry-compressedsize.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 9b1673cf114a1e10c4563ab9223cb56aed552b89 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="function.zip-entry-compressedsize" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -19,10 +19,10 @@
    <type class="union"><type>int</type><type>false</type></type><methodname>zip_entry_compressedsize</methodname>
    <methodparam><type>resource</type><parameter>zip_entry</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    <function>zip_entry_compressedsize</function> retourne la taille compressée
    d'un dossier d'archives donné.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -31,10 +31,10 @@
     <varlistentry>
      <term><parameter>zip_entry</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Un dossier d'archives retourné par la fonction
        <function>zip_read</function>.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -42,9 +42,9 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    La taille compressée, &return.falseforfailure;.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">

--- a/reference/zip/functions/zip-entry-compressionmethod.xml
+++ b/reference/zip/functions/zip-entry-compressionmethod.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 9b1673cf114a1e10c4563ab9223cb56aed552b89 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="function.zip-entry-compressionmethod" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -19,10 +19,10 @@
    <type class="union"><type>string</type><type>false</type></type><methodname>zip_entry_compressionmethod</methodname>
    <methodparam><type>resource</type><parameter>zip_entry</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    <function>zip_entry_compressionmethod</function> retourne la méthode de compression
    utilisée sur le dossier d'archives spécifié par <parameter>zip_entry</parameter>.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -31,9 +31,9 @@
     <varlistentry>
      <term><parameter>zip_entry</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Un dossier d'archives retourné par la fonction <function>zip_read</function>.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -41,9 +41,9 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    La méthode de compression, &return.falseforfailure;.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">

--- a/reference/zip/functions/zip-entry-filesize.xml
+++ b/reference/zip/functions/zip-entry-filesize.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 9b1673cf114a1e10c4563ab9223cb56aed552b89 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="function.zip-entry-filesize" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -19,10 +19,10 @@
    <type class="union"><type>int</type><type>false</type></type><methodname>zip_entry_filesize</methodname>
    <methodparam><type>resource</type><parameter>zip_entry</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    <function>zip_entry_filesize</function> retourne la taille décompressée
    d'un dossier d'archives donné.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -31,10 +31,10 @@
     <varlistentry>
      <term><parameter>zip_entry</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Un dossier d'archives retourné par la fonction
        <function>zip_read</function>.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -42,10 +42,10 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    La taille décompressée du dossier d'archives, &return.falseforfailure;.
-  </para>
- </refsect1> 
+  </simpara>
+ </refsect1>
 
  <refsect1 role="changelog">
   &reftitle.changelog;

--- a/reference/zip/functions/zip-entry-name.xml
+++ b/reference/zip/functions/zip-entry-name.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 9b1673cf114a1e10c4563ab9223cb56aed552b89 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="function.zip-entry-name" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -19,10 +19,10 @@
    <type class="union"><type>string</type><type>false</type></type><methodname>zip_entry_name</methodname>
    <methodparam><type>resource</type><parameter>zip_entry</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    <function>zip_entry_name</function> retourne le nom d'un
    dossier d'archives donné.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -31,9 +31,9 @@
     <varlistentry>
      <term><parameter>zip_entry</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Un dossier d'archives retourné par la fonction <function>zip_read</function>.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -41,9 +41,9 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Le nom du dossier d'archives, &return.falseforfailure;.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">

--- a/reference/zip/functions/zip-entry-open.xml
+++ b/reference/zip/functions/zip-entry-open.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 9b1673cf114a1e10c4563ab9223cb56aed552b89 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="function.zip-entry-open" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -21,10 +21,10 @@
    <methodparam><type>resource</type><parameter>zip_entry</parameter></methodparam>
    <methodparam choice="opt"><type>string</type><parameter>mode</parameter><initializer>"rb"</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    <function>zip_entry_open</function> ouvre un dossier dans un fichier ZIP
    pour lecture.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -33,34 +33,34 @@
     <varlistentry>
      <term><parameter>zip_dp</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Une ressource valide retournée par la fonction
        <function>zip_open</function>.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>zip_entry</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Un dossier d'archives retourné par la fonction
        <function>zip_read</function>.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>mode</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Toutes les méthodes spécifiées dans la documentation
        de la fonction <function>fopen</function>.
-      </para>
+      </simpara>
       <note>
-       <para>
+       <simpara>
         Actuellement, <parameter>mode</parameter> est ignoré et vaut
         toujours <literal>"rb"</literal>. Cela est dû au fait que le support ZIP
         de PHP est uniquement en lecture seule.
-       </para>
+       </simpara>
       </note>
      </listitem>
     </varlistentry>
@@ -69,16 +69,16 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
   <note>
-   <para>
+   <simpara>
     Contrairement à <function>fopen</function> et les autres fonctions
     de fichiers, la valeur retournée par <function>zip_entry_open</function>
     indique uniquement le résultat de l'opération, et n'est pas nécessaire
     pour la lecture ou la fermeture du fichier de dossier d'archives.
-   </para>
+   </simpara>
   </note>
  </refsect1>
 

--- a/reference/zip/functions/zip-entry-read.xml
+++ b/reference/zip/functions/zip-entry-read.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 9b1673cf114a1e10c4563ab9223cb56aed552b89 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="function.zip-entry-read" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -20,9 +20,9 @@
    <methodparam><type>resource</type><parameter>zip_entry</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>len</parameter><initializer>1024</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    <function>zip_entry_read</function> lit dans un dossier d'archives ouvert.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -31,22 +31,22 @@
     <varlistentry>
      <term><parameter>zip_entry</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Un dossier d'archives retourné par la fonction
        <function>zip_read</function>.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>len</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Le nombre d'octets à retourner.
-      </para>
+      </simpara>
       <note>
-       <para>
+       <simpara>
         Ceci doit être la taille non-compressée qu'on souhaite lire.
-       </para>
+       </simpara>
       </note>
      </listitem>
     </varlistentry>
@@ -55,10 +55,10 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retourne les données lues, une chaîne vide si l'on est à la
    fin du fichier, ou &false; si une erreur survient.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">

--- a/reference/zip/functions/zip-open.xml
+++ b/reference/zip/functions/zip-open.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 9b1673cf114a1e10c4563ab9223cb56aed552b89 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="function.zip-open" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -19,9 +19,9 @@
    <type class="union"><type>resource</type><type>int</type><type>false</type></type><methodname>zip_open</methodname>
    <methodparam><type>string</type><parameter>filename</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    <function>zip_open</function> ouvre une nouvelle archive ZIP pour lecture.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -30,9 +30,9 @@
     <varlistentry>
      <term><parameter>filename</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Le nom du fichier de l'archive ZIP à ouvrir.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -40,13 +40,13 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retourne une ressource à utiliser
    plus tard avec les fonctions <function>zip_read</function> et
    <function>zip_close</function>, ou bien retourne soit &false;,
    soit le numéro de l'erreur si le paramètre <parameter>filename</parameter>
    n'existe pas ou dans le cas d'une autre erreur.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">

--- a/reference/zip/functions/zip-read.xml
+++ b/reference/zip/functions/zip-read.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 9b1673cf114a1e10c4563ab9223cb56aed552b89 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="function.zip-read" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -19,10 +19,10 @@
    <type class="union"><type>resource</type><type>false</type></type><methodname>zip_read</methodname>
    <methodparam><type>resource</type><parameter>zip</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    <function>zip_read</function> lit la prochaine entrée dans une archive
    ZIP.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -32,10 +32,10 @@
     <varlistentry>
      <term><parameter>zip</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Un fichier ZIP précédemment ouvert avec la fonction
        <function>zip_open</function>.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -43,12 +43,12 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retourne une ressource de dossier d'archive,
    à utiliser plus tard avec les autres fonctions de la bibliothèque,
    &false; s'il n'y a plus d'entrées à lire dans l'archive ZIP ou le numéro
    de l'erreur si une erreur survient.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">

--- a/reference/zip/setup.xml
+++ b/reference/zip/setup.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 765b2d6eec7dfbaeed900b32aa91a1360d73df42 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no Maintainer: yannick -->
 
 <chapter xml:id="zip.setup" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -9,13 +9,13 @@
  <!-- {{{ Requirements -->
  <section xml:id="zip.requirements">
   &reftitle.required;
-  <para>
+  <simpara>
    Cette extension requiert <link xlink:href="&url.libzip;">libzip</link>.
    Version 1.1.2 était fournie avec PHP jusqu'à la version 7.3.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    La version minimale supportée est 0.11, mais une version ultérieure est vivement recommandée.
-  </para>
+  </simpara>
   <para>
      <simplelist>
       <member>Version 1.2 requise pour le support du chiffrement, voir <methodname>ZipArchive::setEncryptionIndex</methodname></member>
@@ -33,11 +33,11 @@
  <!-- {{{ Resources -->
  <section xml:id="zip.resources">
   &reftitle.resources;
-  <para>
+  <simpara>
    Il y a deux types de ressources utilisées par le module Zip.
    La première est le dossier Zip d'une archive Zip, et la seconde,
    l'entrée Zip de l'archive.
-  </para>
+  </simpara>
  </section>
  <!-- }}} -->
 

--- a/reference/zip/ziparchive.xml
+++ b/reference/zip/ziparchive.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: c0e48705eb88453af785e0e4a6cbd526085dfe3a Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <!-- CREDITS: DavidA -->
 <reference xml:id="class.ziparchive" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
@@ -12,9 +12,9 @@
 <!-- {{{ ZipArchive intro -->
   <section xml:id="ziparchive.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     Un fichier d'archive, compressé avec Zip.
-   </para>
+   </simpara>
   </section>
 <!-- }}} -->
  
@@ -747,46 +747,46 @@
     <varlistentry xml:id="ziparchive.props.lastid">
      <term><varname>lastId</varname></term>
      <listitem>
-      <para>
+      <simpara>
        Valeur de l'index de la dernière entrée (fichier ou dossier)
        Disponible à partir de PHP 8.0.0 et PECL zip 1.18.0.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry xml:id="ziparchive.props.status">
      <term><varname>status</varname></term>
      <listitem>
-      <para>
+      <simpara>
        Le statut de l'archive Zip.
        Disponible pour les archives fermées, à partir de PHP 8.0.0 et PECL zip 1.18.0.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry xml:id="ziparchive.props.statussys">
      <term><varname>statusSys</varname></term>
      <listitem>
-      <para>
+      <simpara>
        Le statut système de l'archive Zip.
        Disponible pour les archives fermées, à partir de PHP 8.0.0 et PECL zip 1.18.0.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry xml:id="ziparchive.props.numfiles">
      <term><varname>numFiles</varname></term>
      <listitem>
-      <para>Le nombre de fichiers dans l'archive</para>
+      <simpara>Le nombre de fichiers dans l'archive</simpara>
      </listitem>
     </varlistentry>
     <varlistentry xml:id="ziparchive.props.filename">
      <term><varname>filename</varname></term>
      <listitem>
-      <para>Le nom du fichier dans le système de fichiers</para>
+      <simpara>Le nom du fichier dans le système de fichiers</simpara>
      </listitem>
     </varlistentry>
     <varlistentry xml:id="ziparchive.props.comment">
      <term><varname>comment</varname></term>
      <listitem>
-      <para>Commentaire pour l'archive</para>
+      <simpara>Commentaire pour l'archive</simpara>
      </listitem>
     </varlistentry>
    </variablelist>

--- a/reference/zip/ziparchive/addemptydir.xml
+++ b/reference/zip/ziparchive/addemptydir.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 0545e305cf06937b14b3f0694d6e716c9881ffd7 Maintainer: dams Status: ready -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="ziparchive.addemptydir" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -13,9 +13,9 @@
    <methodparam><type>string</type><parameter>dirname</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Ajoute un dossier vide dans l'archive Zip.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -25,22 +25,22 @@
     <varlistentry>
      <term><parameter>dirname</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Le dossier à ajouter.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>flags</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Masque de bit consistant de
        <constant>ZipArchive::FL_ENC_GUESS</constant>,
        <constant>ZipArchive::FL_ENC_UTF_8</constant>,
        <constant>ZipArchive::FL_ENC_CP437</constant>.
        Le comportement de ces constantes est décrit sur la page des
        <link linkend="zip.constants">constantes ZIP</link>.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -49,9 +49,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">

--- a/reference/zip/ziparchive/addfile.xml
+++ b/reference/zip/ziparchive/addfile.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: c142be811735a5542c8a2e4c4ed2f81e8cc3acc6 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="ziparchive.addfile" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -16,9 +16,9 @@
    <methodparam choice="opt"><type>int</type><parameter>length</parameter><initializer><constant>ZipArchive::LENGTH_TO_END</constant></initializer></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer><constant>ZipArchive::FL_OVERWRITE</constant></initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Ajoute un fichier à une archive ZIP depuis le chemin fourni.
-  </para>
+  </simpara>
   &zip.filename.separator;
  </refsect1>
 
@@ -29,43 +29,43 @@
     <varlistentry>
      <term><parameter>filepath</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Le chemin vers le fichier à ajouter
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>entryname</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Si fourni, ce sera le nom local dans l'archive ZIP qui écrasera
        le contenu du paramètre <parameter>filepath</parameter>.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>start</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Pour copie partielle, position de départ.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>length</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Pour copie partielle, longueur à copier,
        Si <constant>ZipArchive::LENGTH_TO_END</constant> (0) est spécifié, la taille du fichier est utilisée.
        Si <constant>ZipArchive::LENGTH_UNCHECKED</constant> est spécifié, la totalité du fichier est utilisée
        (à partir de <parameter>start</parameter>).
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>flags</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Masque de bit consistant de
        <constant>ZipArchive::FL_OVERWRITE</constant>,
        <constant>ZipArchive::FL_ENC_GUESS</constant>,
@@ -74,7 +74,7 @@
        <constant>ZipArchive::FL_OPEN_FILE_NOW</constant>.
        Le comportement de ces constantes est décrit sur la page des
        <link linkend="zip.constants">constantes ZIP</link>.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -83,9 +83,9 @@
  
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">
@@ -126,11 +126,11 @@
 
  <refsect1 role="examples">
   &reftitle.examples;
-    <para>
+    <simpara>
      Cet exemple ouvre l'archive ZIP <filename>test.zip</filename>
      et ajoute le fichier <filename>/path/to/index.txt</filename>,
      en tant que <filename>newname.txt</filename>.
-    </para>
+    </simpara>
     <example>
      <title>Ouverture et ajout</title>
      <programlisting role="php">
@@ -152,7 +152,7 @@ if ($zip->open('test.zip') === TRUE) {
  <refsect1 role="notes">
   &reftitle.notes;
   <note>
-   <para>
+   <simpara>
     Lorsqu'un fichier est marqué comme étant à ajouter à l'archive, PHP va 
     verrouiller ce fichier. Le verrou sera relâché uniquement lorsque l'objet
     <classname>ZipArchive</classname> sera fermé, soit via
@@ -160,7 +160,7 @@ if ($zip->open('test.zip') === TRUE) {
     <classname>ZipArchive</classname>. Ceci peut empêcher de supprimer le
     fichier en cours d'ajout même après que le verrou soit
     relâché.       
-   </para>
+   </simpara>
   </note>
  </refsect1>
 

--- a/reference/zip/ziparchive/addfromstring.xml
+++ b/reference/zip/ziparchive/addfromstring.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: c142be811735a5542c8a2e4c4ed2f81e8cc3acc6 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="ziparchive.addfromstring" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -14,9 +14,9 @@
    <methodparam><type>string</type><parameter>content</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer><constant>ZipArchive::FL_OVERWRITE</constant></initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Ajoute un fichier à une archive ZIP en utilisant son contenu.
-  </para>
+  </simpara>
   &zip.filename.separator;
  </refsect1>
  <refsect1 role="parameters">
@@ -26,24 +26,24 @@
     <varlistentry>
      <term><parameter>name</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Le nom de l'entrée à créer
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>content</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Le contenu à utiliser pour créer l'entrée. Ceci est utilisé dans un
        mode binaire sécurisé.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>flags</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Masque de bit consistant de
        <constant>ZipArchive::FL_OVERWRITE</constant>,
        <constant>ZipArchive::FL_ENC_GUESS</constant>,
@@ -51,7 +51,7 @@
        <constant>ZipArchive::FL_ENC_CP437</constant>.
        Le comportement de ces constantes est décrit sur la page des
        <link linkend="zip.constants">constantes ZIP</link>.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -59,9 +59,9 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">

--- a/reference/zip/ziparchive/addglob.xml
+++ b/reference/zip/ziparchive/addglob.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 976425d4f6eec32448be3cc22ec063015921b753 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="ziparchive.addglob" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -15,10 +15,10 @@
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>0</initializer></methodparam>
    <methodparam choice="opt"><type>array</type><parameter>options</parameter><initializer>[]</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Ajoute des fichiers d'un dossier qui correspondent à un masque glob
    <parameter>pattern</parameter>.
-  </para>
+  </simpara>
   &zip.filename.separator;
  </refsect1>
 
@@ -28,17 +28,17 @@
    <varlistentry>
     <term><parameter>pattern</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       Un masque <function>glob</function>.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>flags</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       Un masque d'octets de drapeaux <literal>glob()</literal>.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
@@ -48,39 +48,39 @@
       Un tableau associatif d'options. Les options disponibles sont :
       <itemizedlist>
        <listitem>
-        <para>
+        <simpara>
          <literal>"add_path"</literal>
-        </para>
-        <para>
+        </simpara>
+        <simpara>
          Préfixe à ajouter lors de la traduction du chemin local du fichier
          dans l'archive. Il sera appliqué après les opérations de suppression
          définies par l'option <literal>"remove_path"</literal> ou l'option
          <literal>"remove_all_path"</literal>.
-        </para>
+        </simpara>
        </listitem>
        <listitem>
-        <para>
+        <simpara>
          <literal>"remove_path"</literal>
-        </para>
-        <para>
+        </simpara>
+        <simpara>
          Préfixe à supprimer des chemins des fichiers avant de les ajouter
          à l'archive.
-        </para>
+        </simpara>
        </listitem>
        <listitem>
-        <para>
+        <simpara>
          <literal>"remove_all_path"</literal>
-        </para>
-        <para>
+        </simpara>
+        <simpara>
          &true; pour utiliser le nom du fichier uniquement, et ajouter
          les fichiers directement à la racine de l'archive.
-        </para>
+        </simpara>
        </listitem>
        <listitem>
-        <para>
+        <simpara>
          <literal>"flags"</literal>
-        </para>
-        <para>
+        </simpara>
+        <simpara>
          Masque de bit consistant de
          <constant>ZipArchive::FL_OVERWRITE</constant>,
          <constant>ZipArchive::FL_ENC_GUESS</constant>,
@@ -89,41 +89,41 @@
          <constant>ZipArchive::FL_OPEN_FILE_NOW</constant>.
          Le comportement de ces constantes est décrit sur la page des
          <link linkend="zip.constants">constantes ZIP</link>.
-        </para>
+        </simpara>
        </listitem>
        <listitem>
-        <para>
+        <simpara>
          <literal>"comp_method"</literal>
-        </para>
-        <para>
+        </simpara>
+        <simpara>
          Méthode de compression, l'une des constantes
          <constant>ZipArchive::CM_<replaceable>*</replaceable></constant>.
-        </para>
+        </simpara>
        </listitem>
        <listitem>
-        <para>
+        <simpara>
          <literal>"comp_flags"</literal>
-        </para>
-        <para>
+        </simpara>
+        <simpara>
          Niveau de compression.
-        </para>
+        </simpara>
        </listitem>
        <listitem>
-        <para>
+        <simpara>
          <literal>"enc_method"</literal>
-        </para>
-        <para>
+        </simpara>
+        <simpara>
          Méthode de chiffrement, l'une des constantes
          <constant>ZipArchive::EM_<replaceable>*</replaceable></constant>.
-        </para>
+        </simpara>
        </listitem>
        <listitem>
-        <para>
+        <simpara>
          <literal>"enc_password"</literal>
-        </para>
-        <para>
+        </simpara>
+        <simpara>
          Mot de passe utilisé pour le chiffrement.
-        </para>
+        </simpara>
        </listitem>
       </itemizedlist>
      </para>
@@ -134,9 +134,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Un &array; des fichiers ajoutés en cas de succès &return.falseforfailure;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">
@@ -181,9 +181,9 @@
   &reftitle.examples;
   <example xml:id="ziparchive.addglob.example.basic">
    <title>Exemple avec <methodname>ZipArchive::addGlob</methodname></title>
-   <para>
+   <simpara>
     Ajoute tous les scripts PHP et les fichiers textes du dossier courant.
-   </para>
+   </simpara>
    <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/zip/ziparchive/addpattern.xml
+++ b/reference/zip/ziparchive/addpattern.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 476ab39857fb032076f280fa5397ed483bf7e28d Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="ziparchive.addpattern" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -15,11 +15,11 @@
    <methodparam choice="opt"><type>string</type><parameter>path</parameter><initializer>"."</initializer></methodparam>
    <methodparam choice="opt"><type>array</type><parameter>options</parameter><initializer>[]</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Ajoute des fichiers depuis un dossier qui correspondent à l'expression
    régulière <parameter>pattern</parameter>. L'opération n'est pas récursive.
    L'expression régulière sera uniquement exécutée sur le nom des fichiers.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -28,26 +28,26 @@
    <varlistentry>
     <term><parameter>pattern</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       Une expression régulière <link linkend="book.pcre">PCRE</link>.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>path</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       Le dossier à analyser. Par défaut, le dossier courant.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>options</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       Un tableau associatif d'options acceptées par la méthode
       <methodname>ZipArchive::addGlob</methodname>.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -55,18 +55,18 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Un &array; des fichiers ajoutés en cas de succès &return.falseforfailure;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">
   &reftitle.examples;
   <example xml:id="ziparchive.addpattern.example.basic">
    <title>Exemple avec <methodname>ZipArchive::addPattern</methodname></title>
-   <para>
+   <simpara>
     Ajoute tous les scripts PHP et les fichiers textes du dossier courant.
-   </para>
+   </simpara>
    <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/zip/ziparchive/clearerror.xml
+++ b/reference/zip/ziparchive/clearerror.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 476ab39857fb032076f280fa5397ed483bf7e28d Maintainer: victor-prdh Status: ready -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="ziparchive.clearerror" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -12,9 +12,9 @@
    <modifier>public</modifier> <type>void</type><methodname>ZipArchive::clearError</methodname>
    <void/>
   </methodsynopsis>
-  <para>
+  <simpara>
    Efface le message d'erreur, les messages système et/ou zip.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -24,9 +24,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.void;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/zip/ziparchive/close.xml
+++ b/reference/zip/ziparchive/close.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 28f0dc949d62c97698ac4a0ca814c3780d8cf318 Maintainer: dams Status: ready -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="ziparchive.close" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -12,16 +12,16 @@
    <modifier>public</modifier> <type>bool</type><methodname>ZipArchive::close</methodname>
    <void/>
   </methodsynopsis>
-  <para>
+  <simpara>
    Ferme une archive ouverte ou nouvellement créée et sauvegarde
    les modifications. Cette méthode est appelée automatiquement
    à la fin du script.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Si l'archive ne contient aucun fichier, elle est complètement supprimée par défaut
    (pas d'enregistrement d'une archive vide) en fonction de la valeur de la constante
    <constant>ZipArchive::AFL_CREATE_OR_KEEP_FILE_FOR_EMPTY_ARCHIVE</constant>
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -31,9 +31,9 @@
  
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/zip/ziparchive/count.xml
+++ b/reference/zip/ziparchive/count.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 476ab39857fb032076f280fa5397ed483bf7e28d Maintainer: jbnahan Status: ready -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="ziparchive.count" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -22,9 +22,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retourne le nombre de fichiers dans l'archive.
-  </para>
+  </simpara>
  </refsect1>
 
 </refentry>

--- a/reference/zip/ziparchive/deleteindex.xml
+++ b/reference/zip/ziparchive/deleteindex.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 476ab39857fb032076f280fa5397ed483bf7e28d Maintainer: dams Status: ready -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="ziparchive.deleteindex" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -12,9 +12,9 @@
    <modifier>public</modifier> <type>bool</type><methodname>ZipArchive::deleteIndex</methodname>
    <methodparam><type>int</type><parameter>index</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Efface une entrée de l'archive en utilisant son index.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -23,9 +23,9 @@
     <varlistentry>
      <term><parameter>index</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Index de l'entrée à effacer
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -33,9 +33,9 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="examples">
   &reftitle.examples;

--- a/reference/zip/ziparchive/deletename.xml
+++ b/reference/zip/ziparchive/deletename.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 476ab39857fb032076f280fa5397ed483bf7e28d Maintainer: jpauli Status: ready -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="ziparchive.deletename" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -12,9 +12,9 @@
    <modifier>public</modifier> <type>bool</type><methodname>ZipArchive::deleteName</methodname>
    <methodparam><type>string</type><parameter>name</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Efface une entrée dans l'archive en utilisant son nom.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -23,9 +23,9 @@
     <varlistentry>
      <term><parameter>name</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Nom de l'entrée à effacer
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -33,9 +33,9 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="examples">
   &reftitle.examples;

--- a/reference/zip/ziparchive/extractto.xml
+++ b/reference/zip/ziparchive/extractto.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: b61758269e3619194047cb5d6d4962734372c0a6 Maintainer: jpauli Status: ready -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="ziparchive.extractto" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -14,22 +14,22 @@
    <methodparam><type>string</type><parameter>pathto</parameter></methodparam>
    <methodparam choice="opt"><type class="union"><type>array</type><type>string</type><type>null</type></type><parameter>files</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Extrait l'archive complète ou les fichiers fournis vers un chemin spécifié.
-  </para>
+  </simpara>
   <warning>
-   <para>
+   <simpara>
     Les permissions par défaut pour les fichiers et dossiers extraits
     donnent le plus large accès possible. Ceci peut être restreint en
     définissant le umask courant, qui peut être changé en utilisant
     <function>umask</function>.
-   </para>
-   <para>
+   </simpara>
+   <simpara>
     Pour des raisons de sécurité, les permissions d'origine ne sont pas restaurées.
     Pour un exemple de comment les restaurer, consulter l'échantillon de code sur la
     <link linkend="ziparchive.getexternalattributesindex.examples.perms">page d'exemple</link>
     de la méthode <methodname>ZipArchive::getExternalAttributesIndex</methodname>.
-   </para>
+   </simpara>
   </warning>
  </refsect1>
 
@@ -40,18 +40,18 @@
     <varlistentry>
      <term><parameter>pathto</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Endroit où l'on doit extraire les fichiers
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>files</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Les entrées à extraire. Ce peut être soit le nom d'une entrée ou un
        tableau de noms
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -60,9 +60,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/zip/ziparchive/getarchivecomment.xml
+++ b/reference/zip/ziparchive/getarchivecomment.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 476ab39857fb032076f280fa5397ed483bf7e28d Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="ziparchive.getarchivecomment" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -12,9 +12,9 @@
    <modifier>public</modifier> <type class="union"><type>string</type><type>false</type></type><methodname>ZipArchive::getArchiveComment</methodname>
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Retourne le commentaire de l'archive ZIP.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -24,10 +24,10 @@
     <varlistentry>
      <term><parameter>flags</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Si ce paramètre est défini à <constant>ZipArchive::FL_UNCHANGED</constant>,
        le commentaire original non modifié sera retourné.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -36,9 +36,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retourne le commentaire de l'archive ZIP&return.falseforfailure;.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/zip/ziparchive/getarchiveflag.xml
+++ b/reference/zip/ziparchive/getarchiveflag.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: bb6e8c9fb1f4cc4c83a67a2c3e031ac3c8c28ccc Maintainer: victor-prdh Status: ready -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="ziparchive.getarchiveflag" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -13,9 +13,9 @@
    <methodparam><type>int</type><parameter>flag</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Retourne la valeur d'un drapeau global de l'archive.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -29,24 +29,24 @@
        Le drapeau global à récupérer, parmi les constantes <literal>AFL_*</literal>:
        <itemizedlist>
         <listitem>
-         <para>
+         <simpara>
           <constant>ZipArchive::AFL_RDONLY</constant>
-         </para>
+         </simpara>
         </listitem>
         <listitem>
-         <para>
+         <simpara>
           <constant>ZipArchive::AFL_IS_TORRENTZIP</constant>
-         </para>
+         </simpara>
         </listitem>
         <listitem>
-         <para>
+         <simpara>
           <constant>ZipArchive::AFL_WANT_TORRENTZIP</constant>
-         </para>
+         </simpara>
         </listitem>
         <listitem>
-         <para>
+         <simpara>
           <constant>ZipArchive::AFL_CREATE_OR_KEEP_FILE_FOR_EMPTY_ARCHIVE</constant>
-         </para>
+         </simpara>
         </listitem>
        </itemizedlist>
       </para>
@@ -55,10 +55,10 @@
     <varlistentry>
      <term><parameter>flags</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Si <parameter>flags</parameter> est défini comme <constant>ZipArchive::FL_UNCHANGED</constant>,
        le drapeau original est inchangé et retourné.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -67,9 +67,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retourne 1 si le drapeau est défini pour l'archive, 0 si non, et -1 si une erreur s'est produite.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/zip/ziparchive/getcommentindex.xml
+++ b/reference/zip/ziparchive/getcommentindex.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 476ab39857fb032076f280fa5397ed483bf7e28d Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="ziparchive.getcommentindex" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -13,9 +13,9 @@
    <methodparam><type>int</type><parameter>index</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Retourne le commentaire d'une entrée en utilisant l'index de l'entrée.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -24,18 +24,18 @@
     <varlistentry>
      <term><parameter>index</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Index de l'entrée
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>flags</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Si ce flag est défini à <constant>ZipArchive::FL_UNCHANGED</constant>,
        le commentaire original est retourné.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -43,9 +43,9 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retourne le commentaire en cas de succès&return.falseforfailure;.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="examples">
   &reftitle.examples;

--- a/reference/zip/ziparchive/getcommentname.xml
+++ b/reference/zip/ziparchive/getcommentname.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 476ab39857fb032076f280fa5397ed483bf7e28d Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="ziparchive.getcommentname" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -13,9 +13,9 @@
    <methodparam><type>string</type><parameter>name</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Retourne le commentaire d'une entrée en utilisant le nom de l'entrée.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -24,18 +24,18 @@
     <varlistentry>
      <term><parameter>name</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Nom de l'entrée
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>flags</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Si ce flag est défini à <constant>ZipArchive::FL_UNCHANGED</constant>,
        le commentaire original est retourné.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -43,9 +43,9 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retourne le commentaire en cas de succès&return.falseforfailure;.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="examples">
   &reftitle.examples;

--- a/reference/zip/ziparchive/getexternalattributesindex.xml
+++ b/reference/zip/ziparchive/getexternalattributesindex.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: b61758269e3619194047cb5d6d4962734372c0a6 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="ziparchive.getexternalattributesindex" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -16,9 +16,9 @@
    <methodparam><type>int</type><parameter role="reference">attr</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Récupére les attributs externes d'une entrée définie par son index.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -27,34 +27,34 @@
     <varlistentry>
      <term><parameter>index</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Index de l'entrée.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>opsys</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        En cas de succès, récupère le code du système d'exploitation défini par une des constantes ZipArchive::OPSYS_.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>attr</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        En cas de succès, récupère les attributs externes, la valeur dépend du système d'exploitation.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>flags</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Si ce drapeau est positionné à <constant>ZipArchive::FL_UNCHANGED</constant>,
        les attributs originaux inchangé sont retournées.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -62,17 +62,17 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="examples">
   &reftitle.examples;
-    <para>
+    <simpara>
       Cet exemple extrait toutes les entrées de
       l'archive ZIP <filename>test.zip</filename> et définit
       les droits Unix à partir des attributs externes.
-    </para>
+    </simpara>
     <example xml:id="ziparchive.getexternalattributesindex.examples.perms">
      <title>Extrait toutes les entrées avec leurs droits Unix</title>
      <programlisting role="php">

--- a/reference/zip/ziparchive/getexternalattributesname.xml
+++ b/reference/zip/ziparchive/getexternalattributesname.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 476ab39857fb032076f280fa5397ed483bf7e28d Maintainer: remi Status: ready -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="ziparchive.getexternalattributesname" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -15,9 +15,9 @@
    <methodparam><type>int</type><parameter role="reference">attr</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Récupère les attributs externes d'une entrée définie par son nom.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -26,34 +26,34 @@
     <varlistentry>
      <term><parameter>name</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Nom de l'entrée.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>opsys</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        En cas de succès, récupère le code du système d'exploitation défini par une des constantes ZipArchive::OPSYS_.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>attr</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        En cas de succès, récupère les attributs externes, la valeur dépend du système d'exploitation.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>flags</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Si ce drapeau est positionné à <constant>ZipArchive::FL_UNCHANGED</constant>,
        les attributs originaux inchangé sont retournées.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -61,9 +61,9 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
 </refentry>
 <!-- Keep this comment at the end of the file

--- a/reference/zip/ziparchive/getfromindex.xml
+++ b/reference/zip/ziparchive/getfromindex.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 476ab39857fb032076f280fa5397ed483bf7e28d Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="ziparchive.getfromindex" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -14,9 +14,9 @@
    <methodparam choice="opt"><type>int</type><parameter>len</parameter><initializer>0</initializer></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Retourne le contenu d'une entrée en utilisant son index.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -25,18 +25,18 @@
     <varlistentry>
      <term><parameter>index</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Index de l'entrée
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>len</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        La longueur à lire depuis l'entrée. Si vaut <literal>0</literal>,
        alors toute l'entrée sera lue.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
@@ -46,14 +46,14 @@
        Le flag à utiliser pour ouvrir l'archive.
        <itemizedlist>
         <listitem>
-         <para>
+         <simpara>
           <constant>ZipArchive::FL_UNCHANGED</constant>
-         </para>
+         </simpara>
         </listitem>
         <listitem>
-         <para>
+         <simpara>
           <constant>ZipArchive::FL_COMPRESSED</constant>
-         </para>
+         </simpara>
         </listitem>
        </itemizedlist>
       </para>
@@ -64,9 +64,9 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retourne le contenu de l'entrée en cas de succès&return.falseforfailure;.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="examples">
   &reftitle.examples;

--- a/reference/zip/ziparchive/getfromname.xml
+++ b/reference/zip/ziparchive/getfromname.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 476ab39857fb032076f280fa5397ed483bf7e28d Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="ziparchive.getfromname" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -15,9 +15,9 @@
    <methodparam choice="opt"><type>int</type><parameter>len</parameter><initializer>0</initializer></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Retourne le contenu de l'entrée en utilisant son nom.
-  </para>
+  </simpara>
  </refsect1>
  
  <refsect1 role="parameters">
@@ -27,18 +27,18 @@
     <varlistentry>
      <term><parameter>name</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Nom de l'entrée
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>len</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        La longueur à lire depuis l'entrée. Si vaut <literal>0</literal>,
        alors toute l'entrée sera lue.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
@@ -49,19 +49,19 @@
        peuvent être utilisées.
        <itemizedlist>
         <listitem>
-         <para>
+         <simpara>
           <constant>ZipArchive::FL_UNCHANGED</constant>
-         </para>
+         </simpara>
         </listitem>
         <listitem>
-         <para>
+         <simpara>
           <constant>ZipArchive::FL_COMPRESSED</constant>
-         </para>
+         </simpara>
         </listitem>
         <listitem>
-         <para>
+         <simpara>
           <constant>ZipArchive::FL_NOCASE</constant>
-         </para>
+         </simpara>
         </listitem>
        </itemizedlist>
       </para>
@@ -73,9 +73,9 @@
  
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retourne le contenu de l'entrée en cas de succès&return.falseforfailure;.
-  </para>
+  </simpara>
  </refsect1>
  
  <refsect1 role="examples">

--- a/reference/zip/ziparchive/getnameindex.xml
+++ b/reference/zip/ziparchive/getnameindex.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 476ab39857fb032076f280fa5397ed483bf7e28d Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="ziparchive.getnameindex" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -13,9 +13,9 @@
    <methodparam><type>int</type><parameter>index</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Retourne le nom d'une entrée en utilisant son index.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -24,18 +24,18 @@
     <varlistentry>
      <term><parameter>index</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Index de l'entrée
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>flags</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Si ce paramètre est défini à <constant>ZipArchive::FL_UNCHANGED</constant>,
        le nom original non modifié sera retourné.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -43,9 +43,9 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retourne le nom en cas de succès&return.falseforfailure;.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="examples">
   &reftitle.examples;

--- a/reference/zip/ziparchive/getstatusstring.xml
+++ b/reference/zip/ziparchive/getstatusstring.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 0545e305cf06937b14b3f0694d6e716c9881ffd7 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes Maintainer: yannick -->
 <refentry xml:id="ziparchive.getstatusstring" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -12,9 +12,9 @@
    <modifier>public</modifier> <type>string</type><methodname>ZipArchive::getStatusString</methodname>
    <void/>
   </methodsynopsis>
-  <para>
+  <simpara>
    Retourne le message du statut de l'erreur, du système ou de zip.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -24,9 +24,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retourne une &string; contenant le message du statut.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">

--- a/reference/zip/ziparchive/getstream.xml
+++ b/reference/zip/ziparchive/getstream.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 476ab39857fb032076f280fa5397ed483bf7e28d Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="ziparchive.getstream" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -13,10 +13,10 @@
    <modifier>public</modifier> <type class="union"><type>resource</type><type>false</type></type><methodname>ZipArchive::getStream</methodname>
    <methodparam><type>string</type><parameter>name</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Récupère un gestionnaire de fichier pour l'entrée définie par son nom.
    Actuellement, cette fonction ne supporte que les opérations de lecture.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -26,9 +26,9 @@
     <varlistentry>
      <term><parameter>name</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Le nom de l'entrée à utiliser
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -37,9 +37,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retourne un pointeur de fichier (ressource) en cas de succès,&return.falseforfailure;.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/zip/ziparchive/getstreamindex.xml
+++ b/reference/zip/ziparchive/getstreamindex.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 476ab39857fb032076f280fa5397ed483bf7e28d Maintainer: victor-prdh Status: ready -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="ziparchive.getstreamindex" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -13,10 +13,10 @@
    <methodparam><type>int</type><parameter>index</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Récupère un gestionnaire de fichier pour l'entrée définie par son index. Actuellement,
    cette fonction ne supporte que les opérations de lecture.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -25,18 +25,18 @@
     <varlistentry>
      <term><parameter>index</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        L'index de l'entrée à utiliser.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>flags</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Si flags est défini sur <constant>ZipArchive::FL_UNCHANGED</constant>, le flux original
        est renvoyé.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -44,9 +44,9 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retourne un pointeur de fichier (ressource) en cas de succès&return.falseforfailure;.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="examples">
   &reftitle.examples;

--- a/reference/zip/ziparchive/getstreamname.xml
+++ b/reference/zip/ziparchive/getstreamname.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 476ab39857fb032076f280fa5397ed483bf7e28d Maintainer: victor-prdh Status: ready -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="ziparchive.getstreamname" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -13,10 +13,10 @@
    <methodparam><type>string</type><parameter>name</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Récupère un gestionnaire de fichier pour l'entrée définie par son nom. Actuellement,
    cette fonction ne supporte que les opérations de lecture.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -25,18 +25,18 @@
     <varlistentry>
      <term><parameter>name</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Le nom de l'entrée à utiliser.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>flags</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Si flags est défini sur <constant>ZipArchive::FL_UNCHANGED</constant>, le flux original
        est renvoyé.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -44,9 +44,9 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retourne un pointeur de fichier (ressource) en cas de succès&return.falseforfailure;.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="examples">
   &reftitle.examples;

--- a/reference/zip/ziparchive/iscompressionmethoddupported.xml
+++ b/reference/zip/ziparchive/iscompressionmethoddupported.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 976425d4f6eec32448be3cc22ec063015921b753 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="ziparchive.iscompressionmethoddupported" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -14,9 +14,9 @@
    <methodparam><type>int</type><parameter>method</parameter></methodparam>
    <methodparam choice="opt"><type>bool</type><parameter>enc</parameter><initializer>&true;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Vérifie si une méthode de compression est supportée par libzip.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -26,19 +26,19 @@
     <varlistentry>
      <term><parameter>method</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        La méthode de compression, une des constantes
        <constant>ZipArchive::CM_<replaceable>*</replaceable></constant>.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>enc</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Si &true;, vérifie la compression, sinon, vérifie la
        décompression.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -47,18 +47,18 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="notes">
   &reftitle.notes;
   <note>
-   <para>
+   <simpara>
     Cette fonction est uniquement disponible si la compilation
     a été réalisée avec ≥ 1.7.0.
-   </para>
+   </simpara>
   </note>
  </refsect1>
 

--- a/reference/zip/ziparchive/isencryptionmethoddupported.xml
+++ b/reference/zip/ziparchive/isencryptionmethoddupported.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 976425d4f6eec32448be3cc22ec063015921b753 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="ziparchive.isencryptionmethoddupported" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -14,9 +14,9 @@
    <methodparam><type>int</type><parameter>method</parameter></methodparam>
    <methodparam choice="opt"><type>bool</type><parameter>enc</parameter><initializer>&true;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Vérifie si une méthode de chiffrement est supportée par libzip.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -26,19 +26,19 @@
     <varlistentry>
      <term><parameter>method</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        La méthode de chiffrement, une des constantes
        <constant>ZipArchive::EM_<replaceable>*</replaceable></constant>.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>enc</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Si &true;, vérifie le chiffrement, sinon, vérifie le
        déchiffrement.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -47,18 +47,18 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="notes">
   &reftitle.notes;
   <note>
-   <para>
+   <simpara>
     Cette fonction est uniquement disponible si l'extension a été compilée avec
     libzip ≥ 1.7.0.
-   </para>
+   </simpara>
   </note>
  </refsect1>
 

--- a/reference/zip/ziparchive/locatename.xml
+++ b/reference/zip/ziparchive/locatename.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 476ab39857fb032076f280fa5397ed483bf7e28d Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="ziparchive.locatename" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -13,9 +13,9 @@
    <methodparam><type>string</type><parameter>name</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Localise une entrée en utilisant son nom.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -24,9 +24,9 @@
     <varlistentry>
      <term><parameter>name</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Le nom de l'entrée à chercher
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
@@ -38,14 +38,14 @@
        d'entre eux.
        <itemizedlist>
         <listitem>
-         <para>
+         <simpara>
           <constant>ZipArchive::FL_NOCASE</constant>
-         </para>
+         </simpara>
         </listitem>
         <listitem>
-         <para>
+         <simpara>
           <constant>ZipArchive::FL_NODIR</constant>
-         </para>
+         </simpara>
         </listitem>
        </itemizedlist>
       </para>
@@ -56,9 +56,9 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retourne l'index de l'entrée en cas de succès&return.falseforfailure;.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="examples">
   &reftitle.examples;

--- a/reference/zip/ziparchive/open.xml
+++ b/reference/zip/ziparchive/open.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 28f0dc949d62c97698ac4a0ca814c3780d8cf318 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="ziparchive.open" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,12 +13,12 @@
    <methodparam><type>string</type><parameter>filename</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Ouvre une archive ZIP nouvelle ou pré-existante pour lecture, écriture et modification.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    À partir de libzip 1.6.0, un fichier vide n'est plus une archive valide.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -27,9 +27,9 @@
     <varlistentry>
      <term><parameter>filename</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Le nom du fichier ZIP à ouvrir.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
@@ -39,29 +39,29 @@
        Le mode à utiliser pour ouvrir l'archive.
        <itemizedlist>
         <listitem>
-         <para>
+         <simpara>
           <constant>ZipArchive::OVERWRITE</constant>
-         </para>
+         </simpara>
         </listitem>
         <listitem>
-         <para>
+         <simpara>
           <constant>ZipArchive::CREATE</constant>
-         </para>
+         </simpara>
         </listitem>
         <listitem>
-         <para>
+         <simpara>
           <constant>ZipArchive::RDONLY</constant>
-         </para>
+         </simpara>
         </listitem>
         <listitem>
-         <para>
+         <simpara>
           <constant>ZipArchive::EXCL</constant>
-         </para>
+         </simpara>
         </listitem>
         <listitem>
-         <para>
+         <simpara>
           <constant>ZipArchive::CHECKCONS</constant>
-         </para>
+         </simpara>
         </listitem>
        </itemizedlist>
       </para>

--- a/reference/zip/ziparchive/registercancelcallback.xml
+++ b/reference/zip/ziparchive/registercancelcallback.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 476ab39857fb032076f280fa5397ed483bf7e28d Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="ziparchive.registercancelcallback" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -13,10 +13,10 @@
    <modifier>public</modifier> <type>bool</type><methodname>ZipArchive::registerCancelCallback</methodname>
    <methodparam><type>callable</type><parameter>callback</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Enregistre une fonction de rappel <parameter>callback</parameter> permettant
-   l'annulation pendant la clôture d'une archive. 
-  </para>
+   l'annulation pendant la clôture d'une archive.
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -26,9 +26,9 @@
     <varlistentry>
      <term><parameter>callback</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Si la fonction retourne 0, l'opération continue, sinon, elle sera annulée.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -37,18 +37,18 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">
   &reftitle.examples;
-    <para>
+    <simpara>
      Cet exemple crée un fichier ZIP
      <filename>php.zip</filename> et annule
      l'opération sous certaines conditions.
-    </para>
+    </simpara>
     <example>
      <title>Archivage d'un fichier</title>
      <programlisting role="php">
@@ -70,10 +70,10 @@ if ($zip->open('php.zip', ZipArchive::CREATE | ZipArchive::OVERWRITE)) {
  <refsect1 role="notes">
   &reftitle.notes;
   <note>
-   <para>
+   <simpara>
     Cette fonction est uniquement disponible si l'extension a été
     compilée avec libzip ≥ 1.6.0.
-   </para>
+   </simpara>
   </note>
  </refsect1>
 

--- a/reference/zip/ziparchive/registerprogresscallback.xml
+++ b/reference/zip/ziparchive/registerprogresscallback.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 476ab39857fb032076f280fa5397ed483bf7e28d Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="ziparchive.registerprogresscallback" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -14,10 +14,10 @@
    <methodparam><type>float</type><parameter>rate</parameter></methodparam>
    <methodparam><type>callable</type><parameter>callback</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Enregistre une fonction de rappel <parameter>callback</parameter>
    pour permettre des mises à jour pendant la fermeture de l'archive.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -27,19 +27,19 @@
     <varlistentry>
      <term><parameter>rate</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Modification entre chaque appel de la fonction de rappel
        (de 0.0 à 1.0).
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>callback</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Cette fonction va recevoir le statut <parameter>state</parameter> courant
        sous la forme d'un <type>float</type> (de 0.0 à 1.0).
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -48,17 +48,17 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">
   &reftitle.examples;
-    <para>
+    <simpara>
      Cet exemple crée un fichier archive ZIP
      <filename>php.zip</filename> et affiche la progression.
-    </para>
+    </simpara>
     <example>
      <title>Archive un fichier</title>
      <programlisting role="php">
@@ -79,9 +79,9 @@ if ($zip->open('php.zip', ZipArchive::CREATE | ZipArchive::OVERWRITE)) {
  <refsect1 role="notes">
   &reftitle.notes;
   <note>
-   <para>
+   <simpara>
     Cette fonction n'est disponible que si compilé avec libzip ≥ 1.3.0.
-   </para>
+   </simpara>
   </note>
  </refsect1>
 

--- a/reference/zip/ziparchive/renameindex.xml
+++ b/reference/zip/ziparchive/renameindex.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 476ab39857fb032076f280fa5397ed483bf7e28d Maintainer: dams Status: ready -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="ziparchive.renameindex" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -13,9 +13,9 @@
    <methodparam><type>int</type><parameter>index</parameter></methodparam>
    <methodparam><type>string</type><parameter>new_name</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Renomme une entrée définie par son index.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -24,17 +24,17 @@
     <varlistentry>
      <term><parameter>index</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Index de l'entrée à renommer
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>new_name</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Nouveau nom
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -42,9 +42,9 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="examples">
   &reftitle.examples;

--- a/reference/zip/ziparchive/renamename.xml
+++ b/reference/zip/ziparchive/renamename.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 476ab39857fb032076f280fa5397ed483bf7e28d Maintainer: dams Status: ready -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="ziparchive.renamename" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -13,9 +13,9 @@
    <methodparam><type>string</type><parameter>name</parameter></methodparam>
    <methodparam><type>string</type><parameter>new_name</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Renomme une entrée définie par son nom.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -24,17 +24,17 @@
     <varlistentry>
      <term><parameter>name</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Nom de l'entrée à renommer
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>new_name</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Nouveau nom
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -42,9 +42,9 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="examples">
   &reftitle.examples;

--- a/reference/zip/ziparchive/replacefile.xml
+++ b/reference/zip/ziparchive/replacefile.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: c142be811735a5542c8a2e4c4ed2f81e8cc3acc6 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="ziparchive.replacefile" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -16,9 +16,9 @@
    <methodparam choice="opt"><type>int</type><parameter>length</parameter><initializer><constant>ZipArchive::LENGTH_TO_END</constant></initializer></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Remplace un fichier d'une archive ZIP avec un fichier donné.
-  </para>
+  </simpara>
   &zip.filename.separator;
  </refsect1>
  <refsect1 role="parameters">
@@ -28,42 +28,42 @@
     <varlistentry>
      <term><parameter>filepath</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Le chemin vers le fichier à ajouter.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>index</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        L'index du fichier à remplacer ; son nom restera inchangé.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>start</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Pour une copie partielle, la position de départ.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>length</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Pour copie partielle, longueur à copier,
        Si <constant>ZipArchive::LENGTH_TO_END</constant> (0) est spécifié, la taille du fichier est utilisée.
        Si <constant>ZipArchive::LENGTH_UNCHECKED</constant> est spécifié, la totalité du fichier est utilisée
        (à partir de <parameter>start</parameter>).
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>flags</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Un masque composé d'une des constantes suivantes :
        <constant>ZipArchive::FL_ENC_GUESS</constant>,
        <constant>ZipArchive::FL_ENC_UTF_8</constant>,
@@ -71,7 +71,7 @@
        <constant>ZipArchive::FL_OPEN_FILE_NOW</constant>.
        Le comportement de ces constantes est décrit sur la page
        des <link linkend="zip.constants">constantes ZIP</link>.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -80,9 +80,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">
@@ -117,11 +117,11 @@
 
  <refsect1 role="examples">
   &reftitle.examples;
-    <para>
+    <simpara>
      Cet exemple ouvre un fichier archive ZIP
      <filename>test.zip</filename> et remplace l'index 1 par
      <filename>/path/to/index.txt</filename>.
-    </para>
+    </simpara>
     <example>
      <title>Ouvre et remplace</title>
      <programlisting role="php">

--- a/reference/zip/ziparchive/setarchivecomment.xml
+++ b/reference/zip/ziparchive/setarchivecomment.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 476ab39857fb032076f280fa5397ed483bf7e28d Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="ziparchive.setarchivecomment" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -12,9 +12,9 @@
    <modifier>public</modifier> <type>bool</type><methodname>ZipArchive::setArchiveComment</methodname>
    <methodparam><type>string</type><parameter>comment</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Définit le commentaire d'une archive ZIP.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -23,9 +23,9 @@
     <varlistentry>
      <term><parameter>comment</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Le contenu du commentaire
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -33,9 +33,9 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="examples">
   &reftitle.examples;

--- a/reference/zip/ziparchive/setarchiveflag.xml
+++ b/reference/zip/ziparchive/setarchiveflag.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 28f0dc949d62c97698ac4a0ca814c3780d8cf318 Maintainer: victor-prdh Status: ready -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="ziparchive.setarchiveflag" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -13,9 +13,9 @@
    <methodparam><type>int</type><parameter>flag</parameter></methodparam>
    <methodparam><type>int</type><parameter>value</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Définit un drapeau global d'une archive ZIP.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -28,14 +28,14 @@
        Le drapeau global à changer, parmi les constantes <literal>AFL_*</literal>.
        <itemizedlist>
         <listitem>
-         <para>
+         <simpara>
           <constant>ZipArchive::AFL_WANT_TORRENTZIP</constant>
-         </para>
+         </simpara>
         </listitem>
         <listitem>
-         <para>
+         <simpara>
           <constant>ZipArchive::AFL_CREATE_OR_KEEP_FILE_FOR_EMPTY_ARCHIVE</constant>
-         </para>
+         </simpara>
         </listitem>
        </itemizedlist>
       </para>
@@ -44,9 +44,9 @@
     <varlistentry>
      <term><parameter>value</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        La nouvelle valeur du drapeau.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -55,9 +55,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/zip/ziparchive/setcommentindex.xml
+++ b/reference/zip/ziparchive/setcommentindex.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 476ab39857fb032076f280fa5397ed483bf7e28d Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="ziparchive.setcommentindex" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -13,9 +13,9 @@
    <methodparam><type>int</type><parameter>index</parameter></methodparam>
    <methodparam><type>string</type><parameter>comment</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Définit le commentaire d'une entrée définie par son index.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -24,17 +24,17 @@
     <varlistentry>
      <term><parameter>index</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Index de l'entrée
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>comment</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Le contenu du commentaire
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -42,9 +42,9 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="examples">
   &reftitle.examples;

--- a/reference/zip/ziparchive/setcommentname.xml
+++ b/reference/zip/ziparchive/setcommentname.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 476ab39857fb032076f280fa5397ed483bf7e28d Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="ziparchive.setcommentname" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -13,9 +13,9 @@
    <methodparam><type>string</type><parameter>name</parameter></methodparam>
    <methodparam><type>string</type><parameter>comment</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Définit le commentaire pour une entrée définie par son nom.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -24,17 +24,17 @@
     <varlistentry>
      <term><parameter>name</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Nom de l'entrée
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>comment</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Le contenu du commentaire
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -42,9 +42,9 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="examples">
   &reftitle.examples;

--- a/reference/zip/ziparchive/setcompressionindex.xml
+++ b/reference/zip/ziparchive/setcompressionindex.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 976425d4f6eec32448be3cc22ec063015921b753 Maintainer: jbnahan Status: ready -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="ziparchive.setcompressionindex" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -14,9 +14,9 @@
    <methodparam><type>int</type><parameter>method</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>compflags</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Définit la méthode de compression d'une entrée définie par son index.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -25,26 +25,26 @@
     <varlistentry>
      <term><parameter>index</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Index de l'entrée.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>method</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        La méthode de compression, une des constantes
        <constant>ZipArchive::CM_<replaceable>*</replaceable></constant>.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>compflags</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Niveau de compression.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -52,9 +52,9 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="examples">
   &reftitle.examples;

--- a/reference/zip/ziparchive/setcompressionname.xml
+++ b/reference/zip/ziparchive/setcompressionname.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 976425d4f6eec32448be3cc22ec063015921b753 Maintainer: jbnahan Status: ready -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="ziparchive.setcompressionname" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -14,9 +14,9 @@
    <methodparam><type>int</type><parameter>method</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>compflags</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Définit la méthode de compression d'une entrée définie par son nom.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -25,26 +25,26 @@
     <varlistentry>
      <term><parameter>name</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Nom de l'entrée.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>method</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        La méthode de compression, une des constantes
        <constant>ZipArchive::CM_<replaceable>*</replaceable></constant>.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>compflags</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Niveau de compression.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -52,9 +52,9 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="examples">
   &reftitle.examples;

--- a/reference/zip/ziparchive/setencryptionindex.xml
+++ b/reference/zip/ziparchive/setencryptionindex.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: d76a7fe17dd2488e47d664a8ab38e161b13ac843 Maintainer: jbnahan Status: ready -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="ziparchive.setencryptionindex" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -15,9 +15,9 @@
    <methodparam><type>int</type><parameter>method</parameter></methodparam>
    <methodparam choice="opt"><modifier role="attribute">#[\SensitiveParameter]</modifier><type class="union"><type>string</type><type>null</type></type><parameter>password</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Définit la méthode de chiffrement d'une entrée définie par son index.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -27,25 +27,25 @@
     <varlistentry>
      <term><parameter>index</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Index de l'entrée.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>method</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        La méthode de chiffrement définie par l'une des constantes ZipArchive::EM_.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>password</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Mot de passe optionnel, valeur par défaut utilisée si absent.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -54,9 +54,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">
@@ -84,9 +84,9 @@
  <refsect1 role="notes">
   &reftitle.notes;
   <note>
-   <para>
+   <simpara>
     Cette fonction est seulement disponible quand compilé contre libzip ≥ 1.2.0.
-   </para>
+   </simpara>
   </note>
  </refsect1>
 

--- a/reference/zip/ziparchive/setencryptionname.xml
+++ b/reference/zip/ziparchive/setencryptionname.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: d76a7fe17dd2488e47d664a8ab38e161b13ac843 Maintainer: jbnahan Status: ready -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="ziparchive.setencryptionname" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -14,9 +14,9 @@
    <methodparam><type>int</type><parameter>method</parameter></methodparam>
    <methodparam choice="opt"><modifier role="attribute">#[\SensitiveParameter]</modifier><type class="union"><type>string</type><type>null</type></type><parameter>password</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Définit la méthode de chiffrement d'une entrée définie par son nom.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -25,25 +25,25 @@
     <varlistentry>
      <term><parameter>name</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Nom de l'entrée.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>method</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        La méthode de chiffrement définie par l'une des constantes ZipArchive::EM_.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>password</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Mot de passe optionnel, valeur par défaut utilisée si absent.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -51,9 +51,9 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">
@@ -80,12 +80,12 @@
 
  <refsect1 role="examples">
   &reftitle.examples;
-    <para>
+    <simpara>
      Cet exemple crée un fichier d'archive ZIP
      <filename>test.zip</filename> et ajoute
      le fichier <filename>test.txt</filename>
      chiffré grâce à la méthode AES 256.
-    </para>
+    </simpara>
     <example>
      <title>Archiver et chiffrer un fichier</title>
      <programlisting role="php">
@@ -110,9 +110,9 @@ if ($zip->open('test.zip', ZipArchive::CREATE) === TRUE) {
  <refsect1 role="notes">
   &reftitle.notes;
   <note>
-   <para>
+   <simpara>
     Cette fonction est seulement disponible quand compilé contre libzip ≥ 1.2.0.
-   </para>
+   </simpara>
   </note>
  </refsect1>
 

--- a/reference/zip/ziparchive/setexternalattributesindex.xml
+++ b/reference/zip/ziparchive/setexternalattributesindex.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 476ab39857fb032076f280fa5397ed483bf7e28d Maintainer: remi Status: ready -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="ziparchive.setexternalattributesindex" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -15,9 +15,9 @@
    <methodparam><type>int</type><parameter>attr</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Définit les attributs externes d'une entrée définie par son index.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -26,33 +26,33 @@
     <varlistentry>
      <term><parameter>index</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Index de l'entrée.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>opsys</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Code du système d'exploitation, définie par une des constantes ZipArchive::OPSYS_.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>attr</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Attributs externes, la valeur dépend du système d'exploitation.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>flags</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Drapeaux optionnels. Actuellement inutilisé.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -60,9 +60,9 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
 </refentry>
 <!-- Keep this comment at the end of the file

--- a/reference/zip/ziparchive/setexternalattributesname.xml
+++ b/reference/zip/ziparchive/setexternalattributesname.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 476ab39857fb032076f280fa5397ed483bf7e28d Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="ziparchive.setexternalattributesname" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -15,9 +15,9 @@
    <methodparam><type>int</type><parameter>attr</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Définit les attributs externes d'une entrée définie par son nom.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -26,33 +26,33 @@
     <varlistentry>
      <term><parameter>name</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Nom de l'entrée.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>opsys</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Code du système d'exploitation, définie par une des constantes ZipArchive::OPSYS_.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>attr</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Attributs externes, la valeur dépend du système d'exploitation.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>flags</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Drapeaux optionnels. Actuellement inutilisé.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -60,18 +60,18 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="examples">
   &reftitle.examples;
-    <para>
+    <simpara>
      Cet exemple crée une archive ZIP
      <filename>test.zip</filename> et ajoute
      le fichier <filename>test.txt</filename>
      ainsi que ses permissions Unix dans les attributs externes.
-    </para>
+    </simpara>
     <example>
      <title>Archiver un fichier avec ses droits Unix</title>
      <programlisting role="php">

--- a/reference/zip/ziparchive/setmtimeindex.xml
+++ b/reference/zip/ziparchive/setmtimeindex.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 476ab39857fb032076f280fa5397ed483bf7e28d Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="ziparchive.setmtimeindex" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -14,9 +14,9 @@
    <methodparam><type>int</type><parameter>timestamp</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Définit la date de modification d'une entrée définie par son index.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -25,25 +25,25 @@
     <varlistentry>
      <term><parameter>index</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Index de l'entrée.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>timestamp</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        La date de modification (unix timestamp) du fichier.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>flags</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Drapeaux optionnels, non utilisés quant à présent.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -51,19 +51,19 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">
   &reftitle.examples;
-    <para>
+    <simpara>
      Cet exemple crée un fichier archive ZIP
      <filename>test.zip</filename> et ajoute le fichier
      <filename>test.txt</filename> avec les modifications
      quant à la date de modification.
-    </para>
+    </simpara>
     <example>
      <title>Archive un fichier</title>
      <programlisting role="php">
@@ -87,10 +87,10 @@ if ($zip->open('test.zip', ZipArchive::CREATE) === TRUE) {
  <refsect1 role="notes">
   &reftitle.notes;
   <note>
-   <para>
+   <simpara>
     Cette fonction n'est disponible que si l'extension a été
     compilée avec libzip ≥ 1.0.0.
-   </para>
+   </simpara>
   </note>
  </refsect1>
 

--- a/reference/zip/ziparchive/setmtimename.xml
+++ b/reference/zip/ziparchive/setmtimename.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 476ab39857fb032076f280fa5397ed483bf7e28d Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="ziparchive.setmtimename" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -14,9 +14,9 @@
    <methodparam><type>int</type><parameter>timestamp</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Définit la date de modification d'une entrée par son nom.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -25,25 +25,25 @@
     <varlistentry>
      <term><parameter>name</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Nom de l'entrée.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>timestamp</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        La date de modification (unix timestamp) du fichier.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>flags</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Drapeaux optionnels, non utilisés quant à présent.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -51,19 +51,19 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">
   &reftitle.examples;
-    <para>
+    <simpara>
      Cet exemple crée un fichier archive ZIP
      <filename>test.zip</filename> et ajoute le fichier
      <filename>test.txt</filename> avec les modifications
      faites sur la date de modification.
-    </para>
+    </simpara>
     <example>
      <title>Archive un fichier</title>
      <programlisting role="php">
@@ -87,10 +87,10 @@ if ($zip->open('test.zip', ZipArchive::CREATE) === TRUE) {
  <refsect1 role="notes">
   &reftitle.notes;
   <note>
-   <para>
+   <simpara>
     Cette fonction n'est disponible que si l'extension a été compilée
     avec libzip ≥ 1.0.0.
-   </para>
+   </simpara>
   </note>
  </refsect1>
 

--- a/reference/zip/ziparchive/setpassword.xml
+++ b/reference/zip/ziparchive/setpassword.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: d76a7fe17dd2488e47d664a8ab38e161b13ac843 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="ziparchive.setpassword" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,9 +13,9 @@
    <modifier>public</modifier> <type>bool</type><methodname>ZipArchive::setPassword</methodname>
    <methodparam><modifier role="attribute">#[\SensitiveParameter]</modifier><type>string</type><parameter>password</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Définit le mot de passe de l'archive active.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -24,9 +24,9 @@
    <varlistentry>
     <term><parameter>password</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       Le mot de passe à utiliser sur l'archive.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -34,15 +34,15 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
  
  <refsect1 role="notes">
   &reftitle.notes;
   <note>
-   <para>
+   <simpara>
     À partir de PHP 7.2.0 et libzip 1.2.0, le mot de passe est utilisé pour 
     décompresser l'archive, et est également le mot de passe par défaut pour
     <methodname>ZipArchive::setEncryptionName</methodname> et
@@ -51,7 +51,7 @@
     décompresser l'archive ; elle ne permettait pas de transformer une
     <classname>ZipArchive</classname> non protégée par mot de passe en une
     <classname>ZipArchive</classname> protégée par un mot de passe.
-   </para>
+   </simpara>
   </note>
  </refsect1>
 

--- a/reference/zip/ziparchive/statindex.xml
+++ b/reference/zip/ziparchive/statindex.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 476ab39857fb032076f280fa5397ed483bf7e28d Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="ziparchive.statindex" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -13,9 +13,9 @@
    <methodparam><type>int</type><parameter>index</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Cette fonction obtient des informations d'une entrée définie par son index.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -24,19 +24,19 @@
     <varlistentry>
      <term><parameter>index</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Index de l'entrée
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>flags</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        <constant>ZipArchive::FL_UNCHANGED</constant>
        permet d'obtenir les informations du fichier original de l'archive,
        ignorant toutes les modifications effectuées
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -44,9 +44,9 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retourne un tableau contenant les détails de l'entrée&return.falseforfailure;.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="examples">
   &reftitle.examples;

--- a/reference/zip/ziparchive/statname.xml
+++ b/reference/zip/ziparchive/statname.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 476ab39857fb032076f280fa5397ed483bf7e28d Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="ziparchive.statname" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -13,9 +13,9 @@
    <methodparam><type>string</type><parameter>name</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Cette fonction obtient des informations sur l'entrée définie par son nom.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -24,9 +24,9 @@
     <varlistentry>
      <term><parameter>name</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Nom de l'entrée
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
@@ -39,19 +39,19 @@
        ignorant toutes les modifications effectuées.
        <itemizedlist>
         <listitem>
-         <para>
+         <simpara>
           <constant>ZipArchive::FL_NOCASE</constant>
-         </para>
+         </simpara>
         </listitem>
         <listitem>
-         <para>
+         <simpara>
           <constant>ZipArchive::FL_NODIR</constant>
-         </para>
+         </simpara>
         </listitem>
         <listitem>
-         <para>
+         <simpara>
           <constant>ZipArchive::FL_UNCHANGED</constant>
-         </para>
+         </simpara>
         </listitem>
        </itemizedlist>
       </para>
@@ -62,9 +62,9 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retourne un tableau contenant les détails de l'entrée, &return.falseforfailure;.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="examples">
   &reftitle.examples;

--- a/reference/zip/ziparchive/unchangeall.xml
+++ b/reference/zip/ziparchive/unchangeall.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 476ab39857fb032076f280fa5397ed483bf7e28d Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="ziparchive.unchangeall" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -12,9 +12,9 @@
    <modifier>public</modifier> <type>bool</type><methodname>ZipArchive::unchangeAll</methodname>
    <void/>
   </methodsynopsis>
-  <para>
+  <simpara>
    Annule toutes les modifications faites sur l'archive.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -24,9 +24,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
 </refentry>
 <!-- Keep this comment at the end of the file

--- a/reference/zip/ziparchive/unchangearchive.xml
+++ b/reference/zip/ziparchive/unchangearchive.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 476ab39857fb032076f280fa5397ed483bf7e28d Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="ziparchive.unchangearchive" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -12,10 +12,10 @@
    <modifier>public</modifier> <type>bool</type><methodname>ZipArchive::unchangeArchive</methodname>
    <void/>
   </methodsynopsis>
-  <para>
+  <simpara>
    Annule toutes les modifications faites sur l'archive. Actuellement,
    ceci annule uniquement les modifications effectuées sur les commentaires.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -25,9 +25,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
 </refentry>
 <!-- Keep this comment at the end of the file

--- a/reference/zip/ziparchive/unchangeindex.xml
+++ b/reference/zip/ziparchive/unchangeindex.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 476ab39857fb032076f280fa5397ed483bf7e28d Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="ziparchive.unchangeindex" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -12,9 +12,9 @@
    <modifier>public</modifier> <type>bool</type><methodname>ZipArchive::unchangeIndex</methodname>
    <methodparam><type>int</type><parameter>index</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Annule toutes les modifications faites sur une entrée, définie par son index.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -23,9 +23,9 @@
     <varlistentry>
      <term><parameter>index</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Index de l'entrée
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -33,9 +33,9 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
 </refentry>
 <!-- Keep this comment at the end of the file

--- a/reference/zip/ziparchive/unchangename.xml
+++ b/reference/zip/ziparchive/unchangename.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 476ab39857fb032076f280fa5397ed483bf7e28d Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="ziparchive.unchangename" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -12,9 +12,9 @@
    <modifier>public</modifier> <type>bool</type><methodname>ZipArchive::unchangeName</methodname>
    <methodparam><type>string</type><parameter>name</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Annule toutes les modifications faites sur une entrée, définie par son nom.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -23,9 +23,9 @@
     <varlistentry>
      <term><parameter>name</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Nom de l'entrée
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -33,9 +33,9 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
 </refentry>
 <!-- Keep this comment at the end of the file


### PR DESCRIPTION
Miroir tag-à-tag de php/doc-en#5536 sur l'extension zip : `<para>` devient `<simpara>` partout où le contenu est purement inline. Aucun changement traduit.

Fixes #2790