### PR TITLE
Sync socket_atmark example with EN

### DIFF
--- a/reference/sockets/functions/socket-atmark.xml
+++ b/reference/sockets/functions/socket-atmark.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: eef7fb60d16864b253aa3aa95a57f8b1cfd41451 Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: 2c357a0dd6cc195bce10fa974ea14a2e30eb4b5b Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="function.socket-atmark" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -45,18 +45,54 @@
   &reftitle.examples;
   <para>
    <example>
-    <title>Utilisation de <function>socket_atmark</function> pour définir l'adresse source</title>
+    <title>Utilisation de <function>socket_atmark</function> pour vérifier si le socket est prêt à lire des données hors bande.</title>
     <programlisting role="php">
 <![CDATA[
 <?php
-// Créer un nouveau socket
-$sock = socket_create(AF_INET, SOCK_STREAM, SOL_TCP);
-var_dump(socket_atmark($sock));
-// Ferme
-socket_close($sock);
+$socketServer = socket_create( AF_INET, SOCK_STREAM, SOL_TCP );
+socket_set_option( $socketServer, SOL_SOCKET, SO_REUSEADDR, 1 );
+socket_bind( $socketServer, '127.0.0.1' );
+socket_listen( $socketServer );
+
+$socketClient = socket_create( AF_INET, SOCK_STREAM, SOL_TCP );
+socket_getsockname( $socketServer, $stAddr, $uPort );
+socket_connect( $socketClient, $stAddr, $uPort );
+
+$socket = socket_accept( $socketServer );
+socket_shutdown( $socket, 1 );
+
+$st = 'Ceci est une donnée normale.';
+socket_send( $socketClient, $st, strlen( $st ), 0 );
+$st = '!'; # TCP n'autorise qu'un seul octet de donnée urgente.
+socket_send( $socketClient, $st, strlen( $st ), MSG_OOB );
+$st = 'Pas si urgent.';
+socket_send( $socketClient, $st, strlen( $st ), 0 );
+socket_shutdown( $socketClient );
+
+do {
+    if ( socket_atmark( $socket ) ) {
+        $rc = socket_recv( $socket, $st, 65536, MSG_OOB );
+        echo "Donnée urgente reçue : ({$rc}) {$st}\n";
+    } else {
+        $rc = socket_recv( $socket, $st, 1024, 0 );
+        echo "Donnée normale reçue : ({$rc}) {$st}\n";
+    }
+} while ( $rc > 0 );
+socket_close( $socketServer );
+socket_close( $socketClient );
+socket_close( $socket );
 ?>
 ]]>
     </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+Donnée normale reçue : (28) Ceci est une donnée normale.
+Donnée urgente reçue : (1) !
+Donnée normale reçue : (14) Pas si urgent.
+Donnée normale reçue : (0)
+]]>
+    </screen>
    </example>
   </para>
  </refsect1>


### PR DESCRIPTION
Sync avec php/doc-en#4748: exemple remplacé, ajout du screen output.

Fixes #2860