### PR TITLE
[Sync EN] (void) casting: Add syntax for PHP 8.5 (#5546)

### DIFF
--- a/language/types/type-juggling.xml
+++ b/language/types/type-juggling.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 78a11d3ca004ee937549d932e77a79c51b9777cd Maintainer: girgias Status: ready -->
+<!-- EN-Revision: 50f76f26914c5a9e61aa26f2e36c4acb362a48fd Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <sect1 xml:id="language.types.type-juggling">
  <title>Jonglage de type</title>
@@ -318,6 +318,13 @@ var_dump($bar);
    <member><literal>(unset)</literal> - cast en <type>NULL</type></member>
   </simplelist>
 
+  <simpara>
+   Le cast <link linkend="language.types.void.casting"><literal>(void)</literal></link>
+   est également disponible à partir de PHP 8.5.0, mais il ne s'agit pas d'une conversion
+   de valeur. Il est utilisé en tant qu'instruction pour ignorer explicitement le résultat
+   d'une expression.
+  </simpara>
+
   <warning>
    <para>
     <literal>(integer)</literal> est un alias du cast <literal>(int)</literal>.
@@ -423,6 +430,7 @@ if ($fst === $str) {
     <member><link linkend="language.types.object.casting">Convertir en object</link></member>
     <member><link linkend="language.types.resource.casting">Convertir en resource</link></member>
     <member><link linkend="language.types.null.casting">Convertir en NULL</link></member>
+    <member><link linkend="language.types.void.casting">Ignorer une valeur avec <literal>(void)</literal></link></member>
     <member><link linkend="types.comparisons">Les tables de comparaison de type</link></member>
    </simplelist>
   </para>

--- a/language/types/void.xml
+++ b/language/types/void.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 161dde4fe721309398dd324edbf02aec409f127b Maintainer: pierrick Status: ready -->
+<!-- EN-Revision: 50f76f26914c5a9e61aa26f2e36c4acb362a48fd Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <sect1 xml:id="language.types.void">
  <title>Void</title>
@@ -19,6 +19,39 @@
   </simpara>
  </note>
 
+ <sect2 xml:id="language.types.void.casting">
+  <title>Ignorer une valeur avec <literal>(void)</literal></title>
+
+  <simpara>
+   La syntaxe <literal>(void)</literal> peut être utilisée pour ignorer
+   explicitement le résultat d'une expression. Cela permet d'indiquer que
+   l'omission d'une valeur de retour est intentionnelle, en particulier
+   lors de l'appel d'une fonction ou méthode marquée avec l'attribut
+   <classname>NoDiscard</classname>.
+  </simpara>
+
+  <simpara>
+   Contrairement aux autres casts, <literal>(void)</literal> ne convertit pas
+   la valeur en un autre type et ne produit pas de valeur. Il s'agit d'une
+   instruction et il ne peut pas être utilisé en tant que partie d'une expression.
+  </simpara>
+
+  <example>
+   <title>Ignorer une valeur de retour</title>
+   <programlisting role="php" annotations="non-interactive">
+    <![CDATA[
+<?php
+#[\NoDiscard]
+function process(): bool {
+    return true;
+}
+
+(void) process(); // Ignore explicitement la valeur de retour
+?>
+]]>
+   </programlisting>
+  </example>
+ </sect2>
 </sect1>
 <!-- Keep this comment at the end of the file
 Local variables:


### PR DESCRIPTION
Sync de https://github.com/php/doc-en/commit/50f76f26914c5a9e61aa26f2e36c4acb362a48fd (php/doc-en#5546) : ajout de la nouvelle syntaxe de cast `(void)` introduite en PHP 8.5, et ajout de la sous-section associée dans `language/types/void.xml`.

Fixes #2824