### PR TITLE
[Sync EN] IMAGETYPE_HEIF: Add newly added constant introduced in PHP 8.5 (#5042)

### DIFF
--- a/appendices/migration85/constants.xml
+++ b/appendices/migration85/constants.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: ec45af749649dc0d6a23eaedeed1b601f7460813 Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: f8bab1dfb5246788f144103de56208dd133e9461 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <sect1 xml:id="migration85.constants">
  <title>Nouvelles constantes globales</title>
@@ -162,6 +162,9 @@
   <title>Standard</title>
 
   <simplelist>
+   <member>
+    <constant>IMAGETYPE_HEIF</constant>
+   </member>
    <member>
     <constant>IMAGETYPE_SVG</constant>
     lorsque libxml est chargé.

--- a/reference/exif/functions/exif-imagetype.xml
+++ b/reference/exif/functions/exif-imagetype.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 6a08181be1706dfebdb3ad6e45620bceb08019ba Maintainer: yannick Status: ready -->
+<!-- EN-Revision: f8bab1dfb5246788f144103de56208dd133e9461 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.exif-imagetype">
   <refnamediv>
@@ -138,6 +138,10 @@
         <entry>19</entry>
         <entry><constant>IMAGETYPE_AVIF</constant></entry>
        </row>
+       <row>
+        <entry>20</entry>
+        <entry><constant>IMAGETYPE_HEIF</constant></entry>
+       </row>
       </tbody>
      </tgroup>
     </table>
@@ -176,6 +180,12 @@
        <entry>8.1.0</entry>
        <entry>
         Ajout de la prise en charge de AVIF.
+       </entry>
+      </row>
+      <row>
+       <entry>8.5.0</entry>
+       <entry>
+        Ajout de la prise en charge de HEIF.
        </entry>
       </row>
      </tbody>

--- a/reference/image/constants.xml
+++ b/reference/image/constants.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 7f5d646f3ee39231150e767fb876b56610f56c2b Maintainer: yannick Status: ready -->
+<!-- EN-Revision: f8bab1dfb5246788f144103de56208dd133e9461 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <appendix xml:id="image.constants" xmlns="http://docbook.org/ns/docbook">
  &reftitle.constants;
@@ -699,6 +699,18 @@
     &gd.constants.type;
     <simpara>
      (Disponible à partir de PHP 8.1.0)
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.imagetype-heif">
+   <term>
+    <constant>IMAGETYPE_HEIF</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    &gd.constants.type;
+    <simpara>
+     (Disponible à partir de PHP 8.5.0)
     </simpara>
    </listitem>
   </varlistentry>

--- a/reference/image/functions/image-type-to-mime-type.xml
+++ b/reference/image/functions/image-type-to-mime-type.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 89ae180a851621c308f0ea4604ff2e919aa57a7f Maintainer: yannick Status: ready -->
+<!-- EN-Revision: f8bab1dfb5246788f144103de56208dd133e9461 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="function.image-type-to-mime-type" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -124,6 +124,10 @@
       <row>
        <entry><constant>IMAGETYPE_AVIF</constant></entry>
        <entry><literal>image/avif</literal></entry>
+      </row>
+      <row>
+       <entry><constant>IMAGETYPE_HEIF</constant></entry>
+       <entry><literal>image/heif</literal></entry>
       </row>
      </tbody>
     </tgroup>


### PR DESCRIPTION
Sync de https://github.com/php/doc-en/commit/f8bab1dfb5246788f144103de56208dd133e9461 (php/doc-en#5042) : nouvelle constante `IMAGETYPE_HEIF` (PHP 8.5) ajoutée dans `migration85/constants.xml`, `image/constants.xml`, et dans les tableaux de `exif_imagetype()` et `image_type_to_mime_type()`.

Fixes #2823