### PR TITLE
Translate nits in reference/ (apache to ctype)

### DIFF
--- a/reference/apache/functions/apache-note.xml
+++ b/reference/apache/functions/apache-note.xml
@@ -54,10 +54,10 @@
   &reftitle.returnvalues;
   <para>
    Si <parameter>note_value</parameter> est omis ou &null;, elle renvoie
-   la valeur courante de la variable <literal>note_name</literal>. Sinon,
+   la valeur courante de la note <literal>note_name</literal>. Sinon,
    elle affecte à la note <literal>note_name</literal>
    la valeur <literal>note_value</literal> et
-   retourne la valeur précédente de la variable <literal>note_name</literal>.
+   retourne la valeur précédente de la note <literal>note_name</literal>.
    Si la note ne peut être récupérée, &false; est retourné.
   </para>
  </refsect1>

--- a/reference/apcu/apcuiterator/current.xml
+++ b/reference/apcu/apcuiterator/current.xml
@@ -26,9 +26,8 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   Retourne l'élément courant en cas de succès ou bien la valeur &false; si l'un des
-   trois cas suivants se produit: le pointeur a dépassé le dernier élément, il n'y
-   a pas d'élément dans la liste ou la fonction a échoué.
+   Retourne l'élément courant en cas de succès ou bien la valeur &false; s'il n'y
+   a plus d'éléments, ou en cas d'échec.
   </simpara>
  </refsect1>
 

--- a/reference/apcu/functions/apcu-add.xml
+++ b/reference/apcu/functions/apcu-add.xml
@@ -66,8 +66,8 @@
       prochaine requête). Si aucune valeur n'est passée à
       <parameter>ttl</parameter> (ou si la valeur de <parameter>ttl</parameter> est
       <literal>0</literal>), la variable persistera jusqu'à ce qu'elle soit retirée
-      manuellement du cache, ou, sinon, elle échouera à sortir du cache (lors d'un
-      effacement, redémarrage, etc.).
+      manuellement du cache, ou, sinon, cesse d'exister dans le cache (vidage,
+      redémarrage, etc.).
      </simpara>
     </listitem>
    </varlistentry>

--- a/reference/apcu/functions/apcu-delete.xml
+++ b/reference/apcu/functions/apcu-delete.xml
@@ -27,7 +27,7 @@
      <simpara>
       Le paramètre <parameter>key</parameter> peut être soit une
       <type>string</type> pour une seule clé,
-      soit un <type>array</type> de chaîne de caractères pour plusieurs clés,
+      soit un <type>array</type> de chaînes de caractères pour plusieurs clés,
       soit un <type>object</type> de la classe <classname>APCUIterator</classname>.
      </simpara>
     </listitem>

--- a/reference/apcu/functions/apcu-entry.xml
+++ b/reference/apcu/functions/apcu-entry.xml
@@ -19,8 +19,8 @@
   <simpara>
    Tente de récupérer atomiquement la valeur indexée par la clé <parameter>key</parameter>
    dans le cache. Si elle ne peut pas être récupérée, la fonction passée à
-   <parameter>callback</parameter> est appelée, avec pour unique argument la valeur
-   contenue dans <parameter>key</parameter>. La valeur de retour de l'appel est
+   <parameter>callback</parameter> est appelée, avec pour unique argument
+   <parameter>key</parameter>. La valeur de retour de l'appel est
    ensuite mise en cache avec le paramètre optionnel <parameter>ttl</parameter>,
    puis le résultat est retourné.
   </simpara>
@@ -72,8 +72,8 @@
       prochaine requête). Si aucune valeur n'est passée au paramètre
       <parameter>ttl</parameter> (ou si la valeur de <parameter>ttl</parameter> est
       <literal>0</literal>), la variable persistera jusqu'à ce qu'elle soit retirée
-      manuellement du cache, ou, sinon, elle échouera à sortir du cache (lors d'un
-      effacement, redémarrage, etc.).
+      manuellement du cache, ou, sinon, cesse d'exister dans le cache (vidage,
+      redémarrage, etc.).
      </simpara>
     </listitem>
    </varlistentry>

--- a/reference/array/constants.xml
+++ b/reference/array/constants.xml
@@ -111,7 +111,7 @@
    </term>
    <listitem>
     <simpara>
-     <constant>SORT_LOCALE_STRING</constant> est utilisé pour comparer
+     <constant>SORT_LOCALE_STRING</constant> est utilisée pour comparer
      alphabétiquement les valeurs d'un tri, en utilisant la locale courante.
     </simpara>
    </listitem>
@@ -123,7 +123,7 @@
    </term>
    <listitem>
     <simpara>
-     <constant>SORT_NATURAL</constant> est utilisé pour comparer
+     <constant>SORT_NATURAL</constant> est utilisée pour comparer
      les éléments comme des chaînes, en utilisant un "ordre naturel"
      comme le fait la fonction <function>natsort</function>.
     </simpara>
@@ -136,7 +136,7 @@
    </term>
    <listitem>
     <simpara>
