### PR TITLE
[Sync EN] proc_close: ajout du changelog 8.3.0 (proc_get_status)

### DIFF
--- a/reference/exec/functions/proc-close.xml
+++ b/reference/exec/functions/proc-close.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 350d95443aeb0ea8751d71f262aac56d3ad48f83 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: ef623ccf442df416da4e5bc254b4c5d4f6df9475 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id='function.proc-close' xmlns="http://docbook.org/ns/docbook">
@@ -53,7 +53,29 @@
   </para>
   &note.sigchild;
  </refsect1>
-
+  <refsect1 role="changelog">
+   &reftitle.changelog;
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>8.3.0</entry>
+       <entry>
+        <function>proc_close</function> retourne désormais le code de sortie
+        correct, même si <function>proc_get_status</function> a été appelée
+        préalablement. Auparavant, <literal>-1</literal> était retourné dans ce cas.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </refsect1>
 </refentry>
 
 <!-- Keep this comment at the end of the file


### PR DESCRIPTION
Sync EN (php/doc-en#5483) : ajout du changelog 8.3.0 expliquant que `proc_close` retourne désormais le bon code de sortie même après un appel préalable à `proc_get_status`.

Fixes #2843