### PR TITLE
Sync EN: SAPI 8.5 CLI changes

### DIFF
--- a/features/commandline.xml
+++ b/features/commandline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: a52e3d27cca786940272d0ae8efc21b5d6739070 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: b08b472de7041be8dbae153556b714efa93f20c0 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 
 <chapter xml:id="features.commandline" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -368,7 +368,6 @@ Usage: php [options] [-f] <file> [--] [args...]
   -s               Output HTML syntax highlighted source.
   -v               Version number
   -w               Output source with stripped comments and whitespace.
-  -z <file>        Load Zend extension <file>.
 
   args...          Arguments passed to script. Use -- args when first argument
                    starts with - or script is read from stdin
@@ -851,27 +850,14 @@ Zend Engine v2.3.0, Copyright (c) 1998-2009 Zend Technologies
        </entry>
       </row>
       <row>
-       <entry>-z</entry>
-       <entry>--zend-extension</entry>
-       <entry>
-        <para>
-         Charge une extension Zend. Si et seulement si un fichier est fourni, PHP
-         essaie de charger cette extension dans le dossier courant par défaut
-         des bibliothèques sur le système (généralement spécifié avec
-         <filename>/etc/ld.so.conf</filename> sous Linux par exemple). Passer un nom de
-         fichier avec le chemin complet fera que PHP utilisera ce fichier,
-         sans recherche dans les dossiers classiques. Un chemin de dossier
-         relatif, incluant les informations sur le dossier, indiquera à PHP qu'il doit
-         chercher les extensions uniquement dans ce dossier.
-        </para>
-       </entry>
-      </row>
-      <row>
        <entry></entry>
        <entry>--ini</entry>
        <entry>
         <para>
          Affiche les noms des fichiers de configuration et des dossiers analysés.
+         Il est également possible de passer <literal>--ini=diff</literal> pour afficher
+         les différences entre les fichiers de configuration chargés et la configuration
+         par défaut.
          <example>
           <title>Exemple avec <literal>--ini</literal></title>
           <programlisting role="shell">
@@ -884,6 +870,11 @@ Additional .ini files parsed:      (none)
 ]]>
           </programlisting>
          </example>
+         <note>
+          <simpara>
+           L'option <literal>--ini=diff</literal> n'est pas disponible avant PHP 8.5.0.
+          </simpara>
+         </note>
         </para>
        </entry>
       </row>

--- a/reference/info/functions/cli-get-process-title.xml
+++ b/reference/info/functions/cli-get-process-title.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: a331ac8a86bb5929b79be9a369fac1e3af516241 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: b08b472de7041be8dbae153556b714efa93f20c0 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.cli-get-process-title" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -48,7 +48,7 @@
    sous-jacent n'est pas supporté.
   </para>
  </refsect1>
- 
+
  <refsect1 role="examples">
   &reftitle.examples;
   <para>

--- a/reference/info/functions/cli-set-process-title.xml
+++ b/reference/info/functions/cli-set-process-title.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 2df224f44552cfc88fad705cca33c4cdb01d62ed Maintainer: yannick Status: ready -->
+<!-- EN-Revision: b08b472de7041be8dbae153556b714efa93f20c0 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="function.cli-set-process-title" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -16,12 +16,12 @@
    <methodparam><type>string</type><parameter>title</parameter></methodparam>
   </methodsynopsis>
 
-  <para>
+  <simpara>
    Définit le titre du processus visible avec des outils comme
    <command>top</command> et <command>ps</command>. Cette fonction
    n'est disponible qu'en mode
    <link linkend="features.commandline">CLI</link>.
-  </para>
+  </simpara>
 
  </refsect1>
 
@@ -31,9 +31,9 @@
    <varlistentry>
     <term><parameter>title</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       Le nouveau titre
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -41,26 +41,48 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">
   &reftitle.errors;
-   
-  <para>
+
+  <simpara>
    Une alerte de niveau <constant>E_WARNING</constant> sera générée si le système
    sous-jacent n'est pas supporté.
-  </para>
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       <function>cli_set_process_title</function> émet désormais une alerte
+       <constant>E_WARNING</constant> lorsque le titre du processus défini
+       est trop long ; auparavant, le titre était tronqué.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">
   &reftitle.examples;
-  <para>
-   <example>
-    <title>Exemple avec <function>cli_set_process_title</function></title>
-    <programlisting role="php">
+  <informalexample>
+   <programlisting role="php">
 <![CDATA[
 <?php
 $title = "Mon super script PHP";
@@ -75,18 +97,15 @@ if (!cli_set_process_title($title)) {
 }
 ?>
 ]]>
-    </programlisting>
-   </example>
-  </para>
+   </programlisting>
+  </informalexample>
  </refsect1>
- 
+
  <refsect1 role="seealso">
   &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><function>cli_get_process_title</function></member>
-   </simplelist>
-  </para>
+  <simplelist>
+   <member><function>cli_get_process_title</function></member>
+  </simplelist>
  </refsect1>
 
 </refentry>


### PR DESCRIPTION
Synchronise les changements CLI SAPI 8.5 introduits dans doc-en par https://github.com/php/doc-en/pull/5077 (commit `b08b472d`).

Fixes #2874