### PR TITLE
[sync-en] Closure: mention de la non-sérialisation des objets Closure

### DIFF
--- a/language/predefined/closure.xml
+++ b/language/predefined/closure.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: d74f3573b3831b2db8f31f774cff32eb8560ba6e Maintainer: yannick Status: ready -->
+<!-- EN-Revision: a97672ab04d97f510faee2abe8d961014f77f96d Maintainer: yannick Status: ready -->
 <!-- Reviewed: yes Maintainer: mikaelkael -->
 <reference xml:id="class.closure" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -74,6 +74,17 @@
      </tbody>
     </tgroup>
    </informaltable>
+  </section>
+
+  <section role="notes">
+   &reftitle.notes;
+   <note>
+    <simpara>
+     Les objets <classname>Closure</classname> ne peuvent pas être sérialisés
+     car les fermetures peuvent contenir des variables liées et un contexte d'exécution spécifique.
+     Tenter de sérialiser une fermeture lancera une <exceptionname>Exception</exceptionname>.
+    </simpara>
+   </note>
   </section>
 
  </partintro>


### PR DESCRIPTION
Sync EN de `language/predefined/closure.xml` sur php/doc-en@a97672ab (php/doc-en#5363).

Fixes #2864