### PR TITLE
[Sync EN] WASM: enable runnable examples for language sections (#5456)

### DIFF
--- a/language/constants.xml
+++ b/language/constants.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: f4f96ef8b2a95283c92ea2183fe1dedf06f3ad22 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 6e885e52412ad979aa5fbb620bb84e886fc0ebe8 Maintainer: yannick Status: ready -->
 <!-- Reviewed: no -->
 <!-- CREDITS: DAnnebicque -->
-<chapter xml:id="language.constants" xmlns="http://docbook.org/ns/docbook">
+<chapter xml:id="language.constants" xmlns="http://docbook.org/ns/docbook" annotations="interactive">
  <title>Les constantes</title>
  <simpara>
   Une constante est un identifiant (un nom) qui représente une valeur
@@ -39,7 +39,7 @@
  <para>
   <example>
    <title>Noms valides et invalides pour les constantes</title>
-   <programlisting role="php">
+   <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 // Noms valides
@@ -54,8 +54,6 @@ define("2FOO",    "something");
 // PHP peut un jour fournir une constante magique nommée
 // ainsi, ce qui va corrompre vos scripts.
 define("__FOO__", "something");
-
-?>
 ]]>
     </programlisting>
    </example>
@@ -186,7 +184,6 @@ define("__FOO__", "something");
   echo CONSTANT; // affiche "Bonjour le monde."
   echo Constant; // Lève une Error : Undefined constant "Constant"
                  // Avant PHP 8.0.0, affiche "Constant" et émet un avertissement.
-?>
 ]]>
     </programlisting>
    </example>
@@ -201,23 +198,22 @@ define("__FOO__", "something");
 // Simple valeur scalaire
 const CONSTANT = 'Bonjour le monde !';
 
-echo CONSTANT;
+echo CONSTANT . "\n";
 
 // Expression scalaire
-const ANOTHER_CONST = CONSTANT.'; Au revoir le monde !';
-echo ANOTHER_CONST;
+const ANOTHER_CONST = CONSTANT . '; Au revoir le monde !';
+echo ANOTHER_CONST . "\n";
 
 const ANIMALS = array('chien', 'chat', 'oiseaux');
-echo ANIMALS[1]; // affiche "chat"
+echo ANIMALS[1] . "\n"; // affiche "chat"
 
 // Tableaux constants
-define('ANIMALS', array(
+define('ANIMALS_DEF', array(
     'chien',
     'chat',
     'oiseaux'
 ));
-echo ANIMALS[1]; // affiche "chat"
-?>
+echo ANIMALS_DEF[1] . "\n"; // affiche "chat"
 ]]>
     </programlisting>
    </example>

--- a/language/constants.xml
+++ b/language/constants.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 6e885e52412ad979aa5fbb620bb84e886fc0ebe8 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 6e885e52412ad979aa5fbb620bb84e886fc0ebe8 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <!-- CREDITS: DAnnebicque -->
 <chapter xml:id="language.constants" xmlns="http://docbook.org/ns/docbook" annotations="interactive">

--- a/language/exceptions.xml
+++ b/language/exceptions.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 6e885e52412ad979aa5fbb620bb84e886fc0ebe8 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 6e885e52412ad979aa5fbb620bb84e886fc0ebe8 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 
 <chapter xml:id="language.exceptions" xmlns="http://docbook.org/ns/docbook" annotations="interactive">

--- a/language/exceptions.xml
+++ b/language/exceptions.xml
@@ -1,9 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: c81a48e58fc530a74827316027fae74668d17a1d Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 6e885e52412ad979aa5fbb620bb84e886fc0ebe8 Maintainer: yannick Status: ready -->
 <!-- Reviewed: no -->
 
-<chapter xml:id="language.exceptions" xmlns="http://docbook.org/ns/docbook">
+<chapter xml:id="language.exceptions" xmlns="http://docbook.org/ns/docbook" annotations="interactive">
  <title>Les exceptions</title>
