### PR TITLE
[Sync EN] gmstrftime: align example with locale handling demo

### DIFF
--- a/reference/datetime/functions/gmstrftime.xml
+++ b/reference/datetime/functions/gmstrftime.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: 6c27f7044c7d42c23685afa916e7d7a44cf2bbb2 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="function.gmstrftime" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -99,19 +99,30 @@
 
  <refsect1 role="examples">
   &reftitle.examples;
-  <para>
-   <example>
-    <title>Exemple avec <function>gmstrftime</function></title>
-    <programlisting role="php">
+  <example>
+   <title>Exemple avec <function>gmstrftime</function></title>
+   <programlisting role="php">
 <![CDATA[
 <?php
-setlocale(LC_TIME, 'en_US');
-echo strftime("%b %d %Y %H:%M:%S", mktime(20, 0, 0, 12, 31, 98)) . "\n";
-echo gmstrftime("%b %d %Y %H:%M:%S", mktime(20, 0, 0, 12, 31, 98)) . "\n";
+
+setlocale(LC_TIME, 'es_ES.UTF-8');
+date_default_timezone_set('EST');
+
+echo strftime("%B %d %Y %H:%M:%S",   mktime(20, 0, 0, 12, 31, 98)) . "\n";
+echo gmstrftime("%B %d %Y %H:%M:%S", mktime(20, 0, 0, 12, 31, 98));
 ]]>
-    </programlisting>
-   </example>
-  </para>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+Deprecated: Function strftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in script on line 6
+diciembre 31 1998 20:00:00
+
+Deprecated: Function gmstrftime() is deprecated since 8.1, use IntlDateFormatter::format() instead in script on line 7
+enero 01 1999 01:00:00
+]]>
+   </screen>
+  </example>
  </refsect1>
 
  <refsect1 role="seealso">


### PR DESCRIPTION
Sync de l'exemple de `gmstrftime` avec l'EN (php/doc-en#5014) : nouvelle locale `es_ES.UTF-8`, `date_default_timezone_set('EST')`, format `%B`, et ajout de la sortie d'exemple.

Fixes #2844