### PR TITLE
[Sync EN] WASM: enable runnable examples for Predefined Interfaces & Classes (#5485)

### DIFF
--- a/language/predefined/arrayaccess.xml
+++ b/language/predefined/arrayaccess.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4b06b2d5c3a28a13504972df0f0be6deffabb4c5 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 4b06b2d5c3a28a13504972df0f0be6deffabb4c5 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <reference xml:id="class.arrayaccess" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 

--- a/language/predefined/arrayaccess.xml
+++ b/language/predefined/arrayaccess.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 4b06b2d5c3a28a13504972df0f0be6deffabb4c5 Maintainer: yannick Status: ready -->
 <!-- Reviewed: yes -->
 <reference xml:id="class.arrayaccess" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -82,7 +82,6 @@ $obj[] = 'Ajout 1';
 $obj[] = 'Ajout 2';
 $obj[] = 'Ajout 3';
 print_r($obj);
-?>
 ]]>
     </programlisting>
     &example.outputs.similar;
@@ -92,9 +91,9 @@ bool(true)
 int(2)
 bool(false)
 string(10) "Une valeur"
-obj Object
+Obj Object
 (
-    [container:obj:private] => Array
+    [container] => Array
         (
             [un] => 1
             [trois] => 3

--- a/language/predefined/fiber.xml
+++ b/language/predefined/fiber.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: pierrick Status: ready -->
+<!-- EN-Revision: 4b06b2d5c3a28a13504972df0f0be6deffabb4c5 Maintainer: pierrick Status: ready -->
 <!-- Reviewed: no -->
-<reference xml:id="class.fiber" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+<reference xml:id="class.fiber" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude"
+ annotations="non-interactive">
  <title>La classe Fiber</title>
  <titleabbrev>Fiber</titleabbrev>
 

--- a/language/predefined/fiber.xml
+++ b/language/predefined/fiber.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4b06b2d5c3a28a13504972df0f0be6deffabb4c5 Maintainer: pierrick Status: ready -->
+<!-- EN-Revision: 4b06b2d5c3a28a13504972df0f0be6deffabb4c5 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <reference xml:id="class.fiber" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude"
  annotations="non-interactive">

--- a/language/predefined/fibererror.xml
+++ b/language/predefined/fibererror.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: pierrick Status: ready -->
+<!-- EN-Revision: 4b06b2d5c3a28a13504972df0f0be6deffabb4c5 Maintainer: pierrick Status: ready -->
 <!-- Reviewed: no -->
-<reference xml:id="class.fibererror" role="exception" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+<reference xml:id="class.fibererror" role="exception" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude"
+ annotations="non-interactive">
  <title>FiberError</title>
  <titleabbrev>FiberError</titleabbrev>
 

--- a/language/predefined/fibererror.xml
+++ b/language/predefined/fibererror.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4b06b2d5c3a28a13504972df0f0be6deffabb4c5 Maintainer: pierrick Status: ready -->
+<!-- EN-Revision: 4b06b2d5c3a28a13504972df0f0be6deffabb4c5 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <reference xml:id="class.fibererror" role="exception" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude"
  annotations="non-interactive">

--- a/language/predefined/interfaces.xml
+++ b/language/predefined/interfaces.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 267a3d4e60d8a6da941e72d195386b5841052cca Maintainer: girgias Status: ready -->
+<!-- EN-Revision: 4b06b2d5c3a28a13504972df0f0be6deffabb4c5 Maintainer: girgias Status: ready -->
 <!-- Reviewed: yes -->
 
-<part xml:id="reserved.interfaces" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+<part xml:id="reserved.interfaces" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink"
+ annotations="interactive">
  <title>Interfaces et Classes Prédéfinies</title>
 
  <partintro>

--- a/language/predefined/interfaces.xml
+++ b/language/predefined/interfaces.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4b06b2d5c3a28a13504972df0f0be6deffabb4c5 Maintainer: girgias Status: ready -->
+<!-- EN-Revision: 4b06b2d5c3a28a13504972df0f0be6deffabb4c5 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 
 <part xml:id="reserved.interfaces" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink"

--- a/language/predefined/iteratoraggregate.xml
+++ b/language/predefined/iteratoraggregate.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 4b06b2d5c3a28a13504972df0f0be6deffabb4c5 Maintainer: yannick Status: ready -->
 <!-- Reviewed: yes -->
 <reference xml:id="class.iteratoraggregate" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -50,19 +50,13 @@
 
 class myData implements IteratorAggregate
 {
-    public $property1 = "Propriété publique numéro un";
-    public $property2 = "Propriété publique numéro deux";
-    public $property3 = "Propriété publique numéro trois";
-    public $property4 = "";
-
-    public function __construct()
-    {
-        $this->property4 = "dernière propriété";
-    }
-
     public function getIterator(): Traversable
     {
-        return new ArrayIterator($this);
+        return new ArrayIterator([
+            "clé un" => "valeur un",
+            "clé deux" => "valeur deux",
+            "clé trois" => "valeur trois"
+        ]);
     }
 }
 
@@ -72,24 +66,19 @@ foreach($obj as $key => $value) {
     var_dump($key, $value);
     echo "\n";
 }
-
-?>
 ]]>
     </programlisting>
     &example.outputs.similar;
     <screen>
 <![CDATA[
-string(9) "property1"
-string(30) "Propriété publique numéro un"
+string(7) "clé un"
+string(9) "valeur un"
 
-string(9) "property2"
-string(32) "Propriété publique numéro deux"
+string(9) "clé deux"
+string(11) "valeur deux"
 
-string(9) "property3"
-string(33) "Propriété publique numéro trois"
-
-string(9) "property4"
-string(20) "dernière propriété"
+string(10) "clé trois"
+string(12) "valeur trois"
 
 ]]>
     </screen>

