### PR TITLE
[Sync EN] WASM: Enable runnable examples for language.enumerations section (#5479)

### DIFF
--- a/language/enumerations.xml
+++ b/language/enumerations.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 5744be5a4d239c18d4610581bd32b69a7d82947e Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 1eb67bea30f61f7d9cdfd371146911a0ba07bbd2 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
- <chapter xml:id="language.enumerations" xmlns="http://docbook.org/ns/docbook">
+ <chapter xml:id="language.enumerations" xmlns="http://docbook.org/ns/docbook" annotations="interactive">
   <title>Les énumérations</title>
   <sect1 xml:id="language.enumerations.overview">
    <title>Aperçu des énumérations</title>
@@ -36,10 +36,9 @@
    </para>
 
 
-   <programlisting role="php">
+   <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
-
 enum Suit
 {
     case Hearts;
@@ -47,7 +46,6 @@ enum Suit
     case Clubs;
     case Spades;
 }
-?>
 ]]>
    </programlisting>
 
@@ -59,13 +57,21 @@ enum Suit
     auquel cas seules les valeurs de ce type peuvent être transmises.
    </para>
 
-   <programlisting role="php">
+   <informalexample>
+    <programlisting role="php">
 <![CDATA[
 <?php
+enum Suit
+{
+    case Hearts;
+    case Diamonds;
+    case Clubs;
+    case Spades;
+}
 
 function pick_a_card(Suit $suit)
 {
-    /* ... */
+    var_dump($suit);
 }
 
 $val = Suit::Diamonds;
@@ -78,9 +84,9 @@ pick_a_card(Suit::Clubs);
 
 // TypeError: pick_a_card(): Argument #1 ($suit) must be of type Suit, string given
 pick_a_card('Spades');
-?>
 ]]>
-   </programlisting>
+    </programlisting>
+   </informalexample>
 
    <para>
     Une énumération peut avoir zéro ou plusieurs définitions de <literal>case</literal>, sans maximum.
@@ -97,21 +103,35 @@ pick_a_card('Spades');
     n'est pas égal à <literal>"0"</literal>. Au lieu de cela, chaque cas est soutenu par un objet singleton de ce nom. Cela signifie que :
    </para>
 
-   <programlisting role="php">
+   <informalexample>
+    <programlisting role="php">
 <![CDATA[
 <?php
+enum Suit
+{
+    case Hearts;
+    case Diamonds;
+    case Clubs;
+    case Spades;
+}
 
 $a = Suit::Spades;
 $b = Suit::Spades;
 
-$a === $b; // true
+if ($a === $b) {
+    print "Les couleurs correspondent en utilisant ===\n";
+}
 
-$a instanceof Suit;  // true
+if ($a instanceof Suit) {
+    print "Les couleurs correspondent en utilisant instanceof\n";
+}
 
-$a !== 'Spades'; // true
-?>
+if ($a !== 'Spades') {
+    print "La couleur ne correspond pas à la chaîne\n";
+}
 ]]>
-   </programlisting>
+    </programlisting>
+   </informalexample>
 
    <para>
     Cela signifie également que les valeurs de l'énumération ne sont jamais <literal>&lt;</literal> ou <literal>&gt;</literal> l'une à l'autre,
@@ -132,15 +152,23 @@ $a !== 'Spades'; // true
     Tous les cas ont une propriété en lecture seule, <literal>name</literal>, qui est le nom sensible à la casse du cas lui-même.
    </para>
 
-   <programlisting role="php">
+   <informalexample>
+    <programlisting role="php">
 <![CDATA[
 <?php
+enum Suit
+{
+    case Hearts;
+    case Diamonds;
+    case Clubs;
+    case Spades;
+}
 
 print Suit::Spades->name;
 // Affiche "Spades"
-?>
 ]]>
-   </programlisting>
+    </programlisting>
+   </informalexample>
 
    <para>
     Il est également possible d'utiliser les fonctions <function>defined</function> et <function>constant</function>
@@ -163,10 +191,9 @@ print Suit::Spades->name;
 
   <para>Pour définir un équivalent scalaire pour une énumération, la syntaxe est la suivante :</para>
 
