### PR TITLE
[Sync EN] Memcached: Fill `__construct()` parameters description (#4263)

### DIFF
--- a/reference/memcached/memcached/construct.xml
+++ b/reference/memcached/memcached/construct.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 1d8068ecb070fdc360d750e0c1f3f15796e61ec0 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: c49d175bb3853b8851e961ac01a6f0b24de42269 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="memcached.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -40,16 +40,26 @@
     <varlistentry>
      <term><parameter>callback</parameter></term>
      <listitem>
-      <para>
-       <!-- TODO Document constructor params -->
-      </para>
+      <methodsynopsis>
+       <type>void</type><methodname><replaceable>callback</replaceable></methodname>
+       <methodparam><type>Memcached</type><parameter>memcached</parameter></methodparam>
+       <methodparam><type class="union"><type>string</type><type>null</type></type><parameter>persistent_id</parameter></methodparam>
+      </methodsynopsis>
+      <simpara>
+       Le paramètre <parameter>callback</parameter> est appelé lorsque la
+       connexion est établie. Il devrait être un <type>callable</type> PHP
+       valide qui reçoit l'objet <classname>Memcached</classname> comme premier
+       paramètre, et <parameter>persistent_id</parameter> comme second.
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>connection_str</parameter></term>
      <listitem>
       <para>
-       <!-- TODO Document constructor params -->
+       Ce paramètre est utilisé pour passer des options de connexion
+       supplémentaires aux serveurs memcache, comme un poids de serveur
+       dans un cluster.
       </para>
      </listitem>
     </varlistentry>


### PR DESCRIPTION
Sync de la PR doc-en https://github.com/php/doc-en/pull/4263.

Fixes #2839