### PR TITLE
[Sync EN] Pdo: Document `Pdo\Dblib::ATTR_DATETIME_CONVERT` (#4658)

### DIFF
--- a/reference/pdo_dblib/pdo-dblib.xml
+++ b/reference/pdo_dblib/pdo-dblib.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 3f82c54505bbf99a7dfdee2ae7f674b1e2719bd3 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 608815b2f52cc7dae75eb02e27f457aad1e5e977 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <reference xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xml:id="class.pdo-dblib" role="class">
  <title>La classe Pdo\Dblib</title>
@@ -144,6 +144,14 @@
      <term><constant>Pdo\Dblib::ATTR_DATETIME_CONVERT</constant></term>
      <listitem>
       <simpara>
+       Cet attribut de connexion contrôle le format des chaînes pour les types
+       datetime. Lorsqu'il vaut &false;, PDO_DBLIB retourne un type datetime
+       sous forme de chaîne dans le format que SQL Server retourne
+       (c'est-à-dire <literal>"2017-10-27 10:22:44"</literal>). Lorsqu'il vaut
+       &true;, PDO_DBLIB convertit le type datetime en chaîne en utilisant un
+       format défini par l'utilisateur ou par la locale, tel que spécifié dans
+       le fichier FreeTDS <filename>locales.conf</filename>. Par défaut, cet
+       attribut vaut &false;.
       </simpara>
      </listitem>
     </varlistentry>


### PR DESCRIPTION
Sync de https://github.com/php/doc-en/pull/4658.

Fixes #2831