-  <programlisting role="php">
+  <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
-
 enum Suit: string
 {
     case Hearts = 'H';
@@ -174,7 +201,6 @@ enum Suit: string
     case Clubs = 'C';
     case Spades = 'S';
 }
-?>
 ]]>
   </programlisting>
 
@@ -206,31 +232,47 @@ enum Suit: string
    spécifiée dans la définition.
   </para>
 
-  <programlisting role="php">
+  <informalexample>
+   <programlisting role="php">
 <![CDATA[
 <?php
+enum Suit: string
+{
+    case Hearts = 'H';
+    case Diamonds = 'D';
+    case Clubs = 'C';
+    case Spades = 'S';
+}
 
 print Suit::Clubs->value;
 // Affiche "C"
-?>
 ]]>
-  </programlisting>
+   </programlisting>
+  </informalexample>
 
   <para>
    Afin de garantir que la propriété <literal>value</literal> reste en lecture seule, une variable ne peut pas
    être assignée en tant que référence à cette propriété. En d'autres termes, l'opération suivante entraîne une erreur :
   </para>
 
-  <programlisting role="php">
+  <informalexample>
+   <programlisting role="php">
 <![CDATA[
 <?php
+enum Suit: string
+{
+    case Hearts = 'H';
+    case Diamonds = 'D';
+    case Clubs = 'C';
+    case Spades = 'S';
+}
 
 $suit = Suit::Clubs;
 $ref = &$suit->value;
-// Erreur : Impossible d'acquérir une référence à la propriété Suit::$value
-?>
+// Fatal Error: Cannot indirectly modify readonly property Suit::$value
 ]]>
-  </programlisting>
+   </programlisting>
+  </informalexample>
 
   <para>
    Les enums avec valeur de base implémentent une interface interne <interfacename>BackedEnum</interfacename>,
@@ -262,22 +304,37 @@ $ref = &$suit->value;
    dans les deux modes.
   </para>
 
-  <programlisting role="php">
+  <informalexample>
+   <programlisting role="php">
 <![CDATA[
 <?php
-$record = get_stuff_from_database($id);
-print $record['suit'];
+enum Suit: string
+{
+    case Hearts = 'H';
+    case Diamonds = 'D';
+    case Clubs = 'C';
+    case Spades = 'S';
+}
 
-$suit =  Suit::from($record['suit']);
-// Les données invalides lèvent une ValueError : "X" is not a valid scalar value for enum "Suit"
-print $suit->value;
+function get_stuff_from_database($id) {
+    return [
+        'suit' => 'S',
+    ];
+}
+
+$record = get_stuff_from_database(42);
+print $record['suit'] . "\n";
 
 $suit = Suit::tryFrom('A') ?? Suit::Spades;
 // Les données invalides retournent null, donc Suit::Spades est utilisé à la place.
-print $suit->value;
-?>
+print $suit->value . "\n";
+
+$suit =  Suit::from('X');
+// Les données invalides lèvent une ValueError : "X" is not a valid backing scalar value for enum Suit
+print $suit->value . "\n";
 ]]>
-  </programlisting>
+   </programlisting>
+  </informalexample>
 
   <para>La définition manuelle d'une méthode <literal>from()</literal> ou <literal>tryFrom()</literal> sur une énumération avec valeur de base entraîne une erreur fatale.</para>
 
@@ -292,7 +349,8 @@ print $suit->value;
    tous les cas de cette Enum.
   </para>
 
-  <programlisting role="php">
+  <informalexample>
+   <programlisting role="php">
 <![CDATA[
 <?php
 interface Colorful
@@ -325,15 +383,15 @@ enum Suit implements Colorful
 
 function paint(Colorful $c)
 {
-   /* ... */
+   print $c->color() . "\n";
 }
 
 paint(Suit::Clubs);  // Fonctionne
 
 print Suit::Diamonds->shape(); // Affiche "Rectangle"
-?>
 ]]>
-  </programlisting>
+   </programlisting>
+  </informalexample>
 
   <para>
    Dans cet exemple, les quatre instances de <literal>Suit</literal> ont deux méthodes,
