### PR TITLE
[Sync EN] MongoDB: clean up markup (#5517)

### DIFF
--- a/reference/mongodb/mongodb/driver/query.xml
+++ b/reference/mongodb/mongodb/driver/query.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 
 <reference xml:id="class.mongodb-driver-query" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
@@ -13,10 +13,10 @@
 <!-- {{{ MongoDB\Driver\Query intro -->
   <section xml:id="mongodb-driver-query.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     La classe <classname>MongoDB\Driver\Query</classname> est un objet
     qui représente une requête de base de données.
-   </para>
+   </simpara>
   </section>
 <!-- }}} -->
 

--- a/reference/mongodb/mongodb/driver/query/construct.xml
+++ b/reference/mongodb/mongodb/driver/query/construct.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4639881688d3faaf0073ad71fe0a4b730aea15a0 Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="mongodb-driver-query.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -14,12 +14,12 @@
    <methodparam><type class="union"><type>array</type><type>object</type></type><parameter>filter</parameter></methodparam>
    <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>queryOptions</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Construit un nouvel objet <classname>MongoDB\Driver\Query</classname>, qui est un objet
    de valeur immuable qui représente une requête de base de données. La requête peut
    ensuite être exécutée avec
    <methodname>MongoDB\Driver\Manager::executeQuery</methodname>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -45,26 +45,26 @@
           <entry>allowDiskUse</entry>
           <entry><type>bool</type></entry>
           <entry>
-           <para>
+           <simpara>
             Autorise MongoDB à utiliser des fichiers temporaires sur le disque
             pour stocker des données dépassant la limite de mémoire système de
             100 mégaoctets lors du traitement d'une opération de tri bloquante.
-           </para>
+           </simpara>
           </entry>
          </row>
          <row>
           <entry>allowPartialResults</entry>
           <entry><type>bool</type></entry>
           <entry>
-           <para>
+           <simpara>
             Pour les requêtes sur une collection fragmentée, retourne des
             résultats partiels du mongos si certains fragments ne sont pas
             disponibles au lieu de générer une erreur.
-           </para>
-           <para>
+           </simpara>
+           <simpara>
             Retombe sur l'option dépréciée <literal>"partial"</literal> si non
             spécifiée.
-           </para>
+           </simpara>
           </entry>
          </row>
          <row>
@@ -81,16 +81,16 @@
           <entry>batchSize</entry>
           <entry><type>int</type></entry>
           <entry>
-           <para>
+           <simpara>
             Le nombre de documents à retourner dans le premier lot. Par défaut à
             101. Une taille de lot de 0 signifie que le curseur sera établi, mais
             aucun document ne sera retourné dans le premier lot.
-           </para>
-           <para>
+           </simpara>
+           <simpara>
             Dans les versions de MongoDB antérieures à 3.2, où les requêtes
             utilisent le protocole de filaire hérité OP_QUERY, une taille de lot
             de 1 fermera le curseur indépendamment du nombre de documents.
-           </para>
+           </simpara>
           </entry>
          </row>
          &mongodb.option.collation;
@@ -98,73 +98,73 @@
           <entry>comment</entry>
           <entry><type>mixed</type></entry>
           <entry>
-           <para>
+           <simpara>
             Un commentaire arbitraire pour aider à tracer l'opération à travers
             le profil de la base de données, la sortie currentOp et les journaux.
-           </para>
-           <para>
+           </simpara>
+           <simpara>
             Le commentaire peut être n'importe quel type BSON valide pour MongoDB
             4.4+. Les versions de serveur antérieures ne prennent en charge que
             les valeurs de chaîne.
-           </para>
-           <para>
+           </simpara>
+           <simpara>
             Retombe sur l'option dépréciée <literal>"$comment"</literal> si non
             spécifiée.
-           </para>
+           </simpara>
           </entry>
          </row>
          <row>
           <entry>exhaust</entry>
           <entry><type>bool</type></entry>
           <entry>
-           <para>
+           <simpara>
             Le flux de données en aval à pleine puissance dans plusieurs paquets
             "more", en supposant que le client lira entièrement toutes les données
             interrogées. Plus rapide lorsqu'on tire beaucoup de données et
             savez qu'on veut tout tirer. Remarque : le client n'est pas autorisé
             à ne pas lire toutes les données sauf s'il ferme la connexion.
-           </para>
-           <para>
+           </simpara>
+           <simpara>
             Cette option n'est pas prise en charge par la commande find dans MongoDB
             3.2+ et forcera le pilote à utiliser la version du protocole de filaire
             hérité (c'est-à-dire OP_QUERY).
-           </para>
+           </simpara>
           </entry>
          </row>
          <row>
           <entry>explain</entry>
           <entry><type>bool</type></entry>
           <entry>
-           <para>
+           <simpara>
             Si &true; le curseur <classname>MongoDB\Driver\Cursor</classname> retourné
             contiendra un seul document qui décrit le processus et les index utilisés
             pour retourner la requête.
-           </para>
-           <para>
+           </simpara>
+           <simpara>
             Retombe sur l'option dépréciée <literal>"$explain"</literal> si non
             spécifiée.
-           </para>
-           <para>
+           </simpara>
+           <simpara>
             Cette option n'est pas prise en charge par la commande find dans MongoDB
             3.2+ et ne sera respectée que lors de l'utilisation de la version du
             protocole de filaire hérité (c'est-à-dire OP_QUERY). La commande
             <link xlink:href="&url.mongodb.docs;reference/command/explain/">explain</link>
             doit être utilisée sur MongoDB 3.0+.
-           </para>
+           </simpara>
           </entry>
          </row>
          <row>
           <entry>hint</entry>
           <entry><type class="union"><type>string</type><type>array</type><type>object</type></type></entry>
           <entry>
-           <para>
+           <simpara>
             Spécification de l'index. Spécifiez soit le nom de l'index en tant que
             chaîne, soit le modèle de clé d'index. Si spécifié, le système de requête
             ne considérera que les plans utilisant l'index suggéré.
-           </para>
-           <para>
+           </simpara>
+           <simpara>
             Retombe sur l'option dépréciée <literal>"hint"</literal> si non spécifiée.
-           </para>
+           </simpara>
           </entry>
          </row>
          &mongodb.option.let;
@@ -172,65 +172,65 @@
           <entry>limit</entry>
           <entry><type>int</type></entry>
           <entry>
-           <para>
+           <simpara>
             Le nombre maximum de documents à retourner. Si non spécifié, alors
             par défaut à aucune limite. Une limite de 0 est équivalente à ne pas
             définir de limite.
-           </para>
+           </simpara>
           </entry>
          </row>
          <row>
           <entry>max</entry>
           <entry><type class="union"><type>array</type><type>object</type></type></entry>
           <entry>
-           <para>
+           <simpara>
             La limite supérieure <emphasis>exclusive</emphasis> pour un index spécifique.
-           </para>
-           <para>
+           </simpara>
+           <simpara>
             Retombe sur l'option dépréciée <literal>"$max"</literal> si non
             spécifiée.
-           </para>
+           </simpara>
           </entry>
          </row>
          <row>
           <entry>maxAwaitTimeMS</entry>
           <entry><type>int</type></entry>
           <entry>
-           <para>
+           <simpara>
             Entier positif indiquant la limite de temps en millisecondes pour le
             serveur pour bloquer une opération getMore si aucune donnée n'est
             disponible. Cette option ne doit être utilisée qu'en conjonction avec
             les options <literal>"tailable"</literal> et
             <literal>"awaitData"</literal>.
-           </para>
+           </simpara>
           </entry>
          </row>
          <row>
           <entry>maxTimeMS</entry>
           <entry><type>int</type></entry>
           <entry>
-           <para>
+           <simpara>
             La limite de temps cumulative en millisecondes pour le traitement des
             opérations sur le curseur. MongoDB arrête l'opération au premier point
             d'interruption le plus proche.
-           </para>
-           <para>
+           </simpara>
+           <simpara>
             Retombe sur l'option dépréciée <literal>"$maxTimeMS"</literal> si non
             spécifiée.
-           </para>
+           </simpara>
           </entry>
          </row>
          <row>
           <entry>min</entry>
           <entry><type class="union"><type>array</type><type>object</type></type></entry>
           <entry>
-           <para>
+           <simpara>
             La limite inférieure <emphasis>inclusive</emphasis> pour un index spécifique.
-           </para>
-           <para>
+           </simpara>
+           <simpara>
             Retombe sur l'option dépréciée <literal>"$min"</literal> si non
             spécifiée.
-           </para>
+           </simpara>
           </entry>
          </row>
          <row>
@@ -245,11 +245,11 @@
           <entry>projection</entry>
           <entry><type class="union"><type>array</type><type>object</type></type></entry>
           <entry>
-           <para>
+           <simpara>
             Les <link xlink:href="&url.mongodb.docs;tutorial/project-fields-from-query-results/">spécifications de projection</link>
             pour déterminer quels champs inclure dans les documents retournés.
-           </para>
-           <para>
+           </simpara>
+           <simpara>
             Lors de l'utilisation de la
             <link linkend="mongodb.persistence.deserialization">fonctionnalité ODM</link>
             pour désérialiser les documents en tant que leur classe PHP d'origine,
@@ -257,54 +257,54 @@
             projection. Cela est nécessaire pour que la désérialisation fonctionne
             et sans cela, l'extension renverra (par défaut) un objet
             <classname>stdClass</classname> à la place.
-           </para>
+           </simpara>
           </entry>
          </row>
          <row>
           <entry>readConcern</entry>
           <entry><classname>MongoDB\Driver\ReadConcern</classname></entry>
           <entry>
-           <para>
+           <simpara>
             Un read concern à appliquer à l'opération. Par défaut, le read concern
             de l'<link linkend="mongodb-driver-manager.construct-uri">URI
             de connexion MongoDB</link>
             sera utilisé.
-           </para>
-           <para>
+           </simpara>
+           <simpara>
             Cette option est disponible dans MongoDB 3.2+ et entraînera une
             exception au moment de l'exécution si elle est spécifiée pour une
             version de serveur plus ancienne.
-           </para>
+           </simpara>
           </entry>
          </row>
          <row>
           <entry>returnKey</entry>
           <entry><type>bool</type></entry>
           <entry>
-           <para>
+           <simpara>
             Si &true;, ne retourne que les clés d'index dans les documents
             résultants. La valeur par défaut est &false;. Si &true; et que la
             commande find n'utilise pas d'index, les documents retournés seront vides.
-           </para>
-           <para>
+           </simpara>
+           <simpara>
             Retombe sur l'option dépréciée <literal>"$returnKey"</literal> si non
             spécifiée.
-           </para>
+           </simpara>
           </entry>
          </row>
          <row>
           <entry>showRecordId</entry>
           <entry><type>bool</type></entry>
           <entry>
-           <para>
+           <simpara>
             Détermine si l'identifiant d'enregistrement doit être retourné pour
             chaque document. Si &true;, ajoute un champ <literal>"$recordId"</literal>
             de premier niveau aux documents retournés.
-           </para>
-           <para>
+           </simpara>
+           <simpara>
             Retombe sur l'option dépréciée <literal>"$showDiskLoc"</literal> si non
             spécifiée.
-           </para>
+           </simpara>
           </entry>
          </row>
          <row>
@@ -324,11 +324,11 @@
           <entry>sort</entry>
           <entry><type class="union"><type>array</type><type>object</type></type></entry>
           <entry>
-           <para>La spécification de tri pour l'ordonnancement des résultats.</para>
-           <para>
+           <simpara>La spécification de tri pour l'ordonnancement des résultats.</simpara>
+           <simpara>
             Retombe sur l'option dépréciée <literal>"$orderby"</literal> si non
             spécifiée.
-           </para>
+           </simpara>
           </entry>
          </row>
          <row>
@@ -354,119 +354,117 @@
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>PECL mongodb 2.0.0</entry>
-       <entry>
-        <para>
-         L'option <literal>"partial"</literal> a été supprimée. Utiliser
-         <literal>"allowPartialResults"</literal> à la place.
-        </para>
-        <para>
-         L'option <literal>"maxScan"</literal> a été supprimée. Le Support
-         pour cette option a été supprimé dans MongoDB 4.2.
-        </para>
-        <para>
-         L'option <literal>"modifiers"</literal> a été supprimée. Cette option était
-         utilisée pour les modificateurs d'ancienne requête, qui sont tous dépréciés.
-        </para>
-        <para>
-         L'option <literal>"oplogReplay"</literal> a été supprimée. Cela est ignoré
-         dans MongoDB 4.4 et plus récent.
-        </para>
-        <para>
-         L'option <literal>"snapshot"</literal> a été supprimée. Son support a été
-         supprimé dans MongoDB 4.0.
-        </para>
-        <para>
-         Une valeur négative pour l'option <literal>"limit"</literal> n'implique plus
-         &true; pour l'option <literal>"singleBatch"</literal>. Pour ne recevoir
-         qu'un seul lot de résultats, combinez une valeur positive
-         <literal>"limit"</literal> avec l'option
-         <literal>"singleBatch"</literal>.
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>PECL mongodb 1.14.0</entry>
-       <entry>
-        <para>
-         Ajout de l'option <literal>"let"</literal>. L'option
-         <literal>"comment"</literal> accepte désormais n'importe quel type.
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>PECL mongodb 1.8.0</entry>
-       <entry>
-        <para>
-         Ajout de l'option <literal>"allowDiskUse"</literal>.
-        </para>
-        <para>
-         L'option <literal>"oplogReplay"</literal> est dépréciée.
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>PECL mongodb 1.5.0</entry>
-       <entry>
-        <para>
-         Les options <literal>"maxScan"</literal> et <literal>"snapshot"</literal>
-         sont dépréciées.
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>PECL mongodb 1.3.0</entry>
-       <entry>
-        <para>
-         Ajout de l'option <literal>"maxAwaitTimeMS"</literal>
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>PECL mongodb 1.2.0</entry>
-       <entry>
-        <para>
-         Ajout des options <literal>"allowPartialResults"</literal>,
-         <literal>"collation"</literal>, <literal>"comment"</literal>,
-         <literal>"hint"</literal>, <literal>"max"</literal>,
-         <literal>"maxScan"</literal>, <literal>"maxTimeMS"</literal>,
-         <literal>"min"</literal>, <literal>"returnKey"</literal>,
-         <literal>"showRecordId"</literal>, et <literal>"snapshot"</literal>.
-        </para>
-        <para>
-         Renommer l'option <literal>"partial"</literal> en
-         <literal>"allowPartialResults"</literal>. Pour la compatibilité ascendante,
-         <literal>"partial"</literal> sera toujours lu si
-         <literal>"allowPartialResults"</literal> n'est pas spécifié.
-        </para>
-        <para>
-         Supprime l'option <literal>"secondaryOk"</literal> obsolète. Pour les
-         requêtes utilisant le protocole de filaire hérité OP_QUERY, le pilote
-         définira le bit <literal>secondaryOk</literal> selon les besoins
-         conformément à la
-         <link xlink:href="&url.mongodb.serverselection;">Spécification de sélection du serveur</link>.
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>PECL mongodb 1.1.0</entry>
-       <entry>Ajout de l'option <literal>"readConcern"</literal>.</entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>PECL mongodb 2.0.0</entry>
+      <entry>
+       <simpara>
+        L'option <literal>"partial"</literal> a été supprimée. Utiliser
+        <literal>"allowPartialResults"</literal> à la place.
+       </simpara>
+       <simpara>
+        L'option <literal>"maxScan"</literal> a été supprimée. Le Support
+        pour cette option a été supprimé dans MongoDB 4.2.
+       </simpara>
+       <simpara>
+        L'option <literal>"modifiers"</literal> a été supprimée. Cette option était
+        utilisée pour les modificateurs d'ancienne requête, qui sont tous dépréciés.
+       </simpara>
+       <simpara>
+        L'option <literal>"oplogReplay"</literal> a été supprimée. Cela est ignoré
+        dans MongoDB 4.4 et plus récent.
+       </simpara>
+       <simpara>
+        L'option <literal>"snapshot"</literal> a été supprimée. Son support a été
+        supprimé dans MongoDB 4.0.
+       </simpara>
+       <simpara>
+        Une valeur négative pour l'option <literal>"limit"</literal> n'implique plus
+        &true; pour l'option <literal>"singleBatch"</literal>. Pour ne recevoir
+        qu'un seul lot de résultats, combinez une valeur positive
+        <literal>"limit"</literal> avec l'option
+        <literal>"singleBatch"</literal>.
+       </simpara>
+      </entry>
+     </row>
+     <row>
+      <entry>PECL mongodb 1.14.0</entry>
+      <entry>
+       <simpara>
+        Ajout de l'option <literal>"let"</literal>. L'option
+        <literal>"comment"</literal> accepte désormais n'importe quel type.
+       </simpara>
+      </entry>
+     </row>
+     <row>
+      <entry>PECL mongodb 1.8.0</entry>
+      <entry>
+       <simpara>
+        Ajout de l'option <literal>"allowDiskUse"</literal>.
+       </simpara>
+       <simpara>
+        L'option <literal>"oplogReplay"</literal> est dépréciée.
+       </simpara>
+      </entry>
+     </row>
+     <row>
+      <entry>PECL mongodb 1.5.0</entry>
+      <entry>
+       <simpara>
+        Les options <literal>"maxScan"</literal> et <literal>"snapshot"</literal>
+        sont dépréciées.
+       </simpara>
+      </entry>
+     </row>
+     <row>
+      <entry>PECL mongodb 1.3.0</entry>
+      <entry>
+       <simpara>
+        Ajout de l'option <literal>"maxAwaitTimeMS"</literal>
+       </simpara>
+      </entry>
+     </row>
+     <row>
+      <entry>PECL mongodb 1.2.0</entry>
+      <entry>
+       <simpara>
+        Ajout des options <literal>"allowPartialResults"</literal>,
+        <literal>"collation"</literal>, <literal>"comment"</literal>,
+        <literal>"hint"</literal>, <literal>"max"</literal>,
+        <literal>"maxScan"</literal>, <literal>"maxTimeMS"</literal>,
+        <literal>"min"</literal>, <literal>"returnKey"</literal>,
+        <literal>"showRecordId"</literal>, et <literal>"snapshot"</literal>.
+       </simpara>
+       <simpara>
+        Renommer l'option <literal>"partial"</literal> en
+        <literal>"allowPartialResults"</literal>. Pour la compatibilité ascendante,
+        <literal>"partial"</literal> sera toujours lu si
+        <literal>"allowPartialResults"</literal> n'est pas spécifié.
+       </simpara>
+       <simpara>
+        Supprime l'option <literal>"secondaryOk"</literal> obsolète. Pour les
+        requêtes utilisant le protocole de filaire hérité OP_QUERY, le pilote
+        définira le bit <literal>secondaryOk</literal> selon les besoins
+        conformément à la
+        <link xlink:href="&url.mongodb.serverselection;">Spécification de sélection du serveur</link>.
+       </simpara>
+      </entry>
+     </row>
+     <row>
+      <entry>PECL mongodb 1.1.0</entry>
+      <entry>Ajout de l'option <literal>"readConcern"</literal>.</entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/mongodb/mongodb/driver/readpreference/construct.xml
+++ b/reference/mongodb/mongodb/driver/readpreference/construct.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4639881688d3faaf0073ad71fe0a4b730aea15a0 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="mongodb-driver-readpreference.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -16,9 +16,9 @@
    <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>tagSets</parameter><initializer>&null;</initializer></methodparam>
    <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>options</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Construit un nouveau <classname>MongoDB\Driver\ReadPreference</classname>, qui est un objet de valeur immuable.
-  </para>
+  </simpara>
 
  </refsect1>
 
@@ -42,48 +42,48 @@
          <row>
           <entry><literal>"primary"</literal></entry>
           <entry>
-           <para>
+           <simpara>
             Toutes les opérations lues à partir du jeu de réplicas actuel primaire. 
             Il s'agit de la préférence de lecture par défaut pour MongoDB.
-           </para>
+           </simpara>
           </entry>
          </row>
          <row>
           <entry><literal>"primaryPreferred"</literal></entry>
           <entry>
-           <para>
+           <simpara>
             Dans la plupart des situations, les opérations sont lues à partir du 
             primaire, mais s'il n'est pas disponible, les opérations sont lues à
             partir d'un membre secondaire.
-           </para>
+           </simpara>
           </entry>
          </row>
          <row>
           <entry><literal>"secondary"</literal></entry>
           <entry>
-           <para>
+           <simpara>
             Toutes les opérations sont lues à partir des membres secondaires du jeu 
             de réplicas.
-           </para>
+           </simpara>
           </entry>
          </row>
          <row>
           <entry><literal>"secondaryPreferred"</literal></entry>
           <entry>
-           <para>
+           <simpara>
             Dans la plupart des cas, les opérations sont lues par des membres 
             secondaires, mais si aucun membre secondaire n'est disponible, les 
             opérations sont lues à partir du primaire.
-           </para>
+           </simpara>
           </entry>
          </row>
          <row>
           <entry><literal>"nearest"</literal></entry>
           <entry>
-           <para>
+           <simpara>
             Opérations lues à partir du membre du jeu de réplicas ayant la latence 
             réseau la moins élevée, quel que soit le type du membre.
-           </para>
+           </simpara>
           </entry>
          </row>
         </tbody>
@@ -95,7 +95,7 @@
    <varlistentry>
     <term><parameter>tagSets</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       Les jeux de tag permettent de cibler des opérations de lecture sur des 
       membres spécifiques d'un jeu de réplicas. Ce paramètre doit être un tableau de 
       tableaux associatifs, qui contiennent chacun zéro ou plusieurs paires 
@@ -105,8 +105,8 @@
       sélection échoue, le pilote essaiera les jeux suivants. Un jeu de balises vide 
       (<literal>array()</literal>) correspond à n'importe quel nœud et peut être 
       utilisé comme secours.
-     </para>
-     <para>
+     </simpara>
+     <simpara>
       Les tags ne sont pas compatibles avec le mode 
       <literal>"primary"</literal> et, en général, 
       s'appliquent uniquement lors de la sélection d'un membre secondaire d'un jeu 
@@ -114,7 +114,7 @@
       <literal>"nearest"</literal>, lorsqu'il est 
       combiné avec un jeu de balises, sélectionne le membre correspondant avec la 
       latence réseau la plus basse. Ce membre peut être primaire ou secondaire.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
@@ -136,10 +136,10 @@
           <entry>hedge</entry>
           <entry><type class="union"><type>object</type><type>array</type></type></entry>
           <entry>
-           <para>Spécifie si l'on doit utiliser ou non <link xlink:href="&url.mongodb.docs;core/sharded-cluster-query-router/#mongos-hedged-reads">les lectures
+           <simpara>Spécifie si l'on doit utiliser ou non <link xlink:href="&url.mongodb.docs;core/sharded-cluster-query-router/#mongos-hedged-reads">les lectures
             croisées</link>, qui sont supportés depuis MongoDB 4.4+ pour les
-            requêtes partagées.</para>
-           <para>
+            requêtes partagées.</simpara>
+           <simpara>
             Le serveur des lectures croisées est disponible pour toutes les
             lectures des références non primaires, et est activé par défaut
             lors de l'utilisation du mode <literal>"nearest"</literal>. Cette option
@@ -149,39 +149,39 @@
             le serveur des lectures croisées pour les lectures des références
             <literal>"nearest"</literal> en spécifiant
             <literal>['enabled' => false]</literal>.
-           </para>
+           </simpara>
           </entry>
          </row>
          <row>
           <entry>maxStalenessSeconds</entry>
           <entry>&integer;</entry>
           <entry>
-           <para>
+           <simpara>
             Spécifie un décalage de réplication maximal, ou "obsolescence", pour 
             les lectures des secondaires. Lorsque l'obsolescence estimée d'un 
             secondaire dépasse cette valeur, le pilote cesse de l'utiliser pour les 
             opérations de lecture.
-           </para>
-           <para>
+           </simpara>
+           <simpara>
             Si elle est spécifiée, l'obsolescence maximale doit être un entier signé 
             32 bits supérieur ou égal à 
             <constant>MongoDB\Driver\ReadPreference::SMALLEST_MAX_STALENESS_SECONDS</constant>.
-           </para>
-           <para>
+           </simpara>
+           <simpara>
             Par défaut, 
             <constant>MongoDB\Driver\ReadPreference::NO_MAX_STALENESS</constant>, 
             ce qui signifie que le pilote ne prendra pas en compte le décalage d'un 
             secondaire lors du choix de l'endroit où diriger une opération de 
             lecture.
-           </para>
-           <para>
+           </simpara>
+           <simpara>
             Cette option n'est pas compatible avec le mode 
             <literal>"primary"</literal>.
             La spécification d'une obsolescence maximale requiert également que 
             toutes les instances MongoDB du déploiement utilisent MongoDB 3.4+. Une 
             exception sera levée au moment de l'exécution si toutes les instances de 
             MongoDB dans le déploiement sont d'une version de serveur plus ancienne.
-           </para>
+           </simpara>
           </entry>
          </row>
         </tbody>
@@ -205,60 +205,58 @@
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>PECL mongodb 2.0.0</entry>
-       <entry>
-        Passer un <type>int</type> pour l'argument <parameter>mode</parameter>
-        n'est plus pris en charge.
-       </entry>
-      </row>
-      <row>
-       <entry>PECL mongodb 1.20.0</entry>
-       <entry>
-        Passer un <type>int</type> pour l'argument <parameter>mode</parameter>
-        est <emphasis>DÉPRÉCIÉ</emphasis>.
-       </entry>
-      </row>
-      <row>
-       <entry>PECL mongodb 1.8.0</entry>
-       <entry>
-        Ajout de l'option <literal>"hedge"</literal>.
-       </entry>
-      </row>
-      <row>
-       <entry>PECL mongodb 1.3.0</entry>
-       <entry>
-        <para>
-         L'argument <parameter>mode</parameter> accepte maintenant une valeur de 
-         chaîne, ce qui est compatible avec l'option URI 
-         <literal>"readPreference"</literal> pour 
-         <function>MongoDB\Driver\Manager::__construct</function>
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>PECL mongodb 1.2.0</entry>
-       <entry>
-        <para>
-         Ajout d'un troisième argument d'<parameter>options</parameter>, qui prend 
-         en charge l'option <literal>"maxStalenessSeconds"</literal> .
-        </para>
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>PECL mongodb 2.0.0</entry>
+      <entry>
+       Passer un <type>int</type> pour l'argument <parameter>mode</parameter>
+       n'est plus pris en charge.
+      </entry>
+     </row>
+     <row>
+      <entry>PECL mongodb 1.20.0</entry>
+      <entry>
+       Passer un <type>int</type> pour l'argument <parameter>mode</parameter>
+       est <emphasis>DÉPRÉCIÉ</emphasis>.
+      </entry>
+     </row>
+     <row>
+      <entry>PECL mongodb 1.8.0</entry>
+      <entry>
+       Ajout de l'option <literal>"hedge"</literal>.
+      </entry>
+     </row>
+     <row>
+      <entry>PECL mongodb 1.3.0</entry>
+      <entry>
+       <simpara>
+        L'argument <parameter>mode</parameter> accepte maintenant une valeur de 
+        chaîne, ce qui est compatible avec l'option URI 
+        <literal>"readPreference"</literal> pour 
+        <function>MongoDB\Driver\Manager::__construct</function>
+       </simpara>
+      </entry>
+     </row>
+     <row>
+      <entry>PECL mongodb 1.2.0</entry>
+      <entry>
+       <simpara>
+        Ajout d'un troisième argument d'<parameter>options</parameter>, qui prend 
+        en charge l'option <literal>"maxStalenessSeconds"</literal> .
+       </simpara>
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
 

--- a/reference/mongodb/mongodb/driver/readpreference/construct.xml
+++ b/reference/mongodb/mongodb/driver/readpreference/construct.xml
@@ -43,7 +43,7 @@
           <entry><literal>"primary"</literal></entry>
           <entry>
            <simpara>
-            Toutes les opérations lues à partir du jeu de réplicas actuel primaire. 
+            Toutes les opérations lues à partir du jeu de réplicas actuel primaire.
             Il s'agit de la préférence de lecture par défaut pour MongoDB.
            </simpara>
           </entry>
@@ -52,7 +52,7 @@
           <entry><literal>"primaryPreferred"</literal></entry>
           <entry>
            <simpara>
-            Dans la plupart des situations, les opérations sont lues à partir du 
+            Dans la plupart des situations, les opérations sont lues à partir du
             primaire, mais s'il n'est pas disponible, les opérations sont lues à
             partir d'un membre secondaire.
            </simpara>
@@ -62,7 +62,7 @@
           <entry><literal>"secondary"</literal></entry>
           <entry>
            <simpara>
-            Toutes les opérations sont lues à partir des membres secondaires du jeu 
+            Toutes les opérations sont lues à partir des membres secondaires du jeu
             de réplicas.
            </simpara>
           </entry>
@@ -71,8 +71,8 @@
           <entry><literal>"secondaryPreferred"</literal></entry>
           <entry>
            <simpara>
-            Dans la plupart des cas, les opérations sont lues par des membres 
-            secondaires, mais si aucun membre secondaire n'est disponible, les 
+            Dans la plupart des cas, les opérations sont lues par des membres
+            secondaires, mais si aucun membre secondaire n'est disponible, les
             opérations sont lues à partir du primaire.
            </simpara>
           </entry>
@@ -81,7 +81,7 @@
           <entry><literal>"nearest"</literal></entry>
           <entry>
            <simpara>
-            Opérations lues à partir du membre du jeu de réplicas ayant la latence 
+            Opérations lues à partir du membre du jeu de réplicas ayant la latence
             réseau la moins élevée, quel que soit le type du membre.
            </simpara>
           </entry>
@@ -96,23 +96,23 @@
     <term><parameter>tagSets</parameter></term>
     <listitem>
      <simpara>
-      Les jeux de tag permettent de cibler des opérations de lecture sur des 
-      membres spécifiques d'un jeu de réplicas. Ce paramètre doit être un tableau de 
-      tableaux associatifs, qui contiennent chacun zéro ou plusieurs paires 
-      clé/valeur. Lors de la sélection d'un serveur pour une opération de lecture, 
-      le pilote tente de sélectionner un nœud comportant toutes les balises d'un 
-      ensemble (c'est-à-dire le tableau associatif de paires clé/valeur). Si la 
-      sélection échoue, le pilote essaiera les jeux suivants. Un jeu de balises vide 
-      (<literal>array()</literal>) correspond à n'importe quel nœud et peut être 
+      Les jeux de tag permettent de cibler des opérations de lecture sur des
+      membres spécifiques d'un jeu de réplicas. Ce paramètre doit être un tableau de
+      tableaux associatifs, qui contiennent chacun zéro ou plusieurs paires
+      clé/valeur. Lors de la sélection d'un serveur pour une opération de lecture,
+      le pilote tente de sélectionner un nœud comportant toutes les balises d'un
+      ensemble (c'est-à-dire le tableau associatif de paires clé/valeur). Si la
+      sélection échoue, le pilote essaiera les jeux suivants. Un jeu de balises vide
+      (<literal>array()</literal>) correspond à n'importe quel nœud et peut être
       utilisé comme secours.
      </simpara>
      <simpara>
-      Les tags ne sont pas compatibles avec le mode 
-      <literal>"primary"</literal> et, en général, 
-      s'appliquent uniquement lors de la sélection d'un membre secondaire d'un jeu 
-      pour une opération de lecture. Toutefois, le mode 
-      <literal>"nearest"</literal>, lorsqu'il est 
-      combiné avec un jeu de balises, sélectionne le membre correspondant avec la 
+      Les tags ne sont pas compatibles avec le mode
+      <literal>"primary"</literal> et, en général,
+      s'appliquent uniquement lors de la sélection d'un membre secondaire d'un jeu
+      pour une opération de lecture. Toutefois, le mode
+      <literal>"nearest"</literal>, lorsqu'il est
+      combiné avec un jeu de balises, sélectionne le membre correspondant avec la
       latence réseau la plus basse. Ce membre peut être primaire ou secondaire.
      </simpara>
     </listitem>
@@ -157,29 +157,29 @@
           <entry>&integer;</entry>
           <entry>
            <simpara>
-            Spécifie un décalage de réplication maximal, ou "obsolescence", pour 
-            les lectures des secondaires. Lorsque l'obsolescence estimée d'un 
-            secondaire dépasse cette valeur, le pilote cesse de l'utiliser pour les 
+            Spécifie un décalage de réplication maximal, ou "obsolescence", pour
+            les lectures des secondaires. Lorsque l'obsolescence estimée d'un
+            secondaire dépasse cette valeur, le pilote cesse de l'utiliser pour les
             opérations de lecture.
            </simpara>
            <simpara>
-            Si elle est spécifiée, l'obsolescence maximale doit être un entier signé 
-            32 bits supérieur ou égal à 
+            Si elle est spécifiée, l'obsolescence maximale doit être un entier signé
+            32 bits supérieur ou égal à
             <constant>MongoDB\Driver\ReadPreference::SMALLEST_MAX_STALENESS_SECONDS</constant>.
            </simpara>
            <simpara>
-            Par défaut, 
-            <constant>MongoDB\Driver\ReadPreference::NO_MAX_STALENESS</constant>, 
-            ce qui signifie que le pilote ne prendra pas en compte le décalage d'un 
-            secondaire lors du choix de l'endroit où diriger une opération de 
+            Par défaut,
+            <constant>MongoDB\Driver\ReadPreference::NO_MAX_STALENESS</constant>,
+            ce qui signifie que le pilote ne prendra pas en compte le décalage d'un
+            secondaire lors du choix de l'endroit où diriger une opération de
             lecture.
            </simpara>
            <simpara>
-            Cette option n'est pas compatible avec le mode 
+            Cette option n'est pas compatible avec le mode
             <literal>"primary"</literal>.
-            La spécification d'une obsolescence maximale requiert également que 
-            toutes les instances MongoDB du déploiement utilisent MongoDB 3.4+. Une 
-            exception sera levée au moment de l'exécution si toutes les instances de 
+            La spécification d'une obsolescence maximale requiert également que
+            toutes les instances MongoDB du déploiement utilisent MongoDB 3.4+. Une
+            exception sera levée au moment de l'exécution si toutes les instances de
             MongoDB dans le déploiement sont d'une version de serveur plus ancienne.
            </simpara>
           </entry>
@@ -238,9 +238,9 @@
       <entry>PECL mongodb 1.3.0</entry>
       <entry>
        <simpara>
-        L'argument <parameter>mode</parameter> accepte maintenant une valeur de 
-        chaîne, ce qui est compatible avec l'option URI 
-        <literal>"readPreference"</literal> pour 
+        L'argument <parameter>mode</parameter> accepte maintenant une valeur de
+        chaîne, ce qui est compatible avec l'option URI
+        <literal>"readPreference"</literal> pour
         <function>MongoDB\Driver\Manager::__construct</function>
        </simpara>
       </entry>
@@ -249,7 +249,7 @@
       <entry>PECL mongodb 1.2.0</entry>
       <entry>
        <simpara>
-        Ajout d'un troisième argument d'<parameter>options</parameter>, qui prend 
+        Ajout d'un troisième argument d'<parameter>options</parameter>, qui prend
         en charge l'option <literal>"maxStalenessSeconds"</literal> .
        </simpara>
       </entry>

--- a/reference/mongodb/mongodb/driver/readpreference/getmode.xml
+++ b/reference/mongodb/mongodb/driver/readpreference/getmode.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4639881688d3faaf0073ad71fe0a4b730aea15a0 Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="mongodb-driver-readpreference.getmode" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -9,11 +9,11 @@
 
  <refsynopsisdiv>
   <warning>
-   <para>
+   <simpara>
     Cette fonction a été <emphasis>DÉPRÉCIÉE</emphasis> depuis la version 1.20.0 de l'extension
     et a été supprimée dans la version 2.0. Les applications devraient utiliser
     <methodname>MongoDB\Driver\ReadPreference::getModeString</methodname> à la place.
-   </para>
+   </simpara>
   </warning>
  </refsynopsisdiv>
 
@@ -32,9 +32,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Renvoie l'option "mode" du ReadPreference.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">
@@ -46,21 +46,19 @@
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      &mongodb.changelog.method-removed;
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     &mongodb.changelog.method-removed;
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/mongodb/mongodb/driver/server.xml
+++ b/reference/mongodb/mongodb/driver/server.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 
 <reference xml:id="class.mongodb-driver-server" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
@@ -12,9 +12,9 @@
 <!-- {{{ MongoDB\Driver\Server intro -->
   <section xml:id="mongodb-driver-server.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
 
-   </para>
+   </simpara>
   </section>
 <!-- }}} -->
 
@@ -110,66 +110,66 @@
     <varlistentry xml:id="mongodb-driver-server.constants.type-unknown">
      <term><constant>MongoDB\Driver\Server::TYPE_UNKNOWN</constant></term>
      <listitem>
-      <para>Type de serveur inconnu, retourné par <methodname>MongoDB\Driver\Server::getType</methodname>.</para>
+      <simpara>Type de serveur inconnu, retourné par <methodname>MongoDB\Driver\Server::getType</methodname>.</simpara>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="mongodb-driver-server.constants.type-standalone">
      <term><constant>MongoDB\Driver\Server::TYPE_STANDALONE</constant></term>
      <listitem>
-      <para>Type de serveur autonome, retourné par <methodname>MongoDB\Driver\Server::getType</methodname>.</para>
+      <simpara>Type de serveur autonome, retourné par <methodname>MongoDB\Driver\Server::getType</methodname>.</simpara>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="mongodb-driver-server.constants.type-mongos">
      <term><constant>MongoDB\Driver\Server::TYPE_MONGOS</constant></term>
      <listitem>
-      <para>Type de serveur Mongos, retourné par <methodname>MongoDB\Driver\Server::getType</methodname>.</para>
+      <simpara>Type de serveur Mongos, retourné par <methodname>MongoDB\Driver\Server::getType</methodname>.</simpara>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="mongodb-driver-server.constants.type-possible-primary">
      <term><constant>MongoDB\Driver\Server::TYPE_POSSIBLE_PRIMARY</constant></term>
      <listitem>
-      <para>Jeu de réplique type de serveur principal possible, retourné par <methodname>MongoDB\Driver\Server::getType</methodname>.</para>
-      <para>Un serveur peut être identifié comme un possible primaire s'il n'a pas encore été vérifié, mais une autre mémoire du jeu de réplique pense qu'il est le principal.</para>
+      <simpara>Jeu de réplique type de serveur principal possible, retourné par <methodname>MongoDB\Driver\Server::getType</methodname>.</simpara>
+      <simpara>Un serveur peut être identifié comme un possible primaire s'il n'a pas encore été vérifié, mais une autre mémoire du jeu de réplique pense qu'il est le principal.</simpara>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="mongodb-driver-server.constants.type-rs-primary">
      <term><constant>MongoDB\Driver\Server::TYPE_RS_PRIMARY</constant></term>
      <listitem>
-      <para>Type de serveur principal du jeu de réplique, retourné par <methodname>MongoDB\Driver\Server::getType</methodname>.</para>
+      <simpara>Type de serveur principal du jeu de réplique, retourné par <methodname>MongoDB\Driver\Server::getType</methodname>.</simpara>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="mongodb-driver-server.constants.type-rs-secondary">
      <term><constant>MongoDB\Driver\Server::TYPE_RS_SECONDARY</constant></term>
      <listitem>
-      <para>Réplique de type de serveur secondaire, retourné par <methodname>MongoDB\Driver\Server::getType</methodname>.</para>
+      <simpara>Réplique de type de serveur secondaire, retourné par <methodname>MongoDB\Driver\Server::getType</methodname>.</simpara>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="mongodb-driver-server.constants.type-rs-arbiter">
      <term><constant>MongoDB\Driver\Server::TYPE_RS_ARBITER</constant></term>
      <listitem>
-      <para>Type de serveur arbitre de jeu de réplique, retourné par <methodname>MongoDB\Driver\Server::getType</methodname>.</para>
+      <simpara>Type de serveur arbitre de jeu de réplique, retourné par <methodname>MongoDB\Driver\Server::getType</methodname>.</simpara>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="mongodb-driver-server.constants.type-rs-other">
      <term><constant>MongoDB\Driver\Server::TYPE_RS_OTHER</constant></term>
      <listitem>
-      <para>Type de serveur autre de jeu de réplique, retourné par <methodname>MongoDB\Driver\Server::getType</methodname>.</para>
-      <para>Ces serveurs peuvent être masqués, en cours de démarrage ou en cours de récupération. Ils ne peuvent pas être interrogés, mais leurs listes d'hôtes sont utiles pour découvrir la configuration actuelle du jeu de réplique.</para>
+      <simpara>Type de serveur autre de jeu de réplique, retourné par <methodname>MongoDB\Driver\Server::getType</methodname>.</simpara>
+      <simpara>Ces serveurs peuvent être masqués, en cours de démarrage ou en cours de récupération. Ils ne peuvent pas être interrogés, mais leurs listes d'hôtes sont utiles pour découvrir la configuration actuelle du jeu de réplique.</simpara>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="mongodb-driver-server.constants.type-rs-ghost">
      <term><constant>MongoDB\Driver\Server::TYPE_RS_GHOST</constant></term>
      <listitem>
-      <para>Type de serveur fantôme de jeu de réplique, retourné par <methodname>MongoDB\Driver\Server::getType</methodname>.</para>
-      <para>
+      <simpara>Type de serveur fantôme de jeu de réplique, retourné par <methodname>MongoDB\Driver\Server::getType</methodname>.</simpara>
+      <simpara>
        Les serveurs peuvent être identifiés comme tels dans au moins trois
        situations : brièvement pendant le démarrage du serveur ;
        dans un jeu de réplique non initialisé ; ou lorsque le serveur est évité
@@ -178,14 +178,14 @@
        être utilisée pour découvrir la configuration actuelle du jeu de
        réplique ; toutefois, le client peut surveiller ce serveur dans l'espoir
        qu'il change vers un état plus utile.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="mongodb-driver-server.constants.type-load-balancer">
      <term><constant>MongoDB\Driver\Server::TYPE_LOAD_BALANCER</constant></term>
      <listitem>
-      <para>Type de serveur de Load balancer, retourné par <methodname>MongoDB\Driver\Server::getType</methodname>.</para>
+      <simpara>Type de serveur de Load balancer, retourné par <methodname>MongoDB\Driver\Server::getType</methodname>.</simpara>
      </listitem>
     </varlistentry>
 
@@ -195,29 +195,27 @@
 
   <section role="changelog">
    &reftitle.changelog;
-   <para>
-    <informaltable>
-     <tgroup cols="2">
-      <thead>
-       <row>
-        <entry>&Version;</entry>
-        <entry>&Description;</entry>
-       </row>
-      </thead>
-      <tbody>
-       <row>
-        <entry>PECL mongodb 1.11.0</entry>
-        <entry>
-         <para>
-          Ajout de la constante
-          <constant>MongoDB\Driver\Server::TYPE_LOAD_BALANCER</constant>.
-         </para>
-        </entry>
-       </row>
-      </tbody>
-     </tgroup>
-    </informaltable>
-   </para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>PECL mongodb 1.11.0</entry>
+       <entry>
+        <simpara>
+         Ajout de la constante
+         <constant>MongoDB\Driver\Server::TYPE_LOAD_BALANCER</constant>.
+        </simpara>
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
   </section>
 
  </partintro>

--- a/reference/mongodb/mongodb/driver/server/executebulkwrite.xml
+++ b/reference/mongodb/mongodb/driver/server/executebulkwrite.xml
@@ -119,16 +119,16 @@
       <entry>PECL mongodb 1.4.0</entry>
       <entry>
        Le troisième paramètre est maintenant un tableau
-       d'<parameter>options</parameter>. Pour la compatibilité ascendante, 
+       d'<parameter>options</parameter>. Pour la compatibilité ascendante,
        ce paramètre acceptera toujours un objet <classname>MongoDB\Driver\WriteConcern</classname>.
       </entry>
      </row>
      <row>
       <entry>PECL mongodb 1.3.0</entry>
       <entry>
-       <classname>MongoDBDriverExceptionInvalidArgumentException</classname> est 
-       maintenant levé si <parameter>Bulk</parameter> ne contient pas 
-       d'opérations d'écriture. Auparavant, une 
+       <classname>MongoDBDriverExceptionInvalidArgumentException</classname> est
+       maintenant levé si <parameter>Bulk</parameter> ne contient pas
+       d'opérations d'écriture. Auparavant, une
        <classname>MongoDB\Driver\Exception\BulkWriteException</classname> était levée.
       </entry>
      </row>

--- a/reference/mongodb/mongodb/driver/server/executebulkwrite.xml
+++ b/reference/mongodb/mongodb/driver/server/executebulkwrite.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4639881688d3faaf0073ad71fe0a4b730aea15a0 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="mongodb-driver-server.executebulkwrite" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -16,21 +16,21 @@
    <methodparam><type>MongoDB\Driver\BulkWrite</type><parameter>bulk</parameter></methodparam>
    <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>options</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Exécute une ou plusieurs opérations en écriture sur ce serveur.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Un objet <classname>MongoDB\Driver\BulkWrite</classname> peut être construit avec
    une ou plusieurs opérations de types différents (c.-à-d. mise à jour, suppression,
    et insertion). Le driver va tenter d'envoyer les opérations de même type au
    serveur en un minimum de requête possible afin d'optimiser les aller/retour.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    La valeur par défaut pour l'option <literal>"writeConcern"</literal> sera
    déduite d'une transaction active (indiquée par l'option
    <literal>"session"</literal>), puis par le
    <link linkend="mongodb-driver-manager.construct-uri">URI de connexion</link>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -84,59 +84,57 @@
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>PECL mongodb 2.0.0</entry>
-       <entry>
-        Le paramètre <parameter>options</parameter> n'accepte désormais plus
-        d'instance <classname>MongoDB\Driver\WriteConcern</classname>.
-       </entry>
-      </row>
-      <row>
-       <entry>PECL mongodb 1.21.0</entry>
-       <entry>
-        Passer un objet <classname>MongoDB\Driver\WriteConcern</classname> en tant
-        qu'<parameter>options</parameter> est obsolète et sera supprimé dans la 2.0.
-       </entry>
-      </row>
-      <row>
-       <entry>PECL mongodb 1.4.4</entry>
-       <entry>
-        <classname>MongoDB\Driver\Exception\InvalidArgumentException</classname>
-        sera lancé si l'option <literal>"session"</literal> est utilisée
-        conjointement avec une préoccupation d&#39;écriture non reconnu.
-       </entry>
-      </row>
-      <row>
-       <entry>PECL mongodb 1.4.0</entry>
-       <entry>
-        Le troisième paramètre est maintenant un tableau
-        d'<parameter>options</parameter>. Pour la compatibilité ascendante, 
-        ce paramètre acceptera toujours un objet <classname>MongoDB\Driver\WriteConcern</classname>.
-       </entry>
-      </row>
-      <row>
-       <entry>PECL mongodb 1.3.0</entry>
-       <entry>
-        <classname>MongoDBDriverExceptionInvalidArgumentException</classname> est 
-        maintenant levé si <parameter>Bulk</parameter> ne contient pas 
-        d'opérations d'écriture. Auparavant, une 
-        <classname>MongoDB\Driver\Exception\BulkWriteException</classname> était levée.
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>PECL mongodb 2.0.0</entry>
+      <entry>
+       Le paramètre <parameter>options</parameter> n'accepte désormais plus
+       d'instance <classname>MongoDB\Driver\WriteConcern</classname>.
+      </entry>
+     </row>
+     <row>
+      <entry>PECL mongodb 1.21.0</entry>
+      <entry>
+       Passer un objet <classname>MongoDB\Driver\WriteConcern</classname> en tant
+       qu'<parameter>options</parameter> est obsolète et sera supprimé dans la 2.0.
+      </entry>
+     </row>
+     <row>
+      <entry>PECL mongodb 1.4.4</entry>
+      <entry>
+       <classname>MongoDB\Driver\Exception\InvalidArgumentException</classname>
+       sera lancé si l'option <literal>"session"</literal> est utilisée
+       conjointement avec une préoccupation d&#39;écriture non reconnu.
+      </entry>
+     </row>
+     <row>
+      <entry>PECL mongodb 1.4.0</entry>
+      <entry>
+       Le troisième paramètre est maintenant un tableau
+       d'<parameter>options</parameter>. Pour la compatibilité ascendante, 
+       ce paramètre acceptera toujours un objet <classname>MongoDB\Driver\WriteConcern</classname>.
+      </entry>
+     </row>
+     <row>
+      <entry>PECL mongodb 1.3.0</entry>
+      <entry>
+       <classname>MongoDBDriverExceptionInvalidArgumentException</classname> est 
+       maintenant levé si <parameter>Bulk</parameter> ne contient pas 
+       d'opérations d'écriture. Auparavant, une 
+       <classname>MongoDB\Driver\Exception\BulkWriteException</classname> était levée.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="notes">

--- a/reference/mongodb/mongodb/driver/server/executecommand.xml
+++ b/reference/mongodb/mongodb/driver/server/executecommand.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4639881688d3faaf0073ad71fe0a4b730aea15a0 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="mongodb-driver-server.executecommand" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -16,23 +16,23 @@
    <methodparam><type>MongoDB\Driver\Command</type><parameter>command</parameter></methodparam>
    <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>options</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Exécute une commande sur ce serveur.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Cette méthode n'applique aucune logique spéciale à la commande. Les
    valeurs par défaut pour les options <literal>"readPreference"</literal>,
    <literal>"readConcern"</literal>, et <literal>"writeConcern"</literal>
    seront déduites d'une transaction active (indiquée par l'option
    <literal>"session"</literal>). S'il n'y a pas de transaction active, une
    préférence de lecture primaire sera utilisée pour la sélection du serveur.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Les valeurs par défaut ne seront <emphasis>pas</emphasis> déduites de
    l'<link linkend="mongodb-driver-manager.construct-uri">URI de connexion</link>.
    Il est donc recommandé aux utilisateurs d'utiliser des méthodes de commande
    de lecture et/ou d'écriture spécifiques si possible.
-  </para>
+  </simpara>
   &mongodb.note.server.readpreference;
  </refsect1>
 
@@ -89,50 +89,48 @@
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>PECL mongodb 2.0.0</entry>
-       <entry>
-        Le paramètre <parameter>options</parameter> n'accepte désormais plus
-        d'instance <classname>MongoDB\Driver\WriteConcern</classname>.
-       </entry>
-      </row>
-      <row>
-       <entry>PECL mongodb 1.21.0</entry>
-       <entry>
-        Passer un objet <classname>MongoDB\Driver\ReadPreference</classname> en tant
-        qu'<parameter>options</parameter> est obsolète et sera supprimé dans la 2.0.
-       </entry>
-      </row>
-      <row>
-       <entry>PECL mongodb 1.4.4</entry>
-       <entry>
-        <classname>MongoDB\Driver\Exception\InvalidArgumentException</classname>
-        sera lancé si l'option <literal>"session"</literal> est utilisée
-        conjointement avec une préoccupation d&#39;écriture non reconnu.
-       </entry>
-      </row>
-      <row>
-       <entry>PECL mongodb 1.4.0</entry>
-       <entry>
-        Le troisième paramètre est maintenant un tableau
-        d'<parameter>options</parameter>. Pour la compatibilité ascendante, 
-        ce paramètre acceptera toujours un objet <classname>MongoDB\Driver\ReadPreference</classname>.
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>PECL mongodb 2.0.0</entry>
+      <entry>
+       Le paramètre <parameter>options</parameter> n'accepte désormais plus
+       d'instance <classname>MongoDB\Driver\WriteConcern</classname>.
+      </entry>
+     </row>
+     <row>
+      <entry>PECL mongodb 1.21.0</entry>
+      <entry>
+       Passer un objet <classname>MongoDB\Driver\ReadPreference</classname> en tant
+       qu'<parameter>options</parameter> est obsolète et sera supprimé dans la 2.0.
+      </entry>
+     </row>
+     <row>
+      <entry>PECL mongodb 1.4.4</entry>
+      <entry>
+       <classname>MongoDB\Driver\Exception\InvalidArgumentException</classname>
+       sera lancé si l'option <literal>"session"</literal> est utilisée
+       conjointement avec une préoccupation d&#39;écriture non reconnu.
+      </entry>
+     </row>
+     <row>
+      <entry>PECL mongodb 1.4.0</entry>
+      <entry>
+       Le troisième paramètre est maintenant un tableau
+       d'<parameter>options</parameter>. Pour la compatibilité ascendante, 
+       ce paramètre acceptera toujours un objet <classname>MongoDB\Driver\ReadPreference</classname>.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="notes">

--- a/reference/mongodb/mongodb/driver/server/executecommand.xml
+++ b/reference/mongodb/mongodb/driver/server/executecommand.xml
@@ -124,7 +124,7 @@
       <entry>PECL mongodb 1.4.0</entry>
       <entry>
        Le troisième paramètre est maintenant un tableau
-       d'<parameter>options</parameter>. Pour la compatibilité ascendante, 
+       d'<parameter>options</parameter>. Pour la compatibilité ascendante,
        ce paramètre acceptera toujours un objet <classname>MongoDB\Driver\ReadPreference</classname>.
       </entry>
      </row>

--- a/reference/mongodb/mongodb/driver/server/executequery.xml
+++ b/reference/mongodb/mongodb/driver/server/executequery.xml
@@ -101,7 +101,7 @@
       <entry>PECL mongodb 1.4.0</entry>
       <entry>
        Le troisième paramètre est maintenant un tableau
-       d'<parameter>options</parameter>. Pour la compatibilité ascendante, 
+       d'<parameter>options</parameter>. Pour la compatibilité ascendante,
        ce paramètre acceptera toujours un objet <classname>MongoDB\Driver\ReadPreference</classname>.
       </entry>
      </row>

--- a/reference/mongodb/mongodb/driver/server/executequery.xml
+++ b/reference/mongodb/mongodb/driver/server/executequery.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4639881688d3faaf0073ad71fe0a4b730aea15a0 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="mongodb-driver-server.executequery" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -16,14 +16,14 @@
    <methodparam><type>MongoDB\Driver\Query</type><parameter>query</parameter></methodparam>
    <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>options</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Exécute la requête sur ce serveur.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Les valeurs par défaut pour l'option <literal>"readPreference"</literal> et
    l'option <literal>"readConcern"</literal> de la requête seront déduites d'une transaction active
    (indiquée par l'option <literal>"session"</literal>), puis par l'<link linkend="mongodb-driver-manager.construct-uri">URI de connexion</link>.
-  </para>
+  </simpara>
   &mongodb.note.server.readpreference;
  </refsect1>
 
@@ -74,42 +74,40 @@
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>PECL mongodb 2.0.0</entry>
-       <entry>
-        Le paramètre <parameter>options</parameter> n'accepte désormais plus
-        d'instance <classname>MongoDB\Driver\WriteConcern</classname>.
-       </entry>
-      </row>
-      <row>
-       <entry>PECL mongodb 1.21.0</entry>
-       <entry>
-        Passer un objet <classname>MongoDB\Driver\ReadPreference</classname> en tant
-        qu'<parameter>options</parameter> est obsolète et sera supprimé dans la 2.0.
-       </entry>
-      </row>
-      <row>
-       <entry>PECL mongodb 1.4.0</entry>
-       <entry>
-        Le troisième paramètre est maintenant un tableau
-        d'<parameter>options</parameter>. Pour la compatibilité ascendante, 
-        ce paramètre acceptera toujours un objet <classname>MongoDB\Driver\ReadPreference</classname>.
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>PECL mongodb 2.0.0</entry>
+      <entry>
+       Le paramètre <parameter>options</parameter> n'accepte désormais plus
+       d'instance <classname>MongoDB\Driver\WriteConcern</classname>.
+      </entry>
+     </row>
+     <row>
+      <entry>PECL mongodb 1.21.0</entry>
+      <entry>
+       Passer un objet <classname>MongoDB\Driver\ReadPreference</classname> en tant
+       qu'<parameter>options</parameter> est obsolète et sera supprimé dans la 2.0.
+      </entry>
+     </row>
+     <row>
+      <entry>PECL mongodb 1.4.0</entry>
+      <entry>
+       Le troisième paramètre est maintenant un tableau
+       d'<parameter>options</parameter>. Pour la compatibilité ascendante, 
+       ce paramètre acceptera toujours un objet <classname>MongoDB\Driver\ReadPreference</classname>.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
 

--- a/reference/mongodb/mongodb/driver/server/executereadwritecommand.xml
+++ b/reference/mongodb/mongodb/driver/server/executereadwritecommand.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 80693438668530525ea2a78defbfc9bb218c3b1c Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="mongodb-driver-server.executereadwritecommand" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -15,17 +15,17 @@
    <methodparam><type>MongoDB\Driver\Command</type><parameter>command</parameter></methodparam>
    <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>options</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Exécute la commande sur ce serveur.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Cette méthode appliquera une logique spécifique aux commandes de lecture et d'écriture
    (par exemple <link xlink:href="&url.mongodb.docs;reference/command/aggregate/">aggregate</link>).
    Les valeurs par défaut pour les options <literal>"readConcern"</literal> et
    <literal>"writeConcern"</literal> seront déduites d'une transaction active (indiquée par
    l'option <literal>"session"</literal>), suivie de l'
    <link linkend="mongodb-driver-manager.construct-uri">URI de connexion</link>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -78,28 +78,26 @@
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>PECL mongodb 1.4.4</entry>
-       <entry>
-        Une <classname>MongoDB\Driver\Exception\InvalidArgumentException</classname>
-        va être lancée si l'option <literal>"session"</literal> est utilisée en
-        combinaison avec un writeConcern non reconnu.
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>PECL mongodb 1.4.4</entry>
+      <entry>
+       Une <classname>MongoDB\Driver\Exception\InvalidArgumentException</classname>
+       va être lancée si l'option <literal>"session"</literal> est utilisée en
+       combinaison avec un writeConcern non reconnu.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="notes">

--- a/reference/mongodb/mongodb/driver/server/executewritecommand.xml
+++ b/reference/mongodb/mongodb/driver/server/executewritecommand.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 80693438668530525ea2a78defbfc9bb218c3b1c Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="mongodb-driver-server.executewritecommand" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -15,16 +15,16 @@
    <methodparam><type>MongoDB\Driver\Command</type><parameter>command</parameter></methodparam>
    <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>options</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Exécute la commande sur ce serveur.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Cette méthode appliquera une logique spécifique aux commandes qui écrivent (par exemple
    <link xlink:href="&url.mongodb.docs;reference/command/drop/">drop</link>).
    La valeur par défaut pour l'option <literal>"writeConcern"</literal> sera déduite d'une transaction active (indiquée par
    l'option <literal>"session"</literal>), suivie de l'
    <link linkend="mongodb-driver-manager.construct-uri">URI de connexion</link>.
-  </para>
+  </simpara>
   <note>
    <simpara>
     Cette méthode n'est pas destinée à être utilisée pour exécuter
@@ -87,28 +87,26 @@
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>PECL mongodb 1.4.4</entry>
-       <entry>
-        Une <classname>MongoDB\Driver\Exception\InvalidArgumentException</classname>
-        va être lancée si l'option <literal>"session"</literal> est utilisée en
-        combinaison avec un writeConcern non reconnu.
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>PECL mongodb 1.4.4</entry>
+      <entry>
+       Une <classname>MongoDB\Driver\Exception\InvalidArgumentException</classname>
+       va être lancée si l'option <literal>"session"</literal> est utilisée en
+       combinaison avec un writeConcern non reconnu.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="notes">

--- a/reference/mongodb/mongodb/driver/server/getinfo.xml
+++ b/reference/mongodb/mongodb/driver/server/getinfo.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: bd6e6603b4614c35d9b63c8d157a98569f2358df Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-server.getinfo" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,19 +13,19 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>array</type><methodname>MongoDB\Driver\Server::getInfo</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Retourne un tableau d'informations décrivant le serveur. Ce tableau est dérivé
    de la réponse la plus récente à la commande <link xlink:href="&url.mongodb.docs;reference/command/hello/">hello</link>
    obtenue par la <link xlink:href="&url.mongodb.sdam;">surveillance du serveur</link>.
-  </para>
+  </simpara>
   <note>
-   <para>
+   <simpara>
     Lorsque le pilote est connecté à un équilibreur de charge, cette méthode retourne
     la réponse à la commande <link xlink:href="&url.mongodb.docs;reference/command/hello/">hello</link>
     du serveur de backing lors de la poignée de main initiale de la connexion.
     Cela contraste avec d'autres méthodes (par exemple, <function>MongoDB\Driver\Server::getType</function>),
     qui renverront des informations sur l'équilibreur de charge lui-même.
-   </para>
+   </simpara>
   </note>
  </refsect1>
 
@@ -36,9 +36,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retourne un tableau d'informations décrivant ce serveur.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">
@@ -202,28 +202,26 @@ array(23) {
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>PECL mongodb 1.11.0</entry>
-       <entry>
-        Lorsque le pilote est connecté à un équilibreur de charge,
-        cette méthode renvoie la réponse de la commande <literal>hello</literal> du serveur
-        de backing à partir de la poignée de main de connexion initiale.
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>PECL mongodb 1.11.0</entry>
+      <entry>
+       Lorsque le pilote est connecté à un équilibreur de charge,
+       cette méthode renvoie la réponse de la commande <literal>hello</literal> du serveur
+       de backing à partir de la poignée de main de connexion initiale.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/mongodb/mongodb/driver/server/getlatency.xml
+++ b/reference/mongodb/mongodb/driver/server/getlatency.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: c64016065c9b97fa1cbbef48a9ed105232b423a8 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mongodb-driver-server.getlatency" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,11 +13,11 @@
    <modifier>final</modifier> <modifier>public</modifier> <type class="union"><type>integer</type><type>null</type></type><methodname>MongoDB\Driver\Server::getLatency</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Retourne la latence de ce serveur en millisecondes. C'est la mesure cliente du temps d'un
    <link xlink:href="&url.mongodb.sdam;#round-trip-time">aller/retour</link>
    d'une commande <literal>hello</literal>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -27,10 +27,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retourne la latence du serveur en millisecondes,
    ou &null; si aucune latence n'a été mesurée (par exemple, le client est connecté à un équilibreur de charge).
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">
@@ -42,28 +42,26 @@
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>PECL mongodb 1.11.0</entry>
-       <entry>
-        Cette méthode retournera &null; si aucune latence n'a été mesurée.
-        Dans les versions antérieures, un nombre entier était toujours retourné
-        et une valeur non définie pouvait être signalée comme <literal>-1</literal>.
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>PECL mongodb 1.11.0</entry>
+      <entry>
+       Cette méthode retournera &null; si aucune latence n'a été mesurée.
+       Dans les versions antérieures, un nombre entier était toujours retourné
+       et une valeur non définie pouvait être signalée comme <literal>-1</literal>.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/mongodb/mongodb/driver/serverapi.xml
+++ b/reference/mongodb/mongodb/driver/serverapi.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <reference xml:id="class.mongodb-driver-serverapi" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>La classe MongoDB\Driver\ServerApi</title>
@@ -10,9 +10,9 @@
 <!-- {{{ MongoDB\Driver\ServerApi intro -->
   <section xml:id="mongodb-driver-serverapi.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
 
-   </para>
+   </simpara>
   </section>
 <!-- }}} -->
 
@@ -61,7 +61,7 @@
     <varlistentry xml:id="mongodb-driver-serverapi.constants.v1">
      <term><constant>MongoDB\Driver\ServerApi::V1</constant></term>
      <listitem>
-      <para>Version 1 de l'API serveur.</para>
+      <simpara>Version 1 de l'API serveur.</simpara>
      </listitem>
     </varlistentry>
 
@@ -113,11 +113,11 @@ echo $buildInfo->version, "\n";
 
    <example>
     <title>Déclare une version d'API stricte sur un gestionnaire</title>
-    <para>
+    <simpara>
      L'exemple suivant définit le drapeau <parameter>strict</parameter>, qui
      indique au serveur de rejeter toute commande qui ne fait pas partie de la version
      d'API déclarée. Cela entraîne une erreur lors de l'exécution de la commande buildInfo.
-    </para>
+    </simpara>
     <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/mongodb/mongodb/driver/serverdescription.xml
+++ b/reference/mongodb/mongodb/driver/serverdescription.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <reference xml:id="class.mongodb-driver-serverdescription" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>La classe MongoDB\Driver\ServerDescription</title>
@@ -10,13 +10,13 @@
 <!-- {{{ MongoDB\Driver\ServerDescription intro -->
   <section xml:id="mongodb-driver-serverdescription.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     La classe <classname>MongoDB\Driver\ServerDescription</classname> est un objet de valeur
     qui représente un serveur auquel le pilote est connecté. Les instances
     de cette classe sont retournées par les méthodes
     <function>MongoDB\Driver\Server::getServerDescription</function> et
     <classname>MongoDB\Driver\Monitoring\ServerChangedEvent</classname>.
-   </para>
+   </simpara>
   </section>
 <!-- }}} -->
 
@@ -112,73 +112,73 @@
     <varlistentry xml:id="mongodb-driver-serverdescription.constants.type-unknown">
      <term><constant>MongoDB\Driver\ServerDescription::TYPE_UNKNOWN</constant></term>
      <listitem>
-      <para>Le type de serveur inconnu, retourné par <methodname>MongoDB\Driver\ServerDescription::getType</methodname>.</para>
+      <simpara>Le type de serveur inconnu, retourné par <methodname>MongoDB\Driver\ServerDescription::getType</methodname>.</simpara>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="mongodb-driver-serverdescription.constants.type-standalone">
      <term><constant>MongoDB\Driver\ServerDescription::TYPE_STANDALONE</constant></term>
      <listitem>
-      <para>Le type de serveur autonome, retourné par <methodname>MongoDB\Driver\ServerDescription::getType</methodname>.</para>
+      <simpara>Le type de serveur autonome, retourné par <methodname>MongoDB\Driver\ServerDescription::getType</methodname>.</simpara>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="mongodb-driver-serverdescription.constants.type-mongos">
      <term><constant>MongoDB\Driver\ServerDescription::TYPE_MONGOS</constant></term>
      <listitem>
-      <para>Le type de serveur Mongos, retourné par <methodname>MongoDB\Driver\ServerDescription::getType</methodname>.</para>
+      <simpara>Le type de serveur Mongos, retourné par <methodname>MongoDB\Driver\ServerDescription::getType</methodname>.</simpara>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="mongodb-driver-serverdescription.constants.type-possible-primary">
      <term><constant>MongoDB\Driver\ServerDescription::TYPE_POSSIBLE_PRIMARY</constant></term>
      <listitem>
-      <para>Le type de serveur primaire possible d'un ensemble de réplicas, retourné par <methodname>MongoDB\Driver\ServerDescription::getType</methodname>.</para>
-      <para>Un serveur peut être identifié comme un primaire possible s'il n'a pas encore été vérifié mais qu'un autre serveur de la réplique pense qu'il est le primaire.</para>
+      <simpara>Le type de serveur primaire possible d'un ensemble de réplicas, retourné par <methodname>MongoDB\Driver\ServerDescription::getType</methodname>.</simpara>
+      <simpara>Un serveur peut être identifié comme un primaire possible s'il n'a pas encore été vérifié mais qu'un autre serveur de la réplique pense qu'il est le primaire.</simpara>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="mongodb-driver-serverdescription.constants.type-rs-primary">
      <term><constant>MongoDB\Driver\ServerDescription::TYPE_RS_PRIMARY</constant></term>
      <listitem>
-      <para>Le type de serveur primaire d'un ensemble de réplicas, retourné par <methodname>MongoDB\Driver\ServerDescription::getType</methodname>.</para>
+      <simpara>Le type de serveur primaire d'un ensemble de réplicas, retourné par <methodname>MongoDB\Driver\ServerDescription::getType</methodname>.</simpara>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="mongodb-driver-serverdescription.constants.type-rs-secondary">
      <term><constant>MongoDB\Driver\ServerDescription::TYPE_RS_SECONDARY</constant></term>
      <listitem>
-      <para>Le type de serveur secondaire d'un ensemble de réplicas, retourné par <methodname>MongoDB\Driver\ServerDescription::getType</methodname>.</para>
+      <simpara>Le type de serveur secondaire d'un ensemble de réplicas, retourné par <methodname>MongoDB\Driver\ServerDescription::getType</methodname>.</simpara>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="mongodb-driver-serverdescription.constants.type-rs-arbiter">
      <term><constant>MongoDB\Driver\ServerDescription::TYPE_RS_ARBITER</constant></term>
      <listitem>
-      <para>Le type de serveur arbitre d'un ensemble de réplicas, retourné par <methodname>MongoDB\Driver\ServerDescription::getType</methodname>.</para>
+      <simpara>Le type de serveur arbitre d'un ensemble de réplicas, retourné par <methodname>MongoDB\Driver\ServerDescription::getType</methodname>.</simpara>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="mongodb-driver-serverdescription.constants.type-rs-other">
      <term><constant>MongoDB\Driver\ServerDescription::TYPE_RS_OTHER</constant></term>
      <listitem>
-      <para>Le type de serveur d'un ensemble de réplicas autre que primaire, secondaire ou arbitre, retourné par <methodname>MongoDB\Driver\ServerDescription::getType</methodname>.</para>
-      <para>Ces serveurs peuvent être cachés, démarrer ou récupérer. Ils ne peuvent pas être interrogés, mais leurs listes d'hôtes sont utiles pour découvrir la configuration actuelle de l'ensemble de réplicas.</para>
+      <simpara>Le type de serveur d'un ensemble de réplicas autre que primaire, secondaire ou arbitre, retourné par <methodname>MongoDB\Driver\ServerDescription::getType</methodname>.</simpara>
+      <simpara>Ces serveurs peuvent être cachés, démarrer ou récupérer. Ils ne peuvent pas être interrogés, mais leurs listes d'hôtes sont utiles pour découvrir la configuration actuelle de l'ensemble de réplicas.</simpara>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="mongodb-driver-serverdescription.constants.type-rs-ghost">
      <term><constant>MongoDB\Driver\ServerDescription::TYPE_RS_GHOST</constant></term>
      <listitem>
-      <para>Le type de serveur fantôme d'un ensemble de réplicas, retourné par <methodname>MongoDB\Driver\ServerDescription::getType</methodname>.</para>
-      <para>Les serveurs peuvent être identifiés comme tels dans au moins trois situations : brièvement pendant le démarrage du serveur ; dans un ensemble de réplicas non initialisé ; ou lorsque le serveur est écarté (c'est-à-dire retiré de la configuration de l'ensemble de réplicas). Ils ne peuvent pas être interrogés, ni leur liste d'hôtes utilisée pour découvrir la configuration actuelle de l'ensemble de réplicas ; cependant, le client peut surveiller ce serveur dans l'espoir qu'il passe à un état plus utile.</para>
+      <simpara>Le type de serveur fantôme d'un ensemble de réplicas, retourné par <methodname>MongoDB\Driver\ServerDescription::getType</methodname>.</simpara>
+      <simpara>Les serveurs peuvent être identifiés comme tels dans au moins trois situations : brièvement pendant le démarrage du serveur ; dans un ensemble de réplicas non initialisé ; ou lorsque le serveur est écarté (c'est-à-dire retiré de la configuration de l'ensemble de réplicas). Ils ne peuvent pas être interrogés, ni leur liste d'hôtes utilisée pour découvrir la configuration actuelle de l'ensemble de réplicas ; cependant, le client peut surveiller ce serveur dans l'espoir qu'il passe à un état plus utile.</simpara>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="mongodb-driver-serverdescription.constants.type-load-balancer">
      <term><constant>MongoDB\Driver\ServerDescription::TYPE_LOAD_BALANCER</constant></term>
      <listitem>
-      <para>Le type de serveur équilibreur de charge, retourné par <methodname>MongoDB\Driver\ServerDescription::getType</methodname>.</para>
+      <simpara>Le type de serveur équilibreur de charge, retourné par <methodname>MongoDB\Driver\ServerDescription::getType</methodname>.</simpara>
      </listitem>
     </varlistentry>
 

--- a/reference/mongodb/mongodb/driver/session/getserver.xml
+++ b/reference/mongodb/mongodb/driver/session/getserver.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 53242ee6628dc1ae6989fe002231fddfd8f005c6 Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="mongodb-driver-session.getserver" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,18 +13,18 @@
    <modifier>final</modifier> <modifier>public</modifier> <type class="union"><type>MongoDB\Driver\Server</type><type>null</type></type><methodname>MongoDB\Driver\Session::getServer</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Renvoie le <classname>MongoDB\Driver\Server</classname> auquel cette session
    est épinglée. Si la session n'est pas épinglée à un serveur, &null;
    sera renvoyé.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    La session d'épinglage est principalement utilisée pour les transactions
    éclatées, car toutes les commandes dans une transaction éclatée doivent
    être envoyées à la même instance mongos. Cette méthode est destinée à être
    utilisée par des bibliothèques construites au-dessus de l'extension pour
    permettre l'utilisation d'un serveur épinglé au lieu d'invoquer la sélection du serveur.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -34,10 +34,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Renvoie le <classname>MongoDB\Driver\Server</classname> auquel cette session
    est épinglée, ou &null; si la session n'est pas épinglée à un serveur.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/session/gettransactionoptions.xml
+++ b/reference/mongodb/mongodb/driver/session/gettransactionoptions.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 53242ee6628dc1ae6989fe002231fddfd8f005c6 Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="mongodb-driver-session.gettransactionoptions" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,9 +13,9 @@
    <modifier>final</modifier> <modifier>public</modifier> <type class="union"><type>array</type><type>null</type></type><methodname>MongoDB\Driver\Session::getTransactionOptions</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Renvoie les options pour la transaction en cours.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -25,10 +25,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Renvoie un <type>array</type> contenant les options de transaction actuelles, ou
    &null; si aucune transaction n'est en cours.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/session/gettransactionstate.xml
+++ b/reference/mongodb/mongodb/driver/session/gettransactionstate.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: a8482dea2af701e5aef299fda555ddc9e1587184 Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="mongodb-driver-session.gettransactionstate" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,9 +13,9 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>string</type><methodname>MongoDB\Driver\Session::getTransactionState</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Renvoie l'état de la transaction pour cette session.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -25,9 +25,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Renvoie l'état de la transaction actuelle pour cette session.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/session/isdirty.xml
+++ b/reference/mongodb/mongodb/driver/session/isdirty.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: d5127e772887addc6553066a33b31af086cd93b1 Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="mongodb-driver-session.isdirty" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,10 +13,10 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>bool</type><methodname>MongoDB\Driver\Session::isDirty</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Renvoie si la session a été marquée comme sale (c'est-à-dire qu'elle a été utilisée
    avec une commande qui a rencontré une erreur réseau).
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -26,9 +26,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Renvoie si la session a été marquée comme sale.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/session/isintransaction.xml
+++ b/reference/mongodb/mongodb/driver/session/isintransaction.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 86e6094e86b84a51d00ab217ac50ce8dde33d82a Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="mongodb-driver-session.isintransaction" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,11 +13,11 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>bool</type><methodname>MongoDB\Driver\Session::isInTransaction</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Renvoie si une transaction multi-document est actuellement en cours pour
    cette session. Une transaction est considérée comme "en cours" si elle a été
    démarrée mais n'a pas été validée ou annulée.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -27,10 +27,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Renvoie &true; si une transaction est actuellement en cours pour cette session,
    et &false; sinon.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/session/starttransaction.xml
+++ b/reference/mongodb/mongodb/driver/session/starttransaction.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 734bafeaf071b78b15d375f9af583befddd8c2a2 Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="mongodb-driver-session.starttransaction" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,15 +13,15 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>void</type><methodname>MongoDB\Driver\Session::startTransaction</methodname>
    <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>options</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Commence une transaction multi-document associée à la session. À un moment donné,
    on ne peut avoir qu'une seule transaction ouverte pour une session. Après avoir
    commencé une transaction, l'objet de session doit être passé à chaque opération via
    l'option <literal>"session"</literal> (par exemple
    <methodname>MongoDB\Driver\Manager::executeBulkWrite</methodname>) pour associer
    cette opération à la transaction.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Les transactions peuvent être confirmées via
    <methodname>MongoDB\Driver\Session::commitTransaction</methodname>, et
    annulées avec
@@ -29,7 +29,7 @@
    Les transactions sont également automatiquement annulées lorsque la session est
    fermée par la collecte des ordures ou en appelant explicitement
    <methodname>MongoDB\Driver\Session::endSession</methodname>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -38,13 +38,13 @@
    <varlistentry>
     <term><parameter>options</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       Les options peuvent être passées en argument à cette méthode. Chaque élément de ce
       tableau d'options remplace l'option correspondante de l'option
       <literal>"defaultTransactionOptions"</literal>, si définie lors
       du démarrage de la session avec
       <methodname>MongoDB\Driver\Manager::startSession</methodname>.
-     </para>
+     </simpara>
      <para>
       <table>
        <title>options</title>
@@ -72,9 +72,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.void;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">
@@ -88,28 +88,26 @@
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>PECL mongodb 1.6.0</entry>
-       <entry>
-        <para>
-         L'option <literal>"maxCommitTimeMS"</literal> a été ajoutée.
-        </para>
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>PECL mongodb 1.6.0</entry>
+      <entry>
+       <simpara>
+        L'option <literal>"maxCommitTimeMS"</literal> a été ajoutée.
+       </simpara>
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/mongodb/mongodb/driver/topologydescription.xml
+++ b/reference/mongodb/mongodb/driver/topologydescription.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <reference xml:id="class.mongodb-driver-topologydescription" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>La classe MongoDB\Driver\TopologyDescription</title>
@@ -10,12 +10,12 @@
 <!-- {{{ MongoDB\Driver\TopologyDescription intro -->
   <section xml:id="mongodb-driver-topologydescription.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     La classe <classname>MongoDB\Driver\TopologyDescription</classname> est un
     objet de valeur qui représente une topologie à laquelle le pilote est
     connecté. Les instances de cette classe sont retournées par les méthodes de 
     <classname>MongoDB\Driver\Monitoring\TopologyChangedEvent</classname>.
-   </para>
+   </simpara>
   </section>
 <!-- }}} -->
 
@@ -87,42 +87,42 @@
     <varlistentry xml:id="mongodb-driver-topologydescription.constants.type-unknown">
      <term><constant>MongoDB\Driver\TopologyDescription::TYPE_UNKNOWN</constant></term>
      <listitem>
-      <para>Topologie inconnue, retournée par <methodname>MongoDB\Driver\TopologyDescription::getType</methodname>.</para>
+      <simpara>Topologie inconnue, retournée par <methodname>MongoDB\Driver\TopologyDescription::getType</methodname>.</simpara>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="mongodb-driver-topologydescription.constants.type-single">
      <term><constant>MongoDB\Driver\TopologyDescription::TYPE_SINGLE</constant></term>
      <listitem>
-      <para>Seul serveur (c'est-à-dire connexion directe), retourné par <methodname>MongoDB\Driver\TopologyDescription::getType</methodname>.</para>
+      <simpara>Seul serveur (c'est-à-dire connexion directe), retourné par <methodname>MongoDB\Driver\TopologyDescription::getType</methodname>.</simpara>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="mongodb-driver-topologydescription.constants.type-sharded">
      <term><constant>MongoDB\Driver\TopologyDescription::TYPE_SHARDED</constant></term>
      <listitem>
-      <para>Cluster partagé, retourné par <methodname>MongoDB\Driver\TopologyDescription::getType</methodname>.</para>
+      <simpara>Cluster partagé, retourné par <methodname>MongoDB\Driver\TopologyDescription::getType</methodname>.</simpara>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="mongodb-driver-topologydescription.constants.type-replica-set-no-primary">
      <term><constant>MongoDB\Driver\TopologyDescription::TYPE_REPLICA_SET_NO_PRIMARY</constant></term>
      <listitem>
-      <para>Ensemble de réplicas sans serveur primaire, retourné par <methodname>MongoDB\Driver\TopologyDescription::getType</methodname>.</para>
+      <simpara>Ensemble de réplicas sans serveur primaire, retourné par <methodname>MongoDB\Driver\TopologyDescription::getType</methodname>.</simpara>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="mongodb-driver-topologydescription.constants.type-replica-set-with-primary">
      <term><constant>MongoDB\Driver\TopologyDescription::TYPE_REPLICA_SET_WITH_PRIMARY</constant></term>
      <listitem>
-      <para>Ensemble de réplicas avec un serveur primaire, retourné par <methodname>MongoDB\Driver\TopologyDescription::getType</methodname>.</para>
+      <simpara>Ensemble de réplicas avec un serveur primaire, retourné par <methodname>MongoDB\Driver\TopologyDescription::getType</methodname>.</simpara>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="mongodb-driver-topologydescription.constants.type-load-balanced">
      <term><constant>MongoDB\Driver\TopologyDescription::TYPE_LOAD_BALANCED</constant></term>
      <listitem>
-      <para>Topologie équilibrée, retournée par <methodname>MongoDB\Driver\TopologyDescription::getType</methodname>.</para>
+      <simpara>Topologie équilibrée, retournée par <methodname>MongoDB\Driver\TopologyDescription::getType</methodname>.</simpara>
      </listitem>
     </varlistentry>
 

--- a/reference/mongodb/mongodb/driver/writeconcern/construct.xml
+++ b/reference/mongodb/mongodb/driver/writeconcern/construct.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 734bafeaf071b78b15d375f9af583befddd8c2a2 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="mongodb-driver-writeconcern.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -17,9 +17,9 @@
    <methodparam choice="opt"><type class="union"><type>int</type><type>null</type></type><parameter>wtimeout</parameter><initializer>&null;</initializer></methodparam>
    <methodparam choice="opt"><type class="union"><type>bool</type><type>null</type></type><parameter>journal</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Construit un nouveau <classname>MongoDB\Driver\WriteConcern</classname>, qui est un objet de valeur immuable.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -67,15 +67,15 @@
          <row>
           <entry><constant>MongoDB\Driver\WriteConcern::MAJORITY</constant></entry>
           <entry>
-           <para>
+           <simpara>
             Demande l'accusé de réception que les opérations d'écriture se sont 
             propagées à la majorité des nœuds votants, y compris le principal, et 
             ont été écrites dans le journal sur disque pour ces nœuds.
-           </para>
-           <para>
+           </simpara>
+           <simpara>
             Avant MongoDB 3.0, il s'agit de la majorité des membres du jeu de 
             réplicas (et pas seulement des nœuds votants).
-           </para>
+           </simpara>
           </entry>
          </row>
          <row>
@@ -95,21 +95,21 @@
    <varlistentry>
     <term><parameter>wtimeout</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       Délai d'attente maximal (en millisecondes) avant que les secondaires
       n'échouent.
-     </para>
-     <para>
+     </simpara>
+     <simpara>
       <literal>wtimeout</literal> fera que les opérations en écriture vont retourner
       une erreur (<classname>WriteConcernError</classname>) après le
       délai spécifié. Lorsque ces opérations en écriture retournent, MongoDB
       ne va pas annuler les données modifiées avant que les préoccupations
       en écriture n'atteignent le délai limite <literal>wtimeout</literal>.
-     </para>
-     <para>
+     </simpara>
+     <simpara>
       Si spécifié, <literal>wtimeout</literal> doit être un entier signé 64 bits 
       supérieur ou égal à zéro.
-     </para>
+     </simpara>
      <para>
       <table>
        <title>Délai d'attente maximal des préoccupations d'écriture</title>
@@ -140,9 +140,9 @@
    <varlistentry>
     <term><parameter>journal</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       Attente avant que mongod n'applique l'écriture au journal.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -158,26 +158,24 @@
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>PECL mongodb 1.7.0</entry>
-       <entry>
-        Le paramètre <parameter>wTimeout</parameter> accepte désormais des valeurs 64-bit.
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>PECL mongodb 1.7.0</entry>
+      <entry>
+       Le paramètre <parameter>wTimeout</parameter> accepte désormais des valeurs 64-bit.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
 

--- a/reference/mongodb/mongodb/driver/writeconcern/getwtimeout.xml
+++ b/reference/mongodb/mongodb/driver/writeconcern/getwtimeout.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 734bafeaf071b78b15d375f9af583befddd8c2a2 Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="mongodb-driver-writeconcern.getwtimeout" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,9 +22,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Renvoie l'option "wtimeout" du WriteConcern.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">
@@ -36,28 +36,26 @@
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>PECL mongodb 1.7.0</entry>
-       <entry>
-        Sur les systèmes 32 bits, cette méthode tronquera toujours la valeur
-        <literal>wTimeout</literal> si elle dépasse la plage 32 bits. Dans ce cas, un
-        avertissement sera émis.
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>PECL mongodb 1.7.0</entry>
+      <entry>
+       Sur les systèmes 32 bits, cette méthode tronquera toujours la valeur
+       <literal>wTimeout</literal> si elle dépasse la plage 32 bits. Dans ce cas, un
+       avertissement sera émis.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
 

--- a/reference/mongodb/mongodb/driver/writeconcern/isdefault.xml
+++ b/reference/mongodb/mongodb/driver/writeconcern/isdefault.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 331fbfeac522d4ad00de1e043cc11610d66b88f9 Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="mongodb-driver-writeconcern.isdefault" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,13 +13,13 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>bool</type><methodname>MongoDB\Driver\WriteConcern::isDefault</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Renvoie si c'est le WriteConcern par défaut (c'est-à-dire sans
    options spécifiées). Cette méthode est principalement destinée à être utilisée en conjonction avec
    <methodname>MongoDB\Driver\Manager::getWriteConcern</methodname> pour déterminer
    si le Manager a été construit sans aucune option de WriteConcern.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Le pilote n'inclura pas de WriteConcern par défaut dans ses opérations d'écriture
    (par exemple <methodname>MongoDB\Driver\Manager::executeBulkWrite</methodname>) afin
    de permettre au serveur d'appliquer son propre WriteConcern par défaut, qui peut avoir été
@@ -27,7 +27,7 @@
    Les bibliothèques qui accèdent au WriteConcern du Manager pour l'inclure dans leurs propres
    commandes d'écriture devraient utiliser cette méthode pour s'assurer que les WriteConcern par défaut
    ne sont pas définis.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -37,9 +37,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Renvoie &true; si c'est le WriteConcern par défaut et &false; sinon.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mongodb/mongodb/driver/writeresult/getdeletedcount.xml
+++ b/reference/mongodb/mongodb/driver/writeresult/getdeletedcount.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4639881688d3faaf0073ad71fe0a4b730aea15a0 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="mongodb-driver-writeresult.getdeletedcount" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -14,9 +14,9 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>int</type><methodname>MongoDB\Driver\WriteResult::getDeletedCount</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
 
-  </para>
+  </simpara>
 
  </refsect1>
 
@@ -27,9 +27,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Renvoie le nombre de documents supprimés.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">
@@ -42,21 +42,19 @@
 
   <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      &mongodb.changelog.throw-unacknowledged-write;
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     &mongodb.changelog.throw-unacknowledged-write;
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/mongodb/mongodb/driver/writeresult/getinsertedcount.xml
+++ b/reference/mongodb/mongodb/driver/writeresult/getinsertedcount.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4639881688d3faaf0073ad71fe0a4b730aea15a0 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="mongodb-driver-writeresult.getinsertedcount" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -14,9 +14,9 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>int</type><methodname>MongoDB\Driver\WriteResult::getInsertedCount</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
 
-  </para>
+  </simpara>
 
  </refsect1>
 
@@ -27,9 +27,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Renvoie le nombre de documents insérés (à l'exception d'Upserts).
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">
@@ -42,21 +42,19 @@
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      &mongodb.changelog.throw-unacknowledged-write;
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     &mongodb.changelog.throw-unacknowledged-write;
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/mongodb/mongodb/driver/writeresult/getmatchedcount.xml
+++ b/reference/mongodb/mongodb/driver/writeresult/getmatchedcount.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4639881688d3faaf0073ad71fe0a4b730aea15a0 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="mongodb-driver-writeresult.getmatchedcount" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -14,12 +14,12 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>int</type><methodname>MongoDB\Driver\WriteResult::getMatchedCount</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Si l'opération de mise à jour n'entraîne aucune modification du document
    (par exemple, en définissant la valeur d'un champ sur sa valeur actuelle),
    le nombre correspondant peut être supérieur à la valeur retournée par
    <methodname>MongoDB\Driver\WriteResult::getModifiedCount</methodname>.
-  </para>
+  </simpara>
 
  </refsect1>
 
@@ -30,9 +30,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retourne le nombre de documents sélectionnés pour la mise à jour.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">
@@ -45,21 +45,19 @@
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      &mongodb.changelog.throw-unacknowledged-write;
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     &mongodb.changelog.throw-unacknowledged-write;
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/mongodb/mongodb/driver/writeresult/getmodifiedcount.xml
+++ b/reference/mongodb/mongodb/driver/writeresult/getmodifiedcount.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4639881688d3faaf0073ad71fe0a4b730aea15a0 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="mongodb-driver-writeresult.getmodifiedcount" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -14,12 +14,12 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>int</type><methodname>MongoDB\Driver\WriteResult::getModifiedCount</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
     Si l'opération de mise à jour n'entraîne aucune modification du document 
    (par exemple, en définissant la valeur d'un champ sur sa valeur actuelle), 
    le nombre modifié peut être inférieur à la valeur retournée par
    <methodname>MongoDB\Driver\WriteResult::getMatchedCount</methodname>.
-  </para>
+  </simpara>
 
  </refsect1>
 
@@ -30,9 +30,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retourne le nombre de documents existants mis à jour.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">
@@ -45,21 +45,19 @@
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      &mongodb.changelog.throw-unacknowledged-write;
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     &mongodb.changelog.throw-unacknowledged-write;
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/mongodb/mongodb/driver/writeresult/getupsertedcount.xml
+++ b/reference/mongodb/mongodb/driver/writeresult/getupsertedcount.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4639881688d3faaf0073ad71fe0a4b730aea15a0 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="mongodb-driver-writeresult.getupsertedcount" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -14,9 +14,9 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>int</type><methodname>MongoDB\Driver\WriteResult::getUpsertedCount</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
 
-  </para>
+  </simpara>
 
  </refsect1>
 
@@ -27,9 +27,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Renvoie le nombre de documents insérés par un upsert.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">
@@ -42,21 +42,19 @@
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      &mongodb.changelog.throw-unacknowledged-write;
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     &mongodb.changelog.throw-unacknowledged-write;
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/mongodb/security.xml
+++ b/reference/mongodb/security.xml
@@ -1,55 +1,55 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 3e871fe7eab38f9b0398569c57a1dd0c21e69652 Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <chapter xml:id="mongodb.security" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Sécurité</title>
 
  <section xml:id="mongodb.security.request_injection">
   <title>Attaques par injection de requêtes</title>
-  <para>
+  <simpara>
    Si on passe des paramètres <literal>$_GET</literal> (ou <literal>$_POST</literal>)
    aux requêtes, il faut s'assurer de convertir en chaînes de caractères avant.
    Les utilisateurs peuvent insérer des tableaux associatifs dans les requêtes
    GET et POST, qui pourraient alors devenir des requêtes $ indésirables.
-  </para>
+  </simpara>
 
-  <para>
+  <simpara>
    Un exemple assez anodin : supposez qu'on cherche les informations d'un
    utilisateur avec la requête <emphasis>http://www.example.com?username=bob</emphasis>.
    L'application crée la requête
    <literal>$q = new \MongoDB\Driver\Query( [ 'username' => $_GET['username'] ])</literal>.
-  </para>
+  </simpara>
 
-  <para>
+  <simpara>
    Cela fonctionne bien, mais quelqu'un pourrait subvertir cela en passant
    <emphasis>http://www.example.com?username[$ne]=foo</emphasis>, que PHP
    transformera magiquement en un tableau associatif, transformant le requête en
    <literal>$q = new \MongoDB\Driver\Query( [ 'username' => [ '$ne' => 'foo' ] ] )</literal>,
    qui renverra tous les utilisateurs dont le nom n'est pas "foo" (tous les utilisateurs, probablement).
-  </para>
+  </simpara>
 
-  <para>
+  <simpara>
    C'est une attaque assez facile à contrer : il faut s'assurer que les paramètres
    <literal>$_GET</literal> et <literal>$_POST</literal> sont du type attendu
    avant d'envoyer à la base de données. PHP dispose de la fonction
    <function>filter_var</function> pour aider.
-  </para>
+  </simpara>
 
-  <para>
+  <simpara>
    À noter que ce type d'attaque peut être utilisé avec n'importe quelle interaction
    avec la base de données qui localise un document, y compris les mises à jour,
    les upserts, les suppressions et les commandes findAndModify.
-  </para>
+  </simpara>
 
-  <para>
+  <simpara>
    Voir <link xlink:href="&url.mongodb.dochub.security;">la documentation principale</link>
    pour plus d'informations sur les problèmes de type injection SQL avec MongoDB.
-  </para>
+  </simpara>
  </section>
 
  <section xml:id="mongodb.security.script_injection">
   <title>Attaque par injection de scripts</title>
-  <para>
+  <simpara>
    Lors de l'utilisation de JavaScript, il faut s'assurer que toutes les variables qui
    traversent la frontière PHP-JavaScript sont passées dans le champ
    <literal>scope</literal> de <classname>MongoDB\BSON\Javascript</classname>,
@@ -57,11 +57,11 @@
    on utilise des clauses <literal>$where</literal> dans les requêtes, les
    commandes mapReduce et group, et à tout autre moment où il est possible de passer
    du JavaScript à la base de données.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Par exemple, supposons que nous avons un JavaScript pour saluer un utilisateur
    dans les logs de la base de données. Nous pourrions faire :
-  </para>
+  </simpara>
   <programlisting role="php">
 <![CDATA[
 <?php
@@ -78,9 +78,9 @@ $r = $m->executeCommand( 'dramio', $cmd );
 ?>
 ]]>
   </programlisting>
-  <para>
+  <simpara>
    Cependant, que se passe-t-il si un utilisateur malveillant passe du JavaScript ?
-  </para>
+  </simpara>
   <programlisting role="php">
 <![CDATA[
 <?php
@@ -98,12 +98,12 @@ $r = $m->executeCommand( 'dramio', $cmd );
 ?>
 ]]>
   </programlisting>
-  <para>
+  <simpara>
    Maintenant MongoDB exécute la chaîne JavaScript
    <literal>"print('Hello, '); db.users.drop(); print('!');"</literal>.
    Cette attaque est facile à éviter : utiliser <literal>args</literal> pour passer
    des variables de PHP à JavaScript :
-  </para>
+  </simpara>
   <programlisting role="php">
 <![CDATA[
 <?php
@@ -121,31 +121,31 @@ $r = $m->executeCommand( 'dramio', $cmd );
 ?>
 ]]>
   </programlisting>
-  <para>
+  <simpara>
    Cela ajoute un argument à la portée JavaScript, qui est utilisé comme argument
    pour la fonction <literal>greet</literal>. Maintenant si
    quelqu'un essaie d'envoyer du code malveillant, MongoDB imprimera inoffensivement
    <literal>Hello, '); db.dropDatabase(); print('!</literal>.
-  </para>
+  </simpara>
 
-  <para>
+  <simpara>
    Utiliser des arguments aide à empêcher l'exécution d'entrées malveillantes par
    la base de données. Cependant, il faut s'assurer que le code ne
    retourne pas et n'exécute pas l'entrée de toute façon ! Il est préférable
    d'éviter d'exécuter <emphasis>quelconque</emphasis> JavaScript sur le serveur
    en premier lieu.
-  </para>
+  </simpara>
 
-  <para>
+  <simpara>
    Il est recommandé de rester à l'écart de la clause <link
    xlink:href="&url.mongodb.docs;reference/operator/query/where/#considerations">$where</link>
    dans les requêtes, car elle impacte significativement les performances. Dans
    la mesure du possible, utiliser soit des opérateurs de requête normaux, soit
    le <link xlink:href="&url.mongodb.docs;core/aggregation-pipeline">Framework
    d'agrégation</link>.
-  </para>
+  </simpara>
 
-  <para>
+  <simpara>
    Une alternative à <link
    xlink:href="&url.mongodb.dochub.mapreduce;">MapReduce</link>, qui utilise
    JavaScript, est le <link
@@ -153,13 +153,13 @@ $r = $m->executeCommand( 'dramio', $cmd );
    d'agrégation</link>. Contrairement à Map/Reduce, il utilise un langage
    idiomatique pour construire des requêtes, sans avoir à écrire et utiliser
    l'approche JavaScript plus lente que Map/Reduce nécessite.
-  </para>
+  </simpara>
 
-  <para>
+  <simpara>
    La <link
     xlink:href="&url.mongodb.docs;reference/command/eval/">commande eval</link>
     a été dépréciée depuis MongoDB 3.0, et devrait également être évitée.
-  </para>
+  </simpara>
  </section>
 </chapter>
 


### PR DESCRIPTION
Miroir tag-à-tag du commit doc-en 9f4cb232d0 (PR php/doc-en#5517) sur les 30 fichiers MongoDB en retard côté FR.

Aucun changement de contenu : conversion `<para>` -> `<simpara>` pour les paragraphes inline, retrait du wrapper `<para>` autour de `<informaltable>`, conservation de `<para>` autour de `<table>`.