### PR TITLE
[Sync EN] Fix double anchor tag when classname and link are used together (#5547)

### DIFF
--- a/language/functions.xml
+++ b/language/functions.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9c835d146d452976f21db7d9cb60dca013829d39 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: e290572f2599305beb62b13988024b5da187979d Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <chapter xml:id="language.functions" xmlns="http://docbook.org/ns/docbook" annotations="interactive">
  <title>Les fonctions</title>
@@ -1465,8 +1465,7 @@ Stack trace:
    </simpara>
    <simpara>
     Les fonctions anonymes comme les fonctions fléchées sont implémentées en
-    utilisant la classe
-    <link linkend="class.closure"><classname>Closure</classname></link>.
+    utilisant la classe <classname>Closure</classname>.
    </simpara>
 
    <simpara>

--- a/reference/intl/collator/asort.xml
+++ b/reference/intl/collator/asort.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: c142be811735a5542c8a2e4c4ed2f81e8cc3acc6 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: e290572f2599305beb62b13988024b5da187979d Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="collator.asort" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -145,7 +145,7 @@ array (
   &reftitle.seealso;
   <para>
    <simplelist>
-    <member>Constantes <link linkend="intl.collator-constants"><classname>Collator</classname></link></member>
+    <member>Constantes <link linkend="intl.collator-constants">Collator</link></member>
     <member><function>collator_sort</function></member>
     <member><function>collator_sort_with_sort_keys</function></member>
    </simplelist>

--- a/reference/intl/collator/get-attribute.xml
+++ b/reference/intl/collator/get-attribute.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 1976eae0d815797af97a1e16c5cd90ffc2868395 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: e290572f2599305beb62b13988024b5da187979d Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="collator.getattribute" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -87,7 +87,7 @@ if( $val === false )
   &reftitle.seealso;
   <para>
    <simplelist>
-    <member><link linkend="intl.collator-constants"><classname>Collator</classname> constants</link></member>
+    <member><link linkend="intl.collator-constants">Collator constants</link></member>
     <member><function>collator_set_attribute</function></member>
     <member><function>collator_get_strength</function></member>
    </simplelist>

--- a/reference/intl/collator/get-strength.xml
+++ b/reference/intl/collator/get-strength.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 1976eae0d815797af97a1e16c5cd90ffc2868395 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: e290572f2599305beb62b13988024b5da187979d Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="collator.getstrength" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -81,7 +81,7 @@ $strength = collator_get_strength( $coll );
   &reftitle.seealso;
   <para>
    <simplelist>
-    <member><link linkend="intl.collator-constants"><classname>Collator</classname> constants</link></member>
+    <member><link linkend="intl.collator-constants">Collator constants</link></member>
     <member><function>collator_set_strength</function></member>
     <member><function>collator_get_attribute</function></member>
    </simplelist>

--- a/reference/intl/collator/set-attribute.xml
+++ b/reference/intl/collator/set-attribute.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 0194deb3cec8d79ae6b13700f3cd031d14597838 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: e290572f2599305beb62b13988024b5da187979d Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="collator.setattribute" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -90,7 +90,7 @@ collator_set_attribute($coll, Collator::NORMALIZATION_MODE, Collator::ON);
   &reftitle.seealso;
   <para>
    <simplelist>
-    <member><link linkend="intl.collator-constants"><classname>Collator</classname> constants</link></member>
+    <member><link linkend="intl.collator-constants">Collator constants</link></member>
     <member><function>collator_get_attribute</function></member>
     <member><function>collator_set_strength</function></member>
    </simplelist>

--- a/reference/intl/collator/set-strength.xml
+++ b/reference/intl/collator/set-strength.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 679cf93fa1e54cde82fc9cf545966eb13bcb0638 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: e290572f2599305beb62b13988024b5da187979d Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="collator.setstrength" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -228,7 +228,7 @@ array (
   &reftitle.seealso;
   <para>
    <simplelist>
-    <member>Constantes <link linkend="intl.collator-constants"><classname>Collator</classname></link></member>
+    <member>Constantes <link linkend="intl.collator-constants">Collator</link></member>
     <member><function>collator_get_strength</function></member>
    </simplelist>
   </para>

--- a/reference/intl/collator/sort-with-sort-keys.xml
+++ b/reference/intl/collator/sort-with-sort-keys.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 1976eae0d815797af97a1e16c5cd90ffc2868395 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: e290572f2599305beb62b13988024b5da187979d Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="collator.sortwithsortkeys" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -95,7 +95,7 @@ array (
   &reftitle.seealso;
   <para>
    <simplelist>
-    <member>Constantes <link linkend="intl.collator-constants"><classname>Collator</classname></link></member>
+    <member>Constantes <link linkend="intl.collator-constants">Collator</link></member>
     <member><function>collator_sort</function></member>
     <member><function>collator_asort</function></member>
    </simplelist>

--- a/reference/intl/collator/sort.xml
+++ b/reference/intl/collator/sort.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: c142be811735a5542c8a2e4c4ed2f81e8cc3acc6 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: e290572f2599305beb62b13988024b5da187979d Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="collator.sort" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -139,7 +139,7 @@ array (
   &reftitle.seealso;
   <para>
    <simplelist>
-    <member>Constantes <link linkend="intl.collator-constants"><classname>Collator</classname></link></member>
+    <member>Constantes <link linkend="intl.collator-constants">Collator</link></member>
     <member><function>collator_asort</function></member>
     <member><function>collator_sort_with_sort_keys</function></member>
    </simplelist>


### PR DESCRIPTION
Sync de https://github.com/php/doc-en/commit/e290572f2599305beb62b13988024b5da187979d (php/doc-en#5547) : suppression de la balise `<classname>` à l'intérieur des `<link>` qui produit une double ancre au rendu, sur les 8 fichiers concernés.

Fixes #2825