### PR TITLE
[Sync EN] Fix several issues in versions.xml files (#5507)

### DIFF
--- a/appendices/aliases.xml
+++ b/appendices/aliases.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 6d46a5549bcb66444ce7a3b34301420ba7552bc8 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: e2274fb291cb76151378a209e8c92612d1ba5340 Maintainer: yannick Status: ready -->
 <!-- Reviewed: yes -->
 
 <appendix xml:id="aliases" xmlns="http://docbook.org/ns/docbook">
@@ -135,16 +135,6 @@
      <row>
       <entry>imap_fetchtext</entry>
       <entry><function>imap_body</function></entry>
-      <entry><link linkend="ref.imap">IMAP</link></entry>
-     </row>
-     <row>
-      <entry>imap_getmailboxes</entry>
-      <entry><function>imap_list_full</function></entry>
-      <entry><link linkend="ref.imap">IMAP</link></entry>
-     </row>
-     <row>
-      <entry>imap_getsubscribed</entry>
-      <entry><function>imap_lsub_full</function></entry>
       <entry><link linkend="ref.imap">IMAP</link></entry>
      </row>
      <row>
@@ -595,6 +585,11 @@
      <row>
       <entry>pg_setclientencoding</entry>
       <entry><function>pg_set_client_encoding</function></entry>
+      <entry><link linkend="ref.pgsql">PostgreSQL</link></entry>
+     </row>
+     <row>
+      <entry>pg_exec</entry>
+      <entry><function>pg_query</function></entry>
       <entry><link linkend="ref.pgsql">PostgreSQL</link></entry>
      </row>
      <row>

--- a/appendices/aliases.xml
+++ b/appendices/aliases.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: e2274fb291cb76151378a209e8c92612d1ba5340 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: e2274fb291cb76151378a209e8c92612d1ba5340 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 
 <appendix xml:id="aliases" xmlns="http://docbook.org/ns/docbook">


### PR DESCRIPTION
Miroir de php/doc-en#5507 sur la table des aliases : suppression de 2 alias IMAP obsolètes (`imap_getmailboxes`, `imap_getsubscribed`) et ajout de `pg_exec → pg_query`.

Fixes #2798