@@ -345,10 +403,9 @@ print Suit::Diamonds->shape(); // Affiche "Rectangle"
    Dans le cas d'une Enum avec valeur de base, la déclaration de l'interface suit la déclaration du type de soutien.
   </para>
 
-  <programlisting role="php">
+  <programlisting role="php" annotations="non-interactive">
    <![CDATA[
 <?php
-
 interface Colorful
 {
     public function color(): string;
@@ -370,7 +427,6 @@ enum Suit: string implements Colorful
         };
     }
 }
-?>
 ]]>
   </programlisting>
 
@@ -395,10 +451,9 @@ enum Suit: string implements Colorful
    (bien que ce ne soit pas le code qui s'exécute) :
   </para>
 
-  <programlisting role="php">
+  <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
-
 interface Colorful
 {
     public function color(): string;
@@ -428,11 +483,10 @@ final class Suit implements UnitEnum, Colorful
 
     public static function cases(): array
     {
-        // Méthode illégale, car la définition manuelle d'une méthode cases() sur une énumération n'est pas autorisée. 
+        // Méthode illégale, car la définition manuelle d'une méthode cases() sur une énumération n'est pas autorisée.
         // Voir aussi la section "Liste de valeurs".
     }
 }
-?>
 ]]>
   </programlisting>
 
@@ -451,10 +505,10 @@ final class Suit implements UnitEnum, Colorful
    est principalement pour les constructeurs alternatifs. Par exemple :
   </para>
 
-  <programlisting role="php">
+  <informalexample>
+   <programlisting role="php">
 <![CDATA[
 <?php
-
 enum Size
 {
     case Small;
@@ -470,9 +524,11 @@ enum Size
         };
     }
 }
-?>
+
+var_dump(Size::fromLength(50));
 ]]>
-  </programlisting>
+   </programlisting>
+  </informalexample>
 
   <para>
    Les méthodes statiques peuvent être publiques, privées ou protégées, bien que privées
@@ -491,10 +547,10 @@ enum Size
 
   <para>Une constante d'énumération peut faire référence à un cas d'énumération :</para>
 
-  <programlisting role="php">
+  <informalexample>
+   <programlisting role="php">
 <![CDATA[
 <?php
-
 enum Size
 {
     case Small;
@@ -503,9 +559,11 @@ enum Size
 
     public const Huge = self::Large;
 }
-?>
+
+var_dump(Size::Huge);
 ]]>
-  </programlisting>
+   </programlisting>
+  </informalexample>
  </sect1>
 
  <sect1 xml:id="language.enumerations.traits">
@@ -517,10 +575,10 @@ enum Size
    entraînera une erreur fatale.
   </para>
 
-  <programlisting role="php">
+  <informalexample>
+   <programlisting role="php">
 <![CDATA[
 <?php
-
 interface Colorful
 {
     public function color(): string;
@@ -550,9 +608,13 @@ enum Suit implements Colorful
         };
     }
 }
-?>
+
+$suit = Suit::Spades;
+var_dump($suit->color());
+var_dump($suit->shape());
 ]]>
-  </programlisting>
+   </programlisting>
+  </informalexample>
  </sect1>
 
  <sect1 xml:id="language.enumerations.expressions">
@@ -566,16 +628,15 @@ enum Suit implements Colorful
   </para>
 
   <para>
-   Cependant, les appels implicites à des méthodes magiques telles que <classname>ArrayAccess</classname> sur les enums ne sont pas autorisés dans les définitions statiques 
+   Cependant, les appels implicites à des méthodes magiques telles que <classname>ArrayAccess</classname> sur les enums ne sont pas autorisés dans les définitions statiques
    ou constantes, car nous ne pouvons pas garantir de manière absolue que la valeur résultante est déterministe
    ou que l'invocation de la méthode est exempte d'effets secondaires. Les appels de fonction, les appels de méthode et
    l'accès aux propriétés continuent d'être des opérations non valides dans les expressions constantes.
   </para>
 
