### PR TITLE
[Sync EN] Sockets: ajout des changelogs PHP 8.5

### DIFF
--- a/reference/sockets/constants.xml
+++ b/reference/sockets/constants.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 42402941bba0208a919e03e1320ca4732330eafa Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 890cc22d38fa747c9930fd0d5984c170f2490c1b Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <appendix xml:id="sockets.constants" xmlns="http://docbook.org/ns/docbook">
  &reftitle.constants;
@@ -45,7 +45,23 @@
    </term>
    <listitem>
     <simpara>
-     Disponible à partir de PHP 8.3.0 (uniquement sur FreeBSD)
+     Famille d'adresses de socket pour l'interface <literal>divert(4)</literal>
+     de FreeBSD, utilisée pour recevoir les paquets détournés par le pare-feu.
+     Disponible à partir de PHP 8.3.0 (uniquement sur FreeBSD).
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.af-packet">
+   <term>
+    <constant>AF_PACKET</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Famille d'adresses de socket pour les sockets paquets bas niveau, utilisée
+     pour envoyer et recevoir des paquets bruts au niveau du pilote de
+     périphérique (couche OSI 2).
+     Disponible à partir de PHP 8.5.0 (uniquement sur Linux).
     </simpara>
    </listitem>
   </varlistentry>

--- a/reference/sockets/functions/socket-addrinfo-lookup.xml
+++ b/reference/sockets/functions/socket-addrinfo-lookup.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e2f2172bf114599926878017ab2dce356956fa9e Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 890cc22d38fa747c9930fd0d5984c170f2490c1b Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="function.socket-addrinfo-lookup" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -74,6 +74,16 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Lève désormais une exception <exceptionname>TypeError</exceptionname>
+       si une valeur du tableau <parameter>hints</parameter> ne peut pas être
+       convertie en entier, et peut lever une exception
+       <exceptionname>ValueError</exceptionname> si l'une de ces valeurs
+       provoque un dépassement.
+      </entry>
+     </row>
      <row>
       <entry>8.0.0</entry>
       <entry>

--- a/reference/sockets/functions/socket-bind.xml
+++ b/reference/sockets/functions/socket-bind.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 35883800e764cccacf5772330bc007b6b08ffc6e Maintainer: jpauli Status: ready -->
+<!-- EN-Revision: 890cc22d38fa747c9930fd0d5984c170f2490c1b Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="function.socket-bind" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -86,6 +86,13 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Lève désormais une exception <exceptionname>ValueError</exceptionname>
+       lorsque <parameter>port</parameter> est inférieur à 0 ou supérieur à 65535.
+      </entry>
+     </row>
      &sockets.changelog.socket-param;
     </tbody>
    </tgroup>

--- a/reference/sockets/functions/socket-create-listen.xml
+++ b/reference/sockets/functions/socket-create-listen.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 0e097419a847a077c7d8a74ebc5237ba9d8ddc90 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 890cc22d38fa747c9930fd0d5984c170f2490c1b Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="function.socket-create-listen" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -79,6 +79,13 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Lève désormais une exception <exceptionname>ValueError</exceptionname>
+       lorsque <parameter>port</parameter> est inférieur à 0 ou supérieur à 65535.
+      </entry>
+     </row>
      <row>
       <entry>8.4.0</entry>
       <entry>

--- a/reference/sockets/functions/socket-create.xml
+++ b/reference/sockets/functions/socket-create.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: a871ef72edf436c59422dedd538594db2541d5f1 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 890cc22d38fa747c9930fd0d5984c170f2490c1b Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="function.socket-create" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -240,6 +240,13 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Prend désormais en charge la création de sockets de la famille
+       <constant>AF_PACKET</constant>.
+      </entry>
+     </row>
      <row>
       <entry>8.0.0</entry>
       <entry>

--- a/reference/sockets/functions/socket-getsockname.xml
+++ b/reference/sockets/functions/socket-getsockname.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14dc7c47365f2b71f6c907a5ba5bccf42534d5a9 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 890cc22d38fa747c9930fd0d5984c170f2490c1b Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="function.socket-getsockname" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -92,6 +92,14 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Récupère désormais l'index d'interface et sa représentation textuelle
+       lorsqu'elle est utilisée sur un socket de la famille
+       <constant>AF_PACKET</constant>.
+      </entry>
+     </row>
      &sockets.changelog.socket-param;
     </tbody>
    </tgroup>

--- a/reference/sockets/functions/socket-sendto.xml
+++ b/reference/sockets/functions/socket-sendto.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: e50e79746736dbdfbabe9bd3566793b3ddf38f58 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 890cc22d38fa747c9930fd0d5984c170f2490c1b Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="function.socket-sendto" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -140,6 +140,13 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Lève désormais une exception <exceptionname>ValueError</exceptionname>
+       lorsque <parameter>port</parameter> est inférieur à 0 ou supérieur à 65535.
+      </entry>
+     </row>
      &sockets.changelog.socket-param;
      <row>
       <entry>8.0.0</entry>

--- a/reference/sockets/functions/socket-set-option.xml
+++ b/reference/sockets/functions/socket-set-option.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 93105c67e470df72333493cc2e534635dd16422d Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 890cc22d38fa747c9930fd0d5984c170f2490c1b Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="function.socket-set-option" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -92,6 +92,18 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Lève désormais une exception lorsque
+       <constant>MCAST_LEAVE_GROUP</constant> ou
+       <constant>MCAST_LEAVE_SOURCE_GROUP</constant> est utilisé et que la
+       valeur n'est pas un objet ou un tableau valide, et lève une exception
+       <exceptionname>ValueError</exceptionname> lorsqu'une option multicast
+       est utilisée sur un socket qui n'est pas de la famille
+       <constant>AF_INET</constant> ou <constant>AF_INET6</constant>.
+      </entry>
+     </row>
      &sockets.changelog.socket-param;
     </tbody>
    </tgroup>


### PR DESCRIPTION
Sync EN (php/doc-en#5535) : ajout des entrées de changelog PHP 8.5 sur l'extension sockets (`AF_PACKET`, validations de `port`, options multicast, etc.) et complément de description pour `AF_DIVERT` et `AF_PACKET` dans `constants.xml`.

Fixes #2842