### PR TITLE
[Sync EN] WASM: Enable runnable examples for language.functions section (#5463)

### DIFF
--- a/language/functions.xml
+++ b/language/functions.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e2f2172bf114599926878017ab2dce356956fa9e Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 9c835d146d452976f21db7d9cb60dca013829d39 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
-<chapter xml:id="language.functions" xmlns="http://docbook.org/ns/docbook">
+<chapter xml:id="language.functions" xmlns="http://docbook.org/ns/docbook" annotations="interactive">
  <title>Les fonctions</title>
  
  <sect1 xml:id="functions.user-defined">
@@ -15,7 +15,7 @@
   </para>
   <example>
    <title>Déclaration d'une nouvelle fonction nommée <literal>foo</literal></title>
-   <programlisting role="php">
+   <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 function foo($arg_1, $arg_2, /* ..., */ $arg_n)
@@ -23,7 +23,6 @@ function foo($arg_1, $arg_2, /* ..., */ $arg_n)
     echo "Exemple de fonction.\n";
     return $retval;
 }
-?>
 ]]>
    </programlisting>
   </example>
@@ -31,11 +30,10 @@ function foo($arg_1, $arg_2, /* ..., */ $arg_n)
    <para>
     À partir de PHP 8.0.0, la liste de paramètres peut avoir une virgule finale :
     <informalexample>
-     <programlisting role="php">
+     <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 function foo($arg_1, $arg_2,) { }
-?>
 ]]>
      </programlisting>
     </informalexample>
@@ -71,12 +69,16 @@ function foo($arg_1, $arg_2,) { }
     <programlisting role="php">
 <![CDATA[
 <?php
-
 $makefoo = true;
 
 /* Impossible d'appeler foo() ici,
    car cette fonction n'existe pas.
    Mais nous pouvons utiliser bar() */
+if (function_exists('foo')) {
+    foo();
+} else {
+    echo "La fonction foo n'existe pas (encore).\n";
+}
 
 bar();
 
@@ -96,8 +98,6 @@ function bar()
 {
   echo "J'existe dès le début du programme.\n";
 }
-
-?>
 ]]>
     </programlisting>
    </example>
@@ -118,6 +118,9 @@ function foo()
 
 /* Impossible d'appeler bar() ici
    car il n'existe pas. */
+if (function_exists('bar')) {
+    bar();
+}
 
 foo();
 
@@ -126,8 +129,6 @@ foo();
    accessible. */
 
 bar();
-
-?>  
 ]]>
     </programlisting>
    </example>
@@ -174,7 +175,8 @@ function recursion($a)
         recursion($a + 1);
     }
 }
-?>
+
+recursion(17);
 ]]>
     </programlisting>
    </example>
@@ -215,14 +217,13 @@ function recursion($a)
     À partir de PHP 7.3.0, il est possible d'avoir une virgule finale dans la liste d'arguments
     pour les appels de fonction :
     <informalexample>
-     <programlisting role="php">
+     <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 $v = foo(
     $arg_1,
     $arg_2,
 );
-?>
 ]]>
       </programlisting>
      </informalexample>
@@ -237,7 +238,7 @@ $v = foo(
    </para>
    <example>
     <title>Liste des paramètres de la fonction avec une virgule finale</title>
-    <programlisting role="php">
+    <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 function takes_many_args(
@@ -250,7 +251,6 @@ function takes_many_args(
 {
     // ...
 }
-?>
 ]]>
     </programlisting>
    </example>
@@ -282,7 +282,6 @@ function add_some_extra(&$string)
 $str = 'Ceci est une chaîne';
 add_some_extra($str);
 echo $str; // Affiche : 'Ceci est une chaîne, et un peu plus.'
-?>
 ]]>
      </programlisting>
     </example>
@@ -315,7 +314,6 @@ function servir_cafe ($type = "cappuccino")
 echo servir_cafe();
 echo servir_cafe(null);
 echo servir_cafe("espresso");
-?>
 ]]>
      </programlisting>
      &example.outputs;