--- a/language/predefined/iteratoraggregate.xml
+++ b/language/predefined/iteratoraggregate.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4b06b2d5c3a28a13504972df0f0be6deffabb4c5 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 4b06b2d5c3a28a13504972df0f0be6deffabb4c5 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <reference xml:id="class.iteratoraggregate" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 

--- a/language/predefined/serializable.xml
+++ b/language/predefined/serializable.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 4b06b2d5c3a28a13504972df0f0be6deffabb4c5 Maintainer: yannick Status: ready -->
 <!-- Reviewed: yes -->
 <reference xml:id="class.serializable" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -94,6 +94,7 @@ var_dump($newobj->getData());
     &example.outputs.similar;
     <screen>
 <![CDATA[
+Deprecated: obj implements the Serializable interface, which is deprecated. Implement __serialize() and __unserialize() instead (or in addition, if support for old PHP versions is necessary) in script on line 2
 string(44) "C:3:"obj":29:{s:21:"Mes données privées";}"
 string(21) "Mes données privées"
 ]]>

--- a/language/predefined/serializable.xml
+++ b/language/predefined/serializable.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4b06b2d5c3a28a13504972df0f0be6deffabb4c5 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 4b06b2d5c3a28a13504972df0f0be6deffabb4c5 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <reference xml:id="class.serializable" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 

--- a/language/predefined/unitenum/cases.xml
+++ b/language/predefined/unitenum/cases.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 787d71d9c02bc0329da579ec3ac83729a3d71e3f Maintainer: pierrick Status: ready -->
+<!-- EN-Revision: 4b06b2d5c3a28a13504972df0f0be6deffabb4c5 Maintainer: pierrick Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="unitenum.cases" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -50,21 +50,20 @@ enum Suit
 }
 
 var_dump(Suit::cases());
-?>
 ]]>
    </programlisting>
    &example.outputs;
    <screen>
 <![CDATA[
 array(4) {
-    [0]=>
-    enum(Suit::Hearts)
-    [1]=>
-    enum(Suit::Diamonds)
-    [2]=>
-    enum(Suit::Clubs)
-    [3]=>
-    enum(Suit::Spades)
+  [0]=>
+  enum(Suit::Hearts)
+  [1]=>
+  enum(Suit::Diamonds)
+  [2]=>
+  enum(Suit::Clubs)
+  [3]=>
+  enum(Suit::Spades)
 }
 ]]>
    </screen>

--- a/language/predefined/unitenum/cases.xml
+++ b/language/predefined/unitenum/cases.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4b06b2d5c3a28a13504972df0f0be6deffabb4c5 Maintainer: pierrick Status: ready -->
+<!-- EN-Revision: 4b06b2d5c3a28a13504972df0f0be6deffabb4c5 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="unitenum.cases" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>


### PR DESCRIPTION
Miroir de php/doc-en#5485 : annotations `interactive`/`non-interactive` et refonte des exemples sur les 7 fichiers `language/predefined/` pour le sandbox WASM de php.net.

Fixes #2796