### PR TITLE
Translation nits

### DIFF
--- a/reference/dom/dom/attr/rename.xml
+++ b/reference/dom/dom/attr/rename.xml
@@ -55,7 +55,7 @@
     <term><classname>DOMException</classname> avec le code <constant>Dom\NAMESPACE_ERR</constant></term>
     <listitem>
      <simpara>
-      Levée s'il y a une erreur avec l'espace de noms, tel que déterminé par
+      Levée s'il y a une erreur avec l'espace de noms, telle que déterminée par
       <parameter>qualifiedName</parameter>.
      </simpara>
     </listitem>

--- a/reference/dom/dom/dom-adjacentposition.xml
+++ b/reference/dom/dom/dom-adjacentposition.xml
@@ -47,7 +47,7 @@
     <enumitem>
      <enumidentifier>AfterEnd</enumidentifier>
      <enumitemdescription>
-      Insère après l'élément contextuel.
+      Insérer après l'élément contextuel.
       Ceci n'est possible que si l'élément est dans un document et a un parent.
      </enumitemdescription>
     </enumitem>

--- a/reference/dom/dom/dom-element.xml
+++ b/reference/dom/dom/dom-element.xml
@@ -164,7 +164,7 @@
     <varlistentry xml:id="dom-element.props.prefix">
      <term><varname>prefix</varname></term>
      <listitem>
-      <simpara>L'espace de noms préfixé de l'élément.</simpara>
+      <simpara>Le préfixe d'espace de noms de l'élément.</simpara>
      </listitem>
     </varlistentry>
     <varlistentry xml:id="dom-element.props.localname">

--- a/reference/dom/dom/dom-tokenlist.xml
+++ b/reference/dom/dom/dom-tokenlist.xml
@@ -75,7 +75,7 @@
    &dom.note.modern.utf8;
    <note>
     <simpara>
-     Les tokens de la liste peuvent être accédés via une syntaxe de type tableau.
+     Les jetons de la liste peuvent être accédés via une syntaxe de type tableau.
     </simpara>
    </note>
   </section>

--- a/reference/dom/dom/dom-xmldocument.xml
+++ b/reference/dom/dom/dom-xmldocument.xml
@@ -110,7 +110,7 @@
     <varlistentry xml:id="dom-xmldocument.props.formatoutput">
      <term><varname>formatOutput</varname></term>
      <listitem>
-      <simpara>Indique proprement le format de sortie avec indentation et espace supplémentaire.</simpara>
+      <simpara>Formate joliment la sortie avec indentation et espace supplémentaire.</simpara>
      </listitem>
     </varlistentry>
    </variablelist>

--- a/reference/dom/dom/htmldocument/savehtmlfile.xml
+++ b/reference/dom/dom/htmldocument/savehtmlfile.xml
@@ -25,7 +25,7 @@
     <term><parameter>filename</parameter></term>
     <listitem>
      <simpara>
-      le chemin du fichier sur lequel sauvegarder le document.
+      Le chemin du fichier sur lequel sauvegarder le document.
      </simpara>
     </listitem>
    </varlistentry>

--- a/reference/dom/domchildnode/replacewith.xml
+++ b/reference/dom/domchildnode/replacewith.xml
@@ -27,6 +27,7 @@
      <listitem>
       <para>
        Les nœuds de remplacement.
+       Les chaînes de caractères sont automatiquement converties en nœuds de texte.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/dom/domdocument.xml
+++ b/reference/dom/domdocument.xml
@@ -218,7 +218,7 @@
     <varlistentry xml:id="domdocument.props.doctype">
      <term><varname>doctype</varname></term>
      <listitem>
-      <para>Le Document Type Declaration associé avec ce document.</para>
+      <para>Le Document Type Declaration associé à ce document.</para>
      </listitem>
     </varlistentry>
     <varlistentry xml:id="domdocument.props.documentelement">
@@ -335,7 +335,7 @@
       <para>
        <emphasis>Propriétaire</emphasis>. Si l'on doit ou non
        substituer les entités. Cet attribut ne fait pas partie de la
-       spécification DOM et est spécifique à libxml. Par défaut, &false;
+       spécification DOM et est spécifique à libxml. Par défaut, &false;.
       </para>
       <caution>
        <simpara>

--- a/reference/dom/domdocument/createelementns.xml
+++ b/reference/dom/domdocument/createelementns.xml
@@ -46,7 +46,7 @@
      <listitem>
       <para>
        La valeur de l'élément. Par défaut, un élément vide sera créé.
-       Il est également possible de définir la valeur plus tard en utilisant la fonction
+       Il est également possible de définir la valeur plus tard avec
        <link linkend="domnode.props.nodevalue">DOMElement::$nodeValue</link>.
       </para>
      </listitem>

--- a/reference/dom/domdocument/createprocessinginstruction.xml
+++ b/reference/dom/domdocument/createprocessinginstruction.xml
@@ -27,7 +27,7 @@
      <term><parameter>target</parameter></term>
      <listitem>
       <para>
-       La cible de l'instruction gérée.
+       La cible de l'instruction de traitement.
       </para>
      </listitem>
     </varlistentry>
@@ -35,7 +35,7 @@
      <term><parameter>data</parameter></term>
      <listitem>
       <para>
-       Le contenu de l'instruction gérée.
+       Le contenu de l'instruction de traitement.
       </para>
      </listitem>
     </varlistentry>
@@ -61,7 +61,7 @@
      <term><constant>DOM_INVALID_CHARACTER_ERR</constant></term>
      <listitem>
       <para>
-       Emise si <parameter>target</parameter> contient un caractère invalide.
+       Émise si <parameter>target</parameter> contient un caractère invalide.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/dom/domdocument/getelementbyid.xml
+++ b/reference/dom/domdocument/getelementbyid.xml
@@ -19,9 +19,9 @@
   </para>
   <para>
    Pour que cette fonction fonctionne, il faut soit définir les attributs ID
-   avec <xref linkend="domelement.setidattribute"/>
-   ou définir une DTD qui définit un attribut devant être de type ID.
-   Dans le dernier cas, il faut valider le document avec
+   avec <xref linkend="domelement.setidattribute"/>,
+   soit définir une DTD qui définit un attribut devant être de type ID.
+   Dans ce dernier cas, il faut valider le document avec
    <xref linkend="domdocument.validate"/>
    ou <link linkend="domdocument.props.validateonparse">DOMDocument::$validateOnParse</link>
    avant d'utiliser cette fonction.

--- a/reference/dom/domdocument/load.xml
+++ b/reference/dom/domdocument/load.xml
@@ -42,7 +42,7 @@
      <term><parameter>options</parameter></term>
      <listitem>
       <para>
-       <link linkend="language.operators.bitwise">L'opérateur <literal>OR</literal></link>
+       <link linkend="language.operators.bitwise">L'opérateur <literal>OR</literal> bit à bit</link>
        des <link linkend="libxml.constants">constantes d'options libxml</link>.
       </para>
      </listitem>

--- a/reference/dom/domdocument/loadxml.xml
+++ b/reference/dom/domdocument/loadxml.xml
@@ -35,7 +35,7 @@
      <term><parameter>options</parameter></term>
      <listitem>
       <para>
