### PR TITLE
Sync EN: language/types/boolean.xml (#5553)

### DIFF
--- a/language/types/boolean.xml
+++ b/language/types/boolean.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: fee54c7c435a1664a7a8b0e7b7de7cec4a084c45 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 4657c1173e6b3852cdc8db4fc64f380d10ebae0c Maintainer: yannick Status: ready -->
 <!-- Reviewed: yes Maintainer: mikaelkael -->
 
 <sect1 xml:id="language.types.boolean">
@@ -116,9 +116,7 @@ if ($show_separators) {
    <listitem>
     <simpara>
      les objets internes qui surchargent leur comportement de casting en booléen.
-     Par exemple : les <link linkend="ref.simplexml">objets SimpleXML</link> créés à
-     partir d'éléments vides sans attributs, ou les objets
-     <classname>GMP</classname> représentant la valeur
+     Par exemple, les objets <classname>GMP</classname> représentant la valeur
      <literal>0</literal>.
     </simpara>
    </listitem>


### PR DESCRIPTION
Sync de `language/types/boolean.xml` sur le commit php/doc-en@4657c1173e6b3852cdc8db4fc64f380d10ebae0c (PR php/doc-en#5553) : retrait de l'exemple SimpleXML de la liste des valeurs évaluées à `false`.

Fixes #2856