@@ -346,7 +344,6 @@ function servir_cafe($types = array("cappuccino"), $coffeeMaker = NULL)
 }
 echo servir_cafe();
 echo servir_cafe(array("cappuccino", "lavazza"), "une cafetière");
-?>
 ]]>
      </programlisting>
      &example.outputs;
@@ -380,7 +377,6 @@ function makecoffee($coffeeMaker = new DefaultCoffeeMaker)
 }
 echo makecoffee();
 echo makecoffee(new FancyCoffeeMaker);
-?>
 ]]>
         </programlisting>
 
@@ -415,14 +411,18 @@ function faireunyaourt ($container = "bol", $flavour)
 }
  
 echo faireunyaourt("framboise");   // "framboise" est $container, pas $flavour
-?>
 ]]>
      </programlisting>
      &example.outputs;
      <screen>
 <![CDATA[
-Fatal error: Uncaught ArgumentCountError: Too few arguments
- to function faireunyaourt(), 1 passed in example.php on line 42
+Deprecated: faireunyaourt(): Optional parameter $container declared before required parameter $flavour is implicitly treated as a required parameter in script on line 2
+
+Fatal error: Uncaught ArgumentCountError: Too few arguments to function faireunyaourt(), 1 passed in script on line 7 and exactly 2 expected in script:2
+Stack trace:
+#0 script(7): faireunyaourt('framboise')
+#1 {main}
+  thrown in script on line 2
 ]]>
      </screen>
     </example>
@@ -442,7 +442,6 @@ function faireunyaourt ($flavour, $container = "bol")
 }
  
 echo faireunyaourt ("framboise");   // "framboise" est $flavour
-?>
 ]]>
      </programlisting>
      &example.outputs;
@@ -468,7 +467,6 @@ function faireunyaourt($container = "bol", $flavour = "framboise", $style = "Gre
     return "Préparer un $container de yaourt $style à la $flavour.\n";
 }
 echo faireunyaourt(style: "naturel");
-?>
 ]]>
       </programlisting>
       &example.outputs;
@@ -489,10 +487,9 @@ Préparer un bol de yaourt naturel à la framboise.
       explicite doit être utilisé à la place.
       <example>
        <title>Déclaration des paramètres optionnels après les paramètres obligatoires</title>
-        <programlisting role="php">
+        <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
-
 function foo($a = [], $b) {}     // Valeur par défaut non utilisée ; déconseillée à partir de PHP 8.0.0
 function foo($a, $b) {}          // Fonctionnellement équivalent, pas d’avertissement de dépréciation
 
@@ -501,8 +498,6 @@ function bar(A $a = null, $b) {} // À partir de PHP 8.1.0, $a est implicitement
                                  // mais implicitement nullable (déconseillé à partir de PHP 8.4.0),
                                  // car la valeur par défaut du paramètre est null
 function bar(?A $a, $b) {}       // Recommandé
-
-?>
 ]]>
         </programlisting>
       </example>
@@ -551,7 +546,6 @@ function sum(...$numbers) {
 }
 
 echo sum(1, 2, 3, 4);
-?>
 ]]>
      </programlisting>
      &example.outputs;
@@ -581,7 +575,6 @@ echo add(...[1, 2])."\n";
 
 $a = [1, 2];
 echo add(...$a);
-?>
 ]]>
      </programlisting>
      &example.outputs;
@@ -627,14 +620,17 @@ echo total_intervals('d', $a, $b).' jours';
 
 // Ceci échouera, car null n'est pas un objet DateInterval.
 echo total_intervals('d', null);
-?>
 ]]>
      </programlisting>
      &example.outputs;
      <screen>
 <![CDATA[
 3 jours
-Catchable fatal error: Argument 2 passed to total_intervals() must be an instance of DateInterval, null given, called in - on line 14 and defined in - on line 2
+Fatal error: Uncaught TypeError: total_intervals(): Argument #2 must be of type DateInterval, null given, called in script on line 15 and defined in script:2
+Stack trace:
+#0 script(15): total_intervals('d', NULL)
+#1 {main}
+  thrown in script on line 2
 ]]>
      </screen>
     </example>
