### PR TITLE
[Sync EN] debug_backtrace(): Remove extra whitespaces (#5543)

### DIFF
--- a/reference/errorfunc/functions/debug-backtrace.xml
+++ b/reference/errorfunc/functions/debug-backtrace.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 1e31c8f3a81d8fbfc79c0a6b033f0750cff48581 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 26f18bad4964592e0020daa67f0bac81ae7aeb4c Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="function.debug-backtrace" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>


### PR DESCRIPTION
Sync de doc-en PR #5543 (commit 26f18bad49) vers doc-fr : la traduction FR n'avait pas les doubles espaces, donc seul le hash EN-Revision est mis à jour.

Fixes #2805