### PR TITLE
[Sync EN] Enable runnable WASM examples for attributes/generators/references

### DIFF
--- a/language/attributes.xml
+++ b/language/attributes.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 0f14761ba340c6e49797706ac3f0cf1147d97253 Maintainer: pierrick Status: ready -->
+<!-- EN-Revision: 50e6f42c83ac3f6de5e1086b649e06adedd562ff Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
- <chapter xml:id="language.attributes" xmlns="http://docbook.org/ns/docbook">
+ <chapter xml:id="language.attributes" xmlns="http://docbook.org/ns/docbook" annotations="interactive">
   <title>Attributs</title>
   <sect1 xml:id="language.attributes.overview">
    <title>Aperçu des attributs</title>
@@ -32,7 +32,7 @@
 
    <example>
     <title>Implémentation de méthodes optionnelles d'une interface avec des attributs</title>
-     <programlisting role="php">
+     <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 interface ActionHandler
@@ -120,7 +120,7 @@ executeAction($copyAction);
    <example>
     <title>Syntaxe des attributs</title>
 
-    <programlisting role="php">
+    <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 // a.php
@@ -221,7 +221,11 @@ function dumpAttributeData($reflection) {
 }
 
 dumpAttributeData(new ReflectionClass(Thing::class));
-/*
+]]>
+    </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
 string(11) "MyAttribute"
 array(1) {
   ["value"]=>
@@ -231,10 +235,8 @@ object(MyAttribute)#3 (1) {
   ["value"]=>
   int(1234)
 }
-*/
-
 ]]>
-    </programlisting>
+    </screen>
    </example>
 
    <para>
@@ -249,6 +251,21 @@ object(MyAttribute)#3 (1) {
     <programlisting role="php">
 <![CDATA[
 <?php
+#[Attribute]
+class MyAttribute
+{
+    public $value;
+
+    public function __construct($value)
+    {
+        $this->value = $value;
+    }
+}
+
+#[MyAttribute(value: 1234)]
+class Thing
+{
+}
 
 function dumpMyAttributeData($reflection) {
     $attributes = $reflection->getAttributes(MyAttribute::class);
@@ -278,7 +295,7 @@ dumpMyAttributeData(new ReflectionClass(Thing::class));
   <example>
    <title>Classe d'attribut simple</title>
 
-   <programlisting role="php">
+   <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 
@@ -302,7 +319,7 @@ class MyAttribute
   <example>
    <title>Utilisation de la spécification de la cible pour restreindre l'utilisation des attributs</title>
 
-   <programlisting role="php">
+   <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 
@@ -345,7 +362,7 @@ class MyAttribute
    <example>
     <title>Utilisation de IS_REPEATABLE pour permettre à un attribut d'être utilisé plusieurs fois dans une déclaration</title>
 
-    <programlisting role="php">
+    <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 

--- a/language/generators.xml
+++ b/language/generators.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 08e58ace7e5b538c8ed75d784a54885d5f785d30 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 50e6f42c83ac3f6de5e1086b649e06adedd562ff Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <!-- CREDITS: DAnnebicque -->
 
-<chapter xml:id="language.generators" xmlns="http://docbook.org/ns/docbook">
+<chapter xml:id="language.generators" xmlns="http://docbook.org/ns/docbook" annotations="interactive">
  <title>Les générateurs</title>
  
  <sect1 xml:id="language.generators.overview">
@@ -89,7 +89,6 @@ echo 'Nombres impairs à un seul chiffre depuis xrange() : ';
 foreach (xrange(1, 9, 2) as $number) {
     echo "$number ";
 }
-?>
 ]]>
    </programlisting>
    &example.outputs;
@@ -171,7 +170,6 @@ $generator = gen_one_to_three();
 foreach ($generator as $value) {
     echo "$value\n";
 }
-?>
 ]]>
     </programlisting>
     &example.outputs;
@@ -236,7 +234,6 @@ foreach (input_parser($input) as $id => $fields) {
     echo "    $fields[0]\n";
     echo "    $fields[1]\n";
 }
-?>
 ]]>
      </programlisting>
      &example.outputs;
@@ -276,7 +273,6 @@ function gen_three_nulls() {
 }
 
 var_dump(iterator_to_array(gen_three_nulls()));
-?>
 ]]>
      </programlisting>
      &example.outputs;
@@ -327,7 +323,6 @@ function &gen_reference() {
 foreach (gen_reference() as &$number) {
     echo (--$number).'... ';
 }
-?>
 ]]>
      </programlisting>
      &example.outputs;