@@ -670,7 +666,7 @@ Catchable fatal error: Argument 2 passed to total_intervals() must be an instanc
 
    <example>
     <title>Syntaxe des arguments nommés</title>
-    <programlisting role="php">
+    <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 myFunction(paramName: $value);
@@ -678,14 +674,13 @@ array_foobar(array: $value);
 
 // NON supporté.
 function_name($variableStoringParamName: $value);
-?>
 ]]>
     </programlisting>
    </example>
 
    <example>
     <title>Arguments positionnels comparés aux arguments nommés</title>
-    <programlisting role="php">
+    <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 // Utilisant les arguments positionnels :
@@ -693,7 +688,6 @@ array_fill(0, 100, 50);
 
 // Utilisant les arguments nommés :
 array_fill(start_index: 0, count: 100, value: 50);
-?>
 ]]>
     </programlisting>
    </example>
@@ -704,11 +698,10 @@ array_fill(start_index: 0, count: 100, value: 50);
 
    <example>
     <title>Même exemple que ci-dessus, mais avec un ordre de paramètre différent</title>
-    <programlisting role="php">
+    <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 array_fill(value: 50, count: 100, start_index: 0);
-?>
 ]]>
     </programlisting>
    </example>
@@ -722,13 +715,12 @@ array_fill(value: 50, count: 100, start_index: 0);
 
    <example>
     <title>Combiner les arguments nommés avec les arguments positionnels</title>
-    <programlisting role="php">
+    <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 htmlspecialchars($string, double_encode: false);
 // Identique à
 htmlspecialchars($string, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401, 'UTF-8', false);
-?>
 ]]>
     </programlisting>
    </example>
@@ -740,7 +732,7 @@ htmlspecialchars($string, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401, 'UTF-8', fa
 
    <example>
     <title>Erreur déclenchée lorsqu'un argument est passé plusieurs fois au même paramètre nommé</title>
-    <programlisting role="php">
+    <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 function foo($param) { ... }
@@ -750,8 +742,6 @@ foo(param: 1, param: 2);
 
 foo(1, param: 2);
 // Error: Named parameter $param overwrites previous argument
-
-?>
 ]]>
     </programlisting>
    </example>
@@ -772,7 +762,6 @@ function foo($a, $b, $c = 3, $d = 4) {
 var_dump(foo(...[1, 2], d: 40)); // 46
 var_dump(foo(...['b' => 2, 'a' => 1], d: 40)); // 46
 var_dump(foo(...[1, 2], b: 20)); // Erreur fatale. Le paramètre nommé $b écrase l'argument précédent.
-?>
 ]]>
       </programlisting>
     </example>
@@ -812,7 +801,6 @@ function carre($num)
     return $num * $num;
 }
 echo carre(4); // Affiche '16'
-?>
 ]]>
      </programlisting>
     </example>
@@ -834,10 +822,10 @@ function petit_nombre()
 }
 // La déconstruction d'un tableau collectera chaque membre du tableau individuellement
 [$zero, $one, $two] = petit_nombre();
+var_dump($zero, $one, $two);
 
 // Avant PHP 7.1, la seule alternative équivalente est en utilisant la structure de langage list()
 list ($zero, $un, $deux) = petit_nombre();
-?>
 ]]>
      </programlisting>
     </example>
@@ -850,7 +838,7 @@ list ($zero, $un, $deux) = petit_nombre();
    <para>
     <example>
      <title>Retourner une référence d'une fonction</title>
-     <programlisting role="php">
+     <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 function &retourne_reference()
@@ -859,7 +847,6 @@ function &retourne_reference()
 }
 
 $newref =& retourne_reference();
-?>
 ]]>
      </programlisting>
     </example>
@@ -897,12 +884,12 @@ $newref =& retourne_reference();
 <![CDATA[
 <?php
 function foo() {
-    echo "dans foo()<br />\n";
+    echo "dans foo()\n";
 }
 
 function bar($arg = '')
 {
-    echo "Dans bar(); l'argument était '$arg'.<br />\n";
+    echo "Dans bar(); l'argument était '$arg'.\n";
 }
 
 // Ceci est une fonction détournée de echo
@@ -919,7 +906,6 @@ $func('test');  // Appel bar()
 
 $func = 'echoit';
 $func('test');  // Appel echoit()
-?>
 ]]>
     </programlisting>
    </example>
