### PR TITLE
[Sync EN] Enable runnable WASM examples for language.variables

### DIFF
--- a/language/variables.xml
+++ b/language/variables.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 22583751fbfdaa3eaa41aeb6470d1343f5cb2c78 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 64007e9f6b23f70d8874be11c4eb9d45556b742f Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 
-<chapter xml:id="language.variables" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+<chapter xml:id="language.variables" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink"
+  annotations="interactive">
  <title>Les variables</title>
  
  <sect1 xml:id="language.variables.basics">
@@ -46,7 +47,7 @@
   
   <example>
     <title>Noms de variables valides</title>
-    <programlisting role="php">
+    <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 $var = 'Jean';
@@ -55,7 +56,6 @@ echo "$var, $Var";         // affiche "Jean, Paul"
 
 $_4site = 'pas encore';    // valide : commence par un souligné
 $täyte = 'mansikka';    // valide : 'ä' est ASCII (étendu) 228.
-?>
 ]]>
   </programlisting>
    </example>
@@ -86,7 +86,6 @@ $4site = 'pas encore';     // invalide : commence par un nombre
 ${'nom-invalide'} = 'bar';
 $nom = 'nom-invalide';
 echo ${'nom-invalide'}, " ", $$nom;
-?>
 ]]>
     </programlisting>
     &example.outputs;
@@ -128,9 +127,8 @@ bar bar
 $foo = 'Pierre';              // Assigne la valeur 'Pierre' à $foo
 $bar = &$foo;                 // Référence $foo avec $bar.
 $bar = "Mon nom est $bar";  // Modifie $bar...
-echo $bar;
-echo $foo;                    // $foo est aussi modifiée
-?>
+echo $bar . PHP_EOL;
+echo $foo . PHP_EOL;          // $foo est aussi modifiée
 ]]>
     </programlisting>
    </informalexample>
@@ -143,17 +141,37 @@ echo $foo;                    // $foo est aussi modifiée
     <programlisting role="php">
 <![CDATA[
 <?php
-$foo = 25;
-$bar = &$foo;      // assignation valide
-$bar = &(24 * 7);  // assignation invalide : référence une expression sans nom
-
+$original = 25;
+$ref1 = &$original;        // assignation valide
+$ref2 = &(24 * 7);         // assignation invalide : référence une expression sans nom
+]]>
+    </programlisting>
+   </informalexample>
+   <informalexample>
+    <programlisting role="php">
+<![CDATA[
+<?php
+// Noter l'absence de & indiquant un retour par référence dans la déclaration de la fonction.
+// Autrement dit, la fonction ne retourne pas une référence, donc le résultat ne peut pas être assigné par référence.
 function test()
 {
-   return 25;
+   $original = 25;
+   return $original;
 }
 
-$bar = &test();    // invalide car test() ne retourne pas une variable par référence.
-?>
+// Note : un avis est émis, mais la valeur sans référence est assignée
+$result1 = &test();        // invalide car test() ne retourne pas une variable par référence.
+var_dump($result1);
+
+// Cette fonction est définie comme retournant une référence, mais ne retourne pas une variable
+function &test2()
+{
+    return 26;             // invalide car la valeur retournée n'est pas une référence à une variable.
+}
+
+// Note : la valeur sans référence est assignée
+$result2 = &test2();
+var_dump($result2);
 ]]>
     </programlisting>
    </informalexample>
@@ -175,7 +193,6 @@ $bar = &test();    // invalide car test() ne retourne pas une variable par réf�
 <?php
 // Une variable non initialisée et non référencée (pas de contexte d'utilisation).
 var_dump($unset_var);
-?>
 ]]>
     </programlisting>
     &example.outputs;
@@ -199,7 +216,7 @@ NULL
 <![CDATA[
 <?php
 $unset_array[] = 'valeur'; // Ne génère pas d'avertissement.
-?>
+var_dump($unset_array);
 ]]>
     </programlisting>
    </example>
@@ -265,13 +282,11 @@ $unset_array[] = 'valeur'; // Ne génère pas d'avertissement.
   </simpara>
   <example>
    <title>Exemple de portée de variable globale</title>