-       <link linkend="language.operators.bitwise">L'opérateur <literal>OR</literal></link>
+       <link linkend="language.operators.bitwise">L'opérateur <literal>OR</literal> bit à bit</link>
        des <link linkend="libxml.constants">constantes libxml</link>.
       </para>
      </listitem>

--- a/reference/dom/domdocument/savexml.xml
+++ b/reference/dom/domdocument/savexml.xml
@@ -115,10 +115,10 @@ $title = $root->appendChild($title);
 $text = $doc->createTextNode('Ceci est le titre');
 $text = $title->appendChild($text);
 
-echo "Récupération de tout le document :\n";
+echo "Sauvegarde de tout le document :\n";
 echo $doc->saveXML() . "\n";
 
-echo "Récupération du titre, uniquement :\n";
+echo "Sauvegarde du titre, uniquement :\n";
 echo $doc->saveXML($title);
 
 ?>
@@ -127,13 +127,13 @@ echo $doc->saveXML($title);
     &example.outputs;
     <screen>
 <![CDATA[
-Récupération de tout le document :
+Sauvegarde de tout le document :
 <?xml version="1.0"?>
 <book>
   <title>Ceci est le titre</title>
 </book>
 
-Récupération du titre, uniquement :
+Sauvegarde du titre, uniquement :
 <title>Ceci est le titre</title>
 ]]>
     </screen>

--- a/reference/dom/domdocument/schemavalidatesource.xml
+++ b/reference/dom/domdocument/schemavalidatesource.xml
@@ -35,7 +35,7 @@
      <term><parameter>flags</parameter></term>
      <listitem>
       <para>
-       Un masque de drapeau de validation de schéma Libxml.
+       Un masque de drapeaux de validation de schéma Libxml.
        Actuellement, la seule valeur supportée est
        <link linkend="libxml.constants">LIBXML_SCHEMA_CREATE</link>.
        Disponible depuis Libxml 2.6.14.

--- a/reference/dom/domdocument/xinclude.xml
+++ b/reference/dom/domdocument/xinclude.xml
@@ -20,7 +20,7 @@
   <note>
    <para>
     Vu que la bibliothèque libxml2 résout automatiquement les entités, cette méthode
-    peut produire des résultats non attendus si le fichier XML inclus a une DTD d'attachée.
+    peut produire des résultats non attendus si le fichier XML inclus a une DTD attachée.
    </para>
   </note>
  </refsect1>

--- a/reference/dom/domelement/construct.xml
+++ b/reference/dom/domelement/construct.xml
@@ -33,7 +33,7 @@
      <term><parameter>qualifiedName</parameter></term>
      <listitem>
       <para>
-       Le nom de l'élément. Lorsqu'il est passé dans l'URI de l'espace de noms,
+       Le nom de l'élément. Lorsque l'URI de l'espace de noms est également fournie,
        le nom de l'élément doit comporter un préfixe pour être associé à l'URI.
       </para>
      </listitem>
@@ -50,7 +50,7 @@
      <term><parameter>namespace</parameter></term>
      <listitem>
       <para>
-       Un espace de noms de l'URI pour créer l'élément dans un espace de noms spécifique.
+       Un URI d'espace de noms pour créer l'élément dans un espace de noms spécifique.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/dom/domelement/setattributenodens.xml
+++ b/reference/dom/domelement/setattributenodens.xml
@@ -26,7 +26,7 @@
      <term><parameter>attr</parameter></term>
      <listitem>
       <para>
-       Le nom de l'attribut.
+       Le nœud d'attribut.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/dom/domentity.xml
+++ b/reference/dom/domentity.xml
@@ -96,7 +96,7 @@
      <term><varname>publicId</varname></term>
      <listitem>
       <para>
-       L'identifiant public associé avec l'entité, si spécifiée, et &null;
+       L'identifiant public associé avec l'entité, s'il est spécifié, et &null;
        sinon.
       </para>
      </listitem>
@@ -105,7 +105,7 @@
      <term><varname>systemId</varname></term>
      <listitem>
       <para>
-       L'identifiant système associé avec l'entité, si spécifiée, et
+       L'identifiant système associé avec l'entité, s'il est spécifié, et
        &null; sinon. Peut être une URI absolue ou non.
       </para>
      </listitem>

--- a/reference/dom/domentityreference/construct.xml
+++ b/reference/dom/domentityreference/construct.xml
@@ -45,7 +45,7 @@
 $dom = new DOMDocument('1.0', 'iso-8859-1');
 $element = $dom->appendChild(new DOMElement('root'));
 $entity = $element->appendChild(new DOMEntityReference('nbsp'));
-echo $dom->saveXML(); /* <?xml version="1.0" encoding="iso-8859-1"?><root></root> */
+echo $dom->saveXML(); /* <?xml version="1.0" encoding="iso-8859-1"?><root>&nbsp;</root> */
 
 ?>
 ]]>

--- a/reference/dom/domimplementation/createdocument.xml
+++ b/reference/dom/domimplementation/createdocument.xml
@@ -5,7 +5,7 @@
  <refnamediv>
   <refname>DOMImplementation::createDocument</refname>
   <refpurpose>
-   Crée un objet DOM Document du type spécifié avec ses éléments
+   Crée un objet DOMDocument du type spécifié avec son élément
   </refpurpose>
  </refnamediv>
  <refsect1 role="description">
@@ -29,7 +29,7 @@
      <term><parameter>namespace</parameter></term>
      <listitem>
       <para>
-       L'URI du namespace des éléments du document à créer.
+       L'URI du namespace de l'élément du document à créer.
       </para>
      </listitem>
     </varlistentry>
@@ -37,7 +37,7 @@
      <term><parameter>qualifiedName</parameter></term>
      <listitem>
       <para>
-       Le nom qualifié des éléments du document à créer.
+       Le nom qualifié de l'élément du document à créer.
       </para>
      </listitem>
     </varlistentry>
@@ -57,7 +57,7 @@
   <para>
    Un nouvel objet <classname>DOMDocument</classname>. Si
    <parameter>namespace</parameter>, <parameter>qualifiedName</parameter>,
-   et <parameter>doctype</parameter> sont nulles, le
+   et <parameter>doctype</parameter> sont nuls, le
    <classname>DOMDocument</classname> retourné est vide avec aucun élément de
    document.
   </para>
@@ -84,7 +84,7 @@
      <term><constant>DOM_NAMESPACE_ERR</constant></term>
      <listitem>
       <para>
-       Lancé s'il y a une erreur dans l'espace de noms, déterminé par
+       Levé s'il y a une erreur dans l'espace de noms, déterminée par
        <parameter>namespace</parameter> et
        <parameter>qualifiedName</parameter>.
       </para>

--- a/reference/dom/domimplementation/createdocumenttype.xml
+++ b/reference/dom/domimplementation/createdocumenttype.xml
@@ -39,7 +39,7 @@
      <term><parameter>publicId</parameter></term>
      <listitem>
       <para>