+ <note>
+  <simpara>Voir aussi la classe <exceptionname>Exception</exceptionname></simpara>
+ </note>
  <para>
   PHP a une gestion des exceptions similaire à ce qu'offrent les autres
   langages de programmation.
@@ -124,7 +127,7 @@
     </para>
     <example>
      <title>Convertir l'error reporting en exceptions</title>
-     <programlisting role="php">
+     <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 function exceptions_error_handler($severity, $message, $filename, $lineno) {
@@ -132,7 +135,6 @@ function exceptions_error_handler($severity, $message, $filename, $lineno) {
 }
 
 set_error_handler('exceptions_error_handler');
-?>
 ]]>
      </programlisting>
     </example>
@@ -169,7 +171,6 @@ try {
 
 // On continue l'exécution
 echo "Bonjour le monde !\n";
-?>
 ]]>
     </programlisting>
     &example.outputs;
@@ -211,7 +212,6 @@ try {
 
 // On continue l'exécution
 echo "Bonjour le monde !\n";
-?>
 ]]>
     </programlisting>
     &example.outputs;
@@ -242,7 +242,6 @@ function test() {
 }
 
 echo test();
-?>
 ]]>
     </programlisting>
     &example.outputs;
@@ -277,8 +276,6 @@ class Test {
 
 $foo = new Test;
 $foo->testing();
-
-?>
 ]]>
     </programlisting>
     &example.outputs;
@@ -310,8 +307,6 @@ class Test {
 
 $foo = new Test;
 $foo->testing();
-
-?>
 ]]>
     </programlisting>
     &example.outputs;
@@ -339,7 +334,6 @@ try {
 } catch (SpecificException) {
     print "Une SpecificException a été levée, mais les détails ne nous intéressent pas.";
 }
-?>
 ]]>
     </programlisting>
     &example.outputs;
@@ -369,7 +363,6 @@ try {
 } catch (Exception $e) {
     print $e->getMessage();
 }
-?>
 ]]>
     </programlisting>
     &example.outputs;
@@ -417,13 +410,13 @@ string(6) "Fourth"
   <title>Étendre les Exceptions</title>
   <para>
    Une classe d'exception définie par l'utilisateur peut être définie en étendant
-   la classe Exception intégrée. Les membres et les propriétés ci-dessous montrent
+   la classe <exceptionname>Exception</exceptionname> intégrée. Les membres et les propriétés ci-dessous montrent
    ce qui est accessible dans la classe enfant qui dérive de la classe Exception
    intégrée.
   </para>
   <example>
    <title>La classe d'exception intégrée</title>
-   <programlisting role="php">
+   <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 class Exception implements Throwable
@@ -451,12 +444,11 @@ class Exception implements Throwable
     // Peut être redéfinie
     public function __toString();               // chaîne formatée pour l'affichage
 }
-?>
 ]]>
    </programlisting>
   </example>
   <para>
-   Si une classe étend la classe Exception intégrée et redéfinit le <link
+   Si une classe étend la classe <exceptionname>Exception</exceptionname> intégrée et redéfinit le <link
    linkend="language.oop5.decon">constructeur</link>, il est fortement recommandé
    qu'elle appelle également <link
    linkend="language.oop5.paamayim-nekudotayim">parent::__construct()</link>
@@ -534,7 +526,7 @@ class TestException
 }
 
 
