### PR TITLE
[Sync EN] Enable runnable WASM examples for language.namespaces

### DIFF
--- a/language/namespaces.xml
+++ b/language/namespaces.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 1651836ff309efd14a795eff44ee51455f66c7d3 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 1fade2bc5f160b23c2f46c3f854b833fab0e69f4 Maintainer: yannick Status: ready -->
 <!-- Reviewed: no -->
 <!-- CREDITS: DAnnebicque -->
 <chapter xml:id="language.namespaces" xmlns="http://docbook.org/ns/docbook"
- version="1.1">
+ version="1.1" annotations="interactive">
  <title>Les espaces de noms</title>
 
  <sect1 xml:id="language.namespaces.rationale">
@@ -64,16 +64,19 @@ function mafonction() {}
 const MACONSTANTE = 1;
 
 $a = new MaClasse;
+print $a::class . "\n";
 $c = new \mon\nom\MaClasse; // Voyez la section "Espace global"
+print $c::class . "\n";
 
 $a = strlen('bonjour'); // Voyez "Utilisation des espaces de noms : retour
        // à l'espace global
+print $a . "\n";
 
 $d = namespace\MACONSTANTE; // Voyez "L'opérateur namespace et la constante __NAMESPACE__
+print $d . "\n";
 
 $d = __NAMESPACE__ . '\MACONSTANTE';
 echo constant($d); // Voyez "Espaces de noms et fonctionnalités dynamiques"
-?>
     ]]>
    </programlisting>
   </example>
@@ -109,7 +112,7 @@ echo constant($d); // Voyez "Espaces de noms et fonctionnalités dynamiques"
    clé <xref linkend="control-structures.declare" />.
    <example>
     <title>Déclaration d'un espace de noms</title>
-    <programlisting role="php">
+    <programlisting role="php" annotations="non-interactive">
      <![CDATA[
 <?php
 namespace MonProjet;
@@ -117,8 +120,6 @@ namespace MonProjet;
 const CONNEXION_OK = 1;
 class Connexion { /* ... */ }
 function connecte() { /* ... */ }
-
-?>
 ]]>
     </programlisting>
    </example>
@@ -136,12 +137,11 @@ function connecte() { /* ... */ }
    des espaces :
    <example>
     <title>Erreur de déclaration d'un espace de noms</title>
-    <programlisting role="php">
+    <programlisting role="php" annotations="non-interactive">
      <![CDATA[
 <html>
 <?php
 namespace MonProjet; // erreur fatale : le namespace doit être le premier élément du script
-?>
 ]]>
     </programlisting>
    </example>
@@ -162,7 +162,7 @@ namespace MonProjet; // erreur fatale : le namespace doit être le premier élé
    de noms peut être défini avec ses sous-niveaux :
    <example>
     <title>Déclaration d'un espace de noms avec hiérarchie</title>
-    <programlisting role="php">
+    <programlisting role="php" annotations="non-interactive">
      <![CDATA[
 <?php
 namespace MonProjet\Sous\Niveau;
@@ -170,8 +170,6 @@ namespace MonProjet\Sous\Niveau;
 const CONNEXION_OK = 1;
 class Connexion { /* ... */ }
 function connecte() { /* ... */  }
-
-?>
 ]]>
     </programlisting>
    </example>
@@ -191,7 +189,7 @@ function connecte() { /* ... */  }
   <para>
    <example>
     <title>Déclaration de plusieurs espaces de noms, syntaxe à combinaison simple</title>
-    <programlisting role="php">
+    <programlisting role="php" annotations="non-interactive">
      <![CDATA[
 <?php
 namespace MonProjet;
@@ -205,7 +203,6 @@ namespace AutreProjet;
 const CONNEXION_OK = 1;
 class Connexion { /* ... */ }
 function connecte() { /* ... */  }
-?>
 ]]>
     </programlisting>
    </example>
@@ -218,7 +215,7 @@ function connecte() { /* ... */  }
   <para>
    <example>
     <title>Déclaration de plusieurs espaces de noms, syntaxe à accolades</title>
-    <programlisting role="php">
+    <programlisting role="php" annotations="non-interactive">
      <![CDATA[
 <?php
 namespace MonProjet {
@@ -234,7 +231,6 @@ const CONNEXION_OK = 1;
 class Connexion { /* ... */ }
 function connecte() { /* ... */  }
 }
-?>
 ]]>
     </programlisting>
    </example>