-       L'identifiant publique externe du sous-ensemble.
+       L'identifiant public externe du sous-ensemble.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/dom/domnamednodemap/getnameditemns.xml
+++ b/reference/dom/domnamednodemap/getnameditemns.xml
@@ -46,8 +46,8 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Un nœud, de n'importe quel type ou &null; 
-   si aucun nœud n'est trouvé.
+   Un nœud (de n'importe quel type) avec le nom local et l'URI d'espace de noms
+   spécifiés, ou &null; si aucun nœud n'est trouvé.
   </para>
  </refsect1>
  <refsect1 role="seealso">

--- a/reference/dom/domnode.xml
+++ b/reference/dom/domnode.xml
@@ -385,8 +385,8 @@
      <term><varname>baseURI</varname></term>
      <listitem>
       <para>
-       La base de l'URL absolue du nœud, ou &null; si l'implémentation
-       n'a pas réussi à obtenir l'URL absolue.
+       L'URI de base absolu du nœud, ou &null; si l'implémentation
+       n'a pas réussi à obtenir un URI absolu.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/dom/domnode/appendchild.xml
+++ b/reference/dom/domnode/appendchild.xml
@@ -78,8 +78,8 @@
      <term><constant>DOM_WRONG_DOCUMENT_ERR</constant></term>
      <listitem>
       <para>
-       Levé si <parameter>node</parameter> a été créé depuis un document
-       différent que celui qui a créé ce nœud.
+       Levé si <parameter>node</parameter> a été créé à partir d'un document
+       différent de celui qui a créé ce nœud.
       </para>
      </listitem>
     </varlistentry>
@@ -89,7 +89,7 @@
  <refsect1 role="examples">
   &reftitle.examples;
   <para>
-   L'exemple suivant ajoutera un nouveau nœud à un document nouveau.
+   L'exemple suivant ajoutera un nouveau nœud élément à un document nouveau.
    <example>
     <title>Ajout d'un fils</title>
     <programlisting role="php">

--- a/reference/dom/domnode/c14n.xml
+++ b/reference/dom/domnode/c14n.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="domnode.c14n" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>DOMNode::C14N</refname>
-  <refpurpose>Canonise des nœuds en une chaîne</refpurpose>
+  <refpurpose>Canonicalise des nœuds en une chaîne</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -17,7 +17,7 @@
    <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>nsPrefixes</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
   <para>
-   Canonise des nœuds en une chaîne de caractères.
+   Canonicalise des nœuds en une chaîne de caractères.
   </para>
  </refsect1>
 
@@ -28,7 +28,7 @@
     <term><parameter>exclusive</parameter></term>
     <listitem>
      <para>
-      Active l'analyse des seuls nœuds correspondant à l'Xpath
+      Active l'analyse des seuls nœuds correspondant à l'xpath
       ou aux préfixes d'espace de noms fournis.
      </para>
     </listitem>

--- a/reference/dom/domnode/clonenode.xml
+++ b/reference/dom/domnode/clonenode.xml
@@ -24,7 +24,7 @@
      <term><parameter>deep</parameter></term>
      <listitem>
       <para>
-       Indique si l'on doit copier tous les nœuds fils. Ce paramètre vaut
+       Indique si l'on doit copier tous les nœuds descendants. Ce paramètre vaut
        &false; par défaut.
       </para>
      </listitem>

--- a/reference/dom/domnode/insertbefore.xml
+++ b/reference/dom/domnode/insertbefore.xml
@@ -85,8 +85,8 @@
      <term><constant>DOM_WRONG_DOCUMENT_ERR</constant></term>
      <listitem>
       <para>
-       Levé si <parameter>node</parameter> a été créé depuis un document
-       différent que celui qui a créé ce nœud.
+       Levé si <parameter>node</parameter> a été créé à partir d'un document
+       différent de celui qui a créé ce nœud.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/dom/domnode/removechild.xml
+++ b/reference/dom/domnode/removechild.xml
@@ -93,7 +93,7 @@ echo $doc->saveXML();
     &example.outputs;
     <screen role="xml">
 <![CDATA[
-<?xml version="1.0" encoding="iso-8859-1"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE book PUBLIC "-//OASIS//DTD DocBook XML V4.1.2//EN" 
           "http://www.oasis-open.org/docbook/xml/4.1.2/docbookx.dtd">
 <book id="listing">

--- a/reference/dom/domnode/replacechild.xml
+++ b/reference/dom/domnode/replacechild.xml
@@ -84,8 +84,8 @@
      <term><constant>DOM_WRONG_DOCUMENT_ERR</constant></term>
      <listitem>
       <para>
-       Émise si <parameter>node</parameter> a été créé depuis un document
-       différent que celui qui a créé ce nœud.
+       Levé si <parameter>node</parameter> a été créé depuis un document
+       différent de celui qui a créé ce nœud.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/dom/domnodelist.xml
+++ b/reference/dom/domnodelist.xml
@@ -109,7 +109,7 @@ Remove me once you perform substitutions
    &reftitle.notes;
    <note>
     <simpara>
-      Les nœuds dans la carte peuvent être accédés via la syntaxe de tableau.
+      Les nœuds dans la liste peuvent être accédés via la syntaxe de tableau.
     </simpara>
    </note>
   </section>

--- a/reference/dom/domtext/iswhitespaceinelementcontent.xml
+++ b/reference/dom/domtext/iswhitespaceinelementcontent.xml
@@ -28,7 +28,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Retourne &true; si le nœud contient zéro ou plusieurs caractères blancs
+   Retourne &true; si le nœud contient zéro caractère blanc ou plus
    et rien d'autre. Retourne &false; sinon.
   </para>
  </refsect1>

--- a/reference/dom/domtext/splittext.xml
+++ b/reference/dom/domtext/splittext.xml
@@ -15,8 +15,8 @@
    <methodparam><type>int</type><parameter>offset</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Coupe le nœud en deux nœuds à l'endroit spécifié <parameter>offset</parameter>, 
-   en gardant les deux dans l'arbre comme parents.
+   Coupe le nœud en deux nœuds à l'endroit spécifié <parameter>offset</parameter>,
+   en gardant les deux dans l'arbre comme frères.
   </para>
   <para>
    Après la césure, ce

--- a/reference/dom/domxpath/registerphpfunctions.xml
+++ b/reference/dom/domxpath/registerphpfunctions.xml
@@ -57,14 +57,14 @@
    <listitem>
     <simpara>
      Lance une <exceptionname>ValueError</exceptionname> si
-     le nom d'un callback n'est pas valide.
+     le nom d'une fonction de rappel n'est pas valide.
     </simpara>
    </listitem>
    &dom.errors.compliant.common;
    <listitem>
     <simpara>
      Lance une <exceptionname>TypeError</exceptionname> si
-     un callback donné n'est pas appelable.
+     une fonction de rappel donnée n'est pas appelable.
     </simpara>
    </listitem>
   </itemizedlist>
@@ -85,7 +85,7 @@
      <row xml:id="domxpath.registerphpfunctions..changelog.errors">
        <entry>8.4.0</entry>
        <entry>
-        Les noms de callback invalides lancent maintenant une
+        Les noms de fonction de rappel invalides lancent maintenant une
         <exceptionname>ValueError</exceptionname>.
         Passer une entrée non appelable lance maintenant une
         <exceptionname>TypeError</exceptionname>.
@@ -94,7 +94,7 @@
      <row>
       <entry>8.4.0</entry>
       <entry>
-       Il est désormais possible d'utiliser des <type>callable</type>s pour des callbacks
+       Il est désormais possible d'utiliser des <type>callable</type>s pour des fonctions de rappel
        lors de l'utilisation de <parameter>restrict</parameter> avec des entrées de type <type>array</type>.
       </entry>
      </row>

--- a/reference/ds/ds/collection/clear.xml
+++ b/reference/ds/ds/collection/clear.xml
@@ -5,7 +5,7 @@
 <refentry xml:id="ds-collection.clear" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Ds\Collection::clear</refname>
-  <refpurpose>Supprimer toutes les valeurs</refpurpose>
+  <refpurpose>Supprime toutes les valeurs</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -15,7 +15,7 @@
    <void />
   </methodsynopsis>
   <para>
-    Supprimer toutes les valeurs de la collection.
+    Supprime toutes les valeurs de la collection.
   </para>
  </refsect1>
 

--- a/reference/ds/ds/deque/construct.xml
+++ b/reference/ds/ds/deque/construct.xml
@@ -14,8 +14,8 @@
    <methodparam choice="opt"><type>mixed</type><parameter>values</parameter></methodparam>
   </constructorsynopsis>
   <para>
-    Crée une nouvelle instance, en utilisant soit un objet <classname>traversable</classname>
-    ou un &array; pour les <parameter>valeurs</parameter> initiales.
+    Crée une nouvelle instance, en utilisant soit un objet <classname>traversable</classname>,
+    soit un &array; pour les <parameter>values</parameter> initiales.
   </para>
  </refsect1>
 

--- a/reference/ds/ds/deque/contains.xml
+++ b/reference/ds/ds/deque/contains.xml
@@ -35,7 +35,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-    &false; si l'une des <parameter>valeurs</parameter> fournies n'est pas dans le deque,
+    &false; si l'une des <parameter>values</parameter> fournies n'est pas dans le deque,
     &true; sinon.
   </para>
  </refsect1>

--- a/reference/ds/ds/deque/find.xml
+++ b/reference/ds/ds/deque/find.xml
@@ -16,7 +16,7 @@
    <methodparam><type>mixed</type><parameter>value</parameter></methodparam>
   </methodsynopsis>
   <para>
-    Renvoie l'index de la <parameter>valeur</parameter>, ou &false; si non trouvée.
+    Renvoie l'index de la <parameter>value</parameter>, ou &false; si non trouvée.
   </para>
 
  </refsect1>

--- a/reference/ds/ds/deque/map.xml
+++ b/reference/ds/ds/deque/map.xml
@@ -34,7 +34,7 @@
              </methodsynopsis>
          </para>
          <para>
-            Une <type>fonction de rappel</type> à appliquer à chaque valeur de la deque.
+            Un <type>callable</type> à appliquer à chaque valeur de la deque.
          </para>
 
          <para>
@@ -50,7 +50,7 @@
   &reftitle.returnvalues;
   <para>
     Le résultat de l'application de <parameter>callback</parameter> à chaque valeur
-    du deque.
+    de la deque.
   </para>
   <note>
     <para>

--- a/reference/ds/ds/hashable/hash.xml
+++ b/reference/ds/ds/hashable/hash.xml
@@ -77,7 +77,7 @@ class HashableObject implements \Ds\Hashable
     }
 
     /**
-     * Doit renvoyer la même valeur pour tous les objets égaux, mais n'a pas à
+     * Devrait renvoyer la même valeur pour tous les objets égaux, mais n'a pas à
      * être unique. Cette valeur ne sera pas utilisée pour déterminer l'égalité.
      */
     public function hash()

--- a/reference/ds/ds/map/construct.xml
+++ b/reference/ds/ds/map/construct.xml
@@ -15,7 +15,7 @@
   </constructorsynopsis>
   <para>
     Crée une nouvelle instance, en utilisant soit un objet <classname>traversable</classname>
-    ou un &array; pour les <parameter>values</parameter> initiales.
+    soit un &array; pour les <parameter>values</parameter> initiales.
   </para>
 
  </refsect1>

--- a/reference/ds/ds/map/filter.xml
+++ b/reference/ds/ds/map/filter.xml
@@ -5,7 +5,7 @@
  <refnamediv>
   <refname>Ds\Map::filter</refname>
   <refpurpose>
-    Créer une nouvelle carte en utilisant un <type>callable</type> pour déterminer quelles paires inclure
+    Crée une nouvelle carte en utilisant un <type>callable</type> pour déterminer quelles paires inclure
   </refpurpose>
  </refnamediv>
 

--- a/reference/ds/ds/map/get.xml
+++ b/reference/ds/ds/map/get.xml
@@ -75,7 +75,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-    La valeur mappée à la <parameter>clé</parameter> donnée, ou la <parameter>valeur par défaut</parameter>
+    La valeur mappée à la <parameter>key</parameter> donnée, ou la <parameter>default</parameter>
     si fournie et que la clé n'a pas pu être trouvée dans la carte.
   </para>
  </refsect1>
@@ -98,7 +98,7 @@
 $map = new \Ds\Map(["a" => 1, "b" => 2, "c" => 3]);
 
 var_dump($map->get("a"));       // 1
-var_dump($map->get("d", 10));   // 10 (utiliser par défaut)
+var_dump($map->get("d", 10));   // 10 (valeur par défaut utilisée)
 ?>
 ]]>
    </programlisting>