-// Exemple 1
+echo "# Exemple 1\n";
 try {
     $o = new TestException(TestException::THROW_CUSTOM);
 } catch (MyException $e) {      // Sera capturée
@@ -546,10 +538,9 @@ try {
 
 // Poursuite de l'exécution
 var_dump($o); // Null
-echo "\n\n";
 
 
-// Exemple 2
+echo "\n\n# Exemple 2\n";
 try {
     $o = new TestException(TestException::THROW_DEFAULT);
 } catch (MyException $e) {      // Ne correspond pas à ce type
@@ -561,10 +552,9 @@ try {
 
 // Poursuite de l'exécution
 var_dump($o); // Null
-echo "\n\n";
 
 
-// Exemple 3
+echo "\n\n# Exemple 3\n";
 try {
     $o = new TestException(TestException::THROW_CUSTOM);
 } catch (Exception $e) {        // Sera capturée
@@ -573,10 +563,9 @@ try {
 
 // Poursuite de l'exécution
 var_dump($o); // Null
-echo "\n\n";
 
 
-// Exemple 4
+echo "\n\n# Exemple 4\n";
 try {
     $o = new TestException();
 } catch (Exception $e) {        // Sauté, aucune exception
@@ -585,8 +574,6 @@ try {
 
 // Poursuite de l'exécution
 var_dump($o); // TestException
-echo "\n\n";
-?>
 ]]>
    </programlisting>
   </example>

--- a/language/expressions.xml
+++ b/language/expressions.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 6e885e52412ad979aa5fbb620bb84e886fc0ebe8 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 6e885e52412ad979aa5fbb620bb84e886fc0ebe8 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <chapter xml:id="language.expressions" xmlns="http://docbook.org/ns/docbook" annotations="interactive">
  <title>Les expressions</title>

--- a/language/expressions.xml
+++ b/language/expressions.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: f4f96ef8b2a95283c92ea2183fe1dedf06f3ad22 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 6e885e52412ad979aa5fbb620bb84e886fc0ebe8 Maintainer: yannick Status: ready -->
 <!-- Reviewed: no -->
-<chapter xml:id="language.expressions" xmlns="http://docbook.org/ns/docbook">
+<chapter xml:id="language.expressions" xmlns="http://docbook.org/ns/docbook" annotations="interactive">
  <title>Les expressions</title>
  <simpara>
   Les expressions sont les pièces de construction les plus importantes de PHP.
@@ -26,7 +26,7 @@
   Un exemple plus complexe concerne les fonctions. Par exemple, 
   considérons la fonction suivante :
   <informalexample>
-   <programlisting role="php">
+   <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 function foo ()
@@ -151,7 +151,7 @@ function foo ()
  </para>
  <para>
   <informalexample>
-   <programlisting role="php">
+   <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 $first ? $second : $third
@@ -179,22 +179,32 @@ $first ? $second : $third
 <?php
 function double($i)
 {
-    return $i*2;
+    return $i * 2;
 }
 
 $b = $a = 5;        /* Assigne la valeur 5 aux variables $a et $b  */
 $c = $a++;          /* Post-incrémentation de la variable $a et assignation de
                        la valeur à la variable $c */
+print "a = {$a}; b = {$b}; c = {$c}" . PHP_EOL;
+
 $e = $d = ++$b;     /* Pre-incrémentation, et assignation de la valeur aux
                        variables $d et $e  */
+print "b = {$b}; d = {$d}; e = {$e}" . PHP_EOL;
+
 /* à ce niveau, les variables $d et $e sont égales à 6 */
+
 $f = double($d++);  /* assignation du double de la valeur de $d à la variable $f ($f vaut 12),
                        puis incrémentation de la valeur de $d  */
+print "d = {$d}; f = {$f}" . PHP_EOL;
+
 $g = double(++$e);  /* assigne deux fois la valeur de $e après
                        incrémentation, 2*7 = 14 à $g */
+print "e = {$e}; g = {$g}" . PHP_EOL;
+
 $h = $g += 10;      /* Tout d'abord, $g est incrémentée de 10, et donc $g vaut 24.
                        Ensuite, la valeur de $g, (24) est assignée à la variable $h,
                        qui vaut donc elle aussi 24. */
+print "g = {$g}; h = {$h}" . PHP_EOL;
 ?>
 ]]>
    </programlisting>


### PR DESCRIPTION
Miroir de php/doc-en#5456 : annotations `interactive`/`non-interactive` et refonte des exemples sur `language/{constants,exceptions,expressions}.xml` pour le sandbox WASM de php.net.

Fixes #2795