@@ -396,7 +391,6 @@ function gen() {
 }
 // met à false le second paramètre pour avoir un tableau [0, 1, 2, 3, 4]
 var_dump(iterator_to_array(gen()));
-?>
 ]]>
        </programlisting>
        &example.outputs;
@@ -442,7 +436,6 @@ function eight() {
 foreach (count_to_ten() as $num) {
     echo "$num ";
 }
-?>
 ]]>
      </programlisting>
      &example.outputs;
@@ -486,7 +479,6 @@ foreach ($gen as $num) {
     echo "$num ";
 }
 echo $gen->getReturn();
-?>
 ]]>
      </programlisting>
      &example.outputs;
@@ -511,7 +503,7 @@ echo $gen->getReturn();
   </para>
   
   <informalexample>
-   <programlisting role="php">
+   <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 function getLinesFromFile($fileName) {
@@ -569,7 +561,6 @@ class LineIterator implements Iterator {
         fclose($this->fileHandle);
     }
 }
-?>
 ]]>
    </programlisting>
   </informalexample>

--- a/language/references.xml
+++ b/language/references.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 9463e5b660c4883b91a30f07ff68731bbcc48346 Maintainer: jpauli Status: ready -->
+<!-- EN-Revision: 50e6f42c83ac3f6de5e1086b649e06adedd562ff Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <!-- CREDITS: DAnnebicque -->
 
-<chapter xml:id="language.references" xmlns="http://docbook.org/ns/docbook">
+<chapter xml:id="language.references" xmlns="http://docbook.org/ns/docbook" annotations="interactive">
  <title>Les références</title>
  <sect1 xml:id="language.references.whatare">
   <title>Qu'est-ce qu'une référence ?</title>
@@ -46,13 +46,10 @@
     sorte que deux variables référencent le même contenu.
     Par exemple :
     <informalexample>
-     <programlisting role="php">
+     <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
-
 $a =& $b;
-
-?>
 ]]>
      </programlisting>
     </informalexample>
@@ -88,8 +85,6 @@ var_dump(array_key_exists('b', $b)); // bool(true)
 $c = new stdClass();
 foo($c->d);
 var_dump(property_exists($c, 'd')); // bool(true)
-
-?>
 ]]>
       </programlisting>
      </example>
@@ -99,13 +94,10 @@ var_dump(property_exists($c, 'd')); // bool(true)
     La même syntaxe peut être utilisée avec les fonctions qui
     retournent des références :
     <informalexample>
-     <programlisting role="php">
+     <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
-
 $foo =& find_var($bar);
-
-?>
 ]]>
      </programlisting>
     </informalexample>
@@ -128,7 +120,6 @@ $foo =& find_var($bar);
       <programlisting role="php">
 <![CDATA[
 <?php
-
 $var1 = "Variable Exemple";
 $var2 = "";
 
@@ -148,8 +139,6 @@ echo "var2 est défini à '$var2'\n"; // var2 est défini à ''
 
 global_references(true);
 echo "var2 est défini à '$var2'\n"; // var2 est défini à 'Variable Exemple'
-
-?>
 ]]>
       </programlisting>
      </example>
@@ -167,7 +156,6 @@ echo "var2 est défini à '$var2'\n"; // var2 est défini à 'Variable Exemple'
       <programlisting role="php">
 <![CDATA[
 <?php
-
 $ref = 0;
 $row =& $ref;
 
@@ -176,8 +164,6 @@ foreach (array(1, 2, 3) as $row) {
 }
 
 echo $ref; // 3 - le dernier élément du tableau itéré
-
-?>
 ]]>
       </programlisting>
      </example>
@@ -193,7 +179,6 @@ echo $ref; // 3 - le dernier élément du tableau itéré
      <programlisting role="php">
 <![CDATA[
 <?php
-
 $a = 1;
 $b = array(2, 3);
 
@@ -202,8 +187,8 @@ $arr[0]++;
 $arr[1]++;
 $arr[2]++;
 /* $a == 2, $b == array(3, 4); */
-
-?>
+var_dump($a);
+var_dump($b);
 ]]>
      </programlisting>
     </informalexample>
@@ -225,6 +210,7 @@ $a = 1;
 $b =& $a;
 $c = $b;
 $c = 7; // $c n'est pas une référence ; pas de changement à $a ou $b
+print "a = {$a}; b = {$b}; c = {$c}\n\n";
 
 /* Assignation de variables de type tableau */
 $arr = array(1);