--- a/reference/ds/ds/map/put.xml
+++ b/reference/ds/ds/map/put.xml
@@ -15,7 +15,7 @@
    <methodparam><type>mixed</type><parameter>value</parameter></methodparam>
   </methodsynopsis>
   <para>
-    Associe une <parameter>clé</parameter> à une <parameter>valeur</parameter>,
+    Associe une <parameter>key</parameter> à une <parameter>value</parameter>,
     en écrasant une association précédente si elle existe.
   </para>
 

--- a/reference/ds/ds/map/toarray.xml
+++ b/reference/ds/ds/map/toarray.xml
@@ -27,7 +27,7 @@
         <para>
             Un &array; traitera toutes les clés numériques comme des entiers,
             par exemple <code>"1"</code> et <code>1</code> en tant que clés dans la carte
-            ne résultera qu'en <code>1</code> étant inclus dans le tableau.
+            ne résulteront qu'en <code>1</code> étant inclus dans le tableau.
         </para>
     </caution>
   <note>

--- a/reference/ds/ds/map/union.xml
+++ b/reference/ds/ds/map/union.xml
@@ -54,7 +54,7 @@
   &reftitle.seealso;
   <para>
    <simplelist>
-    <member><link xlink:href="&url.wiki.union.set;">>Union</link> sur Wikipedia</member>
+    <member><link xlink:href="&url.wiki.union.set;">Union</link> sur Wikipedia</member>
    </simplelist>
   </para>
  </refsect1>

--- a/reference/ds/ds/pair/construct.xml
+++ b/reference/ds/ds/pair/construct.xml
@@ -15,7 +15,7 @@
    <methodparam choice="opt"><type>mixed</type><parameter>value</parameter></methodparam>
   </constructorsynopsis>
   <para>