-     <constant>SORT_FLAG_CASE</constant> peut être combiné 
+     <constant>SORT_FLAG_CASE</constant> peut être combinée
      (avec l'opérateur bit OU) avec
      <constant>SORT_STRING</constant> ou
      <constant>SORT_NATURAL</constant> pour trier les chaînes
@@ -158,7 +158,7 @@
    </term>
    <listitem>
     <simpara>
-     <constant>ARRAY_FILTER_USE_KEY</constant> est utilisé avec
+     <constant>ARRAY_FILTER_USE_KEY</constant> est utilisée avec
      <function>array_filter</function> pour passer chaque clé comme premier
      argument à la fonction de rappel fournie.
     </simpara>
@@ -171,7 +171,7 @@
    </term>
    <listitem>
     <simpara>
-     <constant>ARRAY_FILTER_USE_BOTH</constant> est utilisé avec
+     <constant>ARRAY_FILTER_USE_BOTH</constant> est utilisée avec
      <function>array_filter</function> pour passer la valeur et la clé à la
      fonction de rappel fournie.
     </simpara>

--- a/reference/array/functions/array-column.xml
+++ b/reference/array/functions/array-column.xml
@@ -157,7 +157,7 @@ Array
   <para>
    <example>
     <title>
-     Récupère la colonne des noms, indexé par la colonne "id"
+     Récupère la colonne des noms, indexée par la colonne "id"
     </title>
     <programlisting role="php">
 <![CDATA[

--- a/reference/array/functions/array-diff-assoc.xml
+++ b/reference/array/functions/array-diff-assoc.xml
@@ -151,7 +151,7 @@ Array
   <note>
    <simpara>
     Cette fonction ne vérifie qu'une dimension d'un tableau multidimensionnel.
-    Il est possible de vérifier des sous dimensions en utilisant, par exemple,
+    Il est possible de vérifier des sous-dimensions en utilisant, par exemple,
     <literal>array_diff_assoc($array1[0], $array2[0]);</literal>.
    </simpara>
   </note>

--- a/reference/array/functions/array-diff-key.xml
+++ b/reference/array/functions/array-diff-key.xml
@@ -21,7 +21,7 @@
    Compare les clés du tableau <parameter>array</parameter> avec les clés
    des tableaux <parameter>arrays</parameter> et retourne la différence.
    Cette fonction est identique à la fonction <function>array_diff</function>,
-   excepté sur le fait que la comparaison est faite sur les clés, 
+   excepté sur le fait que la comparaison est faite sur les clés,
    plutôt que sur les valeurs.
   </para>
  </refsect1>
@@ -57,7 +57,7 @@
   &reftitle.returnvalues;
   <para>
    Retourne un tableau contenant toutes les entrées du tableau
-   <parameter>array</parameter> dont les clés sont absentes dans 
+   <parameter>array</parameter> dont les clés sont absentes dans
    tous les autres tableaux.
   </para>
  </refsect1>
@@ -80,7 +80,7 @@
    </informaltable>
   </para>
  </refsect1>
- 
+
  <refsect1 role="examples">
   &reftitle.examples;
   <para>
@@ -89,7 +89,7 @@
     <para>
      Les deux clés depuis les paires <literal>clé =&gt; valeur</literal>
      sont considérées comme égales uniquement si
-     <literal>(string) $cle1 === (string) $cle2 </literal>. En d'autres termes, 
+     <literal>(string) $key1 === (string) $key2 </literal>. En d'autres termes,
      une analyse de type stricte est exécutée, donc, la représentation
      sous forme de chaîne de caractères doit être exactement la même.
     </para>

--- a/reference/array/functions/array-diff-uassoc.xml
+++ b/reference/array/functions/array-diff-uassoc.xml
@@ -125,7 +125,7 @@ Array
   <note>
    <para>
     Cette fonction ne vérifie qu'une dimension d'un tableau multidimensionnel.
-    Il est possible de vérifier des sous dimensions en utilisant, par exemple,
+    Il est possible de vérifier des sous-dimensions en utilisant, par exemple,
     <literal>array_diff_uassoc($array1[0], $array2[0], "key_compare_func");</literal>.
    </para>
   </note>

--- a/reference/array/functions/array-diff-ukey.xml
+++ b/reference/array/functions/array-diff-ukey.xml
@@ -49,7 +49,7 @@
      <term><parameter>arrays</parameter></term>
      <listitem>
       <para>
-       Tableaux à comparer contre
+       Tableaux à comparer
       </para>
      </listitem>
     </varlistentry>

--- a/reference/array/functions/array-diff.xml
+++ b/reference/array/functions/array-diff.xml
@@ -52,7 +52,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Retourne un &array; contenant toutes les entités du tableau
+   Retourne un &array; contenant toutes les entrées du tableau
    <parameter>array</parameter> qui ne sont présentes dans aucun des 
    autres tableaux. Les clés du tableau <parameter>array</parameter> sont
    préservées.

--- a/reference/array/functions/array-filter.xml
+++ b/reference/array/functions/array-filter.xml
@@ -171,7 +171,7 @@ Array
     </screen>
    </example>
    <example>
-    <title>Exemple avec <function>array_filter</function>
+    <title>Exemple avec <function>array_filter</function> sans
     <parameter>callback</parameter></title>
     <programlisting role="php">
 <![CDATA[

--- a/reference/array/functions/array-flip.xml
+++ b/reference/array/functions/array-flip.xml
@@ -41,7 +41,7 @@
      <term><parameter>array</parameter></term>
      <listitem>
       <para>
-       Un tableau de paire clés/valeurs à inverser.
+       Un tableau de paires clés/valeurs à inverser.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/array/functions/array-intersect-assoc.xml
+++ b/reference/array/functions/array-intersect-assoc.xml
@@ -42,7 +42,7 @@
      <term><parameter>arrays</parameter></term>
      <listitem>
       <para>
-       Tableaux à comparer contre
+       Tableaux à comparer.
       </para>
      </listitem>
     </varlistentry>
@@ -108,7 +108,7 @@ Array
    Dans notre exemple, il est possible de voir que la paire
    <literal>"a" =&gt; "green"</literal> est présente dans les deux tableaux,
    et donc placée dans le dernier tableau. La valeur
-   <literal>red</literal> n'est pas retournée car dans
+   <literal>"red"</literal> n'est pas retournée car dans
    <varname>$array1</varname> son index est <literal>0</literal> tandis que
    dans le tableau <varname>$array2</varname>, son index est <literal>1</literal>,
    et la clé <literal>"b"</literal> n'est pas retournée, car sa valeur est

--- a/reference/array/functions/array-intersect-key.xml
+++ b/reference/array/functions/array-intersect-key.xml
@@ -40,7 +40,7 @@
      <term><parameter>arrays</parameter></term>
      <listitem>
       <para>
-       Tableaux à comparer contre
+       Tableaux dont les clés seront comparées.
       </para>
      </listitem>
     </varlistentry>
@@ -106,7 +106,7 @@ array(2) {
   </para>
   <para>
    Dans cet exemple, il est possible de voir que seules les clés <literal>'bleu'</literal>
-   et <literal>'vert'</literal> sont présentes dans les deux tableaux et donc, 
+   et <literal>'vert'</literal> sont présentes dans les deux tableaux et donc,
    elles sont retournées. Il est également à noter que les valeurs pour les clés
    <literal>'bleu'</literal> et <literal>'vert'</literal> diffèrent
    entre les deux tableaux. Néanmoins, elles correspondent toujours car
@@ -115,8 +115,8 @@ array(2) {
   </para>
   <para>
    Les deux clés depuis les paires <literal>clé =&gt; valeur</literal>
-   sont considérées comme égales uniquement si 
-   <literal>(string) $cle1 === (string) $cle2 </literal>. En d'autres mots, 
+   sont considérées comme égales uniquement si
+   <literal>(string) $key1 === (string) $key2 </literal>. En d'autres mots,
    une analyse stricte du type est exécutée, donc la représentation sous forme de
    chaîne doit être exactement la même.
   </para>

--- a/reference/array/functions/array-intersect-ukey.xml
+++ b/reference/array/functions/array-intersect-ukey.xml
@@ -40,7 +40,7 @@
      <term><parameter>arrays</parameter></term>
      <listitem>
       <para>
-       Tableaux à comparer contre
+       Tableaux dont les clés sont à comparer.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/array/functions/array-intersect.xml
+++ b/reference/array/functions/array-intersect.xml
@@ -41,7 +41,7 @@
      <term><parameter>arrays</parameter></term>
      <listitem>
       <para>
-       Tableaux à comparer contre
+       Tableaux dont les valeurs sont comparées.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/array/functions/array-is-list.xml
+++ b/reference/array/functions/array-is-list.xml
@@ -39,7 +39,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   retourne &true; si <parameter>array</parameter> est une liste, sinon &false;.
+   Retourne &true; si <parameter>array</parameter> est une liste, sinon &false;.
   </para>
  </refsect1>
  

--- a/reference/array/functions/array-key-exists.xml
+++ b/reference/array/functions/array-key-exists.xml
@@ -58,7 +58,7 @@
    <para>
     <function>array_key_exists</function> va rechercher, uniquement, dans
     les clés de la première dimension. Les clés imbriquées dans les
-    tableaux multidimensionnels ne seront pas trouvées
+    tableaux multidimensionnels ne seront pas trouvées.
    </para>
   </note>
  </refsect1>
@@ -77,7 +77,7 @@
      <row>
       <entry>8.5.0</entry>
       <entry>
-       L’utilisation de <type>null</type> dans le paramètre <parameter>key</parameter> est obsolète, utiliser une chaîne vide à la place.
+       L'utilisation de <type>null</type> dans le paramètre <parameter>key</parameter> est obsolète, utiliser une chaîne vide à la place.
       </entry>
      </row>
      <row>

--- a/reference/array/functions/array-keys.xml
+++ b/reference/array/functions/array-keys.xml
@@ -50,7 +50,7 @@
      <term><parameter>filter_value</parameter></term>
      <listitem>
       <para>
-       Si spécifié, alors seulement les clés contenant ces valeurs seront 
+       Si spécifié, alors seules les clés contenant cette valeur seront
        retournées.
       </para>
      </listitem>

--- a/reference/array/functions/array-map.xml
+++ b/reference/array/functions/array-map.xml
@@ -21,7 +21,7 @@
    les résultats de l'application de la fonction de rappel
    <parameter>callback</parameter> à la valeur correspondante de
    <parameter>array</parameter> (et <parameter>arrays</parameter> si plus de
-   tableaux sont fournis) utilisé en tant qu'arguments pour la fonction de rappel.
+   tableaux sont fournis) utilisés en tant qu'arguments pour la fonction de rappel.
    Le nombre de paramètres que la fonction de rappel <parameter>callback</parameter>
    accepte devrait correspondre au nombre de tableaux passés à
    <function>array_map</function>.

--- a/reference/array/functions/array-merge.xml
+++ b/reference/array/functions/array-merge.xml
@@ -126,7 +126,7 @@ print_r($result);
 ]]>
     </programlisting>
     <para>
-     N'oubliez pas que les index numériques seront réindexés !
+     Il ne faut pas oublier que les index numériques seront réindexés !
     </para>
     <screen role="php">
 <![CDATA[

--- a/reference/array/functions/array-multisort.xml
+++ b/reference/array/functions/array-multisort.xml
@@ -91,7 +91,7 @@
         </listitem>
         <listitem>
          <simpara>
-          <constant>SORT_FLAG_CASE</constant> - peut être combiné (avec le mot clé OR) avec
+          <constant>SORT_FLAG_CASE</constant> - peut être combiné (avec l'opérateur OU bit à bit) avec
           <constant>SORT_STRING</constant> ou
           <constant>SORT_NATURAL</constant> pour trier les chaînes sans tenir compte de la casse
          </simpara>

--- a/reference/array/functions/array-pad.xml
+++ b/reference/array/functions/array-pad.xml
@@ -22,8 +22,8 @@
    <parameter>value</parameter>. Si
    <parameter>length</parameter> est positif, alors le tableau
    est complété à droite, s'il est négatif, il est complété à gauche.
-   Si la valeur absolue de <parameter>length</parameter> est plus
-   petite que la taille du tableau <parameter>array</parameter>,
+   Si la valeur absolue de <parameter>length</parameter> est
+   inférieure ou égale à la taille du tableau <parameter>array</parameter>,
    alors le tableau n'est pas complété.
   </para>
  </refsect1>
@@ -70,8 +70,8 @@
    <parameter>value</parameter>. Si
    <parameter>length</parameter> est positif, alors le tableau
    est complété à droite, s'il est négatif, il est complété à gauche.
-   Si la valeur absolue de <parameter>length</parameter> est plus
-   petite que la taille du tableau <parameter>array</parameter>,
+   Si la valeur absolue de <parameter>length</parameter> est
+   inférieure ou égale à la taille du tableau <parameter>array</parameter>,
    alors le tableau n'est pas complété.
   </para>
  </refsect1>

--- a/reference/array/functions/array-push.xml
+++ b/reference/array/functions/array-push.xml
@@ -60,7 +60,7 @@ $array[] = $var;
      <term><parameter>values</parameter></term>
      <listitem>
       <para>
-       La valeur à insérer à la fin du tableau
+       Les valeurs à insérer à la fin du tableau
        <parameter>array</parameter>.
       </para>
      </listitem>

--- a/reference/array/functions/array-rand.xml
+++ b/reference/array/functions/array-rand.xml
@@ -58,7 +58,7 @@
    aléatoirement. Sinon, un tableau de clés d'entrées aléatoires sera
    retourné. Cela permet de faire une sélection au hasard de clés,
    ou bien de valeurs. Si plusieurs clés sont retournées, alors elles le
-   seront dans l'ordre qu'elles étaient dans le tableau d'origine.  
+   seront dans l'ordre où elles étaient dans le tableau d'origine.
   </para>
  </refsect1>
 
@@ -101,10 +101,7 @@
       <row>
        <entry>7.1.0</entry>
        <entry>
-        L'algorithme 
-         interne de génération aléatoire <link linkend="migration71.incompatible.rand-srand-aliases">a été modifié</link> pour utiliser le 
-         générateur aléatoire de nombre <link xlink:href="&url.mersenne;">
-         Mersenne Twister</link> au lieu de la fonction aléatoire libc
+        L'algorithme interne de génération aléatoire <link linkend="migration71.incompatible.rand-srand-aliases">a été modifié</link> pour utiliser le générateur aléatoire de nombre <link xlink:href="&url.mersenne;">Mersenne Twister</link> au lieu de la fonction aléatoire libc.
        </entry>
       </row>
      </tbody>

--- a/reference/array/functions/array-replace-recursive.xml
+++ b/reference/array/functions/array-replace-recursive.xml
@@ -22,7 +22,8 @@
    tableaux suivants, sa valeur sera remplacée. Si la clé n'existe pas 
    dans le premier tableau, elle sera créée. Si la clé n'existe que dans 
    le premier tableau, elle sera laissée intacte. Si plusieurs tableaux
-   sont passés comme arguments de remplacement, ils seront traités dans l'ordre.
+   sont passés comme arguments de remplacement, ils seront traités dans l'ordre,
+   chaque tableau ultérieur écrasant les valeurs précédentes.
   </para>
   <para>
    <function>array_replace_recursive</function> est récursive : si une valeur est

--- a/reference/array/functions/array-search.xml
+++ b/reference/array/functions/array-search.xml
@@ -54,10 +54,10 @@
        Si le troisième paramètre <parameter>strict</parameter> vaut
        &true;, alors <function>array_search</function> cherchera
        des éléments <emphasis>identiques</emphasis> dans
-       <parameter>haystack</parameter>. Cela signifie que cette fonction       
+       <parameter>haystack</parameter>. Cela signifie que cette fonction
        va effectuer une <link linkend="language.types">comparaison stricte du type</link>
-       de <parameter>needle</parameter> dans <parameter>haystack</parameter>, 
-       et que les objets proviennent de la même instance.
+       de <parameter>needle</parameter> dans <parameter>haystack</parameter>,
+       et que les objets doivent être la même instance.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/array/functions/array-slice.xml
+++ b/reference/array/functions/array-slice.xml
@@ -66,7 +66,7 @@
       </para>
       <para>
        Si le tableau est plus court que <parameter>length</parameter>,
-       alors seuls les éléments du &array; disponible seront présents.
+       alors seuls les éléments du &array; disponibles seront présents.
       </para>
       <para>
        Si <parameter>length</parameter> est fourni et négatif, alors
@@ -84,8 +84,8 @@
      <listitem>
       <note>
        <para>
-        Par défaut <function>array_slice</function> réordonnera et réinitialisera
-        les indices entier du &array;.
+        Par défaut, <function>array_slice</function> réordonnera et réinitialisera
+        les indices entiers du &array;.
         Ce comportement peut être modifié en définissant le paramètre
        <parameter>preserve_keys</parameter> à &true;.
        Les clés sous forme de &string; sont toujours conservées,

--- a/reference/array/functions/array-splice.xml
+++ b/reference/array/functions/array-splice.xml
@@ -216,7 +216,7 @@ array(5) {
   </para>
   <para>
    <example>
-    <title>Déclaration équivalentes à des exemples de <function>array_splice</function> divers</title>
+    <title>Déclarations équivalentes à des exemples de <function>array_splice</function> divers</title>
     <para>
      Les déclarations suivantes sont équivalentes :
     </para>
@@ -228,19 +228,19 @@ array(5) {
 array_push($input, $x, $y);
 array_splice($input, count($input), 0, array($x, $y));
 
-// supprimer le dernier élément à $input
+// supprimer le dernier élément de $input
 array_pop($input);
 array_splice($input, -1);
 
-// supprimer le premier élément à $input
+// supprimer le premier élément de $input
 array_shift($input);
 array_splice($input, 0, 1);
 
-//insérer deux éléments au début de $input
+// insérer deux éléments au début de $input
 array_unshift($input, $x, $y);
 array_splice($input, 0, 0, array($x, $y));
 
-// remplace la valeur dans $input à l'index $x
+// remplacer la valeur dans $input à l'index $x
 $input[$x] = $y; // pour les tableaux dont les clés sont égales à l'offset
 array_splice($input, $x, 1, $y);
 

--- a/reference/array/functions/array-sum.xml
+++ b/reference/array/functions/array-sum.xml
@@ -38,7 +38,8 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Retourne la somme des valeurs, sous la forme d'un &integer; ou d'un &float; <literal>0</literal> si le <parameter>array</parameter> est vide.
+   Retourne la somme des valeurs, sous la forme d'un &integer; ou d'un &float; ;
+   <literal>0</literal> si le <parameter>array</parameter> est vide.
   </para>
  </refsect1>
 

--- a/reference/array/functions/array-udiff-assoc.xml
+++ b/reference/array/functions/array-udiff-assoc.xml
@@ -24,8 +24,8 @@
   <note>
    <simpara>
     Il est à noter que cette fonction ne vérifie qu'une seule dimension d'un tableau
-    multidimensionnel. Il est possible de, bien sûr, tester une dimension
-    particulière en utilisant par exemple,
+    multidimensionnel. Il est bien sûr possible de tester une dimension
+    particulière en utilisant, par exemple,
     <literal>array_udiff_assoc($array1[0], $array2[0], "compare_func");</literal>.
    </simpara>
   </note>
@@ -47,7 +47,7 @@
      <term><parameter>arrays</parameter></term>
      <listitem>
       <para>
-       Tableaux à comparer contre
+       Tableaux à comparer.
       </para>
      </listitem>
     </varlistentry>
@@ -68,7 +68,7 @@
    <function>array_udiff_assoc</function> retourne un tableau contenant
    toutes les valeurs de <parameter>array</parameter> qui ne sont présentes
    dans aucun des autres arguments.
-   Il est à noter que les clés sont utilisées dans les comparaisons contrairement à  
+   Il est à noter que les clés sont utilisées dans les comparaisons contrairement à
    <function>array_diff</function> et <function>array_udiff</function>.
    La comparaison des données est effectuée en utilisant une fonction
    de rappel fournie par l'utilisateur, <parameter>value_compare_func</parameter>. 

--- a/reference/array/functions/array-udiff-uassoc.xml
+++ b/reference/array/functions/array-udiff-uassoc.xml
@@ -43,7 +43,7 @@
      <term><parameter>arrays</parameter></term>
      <listitem>
       <para>
-       Tableaux à comparer contre
+       Tableaux à comparer.
       </para>
      </listitem>
     </varlistentry>
@@ -73,7 +73,7 @@
   &reftitle.returnvalues;
   <para>
    Retourne un &array; contenant toutes les valeurs du tableau
-   <parameter>array</parameter> qui ne sont pas présentes dans
+   <parameter>array</parameter> qui ne sont présentes dans
    aucun autre argument.
   </para>
  </refsect1>
@@ -147,7 +147,7 @@ Array
   <note>
    <simpara>
     Il est à noter que cette fonction ne vérifie qu'une seule dimension d'un tableau
-    multidimensionnel. Il est possible de, bien sûr, tester une dimension
+    multidimensionnel. Il est possible, bien sûr, de tester une dimension
     particulière en utilisant par exemple
     <literal>array_udiff_uassoc($array1[0], $array2[0], "data_compare_func",
      "key_compare_func");</literal>.

--- a/reference/array/functions/array-udiff.xml
+++ b/reference/array/functions/array-udiff.xml
@@ -6,7 +6,7 @@
 <refentry xml:id="function.array-udiff" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>array_udiff</refname>
-  <refpurpose>Calcule la différence entre deux tableaux en utilisant une fonction rappel</refpurpose>
+  <refpurpose>Calcule la différence entre deux tableaux en utilisant une fonction de rappel</refpurpose>
  </refnamediv>
  <refsect1 role="description">
   &reftitle.description;
@@ -17,8 +17,8 @@
    <methodparam><type>callable</type><parameter>value_compare_func</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Calcule la différence entre deux tableaux en utilisant une fonction rappel.
-   Cette fonction agit comme la fonction <function>array_diff</function>
+   Calcule la différence entre des tableaux en utilisant une fonction de rappel
+   pour la comparaison des données. Ceci diffère de <function>array_diff</function>
    qui utilise une fonction interne pour comparer les données.
   </para>
  </refsect1>
@@ -39,7 +39,7 @@
      <term><parameter>arrays</parameter></term>
      <listitem>
       <para>
-       Tableaux à comparer contre
+       Tableaux à comparer.
       </para>
      </listitem>
     </varlistentry>
@@ -58,7 +58,7 @@
   &reftitle.returnvalues;
   <para>
    Retourne un tableau contenant toutes les valeurs du tableau
-   <parameter>array</parameter> qui ne sont pas présentes dans aucun
+   <parameter>array</parameter> qui ne sont présentes dans aucun
    autre argument.
   </para>
  </refsect1>
@@ -171,7 +171,7 @@ class MyCalendar {
     }
 }
 
-// Crée un calendrier pour les rendez-vous hébdomadaires
+// Crée un calendrier pour les rendez-vous hebdomadaires
 $myCalendar = new MyCalendar;
 
 // Enregistre quelques rendez-vous pour cette semaine
@@ -216,10 +216,9 @@ Friday: Fixing buggy code.
   <note>
    <simpara>
     Il est à noter que cette fonction ne vérifie qu'une seule dimension d'un tableau
-    multidimensionnel. Il est possible de, bien sûr, tester une dimension
-    particulière en utilisant par exemple
-    <literal>array_udiff($array1[0], $array2[0],
-    "data_compare_func");</literal>.
+    à n dimensions. Il est bien sûr possible de vérifier des dimensions
+    plus profondes en utilisant
+    <literal>array_udiff($array1[0], $array2[0], "data_compare_func");</literal>.
    </simpara>
   </note>
  </refsect1>

--- a/reference/array/functions/array-uintersect-uassoc.xml
+++ b/reference/array/functions/array-uintersect-uassoc.xml
@@ -42,8 +42,8 @@
      <term><parameter>arrays</parameter></term>
      <listitem>
       <para>
-       Tableaux supplémentaires
-      </para>
+       Tableaux supplémentaires.
+</para>
      </listitem>
     </varlistentry>
 
@@ -69,7 +69,7 @@
   &reftitle.returnvalues;
   <para>
    Retourne un tableau contenant toutes les valeurs du tableau
-   <parameter>array</parameter> qui sont présentes dans tous les
+   <parameter>array1</parameter> qui sont présentes dans tous les
    arguments.
   </para>
  </refsect1>

--- a/reference/array/functions/array-uintersect.xml
+++ b/reference/array/functions/array-uintersect.xml
@@ -39,7 +39,7 @@
      <term><parameter>arrays</parameter></term>
      <listitem>
       <para>
-       Tableaux à comparer contre
+       Tableaux à comparer.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/array/functions/array-unique.xml
+++ b/reference/array/functions/array-unique.xml
@@ -105,7 +105,7 @@
        <entry>7.2.0</entry>
        <entry>
         Si <parameter>flags</parameter> est <constant>SORT_STRING</constant>,
-        précédemment <parameter>array</parameter> était copié et les éléments
+        antérieurement <parameter>array</parameter> était copié et les éléments
         non-uniques étaient supprimés (sans compresser le tableau après), mais
         maintenant un nouveau tableau est construit en ajoutant les éléments uniques.
         Par conséquent, le résultat final peut avoir des index numériques différents.

--- a/reference/array/functions/array-unshift.xml
+++ b/reference/array/functions/array-unshift.xml
@@ -126,8 +126,8 @@ array(4) {
     <para>
      Si un tableau associatif est ajouté en préfixe à un autre tableau
      associatif, le tableau ajouté est indexé numériquement dans le tableau
-     précédent
-    </para>
+     précédent.
+</para>
     <programlisting role="php">
 <![CDATA[
 <?php
@@ -162,6 +162,7 @@ array_unshift($foods, $vegetables);
 
 var_dump($foods);
 
+?>
 ]]>
     </programlisting>
     &example.outputs;

--- a/reference/array/functions/array-walk-recursive.xml
+++ b/reference/array/functions/array-walk-recursive.xml
@@ -18,7 +18,7 @@
   <para>
    Applique la fonction utilisateur <parameter>callback</parameter>
    à chaque élément du tableau <parameter>array</parameter>. Cette
-   fonction se reproduira dans toutes les profondeurs du tableau.
+   fonction parcourt récursivement les sous-tableaux.
   </para>
  </refsect1>
  <refsect1 role="parameters">
@@ -44,7 +44,7 @@
       <note>
        <para>
         Si <parameter>callback</parameter> doit être exécuté avec les valeurs
-        actuelles du tableau, spécifiez le premier paramètre de
+        réelles du tableau, spécifier le premier paramètre de
         <parameter>callback</parameter> par
         <link linkend="language.references">référence</link>.
         Alors, tout changement effectué sur les éléments de ce tableau sera

--- a/reference/array/functions/array-walk.xml
+++ b/reference/array/functions/array-walk.xml
@@ -49,7 +49,7 @@
       <note>
        <para>
         Si <parameter>callback</parameter> doit travailler avec les véritables
-        valeurs du tableau, spécifiez que le premier paramètre de
+        valeurs du tableau, il faut spécifier que le premier paramètre de
         <parameter>callback</parameter> doit être passé par
         <link linkend="language.references">référence</link>. Alors, les
         éléments seront directement modifiés dans le tableau.
@@ -66,7 +66,7 @@
       <para>
        Seules les valeurs du <parameter>array</parameter> peuvent être modifiées ;
        sa structure ne peut pas, c'est-à-dire que l'on ne peut ajouter, supprimer
-       ou réordonner des éléments. Si la fonction de callback ne respecte pas cette
+       ou réordonner des éléments. Si la fonction de rappel ne respecte pas cette
        règle, le comportement va devenir indéfini et imprévisible.
       </para>
      </listitem>

--- a/reference/array/functions/compact.xml
+++ b/reference/array/functions/compact.xml
@@ -140,7 +140,7 @@ Array
     Parce que les <link linkend="language.variables.variable">variables
     variables</link> ne doivent pas être utilisées avec les
     <link linkend="language.variables.superglobals">tableaux superglobaux</link>
-    dans des fonctions, les tableaux Superglobaux ne doivent pas être passés
+    dans des fonctions, les tableaux superglobaux ne doivent pas être passés
     dans la fonction <function>compact</function>.
    </para>
   </note>

--- a/reference/array/functions/each.xml
+++ b/reference/array/functions/each.xml
@@ -24,7 +24,7 @@
   </para>
   <para>
    Après chaque appel à <function>each</function>, le pointeur de tableau est
-   déplacé au prochain élément, ou au-delà dernier élément, lorsqu'on arrive à
+   déplacé au prochain élément, ou au-delà du dernier élément, lorsqu'on arrive à
    la fin. Il faut utiliser <function>reset</function> si l'on veut traverser
    le tableau à nouveau avec <function>each</function>.
   </para>

--- a/reference/array/functions/extract.xml
+++ b/reference/array/functions/extract.xml
@@ -27,7 +27,7 @@
   </para>
   <warning>
    <para>
-    N'utiliser pas <function>extract</function> sur des données non sûres comme les entrées utilisateur
+    Ne pas utiliser <function>extract</function> sur des données non sûres comme les entrées utilisateur
     (ex. <varname>$_GET</varname>, <varname>$_FILES</varname>).
    </para>
   </warning>
@@ -217,7 +217,7 @@ blue, large, sphere, medium
   &reftitle.notes;
   <warning>
    <para>
-    N'utiliser pas <function>extract</function> sur des données inconnues, comme
+    Ne pas utiliser <function>extract</function> sur des données inconnues, comme
     les données utilisateurs (c.-à-d. <varname>$_GET</varname>,
     <varname>$_FILES</varname>, etc.).
     Si on le fait, il faut s'assurer d'utiliser l'une des constantes

--- a/reference/array/functions/key.xml
+++ b/reference/array/functions/key.xml
@@ -38,7 +38,7 @@
   &reftitle.returnvalues;
   <para>
    La fonction <function>key</function> retourne simplement la clé
-   de l'élément du tableau qui est actuellement pointée par le pointeur
+   de l'élément du tableau qui est actuellement pointé par le pointeur
    interne. Cette fonction ne modifie en aucun cas la position de ce pointeur.
    Si le pointeur interne pointe un élément se situant après la fin de la liste
    des éléments, ou bien si le tableau est vide, la fonction

--- a/reference/array/functions/list.xml
+++ b/reference/array/functions/list.xml
@@ -226,8 +226,8 @@ string(1) "a"
     <title><function>list</function> avec des clés</title>
     <simpara>
      À partir de PHP 7.1.0 <function>list</function> peut maintenant contenir également
-     des clés explicites, qui peuvent être donnés comme des expressions arbitraires. 
-     Le mixage des clés &integer; et &string; est autorisé; Toutefois, les éléments 
+     des clés explicites, qui peuvent être données comme des expressions arbitraires.
+     Le mixage des clés &integer; et &string; est autorisé ; toutefois, les éléments
      avec et sans clés ne peuvent pas être mélangés.
     </simpara>
     <programlisting role="php">

--- a/reference/array/functions/next.xml
+++ b/reference/array/functions/next.xml
@@ -98,7 +98,7 @@ echo $mode = end($transport), PHP_EOL;     // $mode = 'plane';
    </simpara>
    <simpara>
     Pour continuer d'utiliser <function>next</function> et détecter proprement
-    si la fin du tableau a été atteinte, la <function>key</function> est &null;.
+    si la fin du tableau a été atteinte, vérifier que la <function>key</function> est &null;.
    </simpara>
   </note>
  </refsect1>

--- a/reference/array/functions/prev.xml
+++ b/reference/array/functions/prev.xml
@@ -68,7 +68,7 @@
   &reftitle.examples;
   <para>
    <example>
-    <title>Exemple avec <function>prev</function></title>
+    <title>Exemple d'utilisation de <function>prev</function> et fonctions liées</title>
     <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/array/functions/sort.xml
+++ b/reference/array/functions/sort.xml
@@ -142,8 +142,8 @@ fruits[3] = orange20
     utilise une implémentation de <link
     xlink:href="&url.wiki.quicksort;">Quicksort</link>.
     Le pivot est choisi au milieu de la partition, résultant ainsi en une optimisation
-    du temps pour les tableaux déjà triés. Mais ceci ne reste qu'un détail de
-    l'implémentation, n'ayant aucun impact.
+    du temps pour les tableaux déjà triés. Il s'agit toutefois d'un détail
+    d'implémentation sur lequel il ne faut pas se reposer.
    </simpara>
   </note>
   <warning>

--- a/reference/bc/bcmath/number/div.xml
+++ b/reference/bc/bcmath/number/div.xml
@@ -47,7 +47,7 @@
   </simpara>
   <simpara>
    C'est-à-dire que si le <property>BcMath\Number::scale</property> du dividende est <literal>5</literal>,
-   la <property>BcMath\Number::scale</property> du résultat est entre <literal>5</literal> et
+   le <property>BcMath\Number::scale</property> du résultat est entre <literal>5</literal> et
    <literal>15</literal>.
   </simpara>
   <simpara>
@@ -57,7 +57,7 @@
    <property>BcMath\Number::scale</property> est réduit de cette quantité.
    Le <property>BcMath\Number::scale</property> ne sera jamais inférieur au
    <property>BcMath\Number::scale</property> avant l'extension.
-   Voir également les <link linkend="bcmath-number.div.example.expansion-scale">exemples de code</link>.
+   Voir également l'<link linkend="bcmath-number.div.example.expansion-scale">exemple de code</link>.
   </simpara>
  </refsect1>
 

--- a/reference/bc/bcmath/number/round.xml
+++ b/reference/bc/bcmath/number/round.xml
@@ -16,7 +16,7 @@
   </methodsynopsis>
   <simpara>
    Renvoie la valeur arrondie de <varname>$this</varname>
-   à la <parameter>précision</parameter> spécifiée
+   à la <parameter>precision</parameter> spécifiée
    (le nombre de chiffres après la virgule).
    <parameter>precision</parameter> peut également être négatif ou nul (par défaut).
   </simpara>
@@ -142,7 +142,7 @@ object(BcMath\Number)#11 (2) {
   </example>
   <example>
    <title>
-    Exemple d'utilisation de <methodname>BcMath\Number::round</methodname> avec différentes valeurs de <parameter>précision</parameter>
+    Exemple d'utilisation de <methodname>BcMath\Number::round</methodname> avec différentes valeurs de <parameter>precision</parameter>
    </title>
    <programlisting role="php">
 <![CDATA[
@@ -353,7 +353,7 @@ object(BcMath\Number)#3 (2) {
   <example>
    <title>
     Exemple d'utilisation de <methodname>BcMath\Number::round</methodname> avec différentes valeurs de <parameter>mode</parameter>
-    en spécifiant <parameter>précision</parameter>
+    en spécifiant <parameter>precision</parameter>
    </title>
    <programlisting role="php">
 <![CDATA[

--- a/reference/bc/functions/bcadd.xml
+++ b/reference/bc/functions/bcadd.xml
@@ -37,7 +37,7 @@
      <term><parameter>num2</parameter></term>
      <listitem>
       <para>
-       L'opérande droite, sous la forme d'une &string;.
+       L'opérande droit, sous la forme d'une &string;.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/bc/functions/bcpowmod.xml
+++ b/reference/bc/functions/bcpowmod.xml
@@ -143,7 +143,7 @@ $b = bcmod(bcpow($x, $y), $mod);
   <note>
    <para>
     Comme cette méthode utilise les opérations de modulo, les nombres
-    non positifs risquent de donner des résultats inattendus.
+    qui ne sont pas des entiers positifs risquent de donner des résultats inattendus.
    </para>
   </note>
  </refsect1>

--- a/reference/bc/functions/bcround.xml
+++ b/reference/bc/functions/bcround.xml
@@ -125,7 +125,7 @@ string(1) "0"
    <programlisting role="php">
 <![CDATA[
 <?php
-echo 'Modes d'arrondi avec 9.5' . PHP_EOL;
+echo "Modes d'arrondi avec 9.5" . PHP_EOL;
 var_dump(bcround('9.5', 0, RoundingMode::HalfAwayFromZero));
 var_dump(bcround('9.5', 0, RoundingMode::HalfTowardsZero));
 var_dump(bcround('9.5', 0, RoundingMode::HalfEven));
@@ -136,7 +136,7 @@ var_dump(bcround('9.5', 0, RoundingMode::NegativeInfinity));
 var_dump(bcround('9.5', 0, RoundingMode::PositiveInfinity));
 
 echo PHP_EOL;
-echo 'Modes d'arrondi avec 8.5' . PHP_EOL;
+echo "Modes d'arrondi avec 8.5" . PHP_EOL;
 var_dump(bcround('8.5', 0, RoundingMode::HalfAwayFromZero));
 var_dump(bcround('8.5', 0, RoundingMode::HalfTowardsZero));
 var_dump(bcround('8.5', 0, RoundingMode::HalfEven));

--- a/reference/bzip2/functions/bzerror.xml
+++ b/reference/bzip2/functions/bzerror.xml
@@ -36,7 +36,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   Retourne un tableau associatif, avec le code erreur dans l'entrée
+   Retourne un tableau associatif, avec le code d'erreur dans l'entrée
    <literal>errno</literal>, et le message d'erreur dans l'entrée
    <literal>errstr</literal>.
   </simpara>

--- a/reference/calendar/book.xml
+++ b/reference/calendar/book.xml
@@ -14,7 +14,7 @@
    L'extension Calendar contient une série de fonctions afin de
    convertir simplement les différents formats de calendrier.
    Elles sont basées sur un comptage de jour Julien. Le comptage
-   Julien est un comptage commençant le 1er Janvier 4713 av. J.-C.
+   Julien est un comptage commençant le 1er janvier 4713 av. J.-C.
    Pour convertir les différents calendriers, il faut tout d'abord
    convertir en nombre de jours Julien, puis, dans le type de calendrier
    du choix. Le comptage de jours Julien est très différent

--- a/reference/calendar/functions/easter-days.xml
+++ b/reference/calendar/functions/easter-days.xml
@@ -6,7 +6,7 @@
 <refentry xml:id="function.easter-days" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>easter_days</refname>
-  <refpurpose>Retourne le nombre de jours entre le 21 Mars et Pâques, pour une année donnée</refpurpose>
+  <refpurpose>Retourne le nombre de jours entre le 21 mars et Pâques, pour une année donnée</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -17,7 +17,7 @@
    <methodparam choice="opt"><type>int</type><parameter>mode</parameter><initializer><constant>CAL_EASTER_DEFAULT</constant></initializer></methodparam>
   </methodsynopsis>
   <para>
-   Retourne le nombre de jours entre le 21 Mars et Pâques, pour une
+   Retourne le nombre de jours entre le 21 mars et Pâques, pour une
    année donnée. Si l'année n'est pas précisée, l'année courante sera utilisée.
   </para>
   <para>
@@ -75,7 +75,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Le nombre de jours entre le 21 Mars et Pâques, pour l'année
+   Le nombre de jours entre le 21 mars et Pâques, pour l'année
    <parameter>year</parameter> fournie.
   </para>
  </refsect1>

--- a/reference/calendar/functions/frenchtojd.xml
+++ b/reference/calendar/functions/frenchtojd.xml
@@ -37,7 +37,7 @@
      <term><parameter>month</parameter></term>
      <listitem>
       <para>
-       Le mois, sous la forme d'un nombre entre 1 (pour Vendémiaire)
+       Le mois, sous la forme d'un nombre de 1 (pour Vendémiaire)
        à 13 (pour la période de 5-6 jours à la fin de chaque année)
       </para>
      </listitem>

--- a/reference/calendar/functions/gregoriantojd.xml
+++ b/reference/calendar/functions/gregoriantojd.xml
@@ -6,7 +6,7 @@
 <refentry xml:id="function.gregoriantojd" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>gregoriantojd</refname>
-  <refpurpose>Convertit une date grégorienne en nombre de jours du calendrier Julien</refpurpose>
+  <refpurpose>Convertit une date grégorienne en nombre de jours du calendrier julien</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -24,10 +24,10 @@
   <para>
    Bien qu'il soit possible de manipuler des dates jusqu'en 4714 avant J.-C.,
    une telle utilisation n'est pas significative. En effet, ce calendrier fut
-   créé le 15 octobre 1582 après J.C. (ou 5 octobre 1582
+   créé le 15 octobre 1582 après J.-C. (ou 5 octobre 1582
    en calendrier julien). Certains pays ne l'acceptèrent que bien plus
-   tard. Par exemple, les britanniques n'y passèrent qu'en 1752, les
-   Russes en 1918 et les Grecs en 1923. La plupart des pays européens
+   tard. Par exemple, la Grande-Bretagne n'y passa qu'en 1752, l'URSS
+   en 1918 et la Grèce en 1923. La plupart des pays européens
    utilisaient le calendrier julien avant le grégorien.
   </para>
  </refsect1>
@@ -60,10 +60,10 @@
      <listitem>
       <para>
        L'année, sous la forme d'un nombre compris entre -4714 et 9999.
-       Les nombres négatifs signifient les années avant J.C., les nombres positifs
-       signifient après J.C.
+       Les nombres négatifs signifient les années avant J.-C., les nombres positifs
+       signifient après J.-C.
        Il est à noter qu'il n'y a pas d'année <literal>0</literal> ; 31 décembre, 1
-       avant J.C. est immédiatement suivi par 1 janvier, 1 après J.C.
+       avant J.-C. est immédiatement suivi par 1 janvier, 1 après J.-C.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/calendar/functions/jddayofweek.xml
+++ b/reference/calendar/functions/jddayofweek.xml
@@ -77,7 +77,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Le jour de la semaine Grégorien, sous la forme d'un &integer; ou d'une &string;.
+   Le jour de la semaine grégorien, sous la forme d'un &integer; ou d'une &string;.
   </para>
  </refsect1>
 </refentry>

--- a/reference/calendar/functions/jdtounix.xml
+++ b/reference/calendar/functions/jdtounix.xml
@@ -16,8 +16,7 @@
   </methodsynopsis>
   <para>
    Retourne un timestamp UNIX correspondant au jour Julien
-   <parameter>julian_day</parameter> ou &false; si <parameter>julian_day</parameter>
-   n'est pas dans l'intervalle autorisé. Le temps retourné est UTC.
+   <parameter>julian_day</parameter>. Le temps retourné est UTC.
   </para>
  </refsect1>
 
@@ -53,7 +52,7 @@
   <para>
    Si <parameter>julian_day</parameter> est hors de l'intervalle autorisé,
    une <classname>ValueError</classname> est lancée.
- </para>
+  </para>
  </refsect1>
 
  <refsect1 role="changelog">

--- a/reference/calendar/functions/jewishtojd.xml
+++ b/reference/calendar/functions/jewishtojd.xml
@@ -36,9 +36,9 @@
       <para>
        Le mois, sous la forme d'un nombre entre <literal>1</literal> et <literal>13</literal>,
        où <literal>1</literal> signifie <literal>Tishri</literal>, 
-       <literal>13</literal> signifie <literal>Eloul</literal>, et 
-       <literal>6</literal> <emphasis>et</emphasis> <literal>7</literal> 
-       signifie <literal>Adar</literal> dans les années régulières, mais 
+       <literal>13</literal> signifie <literal>Elul</literal>, et
+       <literal>6</literal> <emphasis>et</emphasis> <literal>7</literal>
+       signifient <literal>Adar</literal> dans les années régulières, mais
        <literal>Adar I</literal> et <literal>Adar II</literal>, respectivement, 
        dans les années bissextiles.
       </para>

--- a/reference/calendar/functions/juliantojd.xml
+++ b/reference/calendar/functions/juliantojd.xml
@@ -18,20 +18,20 @@
   </methodsynopsis>
   <para>
    Intervalle de validité du calendrier Julien : 4713 avant J.-C. à
-   9999 après J.C.
+   9999 après J.-C.
   </para>
   <para>
    Bien qu'il soit possible de manipuler des dates jusqu'en 4713 avant J.-C.,
    une telle utilisation n'est pas significative. En effet, ce calendrier fut
-   créé en 46 avant J.C., et ses détails ne furent
+   créé en 46 avant J.-C., et ses détails ne furent
    finalisés qu'au plus tôt en 8 après J.-C., et probablement
-   pas avant le quatrième siècle après J.-C.. De plus, le
+   pas avant le quatrième siècle après J.-C. De plus, le
    début de l'année variait suivant les peuples, certains
    n'acceptant pas janvier comme premier mois de l'année.
   </para>
   <caution>
    <para>
-    Il faut se rappeler que le calendrier courant du système utilisé sur le Web est un calendrier
+    Il faut se rappeler que le calendrier actuellement utilisé dans le monde est un calendrier
     grégorien. <function>gregoriantojd</function> peut être utilisé pour convertir ce genre
     de dates en un nombre de jours du calendrier Julien.
    </para>

--- a/reference/classobj/examples.xml
+++ b/reference/classobj/examples.xml
@@ -124,15 +124,18 @@ objectBelongsTo($leafy, Vegetable::class);
 <![CDATA[
 veggie : CLASSE Vegetable
 leafy : CLASSE Spinach, PARENT Vegetable
+
 veggie : Propriétés
         edible = 1
         color = blue
+
 leafy : Méthodes
         function __construct()
         function cook()
         function isCooked()
         function isEdible()
         function getColor()
+
 Parenté :
 L'objet n'appartient pas à une sous-classe de Spinach
 L'objet appartient à la classe Spinach, une sous-classe de Vegetable

--- a/reference/classobj/functions/class-exists.xml
+++ b/reference/classobj/functions/class-exists.xml
@@ -34,7 +34,7 @@
      <term><parameter>autoload</parameter></term>
      <listitem>
       <para>
-       Si l'on doit appeler <link linkend="language.oop5.autoload">autoload</link> par défaut.
+       Si l'<link linkend="language.oop5.autoload">autoload</link> doit être appelé si la classe n'est pas déjà chargée.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/classobj/functions/get-mangled-object-vars.xml
+++ b/reference/classobj/functions/get-mangled-object-vars.xml
@@ -16,9 +16,9 @@
   <para>
    Retourne un &array; dont les éléments sont les propriétés de l'<parameter>object</parameter>.
    Les clés sont les noms des variables membres, avec quelques exceptions notables :
-   les variables privées ont le nom de la classe précédé du nom de la variable,
-   et les variables protégées sont précédées d'un <literal>*</literal>.
-   Ces valeurs précédées ont des octets <literal>NUL</literal> de part et d'autre.
+   les variables privées ont le nom de la classe préfixé au nom de la variable,
+   et les variables protégées sont préfixées d'un <literal>*</literal>.
+   Ces préfixes ont des octets <literal>NUL</literal> de part et d'autre.
    Les <link linkend="language.oop5.properties.typed-properties">propriétés typées</link> non initialisées
    sont rejetées silencieusement.
   </para>

--- a/reference/classobj/functions/interface-exists.xml
+++ b/reference/classobj/functions/interface-exists.xml
@@ -15,7 +15,7 @@
    <methodparam choice="opt"><type>bool</type><parameter>autoload</parameter><initializer>&true;</initializer></methodparam>
   </methodsynopsis>
   <para>
-   Vérifie si une interface a été définie.
+   Vérifie si l'interface fournie a été définie.
   </para>
  </refsect1>
  <refsect1 role="parameters">
@@ -34,7 +34,8 @@
      <term><parameter>autoload</parameter></term>
      <listitem>
       <para>
-       Si l'on doit appeler <link linkend="language.oop5.autoload">autoload</link> ou non par défaut.
+       S'il faut appeler <link linkend="language.oop5.autoload">autoload</link>
+       si l'interface n'est pas déjà chargée.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/cmark/commonmark/interfaces/ivisitor/leave.xml
+++ b/reference/cmark/commonmark/interfaces/ivisitor/leave.xml
@@ -42,7 +42,7 @@
    Retourner <varname>CommonMark\Interfaces\IVisitor::Leave</varname> réinitialisera l'itérateur sous-jacent en sortant de l'actuel <classname>IVisitable</classname>
   </simpara>
   <simpara>
-   Retourner un <classname>IVisitable</classname> réinitialisera l'itérateur sous-jacent en entrant dans le <classname>IVisitable</classname> donné
+   Retourner un <classname>IVisitable</classname> réinitialisera l'itérateur sous-jacent en sortant du <classname>IVisitable</classname> donné
   </simpara>
   <simpara>
    Ne rien retourner permettra à l'itérateur sous-jacent de continuer

--- a/reference/cmark/configure.xml
+++ b/reference/cmark/configure.xml
@@ -9,7 +9,7 @@
  </simpara>
 
  <simpara>
-  Les utilisateurs de Windows doivent inclure <filename>php_cmark.dll</filename> dans &php.ini;.
+  Les utilisateurs de Windows devraient inclure <filename>php_cmark.dll</filename> dans &php.ini;.
  </simpara>
 
 </section>

--- a/reference/com/book.xml
+++ b/reference/com/book.xml
@@ -44,7 +44,7 @@
    beaucoup plus avec COM.
   </para>
   <para>
-   De plus, nous supportons l'instanciation et la création d'assemblées
+   De plus, nous supportons l'instanciation et la création d'assemblages
    .Net utilisant une couche d'interopérabilité COM fournie par Microsoft.
   </para>
  </preface>

--- a/reference/com/com/construct.xml
+++ b/reference/com/com/construct.xml
@@ -117,7 +117,7 @@
            <literal>Server</literal>, ou <constant>CLSCTX_REMOTE_SERVER</constant>
            si l'on définit un serveur. Il est recommandé de consulter la documentation
            de Microsoft pour CoCreateInstance pour plus d'information sur la
-           signification de ces constantes ; on devra typiquement jamais
+           signification de ces constantes ; il ne faudra typiquement jamais
            les utiliser.
           </entry>
          </row>
@@ -144,7 +144,7 @@
       <constant>CP_MACCP</constant>,
       <constant>CP_OEMCP</constant>, <constant>CP_SYMBOL</constant>,
       <constant>CP_THREAD_ACP</constant> (utilise codepage/locale définie pour
-      le thread en cours d'exécution ), <constant>CP_UTF7</constant>
+      le thread en cours d'exécution), <constant>CP_UTF7</constant>
       et <constant>CP_UTF8</constant>. Il est aussi possible d'utiliser le numéro pour
       une codepage donnée ; consulter la documentation de Microsoft pour plus de
       détails sur les codepages et leurs valeurs numériques.

--- a/reference/com/compersisthelper/getmaxstreamsize.xml
+++ b/reference/com/compersisthelper/getmaxstreamsize.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="compersisthelper.getmaxstreamsize" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>COMPersistHelper::GetMaxStreamSize</refname>
-  <refpurpose>Renvoie la taille maximum du stream</refpurpose>
+  <refpurpose>Renvoie la taille maximum du flux</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -14,7 +14,7 @@
    <void/>
   </methodsynopsis>
   <para>
-   Renvoie la taille du stream (en octets) nécessaire pour sauvegarder l'objet.
+   Renvoie la taille du flux (en octets) nécessaire pour sauvegarder l'objet.
   </para>
  </refsect1>
 
@@ -26,7 +26,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Renvoie la taille du stream (en octets) nécessaire pour sauvegarder l'objet.
+   Renvoie la taille du flux (en octets) nécessaire pour sauvegarder l'objet.
   </para>
  </refsect1>
 

--- a/reference/com/compersisthelper/loadfromstream.xml
+++ b/reference/com/compersisthelper/loadfromstream.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="compersisthelper.loadfromstream" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>COMPersistHelper::LoadFromStream</refname>
-  <refpurpose>Charge un objet depuis un stream</refpurpose>
+  <refpurpose>Charge un objet depuis un flux</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -14,7 +14,7 @@
    <methodparam><type>resource</type><parameter>stream</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Initialise un objet à partir du stream où il a été sauvegardé précédemment.
+   Initialise un objet à partir du flux où il a été sauvegardé précédemment.
   </para>
  </refsect1>
 
@@ -25,7 +25,7 @@
     <term><parameter>stream</parameter></term>
     <listitem>
      <simpara>
-      Le stream &resource; à partir duquel charger l'objet.
+      Le flux &resource; à partir duquel charger l'objet.
      </simpara>
     </listitem>
    </varlistentry>

--- a/reference/com/compersisthelper/savetostream.xml
+++ b/reference/com/compersisthelper/savetostream.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="compersisthelper.savetostream" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>COMPersistHelper::SaveToStream</refname>
-  <refpurpose>Sauvegarde un objet dans un stream</refpurpose>
+  <refpurpose>Sauvegarde un objet dans un flux</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -14,7 +14,7 @@
    <methodparam><type>resource</type><parameter>stream</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Sauvegarde un objet dans le stream spécifié.
+   Sauvegarde un objet dans le flux spécifié.
   </para>
  </refsect1>
 
@@ -25,7 +25,7 @@
     <term><parameter>stream</parameter></term>
     <listitem>
      <simpara>
-      Le stream &resource; dans lequel sauvegarder l'objet.
+      Le flux &resource; dans lequel sauvegarder l'objet.
      </simpara>
     </listitem>
    </varlistentry>

--- a/reference/com/dotnet.xml
+++ b/reference/com/dotnet.xml
@@ -16,14 +16,14 @@
     <link xlink:href="&url.com.visible;">visible pour COM</link>.
    </para>
    <para>
-    Ni l'instantiation de classes statiques ni l'appel de méthodes statiques ne sont
+    Ni l'instanciation de classes statiques ni l'appel de méthodes statiques ne sont
     supportés.
     L'instanciation de classes génériques telles que
     <literal>System.Collections.Generic.List</literal> n'est pas non plus prise en charge.
    </para>
    <para>
     Quelques classes .Net n'implémentent pas IDispatch, donc bien qu'elles
-    peuvent être instanciées, appeler des méthodes ou accéder aux propriétés
+    puissent être instanciées, appeler des méthodes ou accéder aux propriétés
     sur ces classes n'est pas supporté.
    </para>
    <note>
@@ -74,11 +74,11 @@
     L'objet retourné est un objet surchargé, ceci signifie que PHP ne voit pas
     les méthodes fixes comme il le fait avec les classes normales ; à la place
     tout accès de propriété ou méthode sont passés à travers COM et à partir de
-    là à DOTNET. Dans d'autres mots, l'objet .Net est mappé via la couche
+    là à DOTNET. Autrement dit, l'objet .Net est mappé via la couche
     d'interopérabilité COM fournie par le moteur d'exécution .Net.
    </para>
    <para>
-    Une fois qu'on a créé un objet dotnet, PHP le traite de façon identique
+    Une fois un objet dotnet créé, PHP le traite de façon identique
     à n'importe quel autre objet COM ; les mêmes règles s'appliquent.
    </para>
   </section>

--- a/reference/com/functions/variant-cmp.xml
+++ b/reference/com/functions/variant-cmp.xml
@@ -72,7 +72,7 @@
          <tbody>
           <row>
            <entry><constant>NORM_IGNORECASE</constant></entry>
-           <entry>Compare avec sensibilité à la casse</entry>
+           <entry>Compare sans sensibilité à la casse</entry>
           </row>
           <row>
            <entry><constant>NORM_IGNORENONSPACE</constant></entry>

--- a/reference/com/functions/variant-div.xml
+++ b/reference/com/functions/variant-div.xml
@@ -79,7 +79,7 @@
       </row>
       <row>
        <entry><parameter>right</parameter> est vide et
-       <parameter>left</parameter> est tout mais non vide</entry>
+       <parameter>left</parameter> est tout sauf vide</entry>
        <entry>Une <classname>com_exception</classname> avec code <constant>DISP_E_DIVBYZERO</constant>
        est lancée</entry>
       </row>

--- a/reference/ctype/functions/ctype-alpha.xml
+++ b/reference/ctype/functions/ctype-alpha.xml
@@ -17,7 +17,7 @@
   <para>
    <function>ctype_alpha</function> vérifie si tous les caractères
    de la chaîne <parameter>text</parameter> sont des lettres.
-   En langage <literal>C</literal>, les lettres sont
+   Dans la locale <literal>C</literal> standard, les lettres sont
    <literal>[A-Za-z]</literal> et <function>ctype_alpha</function> est 
    équivalent à <literal>(ctype_upper($text) || ctype_lower($text))</literal>,
    si <parameter>text</parameter> est un caractère unique, mais 


### PR DESCRIPTION
Corrections de contresens, faux amis, accords, glossaire et terminologie sur 78 fichiers répartis dans 10 extensions (apache, apcu, array, bc, bzip2, calendar, classobj, cmark, com, ctype).