-   <programlisting role="php">
+   <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 $a = 1;
 include 'b.inc'; // La variable $a sera disponible dans b.inc.
-
-?>
 ]]>
    </programlisting>
   </example>
@@ -294,12 +309,11 @@ include 'b.inc'; // La variable $a sera disponible dans b.inc.
 $a = 1; // portée globale
 
 function test()
-{ 
-    echo $a; // La variable $a est indéfinie car elle fait référence à une version locale de $a
+{
+    var_dump($a); // La variable $a est indéfinie car elle fait référence à une version locale de $a
 }
 
 test();
-?>
 ]]>
    </programlisting>
   </example>
@@ -350,7 +364,6 @@ function somme()
 
 somme();
 echo $b;
-?>
 ]]>
      </programlisting>
      &example.outputs;
@@ -394,9 +407,7 @@ function somme()
 
 somme();
 echo $b;
-?>
 ]]>
-
      </programlisting>
     </example>
    </para>
@@ -413,14 +424,13 @@ echo $b;
    <para>
     <example>
      <title>Exemple montrant les superglobales et la portée</title>
-     <programlisting role="php">
+     <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 function test_superglobal()
 {
     echo $_POST['name'];
 }
-?>
 ]]>
      </programlisting>
     </example>
@@ -451,10 +461,13 @@ function test_superglobal()
 function test()
 {
     $a = 0;
-    echo $a;
+    echo $a . PHP_EOL;
     $a++;
 }
-?>
+
+test();
+test();
+test();
 ]]>
      </programlisting>
     </example>
@@ -478,10 +491,13 @@ function test()
 function test()
 {
     static $a = 0;
-    echo $a;
+    echo $a . PHP_EOL;
     $a++;
 }
-?>
+
+test();
+test();
+test();
 ]]>
      </programlisting>
     </example>
@@ -510,13 +526,14 @@ function test()
     static $count = 0;
 
     $count++;
-    echo $count;
+    echo $count . PHP_EOL;
     if ($count < 10) {
         test();
     }
     $count--;
 }
-?>
+
+test();
 ]]>
      </programlisting>
     </example>
@@ -530,7 +547,7 @@ function test()
    <para>
     <example>
      <title>Déclaration de variables statiques</title>
-     <programlisting role="php">
+     <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 function foo(){
@@ -541,7 +558,6 @@ function foo(){
     $int++;
     echo $int;
 }
-?>
 ]]>
      </programlisting>
     </example>
@@ -570,7 +586,6 @@ function exampleFunction($input) {
 // ne conserve pas sa valeur.
 echo exampleFunction('A'); // Affiche : Input: A, Counter: 1
 echo exampleFunction('B'); // Affiche : Input: B, Counter: 1
-?>
 ]]>
     </programlisting>
    </example>
@@ -604,7 +619,6 @@ var_dump(Foo::counter()); // int(1)
 var_dump(Foo::counter()); // int(2)
 var_dump(Bar::counter()); // int(3), avant PHP 8.1.0 int(1)
 var_dump(Bar::counter()); // int(4), avant PHP 8.1.0 int(2)
-?>
 ]]>
       </programlisting>
    </example>
@@ -645,21 +659,20 @@ test_global_ref();
 var_dump($obj);
 test_global_noref();
 var_dump($obj);
-?>
 ]]>
     </programlisting>
-   </informalexample>
 
-   &example.outputs;
+    &example.outputs;
 
-   <screen>
+    <screen>
 <![CDATA[
 NULL
 object(stdClass)#1 (0) {
 }
 ]]>
-   </screen>
-   
+    </screen>
+   </informalexample>
+
    <simpara>
     Un comportement similaire s'applique à la commande <literal>static</literal>.
     Les références ne sont pas stockées dynamiquement :
@@ -710,12 +723,10 @@ $still_obj1 = get_instance_ref();
 echo "\n";
 $obj2 = get_instance_noref();
 $still_obj2 = get_instance_noref();
-?>
 ]]>
     </programlisting>