@@ -233,8 +219,9 @@ $arr2 = $arr; // PAS une assignation par référence!
 $arr2[0]++;
 /* $a == 2, $arr == array(2) */
 /* Les contenus de $arr sont changés même si ce n'était pas une référence ! */
-
-?>
+print "a = {$a}\n";
+var_dump($arr);
+var_dump($arr2);
 ]]>
      </programlisting>
     </informalexample>
@@ -255,16 +242,14 @@ $arr2[0]++;
      <programlisting role="php">
 <![CDATA[
 <?php
-
 function foo(&$var)
 {
     $var++;
 }
 
-$a=5;
+$a = 5;
 foo($a);
-
-?>
+print $a;
 ]]>
      </programlisting>
     </informalexample>
@@ -293,18 +278,15 @@ foo($a);
    sont pas des pointeurs. Cela signifie que le script suivant ne fera pas
    ce à quoi on peut s'attendre :
    <informalexample>
-    <programlisting role="php">
+    <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
-
 function foo(&$var)
 {
     $var =& $GLOBALS["baz"];
 }
 
 foo($bar);
-
-?>
 ]]>
     </programlisting>
    </informalexample>
@@ -333,18 +315,14 @@ foo($bar);
     <programlisting role="php">
 <![CDATA[
 <?php
-
 function foo(&$var)
 {
     $var++;
 }
 
-$a=5;
-
+$a = 5;
 foo($a);
-// $a vaut 6 maintenant
-
-?>
+print $a; // $a vaut 6 maintenant
 ]]>
     </programlisting>
    </informalexample>
@@ -372,10 +350,10 @@ foo($a);
        <programlisting role="php">
 <![CDATA[
 <?php
-
 function foo(&$var)
 {
     $var++;
+    print $var;
 }
 
 function &bar()
@@ -385,8 +363,6 @@ function &bar()
 }
 
 foo(bar());
-
-?>
 ]]>
        </programlisting>
       </informalexample>
@@ -402,7 +378,7 @@ foo(bar());
    référence, car le résultat sera indéfini. Par exemple,
    les passages par référence suivants sont invalides :
    <informalexample>
-    <programlisting role="php">
+    <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 
@@ -426,7 +402,6 @@ class Foobar {}
 
 foo(new Foobar()) // Produit une notice à partir de PHP 7.0.7
                   // Notice: Seules les variables devraient être passées par référence
-?>
 ]]>
     </programlisting>
    </informalexample>
@@ -450,7 +425,6 @@ foo(new Foobar()) // Produit une notice à partir de PHP 7.0.7
     <programlisting role="php">
 <![CDATA[
 <?php
-
 class Foo
 {
     public $value = 42;
@@ -465,8 +439,6 @@ $obj = new Foo();
 $myValue = &$obj->getValue(); // $myValue est une référence de $obj->value, qui vaut 42.
 $obj->value = 2;
 echo $myValue;                // affiche la nouvelle valeur de $obj->value, i.e. 2.
-
-?>
 ]]>
     </programlisting>
    </informalexample>
@@ -513,14 +485,17 @@ $collection = &collector();
 $collection[] = 'foo';
 
 print_r(collector());
-// Array
-// (
-//    [0] => foo
-// )
-
-?>
 ]]>
     </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+Array
+(
+    [0] => foo
+)
+]]>
+    </screen>
    </informalexample>
    <note>
     <simpara>
@@ -533,7 +508,7 @@ print_r(collector());
    Pour passer la référence retournée à une autre fonction attendant une référence,
    il est possible d'utiliser la syntaxe suivante :
    <informalexample>
-    <programlisting role="php">
+    <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 
@@ -544,8 +519,6 @@ function &collector()
 }
 
 array_push(collector(), 'foo');
-
-?>
 ]]>
     </programlisting>
    </informalexample>
@@ -570,12 +543,11 @@ array_push(collector(), 'foo');
     <programlisting role="php">
 <![CDATA[
 <?php
-
 $a = 1;
 $b =& $a;
 unset($a);
-
-?>
+var_dump($a);
+var_dump($b);
 ]]>
     </programlisting>
    </informalexample>
@@ -606,13 +578,10 @@ unset($a);
     cela crée en fait une référence sur une variable
     globale. Autrement dit, cela revient au même que :
     <informalexample>
-     <programlisting role="php">
+     <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
-
 $var =& $GLOBALS["var"];
-
-?>
 ]]>
      </programlisting>
     </informalexample>


### PR DESCRIPTION
Sync of php/doc-en#5484 (commit 50e6f42c83).

Closes #2814