@@ -256,16 +252,22 @@ function connecte() { /* ... */  }
 namespace MonProjet {
 
 const CONNEXION_OK = 1;
-class Connexion { /* ... */ }
-function connecte() { /* ... */  }
+class Connexion {
+    public static function start() {
+        print __METHOD__ . "\n";
+    }
+}
+
+function connecte() {
+    print __FUNCTION__ . "\n";
+}
 }
 
 namespace { // code global
-session_start();
-$a = MonProjet\connecte();
-echo MonProjet\Connexion::start();
+print strlen("bonjour") . "\n";
+MonProjet\connecte();
+MonProjet\Connexion::start();
 }
-?>
 ]]>
     </programlisting>
    </example>
@@ -278,20 +280,26 @@ echo MonProjet\Connexion::start();
     <programlisting role="php">
      <![CDATA[
 <?php
-declare(encoding='UTF-8');
+declare(strict_types=1);
 namespace MonProjet {
 
 const CONNEXION_OK = 1;
-class Connexion { /* ... */ }
-function connecte() { /* ... */  }
+class Connexion {
+    public static function start() {
+        print __METHOD__ . "\n";
+    }
+}
+
+function connecte() {
+    print __FUNCTION__ . "\n";
+}
 }
 
 namespace { // code global
-session_start();
-$a = MonProjet\connecte();
-echo MonProjet\Connexion::start();
+print strlen("bonjour") . "\n";
+MonProjet\connecte();
+MonProjet\Connexion::start();
 }
-?>
 ]]>
     </programlisting>
    </example>
@@ -375,7 +383,7 @@ echo MonProjet\Connexion::start();
    Voici un exemple des trois syntaxes, dans du code réel :
    <informalexample>
     <simpara>file1.php</simpara>
-    <programlisting role="php">
+    <programlisting role="php" annotations="non-interactive">
      <![CDATA[
 <?php
 namespace Foo\Bar\sousespacedenoms;
@@ -386,11 +394,10 @@ class foo
 {
     static function methodestatique() {}
 }
-?>
      ]]>
     </programlisting>
     <simpara>file2.php</simpara>
-    <programlisting role="php">
+    <programlisting role="php" annotations="non-interactive">
      <![CDATA[
 <?php
 namespace Foo\Bar;
@@ -418,7 +425,6 @@ echo sousespacedenoms\FOO; // Devient la constante Foo\Bar\sousespacedenoms\FOO
 \Foo\Bar\foo(); // Devient la fonction Foo\Bar\foo
 \Foo\Bar\foo::methodestatique(); // Devient la classe Foo\Bar\foo, méthode methodestatique
 echo \Foo\Bar\FOO; // Devient la constante Foo\Bar\FOO
-?>
      ]]>
     </programlisting>
    </informalexample>
@@ -439,10 +445,10 @@ function strlen() {}
 const INI_ALL = 3;
 class Exception {}
 
-$a = \strlen('hi'); // appelle la fonction globale strlen
-$b = \INI_ALL; // accès à une constante INI_ALL
+print \strlen('hi') . "\n"; // appelle la fonction globale strlen
+print \INI_ALL . "\n"; // accès à une constante INI_ALL
 $c = new \Exception('error'); // instancie la classe globale Exception
-?>
+print $c::class . "\n";
      ]]>
     </programlisting>
    </example>
@@ -480,7 +486,6 @@ $obj = new $a; // affiche classname::__construct
 $b = 'funcname';
 $b(); // affiche funcname
 echo constant('constname'), "\n"; // affiche global
-?>
     ]]>
     </programlisting>
    </example>
@@ -518,7 +523,6 @@ $b = '\nomdelespacedenoms\funcname';
 $b(); // affiche aussi nomdelespacedenoms\funcname
 echo constant('\nomdelespacedenoms\constname'), "\n"; // affiche namespaced
 echo constant('nomdelespacedenoms\constname'), "\n"; // affiche aussi namespaced
-?>
     ]]>
     </programlisting>
    </example>
@@ -549,7 +553,6 @@ echo constant('nomdelespacedenoms\constname'), "\n"; // affiche aussi namespaced
 namespace MonProjet;
 
 echo '"', __NAMESPACE__, '"'; // affiche "MonProjet"
