### PR TITLE
Sync IntlChar::digit with EN

### DIFF
--- a/reference/intl/intlchar/digit.xml
+++ b/reference/intl/intlchar/digit.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 1976eae0d815797af97a1e16c5cd90ffc2868395 Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: e166139c786f6fd72a5f856c14027a3c22a8ce7a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="intlchar.digit" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -18,14 +18,31 @@
    Renvoie la valeur décimale du point de code dans la base de numération spécifiée.
   </para>
   <para>
-   Si la base de numération n'est pas dans la plage <literal>2&lt;=radix&lt;=36</literal> ou si la valeur de <parameter>codepoint</parameter>
+   Si la base de numération n'est pas dans la plage <literal>2 &lt;= radix &lt;= 36</literal> ou
+   si la valeur de <parameter>codepoint</parameter>
    n'est pas un chiffre valide dans la base spécifiée, &false; est renvoyé.
    Un caractère est un chiffre valide si au moins une des conditions suivantes est vraie:
    <simplelist>
-    <member>Le caractère a une valeur de chiffre décimal. Ces caractères ont la catégorie générale "Nd" (chiffres décimaux) et un Numeric_Type de Decimal. Dans ce cas, la valeur est la valeur de chiffre décimal du caractère.</member>
-    <member>Le caractère est une des lettres latines majuscules 'A' à 'Z'. Dans ce cas, la valeur est c-'A'+10.</member>
-    <member>Le caractère est une des lettres latines minuscules 'a' à 'z'. Dans ce cas, la valeur est c-'a'+10.</member>
-    <member>Les lettres latines de la plage ASCII (0061..007A, 0041..005A) ainsi que de la plage ASCII pleine largeur (FF41..FF5A, FF21..FF3A) sont reconnues.</member>
+    <member>
+     Le caractère a une valeur de chiffre décimal. Ces caractères ont la
+     catégorie générale "Nd" (chiffres décimaux) et un Numeric_Type de "Decimal".
+     Dans ce cas, la valeur est la valeur de chiffre décimal du caractère.
+    </member>
+    <member>
+     Le caractère est une des lettres latines majuscules
+     <literal>'A'</literal> à <literal>'Z'</literal>.
+     Dans ce cas, la valeur est <literal>codepoint - 'A' + 10</literal>.
+    </member>
+    <member>
+     Le caractère est une des lettres latines minuscules
+     <literal>'a'</literal> à <literal>'z'</literal>.
+     Dans ce cas, la valeur est <literal>codepoint - 'a' + 10</literal>.
+    </member>
+    <member>
+     Les lettres latines de la plage ASCII (<literal>0061..007A</literal>,
+     <literal>0041..005A</literal>) ainsi que de la plage ASCII pleine largeur
+     (<literal>FF41..FF5A</literal>, <literal>FF21..FF3A</literal>) sont reconnues.
+    </member>
    </simplelist>
   </para>
  </refsect1>
@@ -66,10 +83,13 @@
    <programlisting role="php">
     <![CDATA[
 <?php
+
 var_dump(IntlChar::digit("0"));
 var_dump(IntlChar::digit("3"));
-var_dump(IntlChar::digit("A"));
+
 var_dump(IntlChar::digit("A", 16));
+var_dump(IntlChar::digit("A"));
+
 ?>
 ]]>
    </programlisting>


### PR DESCRIPTION
Sync avec php/doc-en#3595: balises <literal/>, exemple réordonné.

Fixes #2861