@@ -949,8 +935,6 @@ class Foo
 $foo = new Foo();
 $funcname = "Variable";
 $foo->$funcname();  // Appelle $foo->Variable()
-
-?>
 ]]>
     </programlisting>
    </example>
@@ -968,17 +952,22 @@ class Foo
     static $variable = 'static property';
     static function Variable()
     {
-        echo 'Method Variable called';
+        echo "Method Variable called\n";
     }
 }
 
-echo Foo::$variable; // Ceci affiche 'static property'. Il est nécessaire d'avoir une $variable dans le contexte.
+echo Foo::$variable ."\n"; // Ceci affiche 'static property'. Il est nécessaire d'avoir une $variable dans le contexte.
 $variable = "Variable";
 Foo::$variable();  // Ceci appelle $foo->Variable(), lisant ainsi la $variable depuis le contexte.
-
-?>
 ]]>
     </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+static property
+Method Variable called
+]]>
+    </screen>
    </example>
   </para>
   <para>
@@ -1099,7 +1088,6 @@ var_dump(strlen(null));
 var_dump(str_contains("foobar", null));
 // "Deprecated: Passing null to parameter #2 ($needle) of type string is deprecated" as of PHP 8.1.0
 // bool(true)
-?>
 ]]>
      </programlisting>
     </informalexample>
@@ -1139,7 +1127,6 @@ echo preg_replace_callback('~-([a-z])~', function ($match) {
     return strtoupper($match[1]);
 }, 'bonjour-le-monde');
 // affiche bonjourLeMonde
-?>
 ]]>
    </programlisting>
   </example>
@@ -1163,7 +1150,6 @@ $greet = function($name) {
 
 $greet('World');
 $greet('PHP');
-?>
 ]]>
    </programlisting>
   </example>
@@ -1227,7 +1213,6 @@ $example = function () use ($message): string {
     return "hello $message";
 };
 var_dump($example());
-?>
 ]]>
    </programlisting>
    &example.outputs.similar;
@@ -1314,7 +1299,6 @@ $mon_panier->add('oeuf', 6);
 // Affichage du prix avec 5.5% de TVA
 print $mon_panier->getTotal(0.055) . "\n";
 // Le résultat sera 54.29
-?>
 ]]>
    </programlisting>
   </example>
@@ -1324,7 +1308,6 @@ print $mon_panier->getTotal(0.055) . "\n";
    <programlisting role="php">
 <![CDATA[
 <?php
-
 class Test
 {
     public function testing()
@@ -1338,8 +1321,6 @@ class Test
 $object = new Test;
 $function = $object->testing();
 $function();
-    
-?>
 ]]>
    </programlisting>
    &example.outputs;
@@ -1373,7 +1354,6 @@ object(Test)#1 (0) {
      <programlisting role="php">
 <![CDATA[
 <?php
-
 class Foo
 {
     function __construct()
@@ -1385,15 +1365,17 @@ class Foo
     }
 };
 new Foo();
-
-?>
 ]]>
       </programlisting>
       &example.outputs;
       <screen>
 <![CDATA[
-Notice: Undefined variable: this in %s on line %d
-NULL
+Fatal error: Uncaught Error: Using $this when not in object context in script:7
+Stack trace:
+#0 script(9): Foo::{closure:Foo::__construct():6}()
+#1 script(12): Foo->__construct()
+#2 {main}
+  thrown in script on line 7
 ]]>
       </screen>
      </example>
@@ -1405,20 +1387,22 @@ NULL
       <programlisting role="php">
 <![CDATA[
 <?php
-
 $func = static function() {
     // corps de la fonction
 };
 $func = $func->bindTo(new stdClass);
 $func();
-
-?>
 ]]>
       </programlisting>
       &example.outputs;
       <screen>
 <![CDATA[
-Warning: Cannot bind an instance to a static closure in %s on line %d
+Warning: Cannot bind an instance to a static closure, this will be an error in PHP 9 in script on line 5
+
+Fatal error: Uncaught Error: Value of type null is not callable in script:6
+Stack trace:
+#0 {main}
+  thrown in script on line 6
 ]]>
       </screen>
      </example>
