### PR TITLE
Sync EN: IntlChar::digit fix example output

### DIFF
--- a/reference/intl/intlchar/digit.xml
+++ b/reference/intl/intlchar/digit.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e166139c786f6fd72a5f856c14027a3c22a8ce7a Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: fe67f9ad47e7f04f50c4ec1366bdbcbd8ab940f2 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="intlchar.digit" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -98,8 +98,8 @@ var_dump(IntlChar::digit("A"));
     <![CDATA[
 int(0)
 int(3)
-bool(false)
 int(10)
+bool(false)
 ]]>
    </screen>
   </example>


### PR DESCRIPTION
Synchronise le fix de l'output de l'exemple `IntlChar::digit` (https://github.com/php/doc-en/pull/5566, commit `fe67f9ad`).

Fixes #2875