### PR TITLE
Sync EN: wrap display_errors listitem in para tag

### DIFF
--- a/reference/errorfunc/ini.xml
+++ b/reference/errorfunc/ini.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: a52e3d27cca786940272d0ae8efc21b5d6739070 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 65c33d8869fb7cafa4281974a87116e275ec7c24 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <!-- CREDITS: DavidA -->
 
@@ -213,6 +213,29 @@
       Cette directive détermine si les erreurs doivent être
       affichées à l'écran dans la sortie, ou si elles doivent être cachées à l'utilisateur.
      </para>
+     <para>
+       Valeurs possibles :
+     </para>
+     <itemizedlist>
+         <listitem>
+           <para>Off = N'affiche aucune erreur</para>
+         </listitem>
+         <listitem>
+          <para>stderr = Affiche les erreurs vers <literal>STDERR</literal> (affecte uniquement les binaires CGI/CLI !)</para>
+          </listitem>
+         <listitem>
+          <para> On ou stdout = Affiche les erreurs vers <literal>STDOUT</literal></para>
+         </listitem>
+         <listitem>
+          <para> Valeur par défaut : On</para>
+         </listitem>
+         <listitem>
+          <para>Valeur en développement : On</para>
+         </listitem>
+         <listitem>
+           <para>Valeur en production : Off</para>
+         </listitem>
+       </itemizedlist>
      <para>
       La valeur <literal>"stderr"</literal> envoie les erreurs vers <literal>stderr</literal>
       plutôt que vers <literal>stdout</literal>.


### PR DESCRIPTION
Sync de doc-en@65c33d88. À merger après #2871.

Fixes #2869