-    Crée une nouvelle instance en utilisant une <parameter>clé</parameter> et une <parameter>valeur</parameter> données.
+    Crée une nouvelle instance en utilisant une <parameter>key</parameter> et une <parameter>value</parameter> données.
   </para>
 
  </refsect1>

--- a/reference/ds/ds/queue/construct.xml
+++ b/reference/ds/ds/queue/construct.xml
@@ -14,8 +14,8 @@
    <methodparam choice="opt"><type>mixed</type><parameter>values</parameter></methodparam>
   </constructorsynopsis>
   <para>
-    Crée une nouvelle instance en utilisant soit un objet <classname>traversable</classname>
-    ou un &array; pour les <parameter>values</parameter> initiales.
+    Crée une nouvelle instance en utilisant soit un objet <classname>traversable</classname>,
+    soit un &array; pour les <parameter>values</parameter> initiales.
   </para>
  </refsect1>
 

--- a/reference/ds/ds/queue/pop.xml
+++ b/reference/ds/ds/queue/pop.xml
@@ -33,7 +33,7 @@
  <refsect1 role="errors">
   &reftitle.errors;
   <para>
-   <classname>UnderflowException</classname>.
+   <classname>UnderflowException</classname> si vide.
   </para>
  </refsect1>
 

--- a/reference/ds/ds/sequence/apply.xml
+++ b/reference/ds/ds/sequence/apply.xml
@@ -34,7 +34,7 @@
              </methodsynopsis>
         </para>
         <para>
-            Un <type>callable</type> à appliquer à chaque valeur de la carte.
+            Un <type>callable</type> à appliquer à chaque valeur de la séquence.
         </para>
 
         <para>

--- a/reference/ds/ds/sequence/find.xml
+++ b/reference/ds/ds/sequence/find.xml
@@ -16,7 +16,7 @@
    <methodparam><type>mixed</type><parameter>value</parameter></methodparam>
   </methodsynopsis>
   <para>
-    Renvoie l'index de la <parameter>valeur</parameter>, ou &false; si non trouvée.
+    Renvoie l'index de la <parameter>value</parameter>, ou &false; si non trouvée.
   </para>
 
  </refsect1>

--- a/reference/ds/ds/sequence/map.xml
+++ b/reference/ds/ds/sequence/map.xml
@@ -15,7 +15,7 @@
   </methodsynopsis>
   <para>
     Renvoie le résultat de l'application de <parameter>callback</parameter> à
-    chaque valeur de la deque.
+    chaque valeur de la séquence.
   </para>
  </refsect1>
 
@@ -34,7 +34,7 @@
              </methodsynopsis>
          </para>
          <para>
-            Une <type>fonction de rappel</type> à appliquer à chaque valeur de la deque.
+            Un <type>callable</type> à appliquer à chaque valeur de la séquence.
          </para>
 
          <para>
@@ -50,7 +50,7 @@
   &reftitle.returnvalues;
   <para>
     Le résultat de l'application de <parameter>callback</parameter> à chaque valeur
-    du deque.
+    de la séquence.
   </para>
   <note>
     <para>

--- a/reference/ds/ds/sequence/slice.xml
+++ b/reference/ds/ds/sequence/slice.xml
@@ -32,8 +32,8 @@
             L'index auquel commence la sous-séquence.
         </para>
         <para>
-            Si positif, le sous-deque commencera à cet index dans le deque.
-            Si négatif, le sous-deque commencera à cette distance de la fin.
+            Si positif, la sous-séquence commencera à cet index dans la séquence.
+            Si négatif, la sous-séquence commencera à cette distance de la fin.
         </para>
     </listitem>
     </varlistentry>
@@ -41,16 +41,16 @@
     <term><parameter>length</parameter></term>
     <listitem>
      <para>
-        Si une longueur est donnée et est positive, le sous-deque résultant
+        Si une longueur est donnée et est positive, la sous-séquence résultante
         aura jusqu'à autant de valeurs.
 
         Si la longueur entraîne un dépassement, seules
-        les valeurs jusqu'à la fin du deque seront incluses.
+        les valeurs jusqu'à la fin de la séquence seront incluses.
 
-        Si une longueur est donnée et est négative, le sous-deque
+        Si une longueur est donnée et est négative, la sous-séquence
         s'arrêtera à autant de valeurs de la fin.
 
-        Si une longueur n'est pas fournie, le sous-deque
+        Si une longueur n'est pas fournie, la sous-séquence
         contiendra toutes les valeurs entre l'index et la
         fin de la séquence.
      </para>

--- a/reference/ds/ds/set/add.xml
+++ b/reference/ds/ds/set/add.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="ds-set.add" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Ds\Set::add</refname>
-  <refpurpose>Ajoute des valeurs à la séquence</refpurpose>
+  <refpurpose>Ajoute des valeurs à l'ensemble</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -41,7 +41,7 @@
     <term><parameter>values</parameter></term>
     <listitem>
      <para>
-        Les valeurs à ajouter à la séquence.
+        Les valeurs à ajouter à l'ensemble.
      </para>
     </listitem>
    </varlistentry>

--- a/reference/ds/ds/set/clear.xml
+++ b/reference/ds/ds/set/clear.xml
@@ -14,7 +14,7 @@
    <void />
   </methodsynopsis>
   <para>
-    Supprime toutes les valeurs de la séquence.
+    Supprime toutes les valeurs de l'ensemble.
   </para>
  </refsect1>
 

--- a/reference/ds/ds/set/construct.xml
+++ b/reference/ds/ds/set/construct.xml
@@ -14,8 +14,8 @@
    <methodparam choice="opt"><type>mixed</type><parameter>values</parameter><initializer>[]</initializer></methodparam>
   </constructorsynopsis>
   <para>
-    Crée une nouvelle instance, en utilisant soit un objet <classname>traversable</classname>
-    ou un &array; pour les <parameter>valeurs</parameter> initiales.
+    Crée une nouvelle instance, en utilisant soit un objet <classname>traversable</classname>,
+    soit un &array; pour les <parameter>values</parameter> initiales.
   </para>
 
  </refsect1>

--- a/reference/ds/ds/set/contains.xml
+++ b/reference/ds/ds/set/contains.xml
@@ -53,8 +53,8 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-    &false; si l'une des <parameter>valeurs</parameter> fournies n'est pas dans
-    la séquence, sinon &true;.
+    &false; si l'une des <parameter>values</parameter> fournies n'est pas dans
+    l'ensemble, sinon &true;.
   </para>
  </refsect1>
 

--- a/reference/ds/ds/set/copy.xml
+++ b/reference/ds/ds/set/copy.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="ds-set.copy" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Ds\Set::copy</refname>
-  <refpurpose>Renvoie une copie superficielle de la séquence</refpurpose>
+  <refpurpose>Renvoie une copie superficielle de l'ensemble</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -14,7 +14,7 @@
    <void />
   </methodsynopsis>
   <para>
-    Renvoie une copie superficielle de la séquence.
+    Renvoie une copie superficielle de l'ensemble.
   </para>
  </refsect1>
 
@@ -26,7 +26,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Renvoie une copie superficielle de la séquence.
+   Renvoie une copie superficielle de l'ensemble.
   </para>
  </refsect1>
 

