### PR TITLE
streamWrapper::stream_lock : sync EN, documentation de LOCK_NB comme bitmask

### DIFF
--- a/reference/stream/streamwrapper/stream-lock.xml
+++ b/reference/stream/streamwrapper/stream-lock.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: fa5ef560a6ea59e32de1e383969ac728526a1335 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 38231ac293eaabd5161c7276a72b9683ad02fd3c Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="streamwrapper.stream-lock" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -15,13 +15,13 @@
    <modifier>public</modifier> <type>bool</type><methodname>streamWrapper::stream_lock</methodname>
    <methodparam><type>int</type><parameter>operation</parameter></methodparam>
   </methodsynopsis>
-  <para>
-   Cette méthode est appelée en réponse à <function>flock</function>, 
-   parfois avec <function>file_put_contents</function> 
+  <simpara>
+   Cette méthode est appelée en réponse à <function>flock</function>,
+   parfois avec <function>file_put_contents</function>
    (si l'option <parameter>flags</parameter> contient <constant>LOCK_EX</constant>),
    <function>stream_set_blocking</function> et quand on ferme le flux
    (<constant>LOCK_UN</constant>).
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -46,18 +46,16 @@
         </listitem>
         <listitem>
          <simpara>
-          <constant>LOCK_UN</constant> pour lire le verrou (partagé ou exclusif)
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>LOCK_NB</constant> pour que 
-          <function>flock</function> bloque pour le verrouillage
-          (non supporté sur Windows).
+          <constant>LOCK_UN</constant> pour libérer un verrou (partagé ou exclusif).
          </simpara>
         </listitem>
        </itemizedlist>
       </para>
+      <simpara>
+       Il est également possible d'ajouter <constant>LOCK_NB</constant> en
+       masque binaire à l'une des opérations ci-dessus, si le verrou ne doit
+       pas bloquer pendant la tentative de verrouillage (non supporté sur Windows).
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -66,17 +64,17 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors"><!-- {{{ -->
   &reftitle.errors;
-  <para>
+  <simpara>
    Émet un <constant>E_WARNING</constant> si l'appel à cette
    méthode échoue (c.-à-d., pas implémentée).
-  </para>
+  </simpara>
  </refsect1><!-- }}} -->
 
  <refsect1 role="seealso">


### PR DESCRIPTION
Sync EN de php/doc-en#5257 (commit 38231ac) : `LOCK_NB` est désormais documenté comme un masque binaire à combiner aux autres opérations, et plusieurs `para` deviennent des `simpara`. Correction au passage de la traduction de `LOCK_UN` (`lire` au lieu de `libérer`).

Fixes #2850