### PR TITLE
[Sync EN] Tutorial: Improved "What's Next" section (#5491)

### DIFF
--- a/chapters/tutorial.xml
+++ b/chapters/tutorial.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 876557ae38f6ca5035618f7cea48ca627118b437 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 1340d3595bde8489ea1385868ffd75471a56999b Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 
  <chapter xml:id="tutorial" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -319,15 +319,15 @@ Vous utilisez Firefox.
 <![CDATA[
 <?php
 if (str_contains($_SERVER['HTTP_USER_AGENT'], 'Firefox')) {
-?>
-<h3>str_contains() a retourné true</h3>
-<p>Vous utilisez Firefox</p>
-<?php
+    ?>
+    <h3>str_contains() a retourné true</h3>
+    <p>Vous utilisez Firefox</p>
+    <?php
 } else {
-?>
-<h3>str_contains() a retourné false</h3>
-<p>Vous n'utilisez pas Firefox</p>
-<?php
+    ?>
+    <h3>str_contains() a retourné false</h3>
+    <p>Vous n'utilisez pas Firefox</p>
+    <?php
 }
 ?>
 ]]>
@@ -439,16 +439,83 @@ Tu as 29 ans.
 
   <section xml:id="tutorial.whatsnext">
    <info><title>Et après ?</title></info>
+   <simpara>
+    Avec ces nouvelles connaissances, il devrait être possible de comprendre l'essentiel du manuel.
+   </simpara>
    <para>
-    Avec ces connaissances, il est maintenant possible de comprendre
-    l'essentiel de la documentation PHP, et les différents scripts d'exemples
-    disponibles dans les archives.
+    En particulier, il est possible d'explorer les fonctionnalités suivantes :
+    <simplelist>
+     <member>Lecture et écriture de fichiers avec les <link linkend="book.filesystem">fonctions du système de fichiers</link></member>
+     <member><link linkend="features.file-upload">Gestion des envois de fichiers</link></member>
+     <member>Récupération de pages et de fichiers distants avec <link linkend="book.curl">Curl</link></member>
+     <member>
+      Stockage et analyse de données dans une base de données avec <link linkend="book.pdo">PDO</link>
+      (<link linkend="ref.pdo-sqlite">SQLite</link> peut être utilisé sans avoir à exécuter un serveur de base de données)
+     </member>
+     <member>Persistance des données entre les requêtes avec les <link linkend="book.session">sessions</link></member>
+    </simplelist>
    </para>
+   <simpara>
+    Le <link xlink:href="&url.packagist;">dépôt Packagist</link> regorge de bibliothèques et de
+    <link xlink:href="&url.packagist;/search/?tags=framework">frameworks</link> pour toutes les occasions, tous
+    installables via le <link linkend="install.composer.intro">gestionnaire de paquets Composer</link>.
+   </simpara>
+   <simpara>
+    Pour de l'aide et des conseils de la communauté, voir la <link xlink:href="&url.php.support;">page d'aide</link>.
+   </simpara>
+   <simpara>
+    Pour des podcasts, présentations et autres vidéos, voir le
+    <link xlink:href="&url.phpctv;">PeerTube communautaire</link>.
+   </simpara>
+   <simpara>
+    D'autres ressources communautaires utiles incluent les « awesome lists » (répertoires curés de liens) et les
+    « developer roadmaps » (listes de sujets liés).
+   </simpara>
    <para>
-    Différentes présentations des capacités de PHP sont disponibles sur le
-    site des conférences PHP :
-    <link xlink:href="&url.php.talks;">&url.php.talks;</link>.
+    Lorsqu'il n'est pas évident de savoir par où commencer, il est utile de décomposer le projet ou le problème en
+    parties plus petites, ce qui permet de mieux distinguer ce qui est déjà maîtrisé et ce qui reste à apprendre. La
+    liste peut être aussi détaillée que nécessaire. Par exemple, la construction d'un blog peut se décomposer ainsi :
+    <itemizedlist>
+     <listitem>
+      <simpara>Liste et affichage des pages</simpara>
+      <itemizedlist>
+       <listitem>
+        <simpara>Lecture d'enregistrements (pages) depuis une base de données</simpara>
+       </listitem>
+      </itemizedlist>
+     </listitem>
+     <listitem>
+      <simpara>Création de pages</simpara>
+      <itemizedlist>
+       <listitem>
+        <simpara>Traitement de la soumission de formulaire</simpara>
+       </listitem>
+       <listitem>
+        <simpara>Écriture d'enregistrements (pages) dans une base de données</simpara>
+       </listitem>
+      </itemizedlist>
+     </listitem>
+     <listitem>
+      <simpara>Connexion administrateur</simpara>
+      <itemizedlist>
+       <listitem>
+        <simpara>Lecture d'enregistrements (utilisateurs) depuis une base de données</simpara>
+       </listitem>
+       <listitem>
+        <simpara>Gestion des mots de passe</simpara>
+       </listitem>
+       <listitem>
+        <simpara>Persistance des données (connexion utilisateur) entre les requêtes / pages (sessions)</simpara>
+       </listitem>
+      </itemizedlist>
+     </listitem>
+    </itemizedlist>
    </para>
+   <simpara>
+    S'il n'y a rien de particulier à construire, il est possible de chercher des exercices de code comme des katas,
+    des défis et du « code golf ». Même s'ils ne ciblent pas spécifiquement PHP, la plupart devraient être
+    réalisables et mettront probablement à l'épreuve les connaissances et la réflexion.
+   </simpara>
   </section>
  </chapter>
 


### PR DESCRIPTION
Sync de php/doc-en#5491. Réécriture de la section « Et après ? » du tutoriel et alignement de l'indentation de l'exemple Firefox.

Fixes #2833