### PR TITLE
hash : sync EN, mention de E_WARNING dans le changelog

### DIFF
--- a/reference/hash/functions/hash-hmac-file.xml
+++ b/reference/hash/functions/hash-hmac-file.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 539a9823a805ac29cab7fa4baf3ae3a28116a2f5 Maintainer: jsgoupil Status: ready -->
+<!-- EN-Revision: df2a77acbbb9d381426b863fcfa4d66ac7f5ab6d Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="function.hash-hmac-file" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -104,8 +104,9 @@
        <entry>
         Lève une exception <classname>ValueError</classname> dorénavant si
         le paramètre <parameter>algo</parameter> est inconnu ou n'est pas
-        une fonction de hachage cryptographique; précédemment, &false;
-        était retourné à la place.
+        une fonction de hachage cryptographique ; précédemment, &false;
+        était retourné et un message <constant>E_WARNING</constant>
+        était émis.
        </entry>
       </row>
       <row>

--- a/reference/hash/functions/hash-hmac.xml
+++ b/reference/hash/functions/hash-hmac.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 539a9823a805ac29cab7fa4baf3ae3a28116a2f5 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: df2a77acbbb9d381426b863fcfa4d66ac7f5ab6d Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="function.hash-hmac" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -103,7 +103,8 @@
         <function>hash_hmac</function> lance désormais une exception
         <classname>ValueError</classname> si l'<parameter>algo</parameter>
         est inconnu ou n'est pas une fonction de hachage cryptographique ;
-        auparavant, &false; était retourné à la place.
+        auparavant, &false; était retourné et un message
+        <constant>E_WARNING</constant> était émis.
        </entry>
       </row>
       <row>

--- a/reference/hash/functions/hash.xml
+++ b/reference/hash/functions/hash.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 539a9823a805ac29cab7fa4baf3ae3a28116a2f5 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: df2a77acbbb9d381426b863fcfa4d66ac7f5ab6d Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="function.hash" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -72,6 +72,14 @@
   </para>
  </refsect1>
 
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simpara>
+   Lève une exception <exceptionname>ValueError</exceptionname> si
+   le paramètre <parameter>algo</parameter> est inconnu.
+  </simpara>
+ </refsect1>
+
  <refsect1 role="changelog">
   &reftitle.changelog;
   <para>
@@ -91,9 +99,10 @@
       <row>
        <entry>8.0.0</entry>
        <entry>
-        <function>hash</function> lance désormais une exception
-        <classname>ValueError</classname> si l'<parameter>algo</parameter>
-        est inconnu ; auparavant, &false; était retourné à la place.
+        Lève désormais une exception <exceptionname>ValueError</exceptionname>
+        si l'<parameter>algo</parameter>
+        est inconnu ; auparavant, &false; était retourné et un message
+        <constant>E_WARNING</constant> était émis.
        </entry>
       </row>
      </tbody>


### PR DESCRIPTION
Sync EN de php/doc-en#5271 (commit df2a77a) : mention du `E_WARNING` historique dans le changelog 8.0.0 de `hash`, `hash_hmac` et `hash_hmac_file`, et ajout de la section `errors` pour `hash`.

Fixes #2848