-?>
 ]]>
     </programlisting>
    </example>
@@ -558,9 +561,7 @@ echo '"', __NAMESPACE__, '"'; // affiche "MonProjet"
     <programlisting role="php">
      <![CDATA[
 <?php
-
 echo '"', __NAMESPACE__, '"'; // affiche ""
-?>
 ]]>
     </programlisting>
    </example>
@@ -568,7 +569,7 @@ echo '"', __NAMESPACE__, '"'; // affiche ""
    dynamiquement des noms, tels que :
    <example>
     <title>Utilisation de __NAMESPACE__ pour une construction dynamique de noms</title>
-    <programlisting role="php">
+    <programlisting role="php" annotations="non-interactive">
      <![CDATA[
 <?php
 namespace MonProjet;
@@ -578,7 +579,6 @@ function get($classname)
     $a = __NAMESPACE__ . '\\' . $classname;
     return new $a;
 }
-?>
 ]]>
     </programlisting>
    </example>
@@ -590,7 +590,7 @@ function get($classname)
    <literal>self</literal> des classes.
    <example>
     <title>l'opérateur namespace, dans un espace de noms</title>
-    <programlisting role="php">
+    <programlisting role="php" annotations="non-interactive">
      <![CDATA[
 <?php
 namespace MonProjet;
@@ -605,13 +605,12 @@ namespace\sub\func(); // appelle la fonction MonProjet\sub\func()
 namespace\cname::method(); // appelle la méthode statique "method" de la classe MonProjet\cname
 $a = new namespace\sub\cname(); // instancie un objet de la classe MonProjet\sub\cname
 $b = namespace\CONSTANT; // assigne la valeur de la constante MonProjet\CONSTANT à $b
-?>
 ]]>
     </programlisting>
    </example>
    <example>
     <title>l'opérateur namespace, dans le namespace global</title>
-    <programlisting role="php">
+    <programlisting role="php" annotations="non-interactive">
      <![CDATA[
 <?php
 
@@ -620,7 +619,6 @@ namespace\sub\func(); // appelle la fonction sub\func()
 namespace\cname::method(); // appelle la méthode statique "method" de la classe cname
 $a = new namespace\sub\cname(); // instancie un objet de la classe sub\cname
 $b = namespace\CONSTANT; // assigne la valeur de la constante CONSTANT à $b
-?>
 ]]>
     </programlisting>
    </example>
@@ -644,7 +642,7 @@ $b = namespace\CONSTANT; // assigne la valeur de la constante CONSTANT à $b
    Voici un exemple qui présente les cinq types d'importation :
    <example>
     <title>importation et alias avec l'opérateur use</title>
-    <programlisting role="php">
+    <programlisting role="php" annotations="non-interactive">
      <![CDATA[
 <?php
 namespace foo;
@@ -672,7 +670,6 @@ $a = new ArrayObject(array(1)); // instancie un objet de la classe ArrayObject
 // Sans l'instruction "use ArrayObject" nous aurions instantié un objet de la classe foo\ArrayObject
 func(); // Appelle la fonction My\Full\functionName
 echo CONSTANT; // affiche la valeur de My\Full\CONSTANT
-?>
 ]]>
     </programlisting>
    </example>
@@ -686,14 +683,13 @@ echo CONSTANT; // affiche la valeur de My\Full\CONSTANT
    De plus, PHP supporte des raccourcis pratiques, tels que les commandes use multiples.
    <example>
     <title>importation et alias multiples avec l'opérateur use</title>
-    <programlisting role="php">
+    <programlisting role="php" annotations="non-interactive">
      <![CDATA[
 <?php
 use My\Full\Classname as Another, My\Full\NSname;
 
 $obj = new Another; // instancie un objet de la classe My\Full\Classname
 NSname\subns\func(); // appelle la fonction My\Full\NSname\subns\func
-?>
 ]]>
     </programlisting>
    </example>
@@ -703,7 +699,7 @@ NSname\subns\func(); // appelle la fonction My\Full\NSname\subns\func
    les classes, fonctions et constantes dynamiques.
    <example>
     <title>Importation et noms d'espaces dynamiques</title>
