### PR TITLE
Sync EN: display_errors possible values

### DIFF
--- a/reference/errorfunc/ini.xml
+++ b/reference/errorfunc/ini.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: a52e3d27cca786940272d0ae8efc21b5d6739070 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 8c2b31ab87650423cac6f58a453d702acf2eb1b7 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <!-- CREDITS: DavidA -->
 
@@ -213,6 +213,29 @@
       Cette directive détermine si les erreurs doivent être
       affichées à l'écran dans la sortie, ou si elles doivent être cachées à l'utilisateur.
      </para>
+     <para>
+       Valeurs possibles :
+     </para>
+     <itemizedlist>
+         <listitem>
+           Off = N'affiche aucune erreur
+         </listitem>
+         <listitem>
+          stderr = Affiche les erreurs vers <literal>STDERR</literal> (affecte uniquement les binaires CGI/CLI !)
+          </listitem>
+         <listitem>
+           On ou stdout = Affiche les erreurs vers <literal>STDOUT</literal>
+         </listitem>
+         <listitem>
+           Valeur par défaut : On
+         </listitem>
+         <listitem>
+          Valeur en développement : On
+         </listitem>
+         <listitem>
+           Valeur en production : Off
+         </listitem>
+       </itemizedlist>
      <para>
       La valeur <literal>"stderr"</literal> envoie les erreurs vers <literal>stderr</literal>
       plutôt que vers <literal>stdout</literal>.


### PR DESCRIPTION
Sync de doc-en@8c2b31ab pour ajouter la liste des valeurs possibles de `display_errors`.

Fixes #2870