-  <programlisting role="php">
+  <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
-
 // Ceci est une définition d'Enum tout à fait valide.
 enum Direction implements ArrayAccess
 {
@@ -618,7 +679,6 @@ $x = Direction::Up['short'];
 var_dump("\$x is " . var_export($x, true));
 
 $foo = new Foo();
-?>
 ]]>
   </programlisting>
  </sect1>
@@ -649,13 +709,13 @@ $foo = new Foo();
    <member>Les Enums peuvent implémenter un nombre quelconque d'interfaces.</member>
    <member>
     Les enums et les cas peuvent avoir des <link linkend="language.attributes">attributs</link>
-    qui leur sont attachés. Le filtre <constant>TARGET_CLASS</constant> 
-    inclut les Enums elles-mêmes. Le filtre cible <constant>TARGET_CLASS_CONST</constant> 
+    qui leur sont attachés. Le filtre <constant>TARGET_CLASS</constant>
+    inclut les Enums elles-mêmes. Le filtre cible <constant>TARGET_CLASS_CONST</constant>
     inclut les cas d'Enum.
    </member>
    <member>
     Les méthodes magiques <link linkend="object.call">__call</link>, <link linkend="object.callstatic">__callStatic</link>,
-    et <link linkend="object.invoke">__invoke</link> 
+    et <link linkend="object.invoke">__invoke</link>
    </member>
    <member>Les constantes <constant>__CLASS__</constant> et <constant>__FUNCTION__</constant> se comportent normalement</member>
   </simplelist>
@@ -672,16 +732,14 @@ $foo = new Foo();
    <methodname>ReflectionClass::newInstanceWithoutConstructor</methodname> de la réflexion. Ces deux méthodes entraîneront une erreur.
   </para>
 
-  <programlisting role="php">
+  <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
-
 $clovers = new Suit();
 // Erreur : Cannot instantiate enum Suit
 
 $horseshoes = (new ReflectionClass(Suit::class))->newInstanceWithoutConstructor()
 // Erreur : Cannot instantiate enum Suit
-?>
 ]]>
   </programlisting>
  </sect1>
@@ -696,15 +754,32 @@ $horseshoes = (new ReflectionClass(Suit::class))->newInstanceWithoutConstructor(
    tous les cas définis dans l'ordre de leur déclaration.
   </para>
 
-  <programlisting role="php">
+  <informalexample>
+   <programlisting role="php">
 <![CDATA[
 <?php
+enum Suit
+{
+    case Hearts;
+    case Diamonds;
+    case Clubs;
+    case Spades;
+}
 
-Suit::cases();
-// Produit : [Suit::Hearts, Suit::Diamonds, Suit::Clubs, Suit::Spades]
-?>
+var_dump(Suit::cases());
+
+enum SuitBacked: string
+{
+    case Hearts = 'H';
+    case Diamonds = 'D';
+    case Clubs = 'C';
+    case Spades = 'S';
+}
+
+var_dump(SuitBacked::cases());
 ]]>
-  </programlisting>
+   </programlisting>
+  </informalexample>
 
   <para>La définition manuelle d'une méthode <literal>cases()</literal> sur un Enum entraînera une erreur fatale.</para>
  </sect1>
@@ -718,17 +793,25 @@ Suit::cases();
    en mesure d'utiliser ce code pour définir une variable à la valeur singleton existante. Cela garantit que :
   </para>
 
-  <programlisting role="php">
+  <informalexample>
+   <programlisting role="php">
 <![CDATA[
 <?php
+enum Suit: string
+{
+    case Hearts = 'H';
+    case Diamonds = 'D';
+    case Clubs = 'C';
+    case Spades = 'S';
+}
 
 Suit::Hearts === unserialize(serialize(Suit::Hearts));
 
 print serialize(Suit::Hearts);
 // E:11:"Suit:Hearts";
-?>
 ]]>
-  </programlisting>
+   </programlisting>
+  </informalexample>
 
   <para>
    Lors de la désérialisation, si un enum et un cas ne peuvent pas être trouvés pour correspondre à une valeur sérialisée,
@@ -745,10 +828,10 @@ print serialize(Suit::Hearts);
    des objets afin de minimiser la confusion.
   </para>
 
-  <programlisting role="php">
+  <informalexample>
+   <programlisting role="php">
 <![CDATA[
 <?php
-
 enum Foo {
     case Bar;
 }
@@ -770,9 +853,9 @@ Baz Enum:int {
     [value] => 5
 }
 */
-?>
 ]]>
-  </programlisting>
+   </programlisting>
+  </informalexample>
  </sect1>
 
  <sect1 xml:id="language.enumerations.object-differences.inheritance">
@@ -783,10 +866,9 @@ Baz Enum:int {
    Les classes ont des contrats sur leurs méthodes :
   </simpara>
 
-  <programlisting role="php">
+  <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
-
 class A {}
 class B extends A {}
 
@@ -795,7 +877,6 @@ function foo(A $a) {}
 function bar(B $b) {
     foo($b);
 }
-?>
 ]]>
  </programlisting>
 