-    <programlisting role="php">
+    <programlisting role="php" annotations="non-interactive">
      <![CDATA[
 <?php
 use My\Full\Classname as Another, My\Full\NSname;
@@ -711,7 +707,6 @@ use My\Full\Classname as Another, My\Full\NSname;
 $obj = new Another; // instancie un objet de la classe My\Full\Classname
 $a = 'Another';
 $obj = new $a;      // instancie un objet de la classe Another
-?>
 ]]>
     </programlisting>
    </example>
@@ -721,7 +716,7 @@ $obj = new $a;      // instancie un objet de la classe Another
    absolus restent absolus, et inchangés par un import.
    <example>
     <title>Importation et noms d'espaces absolus</title>
-    <programlisting role="php">
+    <programlisting role="php" annotations="non-interactive">
      <![CDATA[
 <?php
 use My\Full\Classname as Another, My\Full\NSname;
@@ -730,7 +725,6 @@ $obj = new Another; // instancie un objet de la classe My\Full\Classname
 $obj = new \Another; // instancie un objet de la classe Another
 $obj = new Another\untruc; // instancie un objet de la classe My\Full\Classname\untruc
 $obj = new \Another\untruc; // instancie un objet de la classe Another\untruc
-?>
 ]]>
     </programlisting>
    </example>
@@ -758,7 +752,6 @@ function toGreenlandic()
 
     // ...
 }
-?>
 ]]>
      </programlisting>
     </example>
@@ -778,7 +771,7 @@ function toGreenlandic()
     seule instruction &use.namespace;.
    </para>
    <informalexample>
-    <programlisting role="php">
+    <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 
@@ -816,7 +809,7 @@ use const some\namespace\{ConstA, ConstB, ConstC};
    global, même dans un contexte d'espace de noms spécifique.
    <example>
     <title>Spécification d'espace de noms global</title>
-    <programlisting role="php">
+    <programlisting role="php" annotations="non-interactive">
      <![CDATA[
 <?php
 namespace A\B\C;
@@ -827,7 +820,6 @@ function fopen() {
      $f = \fopen(...); // appel à fopen global
      return $f;
 }
-?>
     ]]>
     </programlisting>
    </example>
@@ -852,10 +844,11 @@ namespace A\B\C;
 class Exception extends \Exception {}
 
 $a = new Exception('hi'); // $a est un objet de la classe A\B\C\Exception
+var_dump($a::class);
 $b = new \Exception('hi'); // $b est un objet de la classe Exception
+var_dump($b::class);
 
 $c = new ArrayObject; // erreur fatale, classe A\B\C\ArrayObject non trouvée
-?>
     ]]>
     </programlisting>
    </example>
@@ -885,7 +878,6 @@ if (is_array('hi')) { // affiche "n'est pas un tableau"
 } else {
     echo "n'est pas un tableau\n";
 }
-?>
     ]]>
     </programlisting>
    </example>
@@ -1022,7 +1014,7 @@ if (is_array('hi')) { // affiche "n'est pas un tableau"
   </para>
   <example>
    <title>Exemples de résolutions d'espaces de noms</title>
-   <programlisting role="php">
+   <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 namespace A;
@@ -1082,7 +1074,6 @@ A\B::foo();   // appelle la méthode "foo" de la classe "B" de l'espace de noms 
 
 \A\B::foo();  // appelle la méthode "foo" de la classe "B" de l'espace de noms "A"
               // si la classe "A\B" n'est pas trouvée, il essaie l'autochargement sur la classe "A\B"
-?>
 ]]>
    </programlisting>
   </example>
@@ -1195,7 +1186,7 @@ A\B::foo();   // appelle la méthode "foo" de la classe "B" de l'espace de noms 
 <![CDATA[
 <?php
 $a = new \stdClass;
-?>
+print $a::class;
 ]]>
      </programlisting>
     </example>
@@ -1210,7 +1201,7 @@ $a = new \stdClass;
 <![CDATA[
 <?php
 $a = new stdClass;
-?>
+print $a::class;
 ]]>
      </programlisting>
     </example>
@@ -1226,14 +1217,16 @@ $a = new stdClass;
 <?php
 namespace foo;
 $a = new \stdClass;
+print $a::class . "\n";
 
-function test(\ArrayObject $parameter_type_example = null) {}
+function test(?\ArrayObject $parameter_type_example = null) {}
 
-$a = \DirectoryIterator::CURRENT_AS_FILEINFO;
+$a = \FilesystemIterator::CURRENT_AS_FILEINFO;
+print $a . "\n";
 
 // extension d'une classe interne ou globale
 class MyException extends \Exception {}