--- a/reference/ds/ds/set/count.xml
+++ b/reference/ds/ds/set/count.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="ds-set.count" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Ds\Set::count</refname>
-  <refpurpose>Renvoie le nombre de valeurs dans la séquence</refpurpose>
+  <refpurpose>Renvoie le nombre de valeurs dans l'ensemble</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/ds/ds/set/diff.xml
+++ b/reference/ds/ds/set/diff.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="ds-set.diff" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Ds\Set::diff</refname>
-  <refpurpose>Crée un nouvel ensemble en utilisant des valeurs qui ne sont pas dans une autre séquence</refpurpose>
+  <refpurpose>Crée un nouvel ensemble en utilisant des valeurs qui ne sont pas dans un autre ensemble</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -14,7 +14,7 @@
    <methodparam><type>Ds\Set</type><parameter>set</parameter></methodparam>
   </methodsynopsis>
   <para>
-    Crée un nouvel ensemble utilisant des valeurs qui ne sont pas dans une autre séquence.
+    Crée un nouvel ensemble utilisant des valeurs qui ne sont pas dans un autre ensemble.
   </para>
   <para>
     <code>A \ B = {x ∈ A | x ∉ B}</code>

--- a/reference/ds/ds/set/first.xml
+++ b/reference/ds/ds/set/first.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="ds-set.first" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Ds\Set::first</refname>
-  <refpurpose>Renvoie la première valeur de la séquence</refpurpose>
+  <refpurpose>Renvoie la première valeur de l'ensemble</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -14,7 +14,7 @@
    <void />
   </methodsynopsis>
   <para>
-    Renvoie la première valeur de la séquence.
+    Renvoie la première valeur de l'ensemble.
   </para>
 
  </refsect1>
@@ -27,7 +27,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-    La première valeur de la séquence.
+    La première valeur de l'ensemble.
   </para>
  </refsect1>
 

--- a/reference/ds/ds/set/intersect.xml
+++ b/reference/ds/ds/set/intersect.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="ds-set.intersect" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Ds\Set::intersect</refname>
-  <refpurpose>Crée un nouvel ensemble en utilisant des valeurs communes avec une autre séquence</refpurpose>
+  <refpurpose>Crée un nouvel ensemble en utilisant des valeurs communes avec un autre ensemble</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -31,7 +31,7 @@
     <term><parameter>set</parameter></term>
     <listitem>
      <para>
-        L'autre séquence.
+        L'autre ensemble.
      </para>
     </listitem>
    </varlistentry>

--- a/reference/ds/ds/set/last.xml
+++ b/reference/ds/ds/set/last.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="ds-set.last" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Ds\Set::last</refname>
-  <refpurpose>Renvoie la dernière valeur de la séquence</refpurpose>
+  <refpurpose>Renvoie la dernière valeur de l'ensemble</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -14,7 +14,7 @@
    <void />
   </methodsynopsis>
   <para>
-    Renvoie la dernière valeur de la séquence.
+    Renvoie la dernière valeur de l'ensemble.
   </para>
 
  </refsect1>
@@ -27,7 +27,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-    La dernière valeur de la séquence.
+    La dernière valeur de l'ensemble.
   </para>
  </refsect1>
 

--- a/reference/ds/ds/set/map.xml
+++ b/reference/ds/ds/set/map.xml
@@ -14,7 +14,7 @@
    <methodparam><type>callable</type><parameter>callback</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Renvoie le résultat de l'application d'une <parameter>fonction de rappel</parameter> à
+   Renvoie le résultat de l'application d'une fonction de rappel <parameter>callback</parameter> à
    chaque valeur de l'ensemble.
   </para>
  </refsect1>
@@ -42,7 +42,7 @@
   &reftitle.returnvalues;
   <para>
    Renvoie un nouvel objet <classname>Ds\Set</classname> où chaque valeur
-   est le résultat de l'application de la <parameter>fonction de rappel</parameter> à chaque valeur
+   est le résultat de l'application de la fonction de rappel <parameter>callback</parameter> à chaque valeur
    de l'ensemble.
   </para>
  </refsect1>

--- a/reference/ds/ds/set/merge.xml
+++ b/reference/ds/ds/set/merge.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="ds-set.merge" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Ds\Set::merge</refname>
-  <refpurpose>Renvoie le résultat de l'ajout de toutes les valeurs de la séquence</refpurpose>
+  <refpurpose>Renvoie le résultat de l'ajout de toutes les valeurs données à l'ensemble</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -14,7 +14,7 @@
    <methodparam><type>mixed</type><parameter>values</parameter></methodparam>
   </methodsynopsis>
   <para>
-    Renvoie le résultat de l'ajout de toutes les valeurs de la séquence.
+    Renvoie le résultat de l'ajout de toutes les valeurs données à l'ensemble.
   </para>
 
  </refsect1>
@@ -36,7 +36,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-    Le résultat de l'ajout de toutes les valeurs données à la séquence,
+    Le résultat de l'ajout de toutes les valeurs données à l'ensemble,
     effectivement le même que d'ajouter les valeurs à une copie, puis de renvoyer cette copie.
   </para>
   <note>

--- a/reference/ds/ds/set/remove.xml
+++ b/reference/ds/ds/set/remove.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="ds-set.remove" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Ds\Set::remove</refname>
-  <refpurpose>Supprime toutes les valeurs données de la séquence</refpurpose>
+  <refpurpose>Supprime toutes les valeurs données de l'ensemble</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -14,7 +14,7 @@
    <methodparam rep="repeat"><type>mixed</type><parameter>values</parameter></methodparam>
   </methodsynopsis>
   <para>
-    Supprime toutes les <parameter>values</parameter> données de la séquence, en ignorant celles qui ne sont pas dans la séquence.
+    Supprime toutes les <parameter>values</parameter> données de l'ensemble, en ignorant celles qui ne sont pas dans l'ensemble.
   </para>
 
  </refsect1>

--- a/reference/ds/ds/set/reversed.xml
+++ b/reference/ds/ds/set/reversed.xml
@@ -14,7 +14,7 @@
    <void />
   </methodsynopsis>
   <para>
-    Renvoie une copie renversée de la séquence.
+    Renvoie une copie renversée de l'ensemble.
   </para>
 
  </refsect1>
@@ -27,7 +27,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-    Une copie renversée de la séquence.
+    Une copie renversée de l'ensemble.
 
     <note>
         <para>

--- a/reference/ds/ds/set/slice.xml
+++ b/reference/ds/ds/set/slice.xml
@@ -29,11 +29,11 @@
     <term><parameter>index</parameter></term>
     <listitem>
         <para>
-            L'index auquel commence la sous-séquence .
+            L'index auquel commence le sous-ensemble.
         </para>
         <para>
-            Si positif, la sous-séquence commencera à cet index dans la séquence.
-            Si négatif, la sous-séquence commencera à cette distance de la fin.
+            Si positif, le sous-ensemble commencera à cet index dans l'ensemble.
+            Si négatif, le sous-ensemble commencera à cette distance de la fin.
         </para>
     </listitem>
     </varlistentry>
@@ -41,18 +41,18 @@
     <term><parameter>length</parameter></term>
     <listitem>
      <para>
