### PR TITLE
[Sync EN] fpm: improve configuration, mention ondemand mode (#4619)

### DIFF
--- a/install/fpm/configuration.xml
+++ b/install/fpm/configuration.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: a52e3d27cca786940272d0ae8efc21b5d6739070 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 1f01e2a8e478c63bd6598cde09235ec027b23dd5 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no Maintainer: itanea -->
 <sect1 xml:id="install.fpm.configuration" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Configuration</title>
@@ -396,16 +396,16 @@
      <para>
       <literal>static</literal> - nombre de processus fils fixés (<literal>pm.max_children</literal>).
      </para>
-     <para>
+     <simpara>
       <literal>ondemand</literal> - le processus se réactive à la demande
       (lorsque demandé, c'est l'opposé de dynamique où <literal>pm.start_servers</literal>
       sont démarrés lorsque le service démarre).
-     </para>
-     <para>
+     </simpara>
+     <simpara>
       <literal>dynamic</literal> - nombre de processus fils dynamiques basé sur les directives suivantes:
-      <literal>pm.max_children</literal>, <literal>pm.start_servers</literal>, 
+      <literal>pm.max_children</literal>, <literal>pm.start_servers</literal>,
       <literal>pm.min_spare_servers</literal>, <literal>pm.max_spare_servers</literal>.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry xml:id="pm.max-children">
@@ -414,11 +414,12 @@
      &integer;
     </term>
     <listitem>
-     <para>
+     <simpara>
       Nombre de processus fils à créer lorsque <literal>pm</literal> est réglé sur
       <literal>static</literal>. Nombre maximum de processus fils à créer lorsque
-      <literal>pm</literal> est réglé sur <literal>dynamic</literal>. Option obligatoire.
-     </para>
+      <literal>pm</literal> est réglé sur <literal>dynamic</literal> ou <literal>ondemand</literal>.
+      Option obligatoire.
+     </simpara>
      <para>
       Cette option affecte la limite du nombre de requêtes simultanées qui seront servies. Équivalent à
       ApacheMaxClients avec mpm_prefork et à <varname>PHP_FCGI_CHILDREN</varname> dans l'implémentation originale


### PR DESCRIPTION
Sync de https://github.com/php/doc-en/commit/1f01e2a8e478c63bd6598cde09235ec027b23dd5 (php/doc-en#4619) : `pm.max_children` s'applique aussi à `pm = ondemand`, et passage des `<para>` purement inline en `<simpara>` pour suivre l'EN.

Fixes #2822