@@ -809,10 +890,9 @@ function bar(B $b) {
    Les enums ont des contrats sur leurs cas, pas sur les méthodes :
   </simpara>
 
-  <programlisting role="php">
+  <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
-
 enum ErrorCode {
     case SOMETHING_BROKE;
 }
@@ -824,8 +904,6 @@ function quux(ErrorCode $errorCode)
         ErrorCode::SOMETHING_BROKE => true,
     };
 }
-
-?>
 ]]>
   </programlisting>
 
@@ -839,10 +917,9 @@ function quux(ErrorCode $errorCode)
   </simpara>
 
 
-  <programlisting role="php">
+  <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
-
 // Code d'expérience de pensée où les enums ne sont pas finaux.
 // À noter : cela ne fonctionnera pas en PHP.
 enum MoreErrorCode extends ErrorCode {
@@ -854,10 +931,8 @@ function fot(MoreErrorCode $errorCode) {
 }
 
 fot(MoreErrorCode::PEBKAC);
-
-?>
 ]]>
- </programlisting>
+  </programlisting>
 
   <simpara>
    En vertu des règles d'héritage normales, une classe qui en étend une autre passera
@@ -880,10 +955,9 @@ fot(MoreErrorCode::PEBKAC);
   <para>
    <example>
     <title>Valeurs limitées de base</title>
-    <programlisting role="php">
+    <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
-
 enum SortOrder
 {
     case Asc;
@@ -894,7 +968,6 @@ function query($fields, $filter, SortOrder $order = SortOrder::Asc)
 {
      /* ... */
 }
-?>
 ]]>
     </programlisting>
     <para>
@@ -914,7 +987,6 @@ function query($fields, $filter, SortOrder $order = SortOrder::Asc)
     <programlisting role="php">
 <![CDATA[
 <?php
-
 enum UserStatus: string
 {
     case Pending = 'P';
@@ -932,7 +1004,9 @@ enum UserStatus: string
         };
     }
 }
-?>
+
+$status = UserStatus::Suspended;
+var_dump($status->label());
 ]]>
     </programlisting>
 
@@ -952,11 +1026,31 @@ enum UserStatus: string
     <programlisting role="php">
 <![CDATA[
 <?php
+enum UserStatus: string
+{
+    case Pending = 'P';
+    case Active = 'A';
+    case Suspended = 'S';
+    case CanceledByUser = 'C';
+
+    public function label(): string
+    {
+        return match($this) {
+            self::Pending => 'Pending',
+            self::Active => 'Active',
+            self::Suspended => 'Suspended',
+            self::CanceledByUser => 'Canceled by user',
+        };
+    }
+}
 
 foreach (UserStatus::cases() as $case) {
-    printf('<option value="%s">%s</option>\n', $case->value, $case->label());
+    printf(
+        "<option value=\"%s\">%s</option>\n",
+        htmlentities($case->value),
+        htmlentities($case->label())
+    );
 }
-?>
 ]]>
     </programlisting>
    </example>


### PR DESCRIPTION
Sync de doc-en PR #5479 (commit 1eb67bea30) vers doc-fr.

Fixes #2807