-?>
+print MyException::class . "\n";
 ]]>
      </programlisting>
     </example>
@@ -1255,20 +1248,22 @@ namespace foo;
 class MaClasse {}
 
 // utilisation d'une classe dans l'espace de noms courant, sous forme de type de paramètre
-function test(MaClasse $parameter_type_example = null) {}
+function test(?MaClasse $parameter_type_example = null) {}
 
 // une autre manière d'utiliser une classe dans l'espace de noms courant comme type de paramètre
-function test(\foo\MaClasse $parameter_type_example = null) {}
+function test2(?\foo\MaClasse $parameter_type_example = null) {}
 
 // extension d'une classe dans l'espace de noms courant
 class Extended extends MaClasse {}
+print Extended::class . "\n";
 
 // accès à une fonction globale
-$a = \globalfunc();
+$a = \strlen("test");
+print $a . "\n";
 
 // accès à une constante globale
 $b = \INI_ALL;
-?>
+print $b . "\n";
 ]]>
      </programlisting>
     </example>
@@ -1286,14 +1281,13 @@ $b = \INI_ALL;
     <literal>Exception</literal>.
     <example>
      <title>Noms d'espaces absolus</title>
-     <programlisting role="php">
+     <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 namespace foo;
 $a = new \mon\nom(); // instancie la classe "mon\nom"
 echo \strlen('hi'); // appelle la fonction "strlen"
 $a = \INI_ALL; // $a reçoit la valeur de la constante "INI_ALL"
-?>
 ]]>
      </programlisting>
     </example>
@@ -1318,7 +1312,7 @@ $a = \INI_ALL; // $a reçoit la valeur de la constante "INI_ALL"
    <para>
     <example>
      <title>Noms qualifiés</title>
-     <programlisting role="php">
+     <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 namespace foo;
@@ -1328,7 +1322,6 @@ $a = new mon\nom(); // instancie la classe "foo\mon\nom"
 foo\bar::name(); // appelle la méthode statique "name" dans la classe "blah\blah\bar"
 mon\bar(); // appelle la fonction "foo\mon\bar"
 $a = mon\BAR; // affecte à $a la valeur de la constante "foo\mon\BAR"
-?>
 ]]>
      </programlisting>
     </example>
@@ -1352,7 +1345,7 @@ $a = mon\BAR; // affecte à $a la valeur de la constante "foo\mon\BAR"
    <para>
     <example>
      <title>Classes sans qualification</title>
-     <programlisting role="php">
+     <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 namespace foo;
@@ -1360,7 +1353,6 @@ use blah\blah as foo;
 
 $a = new nom(); // instancie la classe "foo\nom"
 foo::nom(); // appelle la méthode statique "nom" dans la classe "blah\blah"
-?>
 ]]>
      </programlisting>
     </example>
@@ -1394,8 +1386,12 @@ use blah\blah as foo;
 
 const FOO = 1;
 
-function mon() {}
-function foo() {}
+function mon() {
+    print __FUNCTION__ . "\n";
+}
+function foo() {
+    print __FUNCTION__ . "\n";
+}
 function sort(&$a)
 {
     \sort($a); // Appel de la fonction globale "sort"
@@ -1404,14 +1400,16 @@ function sort(&$a)
 }
 
 mon(); // appelle "foo\mon"
-$a = strlen('hi'); // appelle la fonction globale "strlen" car "foo\strlen" n'existe pas
+print strlen('hi') . "\n"; // appelle la fonction globale "strlen" car "foo\strlen" n'existe pas
 $arr = array(1,3,2);
 $b = sort($arr); // appelle la fonction "foo\sort"
-$c = foo(); // appelle la fonction "foo\foo" : l'importation n'est pas appliquée
+var_dump($b);
+foo(); // appelle la fonction "foo\foo" : l'importation n'est pas appliquée
 
 $a = FOO; // assigne à $a la valeur de la constante "foo\FOO" : l'importation n'est pas appliquée
+print $a;
 $b = INI_ALL; // assigne à $b la valeur de la constante "INI_ALL"
-?>
+print $b;
 ]]>
      </programlisting>
     </example>
@@ -1424,25 +1422,23 @@ $b = INI_ALL; // assigne à $b la valeur de la constante "INI_ALL"
     La combinaison de scripts suivante est valide :
     <informalexample>
      <simpara>file1.php</simpara>
