### PR TITLE
[Sync EN] curl: Clarify correct behaviour of `CURLOPT_CAINFO_BLOB` (#4746)

### DIFF
--- a/reference/curl/constants_curl_setopt.xml
+++ b/reference/curl/constants_curl_setopt.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: d7d6dd60085409b295916649e4bd7107742659a2 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: e38c9165b91df5e9c52eb705c169938bcdc20d31 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
  <variablelist role="constant_list">
   <title><function>curl_setopt</function></title>
@@ -185,7 +185,7 @@
    </term>
    <listitem>
     <para>
-     Un <type>string</type> avec le nom d'un fichier PEM contenant un ou plusieurs certificats pour vérifier le pair avec.
+     Un <type>string</type> binaire de contenu encodé en PEM contenant un ou plusieurs certificats pour vérifier le pair avec.
      Cette option remplace <constant>CURLOPT_CAINFO</constant>.
      Disponible à partir de PHP 8.2.0 et de cURL 7.77.0.
     </para>


### PR DESCRIPTION
Sync de https://github.com/php/doc-en/pull/4746.

Fixes #2830