### PR TITLE
[Sync EN] debug_backtrace(): preciser les conditions d'omission

### DIFF
--- a/reference/errorfunc/functions/debug-backtrace.xml
+++ b/reference/errorfunc/functions/debug-backtrace.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 26f18bad4964592e0020daa67f0bac81ae7aeb4c Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: a8dfc2c067cbaadab174f0470e3d0dd0bc811d73 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="function.debug-backtrace" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -165,7 +165,7 @@
        <entry>object</entry>
        <entry>&object;</entry>
        <entry>
-        L'<link linkend="language.oop5">objet</link> courant.
+        L'<link linkend="language.oop5">objet</link> courant si <constant>DEBUG_BACKTRACE_PROVIDE_OBJECT</constant> est fourni.
        </entry>
       </row>
       <row>
@@ -182,7 +182,7 @@
        <entry>&array;</entry>
        <entry>
         Si à l'intérieur d'une fonction, ceci liste des arguments. Si
-        dans un fichier inclus, ceci liste des fichiers inclus.
+        dans un fichier inclus, ceci liste des fichiers inclus. Sauf si <constant>DEBUG_BACKTRACE_IGNORE_ARGS</constant> est fourni.
        </entry>
       </row>
      </tbody>


### PR DESCRIPTION
Sync de php/doc-en#5544 (commit a8dfc2c067).

Ajoute la mention de `DEBUG_BACKTRACE_PROVIDE_OBJECT` pour la cle `object` et de `DEBUG_BACKTRACE_IGNORE_ARGS` pour la cle `args`.

Closes #2816