### PR TITLE
[Sync EN] yar: call.xml add missing parameters, CS (#5492)

### DIFF
--- a/reference/yar/yar_concurrent_client/call.xml
+++ b/reference/yar/yar_concurrent_client/call.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: e2f2172bf114599926878017ab2dce356956fa9e Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: c50df321d2cccb1044219a98d4c5c7677d4b29cf Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="yar-concurrent-client.call" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -23,7 +23,7 @@
   <para>
    Enregistre un appel RPC, mais ne l'envoie pas immédiatement ; il sera
    envoyé pendant l'appel à la méthode
-   <methodname>Yar_Concurrent_Client::loop</methodname>
+   <methodname>Yar_Concurrent_Client::loop</methodname>.
   </para>
  </refsect1>
 
@@ -34,7 +34,7 @@
     <term><parameter>uri</parameter></term>
     <listitem>
      <para>
-      L'URI du serveur RPC (http, tcp)
+       L'URI du serveur RPC (HTTP, TCP).
      </para>
     </listitem>
    </varlistentry>
@@ -42,7 +42,7 @@
     <term><parameter>method</parameter></term>
     <listitem>
      <para>
-      Nom du service (i.e. le nom de la méthode)
+      Nom du service (i.e. le nom de la méthode).
      </para>
     </listitem>
    </varlistentry>
@@ -50,7 +50,7 @@
     <term><parameter>parameters</parameter></term>
     <listitem>
      <para>
-      Paramètres
+      Paramètres.
      </para>
     </listitem>
    </varlistentry>
@@ -62,41 +62,62 @@
      </para>
     </listitem>
    </varlistentry>
+   <varlistentry>
+    <term><parameter>error_callback</parameter></term>
+    <listitem>
+     <simpara>
+      Si cette fonction de rappel est définie, alors Yar l'appellera lorsqu'une erreur surviendra.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>options</parameter></term>
+    <listitem>
+     <simpara>
+      Un &array; d'options.
+      Voir la liste des <link linkend="yar.constants">constantes</link>.
+     </simpara>
+    </listitem>
+   </varlistentry>
   </variablelist>
  </refsect1>
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Un ID unique ; peut être utilisé pour identifier l'appel.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">
   &reftitle.examples;
-  <example>
-   <title>Exemple avec <function>Yar_Concurrent_Client::call</function></title>
+  <informalexample>
    <programlisting role="php">
 <![CDATA[
 <?php
-function callback($retval, $callinfo) {
-     var_dump($retval);
+
+function callback($retval, $callinfo)
+{
+    var_dump($retval);
 }
 
-function error_callback($type, $error, $callinfo) {
+function error_callback($type, $error, $callinfo)
+{
     error_log($error);
 }
 
 Yar_Concurrent_Client::call("http://host/api/", "some_method", array("parameters"), "callback");
-Yar_Concurrent_Client::call("http://host/api/", "some_method", array("parameters"));   // si la fonction de rappel n'est pas spécifiée,
-                                                                               // la fonction de rappel de la boucle sera utilisée
-Yar_Concurrent_Client::call("http://host/api/", "some_method", array("parameters"), "callback", NULL, array(YAR_OPT_PACKAGER => "json"));
-                                                                               // ce serveur accepte le packager json
-Yar_Concurrent_Client::call("http://host/api/", "some_method", array("parameters"), "callback", NULL, array(YAR_OPT_TIMEOUT=>1));
-                                                                               // Délai d'attente maximal personnalisé
 
-//Les requêtes ne sont pas envoyées pour le moment
-?>
+// Si la fonction de rappel n'est pas spécifiée, la fonction de rappel de la boucle sera utilisée
+Yar_Concurrent_Client::call("http://host/api/", "some_method", array("parameters"));
+
+// Ce serveur accepte le packager JSON
+Yar_Concurrent_Client::call("http://host/api/", "some_method", array("parameters"), "callback", NULL, array(YAR_OPT_PACKAGER => "json"));
+
+// Délai d'attente maximal personnalisé
+Yar_Concurrent_Client::call("http://host/api/", "some_method", array("parameters"), "callback", NULL, array(YAR_OPT_TIMEOUT => 1));
+
+// Les requêtes ne sont pas envoyées pour le moment
 ]]>
    </programlisting>
    &example.outputs.similar;
@@ -104,9 +125,8 @@ Yar_Concurrent_Client::call("http://host/api/", "some_method", array("parameters
 <![CDATA[
 ]]>
    </screen>
-  </example>
+  </informalexample>
  </refsect1>
-
 
  <refsect1 role="seealso">
   &reftitle.seealso;


### PR DESCRIPTION
Miroir de php/doc-en#5492 : ajout des paramètres `error_callback` et `options` dans `Yar_Concurrent_Client::call`, et nettoyage de coding style.

Fixes #2797