-        Si une longueur est donnée et est positive, la sous-séquence résultante
+        Si une longueur est donnée et est positive, le sous-ensemble résultant
         aura jusqu'à autant de valeurs.
 
         Si la longueur entraîne un dépassement, seules
         les valeurs jusqu'à la fin de l'ensemble seront incluses.
 
-        Si une longueur est donnée et est négative, la sous-séquence
+        Si une longueur est donnée et est négative, le sous-ensemble
         s'arrêtera à autant de valeurs de la fin.
 
-        Si une longueur n'est pas fournie, la sous-séquence
+        Si une longueur n'est pas fournie, le sous-ensemble
         contiendra toutes les valeurs entre l'index et la
-        fin de la séquence.
+        fin de l'ensemble.
      </para>
     </listitem>
    </varlistentry>

--- a/reference/ds/ds/set/sort.xml
+++ b/reference/ds/ds/set/sort.xml
@@ -69,7 +69,7 @@ Ds\Set Object
    </screen>
   </example>
   <example>
-   <title>Exemple de <function>Ds\Set::sort</function></title>
+   <title>Exemple de <function>Ds\Set::sort</function> en utilisant un comparateur</title>
    <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/ds/ds/set/sorted.xml
+++ b/reference/ds/ds/set/sorted.xml
@@ -14,7 +14,7 @@
    <methodparam choice="opt"><type>callable</type><parameter>comparator</parameter></methodparam>
   </methodsynopsis>
   <para>
-    Renvoie une copie triée de la séquence, en utilisant une fonction <parameter>comparator</parameter> optionnelle.
+    Renvoie une copie triée de l'ensemble, en utilisant une fonction <parameter>comparator</parameter> optionnelle.
   </para>
 
  </refsect1>
@@ -34,7 +34,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-    Renvoie une copie triée de la séquence.
+    Renvoie une copie triée de l'ensemble.
   </para>
  </refsect1>
 

--- a/reference/ds/ds/set/sum.xml
+++ b/reference/ds/ds/set/sum.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="ds-set.sum" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Ds\Set::sum</refname>
-  <refpurpose>Renvoie la somme de toutes les valeurs de la séquence</refpurpose>
+  <refpurpose>Renvoie la somme de toutes les valeurs de l'ensemble</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -14,7 +14,7 @@
    <void />
   </methodsynopsis>
   <para>
-    Renvoie la somme de toutes les valeurs de la séquence.
+    Renvoie la somme de toutes les valeurs de l'ensemble.
   </para>
   <note>
     <para>
@@ -33,7 +33,7 @@
   &reftitle.returnvalues;
   <para>
     La somme de toutes les valeurs de l'ensemble en tant que <type>float</type> ou <type>int</type>
-    en fonction des valeurs de la séquence.
+    en fonction des valeurs de l'ensemble.
   </para>
  </refsect1>
 

--- a/reference/ds/ds/set/toarray.xml
+++ b/reference/ds/ds/set/toarray.xml
@@ -34,7 +34,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-    Un &array; contenant toutes les valeurs dans le même ordre que la séquence.
+    Un &array; contenant toutes les valeurs dans le même ordre que l'ensemble.
   </para>
  </refsect1>
 

--- a/reference/ds/ds/set/xor.xml
+++ b/reference/ds/ds/set/xor.xml
@@ -16,6 +16,7 @@
   <para>
     Crée un nouvel ensemble qui contient les valeurs de l'instance actuelle
     ou d'un autre <parameter>set</parameter>,
+    mais pas des deux.
   </para>
   <para>
     <code>A ⊖ B = {x : x ∈ (A \ B) ∪ (B \ A)}</code>
@@ -29,7 +30,7 @@
     <term><parameter>set</parameter></term>
     <listitem>
      <para>
-        L'autre séquence.
+        L'autre ensemble.
      </para>
     </listitem>
    </varlistentry>

--- a/reference/ds/ds/vector/apply.xml
+++ b/reference/ds/ds/vector/apply.xml
@@ -34,11 +34,11 @@
              </methodsynopsis>
         </para>
         <para>
-            Un <type>callable</type> à appliquer à chaque valeur de la carte.
+            Un <type>callable</type> à appliquer à chaque valeur du vecteur.
         </para>
 
         <para>
-            La fonction de rappel doit retourner la valeur par laquelle elle doit être remplacée.
+            La fonction de rappel devrait retourner la valeur par laquelle elle doit être remplacée.
         </para>
     </listitem>
 

--- a/reference/ds/ds/vector/construct.xml
+++ b/reference/ds/ds/vector/construct.xml
@@ -14,8 +14,8 @@
    <methodparam choice="opt"><type>mixed</type><parameter>values</parameter></methodparam>
   </constructorsynopsis>
   <para>
-    Crée une nouvelle instance, en utilisant soit un objet <classname>traversable</classname>
-    ou un &array; pour les <parameter>valeurs</parameter> initiales.
+    Crée une nouvelle instance, en utilisant soit un objet <classname>traversable</classname>,
+    soit un &array; pour les <parameter>values</parameter> initiales.
   </para>
  </refsect1>
 

--- a/reference/ds/ds/vector/contains.xml
+++ b/reference/ds/ds/vector/contains.xml
@@ -35,7 +35,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-    &false; si l'une des <parameter>valeurs</parameter> fournies n'est pas dans le
+    &false; si l'une des <parameter>values</parameter> fournies n'est pas dans le
     vecteur, sinon &true;.
   </para>
  </refsect1>

--- a/reference/ds/ds/vector/find.xml
+++ b/reference/ds/ds/vector/find.xml
@@ -16,7 +16,7 @@
    <methodparam><type>mixed</type><parameter>value</parameter></methodparam>
   </methodsynopsis>
   <para>
-    Renvoie l'index de la <parameter>valeur</parameter>, ou &false; si non trouvée.
+    Renvoie l'index de la <parameter>value</parameter>, ou &false; si non trouvée.
   </para>
 
  </refsect1>

--- a/reference/ds/ds/vector/join.xml
+++ b/reference/ds/ds/vector/join.xml
@@ -35,7 +35,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-    Toutes les valeurs de la séquence rassemblées en une chaîne.
+    Toutes les valeurs du vecteur rassemblées en une chaîne.
   </para>
  </refsect1>
 

--- a/reference/ds/ds/vector/map.xml
+++ b/reference/ds/ds/vector/map.xml
@@ -34,7 +34,7 @@
              </methodsynopsis>
          </para>
          <para>
-            Une <type>fonction de rappel</type> à appliquer à chaque valeur de la deque.
+            Un <type>callable</type> à appliquer à chaque valeur du vecteur.
          </para>
 
          <para>

--- a/reference/zookeeper/configure.xml
+++ b/reference/zookeeper/configure.xml
@@ -17,7 +17,7 @@
  <para>
   Pour utiliser zookeeper, configurer PHP avec l'option 
   <option role="configure">--with-libzookeeper-dir=DIR</option>.
-  DIR est le prefixe du dossier d'installation du client C, il doit contenir le 
+  DIR est le préfixe du dossier d'installation du client C, il doit contenir le
   fichier <filename>include/zookeeper/zookeeper.h</filename>
  </para>
  <para>