@@ -1510,9 +1494,8 @@ Warning: Cannot bind an instance to a static closure in %s on line %d
      <programlisting role="php">
 <![CDATA[
 <?php
-
 $y = 1;
- 
+
 $fn1 = fn($x) => $x + $y;
 // équivalent à utiliser $y par valeur :
 $fn2 = function ($x) use ($y) {
@@ -1520,7 +1503,6 @@ $fn2 = function ($x) use ($y) {
 };
 
 var_export($fn1(3));
-?>
 ]]>
      </programlisting>
      &example.outputs;
@@ -1540,12 +1522,10 @@ var_export($fn1(3));
      <programlisting role="php">
 <![CDATA[
 <?php
-
 $z = 1;
 $fn = fn($x) => fn($y) => $x * $y + $z;
 // Affiche 51
 var_export($fn(5)(10));
-?>
 ]]>
      </programlisting>
     </example>
@@ -1560,18 +1540,15 @@ var_export($fn(5)(10));
    <para>
     <example>
      <title>Exemples de fonctions fléchées</title>
-     <programlisting role="php">
+     <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
-
 fn(array $x) => $x;
 static fn($x): int => $x;
 fn($x = 42) => $x;
 fn(&$x) => $x;
 fn&($x) => $x;
 fn($x, ...$rest) => $rest;
-
-?>
 ]]>
      </programlisting>
     </example>
@@ -1594,13 +1571,10 @@ fn($x, ...$rest) => $rest;
      <programlisting role="php">
 <![CDATA[
 <?php
-
 $x = 1;
 $fn = fn() => $x++; // N'a aucun effet
 $fn();
 var_export($x);  // Affiche 1
-
-?>
 ]]>
      </programlisting>
     </example>
@@ -1661,7 +1635,7 @@ var_export($x);  // Affiche 1
    appelée dans la grammaire de PHP :
    <example>
     <title>Syntaxe callable de première classe basique</title>
-    <programlisting role="php">
+    <programlisting role="php" annotations="non-interactive">
      <![CDATA[
 <?php
 class Foo {
@@ -1683,7 +1657,6 @@ $f6 = $classStr::$staticmethodStr(...);
 $f7 = 'strlen'(...);
 $f8 = [$obj, 'method'](...);
 $f9 = [Foo::class, 'staticmethod'](...);
-?>
 ]]>
     </programlisting>
    </example>
@@ -1717,6 +1690,14 @@ $privateMethod = $foo->getPrivateMethod();
 $privateMethod();
 // Erreur fatale : Call to private method Foo::privateMethod() from global scope
 // Ceci est dû au fait que l'appel est effectué en dehors de Foo et la visibilité sera vérifiée depuis ce point.
+]]>
+    </programlisting>
+   </example>
+  </para>
+  <informalexample>
+   <programlisting role="php">
+<![CDATA[
+<?php
 class Foo1 {
     public function getPrivateMethod() {
         // Utilise la portée où le callable est acquis.
@@ -1729,12 +1710,9 @@ class Foo1 {
 $foo1 = new Foo1;
 $privateMethod = $foo1->getPrivateMethod();
 $privateMethod();  // Foo1::privateMethod
-?>
 ]]>
-    </programlisting>
-   </example>
-
-  </para>
+   </programlisting>
+  </informalexample>
 
   <note>
    <para>
@@ -1749,12 +1727,11 @@ $privateMethod();  // Foo1::privateMethod
     l'<link linkend="language.oop5.basic.nullsafe">opérateur nullsafe</link>.
     Les deux cas suivants entraînent une erreur de compilation :
     <informalexample>
-     <programlisting role="php">
+     <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 $obj?->method(...);
 $obj?->prop->method(...);
-?>
 ]]>
      </programlisting>
     </informalexample>


### PR DESCRIPTION
Sync de doc-en PR #5463 (commit 9c835d146d) vers doc-fr.

Fixes #2806