-   </informalexample>
-   &example.outputs;
-   <screen>
+    &example.outputs;
+    <screen>
 <![CDATA[
 Static object: NULL
 Static object: NULL
@@ -726,8 +737,9 @@ Static object: object(stdClass)#3 (1) {
   int(1)
 }
 ]]>
-   </screen>
-   
+    </screen>
+   </informalexample>
+
    <simpara>
     Ces exemples illustrent les problèmes rencontrés lors de l'assignation
     de référence à des variables statiques, qui sont
@@ -752,7 +764,7 @@ Static object: object(stdClass)#3 (1) {
 <![CDATA[
 <?php
 $a = 'bonjour';
-?>
+var_dump($a);
 ]]>
    </programlisting>
   </informalexample>
@@ -769,8 +781,9 @@ $a = 'bonjour';
    <programlisting role="php">
 <![CDATA[
 <?php
+$a = 'bonjour';
 $$a = 'monde';
-?>
+var_dump($bonjour);
 ]]>
    </programlisting>
   </informalexample>
@@ -785,8 +798,9 @@ $$a = 'monde';
    <programlisting role="php">
 <![CDATA[
 <?php
-    echo "$a {$$a}";
-?>
+$a = 'bonjour';
+$$a = 'monde';
+echo "$a {$$a}";
 ]]>
    </programlisting>
   </informalexample>
@@ -799,8 +813,9 @@ $$a = 'monde';
    <programlisting  role="php">
 <![CDATA[
 <?php
+$a = 'bonjour';
+$$a = 'monde';
 echo "$a $bonjour";
-?>
 ]]>
    </programlisting>
   </informalexample>
@@ -866,7 +881,6 @@ echo $foo->{$start . $end} . "\n";
 $arr = 'arr';
 echo $foo->{$arr[1]} . "\n";
 echo $foo->{$arr}[1] . "\n";
-?>
 ]]>
     </programlisting>
     &example.outputs;
@@ -930,12 +944,11 @@ I am B.
    <para>
     <example>
      <title>Accéder simplement à des variables de formulaires POST</title>
-     <programlisting role="php">
+     <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 echo $_POST['username'];
 echo $_REQUEST['username'];
-?>
 ]]>
      </programlisting>
     </example>
@@ -973,7 +986,7 @@ echo $_REQUEST['username'];
    <para>
     <example>
      <title>Variables de formulaires complexes</title>
-     <programlisting role="php">
+     <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 if ($_POST) {
@@ -1071,12 +1084,11 @@ if ($_POST) {
    </simpara>
    
    <informalexample>
-    <programlisting role="php">
+    <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 setcookie("MyCookie[foo]", 'Test 1', time()+3600);
 setcookie("MyCookie[bar]", 'Test 2', time()+3600);
-?>
 ]]>
     </programlisting>
    </informalexample>
@@ -1100,7 +1112,7 @@ setcookie("MyCookie[bar]", 'Test 2', time()+3600);
    
    <example>
     <title>Exemple avec <function>setcookie</function></title>
-    <programlisting role="php">
+    <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 if (isset($_COOKIE['compte'])) {
@@ -1110,7 +1122,6 @@ if (isset($_COOKIE['compte'])) {
 }
 setcookie('compte', $compte, time()+3600);
 setcookie("Panier[$compte]", $item, time()+3600);
-?>
 ]]>
     </programlisting>
    </example>
@@ -1125,11 +1136,10 @@ setcookie("Panier[$compte]", $item, time()+3600);
     sont passées à un script. Cependant, il faut noter que
     les points (.) ne sont pas autorisés dans les noms de variables
     PHP. Pour cette raison, il convient d'examiner :
-    <programlisting role="php">
+    <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
-  $varname.ext;  /* nom de variable invalide */
-?>
+$varname.ext;  /* nom de variable invalide */
 ]]>
     </programlisting>
     Dans ce cas, l'analyseur croit voir la variable nommée


### PR DESCRIPTION
Sync of php/doc-en#5455 (commit 64007e9f6b).

Adds `annotations="interactive"` on the chapter, `annotations="non-interactive"` on examples that aren't standalone runnable, makes the others runnable, and updates the EN-Revision hash.

Closes #2815