--- a/reference/zookeeper/functions/zookeeper_dispatch.xml
+++ b/reference/zookeeper/functions/zookeeper_dispatch.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="function.zookeeper-dispatch" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>zookeeper_dispatch</refname>
-  <refpurpose>Appelle les fonctions de rappels pour les opérations en attente</refpurpose>
+  <refpurpose>Appelle les fonctions de rappel pour les opérations en attente</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -15,7 +15,7 @@
   </methodsynopsis>
 
   <para>
-   La fonction <function>zookeeper_dispatch</function> appelle les fonctions de rappels passées par les opérations comme <methodname>Zookeeper::get</methodname> ou <methodname>Zookeeper::exists</methodname>.
+   La fonction <function>zookeeper_dispatch</function> appelle les fonctions de rappel passées par les opérations comme <methodname>Zookeeper::get</methodname> ou <methodname>Zookeeper::exists</methodname>.
   </para>
 
   <caution>
@@ -54,7 +54,7 @@
   <example xml:id="function.zookeeper-dispatch.example.1">
    <title>Exemple de <methodname>zookeeper_dispatch</methodname> #1</title>
    <para>
-     Répartir manuellement les fonctions de rappels.
+     Répartir manuellement les fonctions de rappel.
    </para>
    <programlisting role="php">
 <![CDATA[

--- a/reference/zookeeper/ini.xml
+++ b/reference/zookeeper/ini.xml
@@ -70,7 +70,7 @@
     </term>
     <listitem>
      <para>
-      Autorise le verrouillage des sessions PHP
+      Autorise le verrouillage des sessions PHP.
      </para>
     </listitem>
    </varlistentry>
@@ -83,7 +83,7 @@
     <listitem>
      <para>
       Temps d'attente en microsecondes pour les tentatives de verrouillage de la session PHP.
-      Soyez prudent lors de la définition de cette valeur. Les valeurs valides sont des entiers, 
+      Il faut être prudent lors de la définition de cette valeur. Les valeurs valides sont des entiers,
       où 0 est interprété comme la valeur par défaut.
       Les valeurs négatives entraînent un verrouillage réduit à une tentative de verrouillage.
      </para>

--- a/reference/zookeeper/zookeeper.xml
+++ b/reference/zookeeper/zookeeper.xml
@@ -737,7 +737,7 @@
      <varlistentry xml:id="zookeeper.constants.invalidcallback">
       <term><constant>Zookeeper::INVALIDCALLBACK</constant></term>
       <listitem>
-       <para>Callback spécifié invalide.</para>
+       <para>Fonction de rappel spécifiée invalide.</para>
       </listitem>
      </varlistentry>
      <varlistentry xml:id="zookeeper.constants.invalidacl">

--- a/reference/zookeeper/zookeeper/delete.xml
+++ b/reference/zookeeper/zookeeper/delete.xml
@@ -53,7 +53,7 @@
   </para>
   <caution>
     <para>
-      Depuis la version 0.3.0, cette méthode émet <classname>ZookeeperException</classname> et ses dérivés.
+      À partir de la version 0.3.0, cette méthode émet <classname>ZookeeperException</classname> et ses dérivés.
     </para>
   </caution>
  </refsect1>

--- a/reference/zookeeper/zookeeper/isrecoverable.xml
+++ b/reference/zookeeper/zookeeper/isrecoverable.xml
@@ -27,7 +27,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Renvoie true/faux en cas de succès, et faux en cas d'échec.
+   Renvoie true/false en cas de succès, et false en cas d'échec.
   </para>
  </refsect1>
 

--- a/reference/zookeeper/zookeeper/setdebuglevel.xml
+++ b/reference/zookeeper/zookeeper/setdebuglevel.xml
@@ -81,7 +81,7 @@ SUCCESS
  <refsect1 role="seealso">
   &reftitle.seealso;
   <simplelist>
-   <member><link linkend="zookeeper.constants.log-levels">Niveau de journalisation ZooKeeper</link></member>
+   <member><link linkend="zookeeper.constants.log-levels">Niveaux de journalisation ZooKeeper</link></member>
    <member><classname>ZookeeperException</classname></member>
   </simplelist>
  </refsect1>

--- a/reference/zookeeper/zookeeper/setwatcher.xml
+++ b/reference/zookeeper/zookeeper/setwatcher.xml
@@ -44,7 +44,7 @@
   </para>
   <caution>
     <para>
-      Depuis la version 0.3.0, cette méthode émet <classname>ZookeeperException</classname> et ses dérivés.
+      À partir de la version 0.3.0, cette méthode émet <classname>ZookeeperException</classname> et ses dérivés.
     </para>
   </caution>
  </refsect1>

--- a/security/database.xml
+++ b/security/database.xml
@@ -253,7 +253,7 @@ union select '1', concat(uname||'-'||passwd) as name, '1971-01-01', '0' from use
    </para>
    <para>
     Les instructions <literal>UPDATE</literal> et <literal>INSERT</literal> sont également
-    susceptibles à de telles attaques
+    susceptibles de telles attaques.
     <example>
      <title>Modifier un mot de passe ... et gain de droits ! (n'importe quel serveur de bases de données)</title>
      <programlisting role="php">

--- a/security/errors.xml
+++ b/security/errors.xml
@@ -108,7 +108,7 @@
   soit de désactiver l'affichage des erreurs en utilisant l'option de configuration
   <literal>display_errors</literal> de &php.ini;. En choisissant la
   seconde solution, il est également recommandé de définir le chemin vers le fichier
-  de log en utilisant la directive de configuration <literal>error_log</literal>,
+  de journal d'événements en utilisant la directive de configuration <literal>error_log</literal>,
   et d'activer la directive <literal>log_errors</literal>.
   <example>
    <title>Détecter des variables non protégées avec E_ALL</title>

--- a/security/filesystem.xml
+++ b/security/filesystem.xml
@@ -54,10 +54,10 @@ echo "Ce fichier a été effacé !";
   documents dans les comptes des autres utilisateurs.
   Dans ce cas, il est préférable d'utiliser une autre forme d'identification.
   Il faut considérer ce qui pourrait se passer si les utilisateurs passent
-  <literal>../etc/</literal> et <literal>passwd</literal> comme arguments!
+  <literal>../etc/</literal> et <literal>passwd</literal> comme arguments !
   Le code serait exécuté tel que :
   <example>
-   <title>Une attaque du système de fichiers!</title>
+   <title>Une attaque du système de fichiers !</title>
    <programlisting role="php">
 <![CDATA[
 <?php

--- a/security/general.xml
+++ b/security/general.xml
@@ -31,7 +31,7 @@
   bien notées, avec l'heure à laquelle elles ont été exécutées, depuis
   quel emplacement géographique, leur type, etc. mais que l'utilisateur
   est identifié uniquement par un cookie, la robustesse du lien entre
-  l'utilisateur et les logs de transactions est sévèrement réduite.
+  l'utilisateur et le journal des transactions est sévèrement réduite.
  </simpara>
  <simpara>
   Lors des tests d'un site, il faut garder à l'esprit qu'il est impossible


### PR DESCRIPTION
Corrections de traduction (contresens, accords, glossaire) sur `reference/dom/`, `reference/ds/`, `reference/zookeeper/` et `security/`.