-     <programlisting role="php">
+     <programlisting role="php" annotations="non-interactive">
      <![CDATA[
 <?php
 namespace mes\trucs;
 class MaClasse {}
-?>
      ]]>
      </programlisting>
      <simpara>another.php</simpara>
-     <programlisting role="php">
+     <programlisting role="php" annotations="non-interactive">
      <![CDATA[
 <?php
 namespace another;
 class untruc {}
-?>
      ]]>
      </programlisting>
      <simpara>file2.php</simpara>
-     <programlisting role="php">
+     <programlisting role="php" annotations="non-interactive">
      <![CDATA[
 <?php
 namespace mes\trucs;
@@ -1451,7 +1447,6 @@ include 'another.php';
 
 use another\untruc as MaClasse;
 $a = new MaClasse; // instancie la classe "untruc" de l'espace de noms another
-?>
      ]]>
      </programlisting>
     </informalexample>
@@ -1464,14 +1459,13 @@ $a = new MaClasse; // instancie la classe "untruc" de l'espace de noms another
     <literal>MaClasse</literal> est définie dans le même fichier que l'instruction
     <literal>use</literal>.
     <informalexample>
-     <programlisting role="php">
+     <programlisting role="php" annotations="non-interactive">
      <![CDATA[
 <?php
 namespace mes\trucs;
 use another\untruc as MaClasse;
 class MaClasse {} // erreur fatale: MaClasse est en conflit avec la commande d'importation
 $a = new MaClasse;
-?>
      ]]>
      </programlisting>
     </informalexample>
@@ -1490,7 +1484,6 @@ namespace mes\trucs {
         class foo {}
     }
 }
-?>
      ]]>
      </programlisting>
     </informalexample>
@@ -1503,7 +1496,6 @@ namespace mes\trucs {
 namespace mes\trucs\nested {
     class foo {}
 }
-?>
      ]]>
      </programlisting>
     </informalexample>
@@ -1519,7 +1511,7 @@ namespace mes\trucs\nested {
     inattendue :
     <example>
      <title>Dangers de l'utilisation des espaces de noms dans une chaîne</title>
-     <programlisting role="php">
+     <programlisting role="php" annotations="non-interactive">
       <![CDATA[
 <?php
 $a = "dangereux\nom"; // \n est une nouvelle ligne dans une chaîne!
@@ -1527,7 +1519,6 @@ $obj = new $a;
 
 $a = 'pas\vraiment\dangereux'; // aucun problème ici
 $obj = new $a;
-?>
       ]]>
      </programlisting>
     </example>
@@ -1546,7 +1537,7 @@ $obj = new $a;
     produit une erreur fatale si indéfinie.
     <example>
      <title>Constantes indéfinies</title>
-     <programlisting role="php">
+     <programlisting role="php" annotations="non-interactive">
       <![CDATA[
 <?php
 namespace bar;
@@ -1554,7 +1545,6 @@ $a = FOO; // produit une alerte : constante indéfinie "FOO", qui prend la valeu
 $a = \FOO; // erreur fatale, constante d'espace de noms indéfinie FOO
 $a = Bar\FOO; // erreur fatale, constante d'espace de noms indéfinie bar\Bar\FOO
 $a = \Bar\FOO; // erreur fatale, constante d'espace de noms indéfinie Bar\FOO
-?>
       ]]>
      </programlisting>
     </example>
@@ -1574,7 +1564,6 @@ namespace bar;
 const NULL = 0; // erreur fatale;
 const true = 'stupid'; // encore une erreur fatale;
 // etc.
-?>
       ]]>
      </programlisting>
     </example>

--- a/language/namespaces.xml
+++ b/language/namespaces.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 1fade2bc5f160b23c2f46c3f854b833fab0e69f4 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 1fade2bc5f160b23c2f46c3f854b833fab0e69f4 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <!-- CREDITS: DAnnebicque -->
 <chapter xml:id="language.namespaces" xmlns="http://docbook.org/ns/docbook"


### PR DESCRIPTION
Sync of php/doc-en#5478 (commit 1fade2bc5f).

Adds `annotations="interactive"` on the chapter, `annotations="non-interactive"` on examples that aren't standalone runnable, makes the others runnable, and updates the EN-Revision hash.

Closes #2813