### PR TITLE
POSIX : sync EN, ajout des entrées de changelog pour les changements de PHP 8.5

### DIFF
--- a/reference/posix/functions/posix-fpathconf.xml
+++ b/reference/posix/functions/posix-fpathconf.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 8d417bd83842efbde90dbb51c31f99f474437ce4 Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: 42ed815ea41bc1ceb3c1417e1aa8778d327e314a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="function.posix-fpathconf" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -55,6 +55,30 @@
    Lance une <classname>ValueError</classname>
    si <parameter>file_descriptor</parameter> est invalide.
   </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Définit désormais <varname>last_error</varname> à
+       <constant>EBADF</constant> et émet un <constant>E_WARNING</constant>
+       lorsqu'un descripteur de fichier invalide est rencontré.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/posix/functions/posix-isatty.xml
+++ b/reference/posix/functions/posix-isatty.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 394815225713c1aad0007d80f2c3c3592d085084 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 42ed815ea41bc1ceb3c1417e1aa8778d327e314a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="function.posix-isatty" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -48,6 +48,13 @@
         </row>
       </thead>
       <tbody>
+       <row>
+        <entry>8.5.0</entry>
+        <entry>
+         Émet désormais une erreur de niveau <constant>E_WARNING</constant>
+         lorsqu'un <parameter>file_descriptor</parameter> invalide est rencontré.
+        </entry>
+       </row>
        <row>
         <entry>8.4.0</entry>
         <entry>

--- a/reference/posix/functions/posix-kill.xml
+++ b/reference/posix/functions/posix-kill.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 265acc36ee4a1f4553a52030bf1717521c24dfb4 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 42ed815ea41bc1ceb3c1417e1aa8778d327e314a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="function.posix-kill" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -50,6 +50,30 @@
   <para>
    &return.success;
   </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Lève désormais une exception <exceptionname>ValueError</exceptionname>
+       lorsque <parameter>process_id</parameter> est inférieur ou supérieur
+       à ce que la plate-forme supporte (intervalle d'un entier signé ou d'un long).
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/posix/functions/posix-setpgid.xml
+++ b/reference/posix/functions/posix-setpgid.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 265acc36ee4a1f4553a52030bf1717521c24dfb4 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 42ed815ea41bc1ceb3c1417e1aa8778d327e314a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="function.posix-setpgid" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -50,6 +50,31 @@
   <para>
    &return.success;
   </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Lève désormais une exception <exceptionname>ValueError</exceptionname>
+       lorsque <parameter>process_id</parameter> ou
+       <parameter>process_group_id</parameter> est inférieur à zéro ou
+       supérieur à ce que la plate-forme supporte.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/posix/functions/posix-setrlimit.xml
+++ b/reference/posix/functions/posix-setrlimit.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 265acc36ee4a1f4553a52030bf1717521c24dfb4 Maintainer: girgias Status: ready -->
+<!-- EN-Revision: 42ed815ea41bc1ceb3c1417e1aa8778d327e314a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="function.posix-setrlimit" xmlns="http://docbook.org/ns/docbook">
@@ -65,6 +65,32 @@
   <para>
    &return.success;
   </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Lève désormais une exception <exceptionname>ValueError</exceptionname>
+       lorsque <parameter>hard_limit</parameter> ou
+       <parameter>soft_limit</parameter> est inférieur à -1, ou lorsque
+       <parameter>soft_limit</parameter> est supérieur à
+       <parameter>hard_limit</parameter>.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/posix/functions/posix-ttyname.xml
+++ b/reference/posix/functions/posix-ttyname.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 9c166423255b3d5e02f74232f2d05fd3b59d5d62 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 42ed815ea41bc1ceb3c1417e1aa8778d327e314a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="function.posix-ttyname" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -57,6 +57,14 @@
         </row>
       </thead>
       <tbody>
+        <row>
+          <entry>8.5.0</entry>
+          <entry>
+            <varname>last_error</varname> est désormais défini à
+            <constant>EBADF</constant> lorsqu'un
+            <parameter>file_descriptor</parameter> invalide est rencontré.
+          </entry>
+        </row>
         <row>
           <entry>8.3.0</entry>
           <entry>


### PR DESCRIPTION
Sync EN de php/doc-en#5534 (commit 42ed815) : ajout des changelogs PHP 8.5 manquants pour `posix_kill`, `posix_setpgid`, `posix_setrlimit`, `posix_ttyname`, `posix_isatty` et `posix_fpathconf` (lever de `ValueError`, `last_error`, `E_WARNING`).

Fixes #2852