### PR TITLE
Sync EN: Fix various typos across the manual (#5570)

### DIFF
--- a/appendices/migration56/openssl.xml
+++ b/appendices/migration56/openssl.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 497c40ac164d5873fd87f622dfdeb5206392b446 Maintainer: jbnahan Status: ready -->
+<!-- EN-Revision: ee1ce6a0e1875b6851274f8c373ca2bd48630fa0 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes Maintainer: girgias -->
 <sect1 xml:id="migration56.openssl" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Changement pour OpenSSL dans PHP 5.6.x</title>

--- a/appendices/migration80/new-classes.xml
+++ b/appendices/migration80/new-classes.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 0b48d83885dc23f3818284dd6c10f21890cdf72a Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: ee1ce6a0e1875b6851274f8c373ca2bd48630fa0 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <sect1 xml:id="migration80.new-classes" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Nouvelles classes et interfaces</title>

--- a/appendices/migration83/new-features.xml
+++ b/appendices/migration83/new-features.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 617b58b308d1f1916efaa4a3eb158fed251ae439 Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: ee1ce6a0e1875b6851274f8c373ca2bd48630fa0 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <sect1 xml:id="migration83.new-features" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Nouvelles fonctionnalités</title>

--- a/appendices/migration84/deprecated.xml
+++ b/appendices/migration84/deprecated.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e3fc9c49817a5249d1efb9c79c93307ecebf2f53 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: ee1ce6a0e1875b6851274f8c373ca2bd48630fa0 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <sect1 xml:id="migration84.deprecated">
  <title>Fonctionnalités dépréciées</title>

--- a/chmonly/integration.xml
+++ b/chmonly/integration.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 96c9d88bad9a7d7d44bfb7f26c226df7ee9ddf26 Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: ee1ce6a0e1875b6851274f8c373ca2bd48630fa0 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
  <chapter xml:id="chm.integration" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
   <title>Intégration du Manuel PHP</title>

--- a/install/macos/bundled.xml
+++ b/install/macos/bundled.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 04d9aded7bbd447523cf038ddf88e6d7f7e43c53 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: ee1ce6a0e1875b6851274f8c373ca2bd48630fa0 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 
 <sect1 xml:id="install.macosx.bundled" xmlns="http://docbook.org/ns/docbook">

--- a/install/unix/debian.xml
+++ b/install/unix/debian.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4cb53ecbd763db2db808e90d7eda63afb380e6df Maintainer: gui Status: ready -->
+<!-- EN-Revision: ee1ce6a0e1875b6851274f8c373ca2bd48630fa0 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 
 <sect1 xml:id="install.unix.debian" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/install/unix/dnf.xml
+++ b/install/unix/dnf.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4cb53ecbd763db2db808e90d7eda63afb380e6df Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: ee1ce6a0e1875b6851274f8c373ca2bd48630fa0 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <sect1 xml:id="install.unix.dnf" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Installation depuis les paquets sur les distributions GNU/Linux qui utilisent DNF</title>

--- a/language/basic-syntax.xml
+++ b/language/basic-syntax.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 0e618211e53c66f33762be225a4d57c08ef4b2f7 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: ee1ce6a0e1875b6851274f8c373ca2bd48630fa0 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <!-- CREDITS: DavidA -->
 

--- a/language/control-structures/for.xml
+++ b/language/control-structures/for.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 7104ee97ced1768a3231588dfc0bc0d7eb1117ad Maintainer: yannick Status: ready -->
+<!-- EN-Revision: ee1ce6a0e1875b6851274f8c373ca2bd48630fa0 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 
 <sect1 xml:id="control-structures.for" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/language/namespaces.xml
+++ b/language/namespaces.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 1fade2bc5f160b23c2f46c3f854b833fab0e69f4 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: ee1ce6a0e1875b6851274f8c373ca2bd48630fa0 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <!-- CREDITS: DAnnebicque -->
 <chapter xml:id="language.namespaces" xmlns="http://docbook.org/ns/docbook"

--- a/language/oop5/lazy-objects.xml
+++ b/language/oop5/lazy-objects.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 617cc59b5902de0cadd32883b72b113bf62cf1b6 Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: ee1ce6a0e1875b6851274f8c373ca2bd48630fa0 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <sect1 xml:id="language.oop5.lazy-objects" xmlns="http://docbook.org/ns/docbook">
  <title>Objets paresseux</title>

--- a/language/predefined/fiber/isrunning.xml
+++ b/language/predefined/fiber/isrunning.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 8fee3ae9715ffa15922469eb7d98f4878917a6ee Maintainer: pierrick Status: ready -->
+<!-- EN-Revision: ee1ce6a0e1875b6851274f8c373ca2bd48630fa0 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="fiber.isrunning" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>

--- a/language/predefined/stringable.xml
+++ b/language/predefined/stringable.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 85050f5f88cca909b14b7cccc1dcedbb784a4fd6 Maintainer: victor-prdh Status: ready -->
+<!-- EN-Revision: ee1ce6a0e1875b6851274f8c373ca2bd48630fa0 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <reference xml:id="class.stringable" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 

--- a/reference/apcu/apcuiterator/current.xml
+++ b/reference/apcu/apcuiterator/current.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 804d8a05451c13328eb1192553dcb2374706cabb Maintainer: moradZahid Status: ready -->
+<!-- EN-Revision: ee1ce6a0e1875b6851274f8c373ca2bd48630fa0 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="apcuiterator.current">
  <refnamediv>

--- a/reference/apcu/ini.xml
+++ b/reference/apcu/ini.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 804d8a05451c13328eb1192553dcb2374706cabb Maintainer: moradZahid Status: ready -->
+<!-- EN-Revision: ee1ce6a0e1875b6851274f8c373ca2bd48630fa0 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <section xmlns="http://docbook.org/ns/docbook" xml:id="apcu.configuration">
  &reftitle.runtime;

--- a/reference/array/functions/each.xml
+++ b/reference/array/functions/each.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 2e60c5134e7a847c99f81eb3f7ecee1f5efeeace Maintainer: yannick Status: ready -->
+<!-- EN-Revision: ee1ce6a0e1875b6851274f8c373ca2bd48630fa0 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <!-- CREDITS: DavidA. -->
 <refentry xml:id="function.each" xmlns="http://docbook.org/ns/docbook">

--- a/reference/calendar/constants.xml
+++ b/reference/calendar/constants.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 5e9500ddad6dbc2f1b01d7da8b53379c8b7c386c Maintainer: yannick Status: ready -->
+<!-- EN-Revision: ee1ce6a0e1875b6851274f8c373ca2bd48630fa0 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 
 <appendix xml:id="calendar.constants" xmlns="http://docbook.org/ns/docbook">

--- a/reference/calendar/functions/juliantojd.xml
+++ b/reference/calendar/functions/juliantojd.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: db43575bd6c986a35552e4cbdfd643ae05edd092 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: ee1ce6a0e1875b6851274f8c373ca2bd48630fa0 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 
 <refentry xml:id="function.juliantojd" xmlns="http://docbook.org/ns/docbook">

--- a/reference/com/dotnet/construct.xml
+++ b/reference/com/dotnet/construct.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 49ff12041acd30489ef8cb7b1e08ec1ddf4dc6bc Maintainer: girgias Status: ready -->
+<!-- EN-Revision: ee1ce6a0e1875b6851274f8c373ca2bd48630fa0 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="dotnet.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>

--- a/reference/com/functions/variant-date-to-timestamp.xml
+++ b/reference/com/functions/variant-date-to-timestamp.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 20216b916ed583938672cd09c2c2f430351430d1 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: ee1ce6a0e1875b6851274f8c373ca2bd48630fa0 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="function.variant-date-to-timestamp" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>

--- a/reference/cubrid/cubridmysql/cubrid-affected-rows.xml
+++ b/reference/cubrid/cubridmysql/cubrid-affected-rows.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 22492de2eede0a31a4ac486489d5475e1536354d Maintainer: yannick Status: ready -->
+<!-- EN-Revision: ee1ce6a0e1875b6851274f8c373ca2bd48630fa0 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.cubrid-affected-rows">
  <refnamediv>

--- a/reference/cubrid/cubridmysql/cubrid-ping.xml
+++ b/reference/cubrid/cubridmysql/cubrid-ping.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 22492de2eede0a31a4ac486489d5475e1536354d Maintainer: yannick Status: ready -->
+<!-- EN-Revision: ee1ce6a0e1875b6851274f8c373ca2bd48630fa0 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.cubrid-ping">
  <refnamediv>

--- a/reference/cubrid/functions/cubrid-bind.xml
+++ b/reference/cubrid/functions/cubrid-bind.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 22492de2eede0a31a4ac486489d5475e1536354d Maintainer: yannick Status: ready -->
+<!-- EN-Revision: ee1ce6a0e1875b6851274f8c373ca2bd48630fa0 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.cubrid-bind">
  <refnamediv>

--- a/reference/cubrid/functions/cubrid-execute.xml
+++ b/reference/cubrid/functions/cubrid-execute.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 22492de2eede0a31a4ac486489d5475e1536354d Maintainer: yannick Status: ready -->
+<!-- EN-Revision: ee1ce6a0e1875b6851274f8c373ca2bd48630fa0 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.cubrid-execute">
  <refnamediv>

--- a/reference/cubrid/functions/cubrid-set-autocommit.xml
+++ b/reference/cubrid/functions/cubrid-set-autocommit.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 22492de2eede0a31a4ac486489d5475e1536354d Maintainer: yannick Status: ready -->
+<!-- EN-Revision: ee1ce6a0e1875b6851274f8c373ca2bd48630fa0 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.cubrid-set-autocommit">
  <refnamediv>

--- a/reference/datetime/dateperiod.xml
+++ b/reference/datetime/dateperiod.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: ee1ce6a0e1875b6851274f8c373ca2bd48630fa0 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <!-- CREDITS: DavidA -->
 <reference xml:id="class.dateperiod" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">

--- a/reference/datetime/datetimeimmutable/createfromformat.xml
+++ b/reference/datetime/datetimeimmutable/createfromformat.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e2f2172bf114599926878017ab2dce356956fa9e Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: ee1ce6a0e1875b6851274f8c373ca2bd48630fa0 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="datetimeimmutable.createfromformat" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>

--- a/reference/datetime/functions/date-parse.xml
+++ b/reference/datetime/functions/date-parse.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: ee1ce6a0e1875b6851274f8c373ca2bd48630fa0 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="function.date-parse" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>

--- a/reference/dio/functions/dio-fcntl.xml
+++ b/reference/dio/functions/dio-fcntl.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 094906da54e6b9296c52505026c0f6a3fe68f6a6 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: ee1ce6a0e1875b6851274f8c373ca2bd48630fa0 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <!-- CREDITS: DavidA -->
 

--- a/reference/dio/functions/dio-tcsetattr.xml
+++ b/reference/dio/functions/dio-tcsetattr.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: bce2cb849721c70737eb32ce958131e22677770c Maintainer: jsgoupil Status: ready -->
+<!-- EN-Revision: ee1ce6a0e1875b6851274f8c373ca2bd48630fa0 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="function.dio-tcsetattr" xmlns="http://docbook.org/ns/docbook">
@@ -99,7 +99,7 @@ dio_tcsetattr($fd, array(
 
 while (true) {
     $data = dio_read($fd, 256);
-    if ($data !== null && $date !== '') {
+    if ($data !== null && $data !== '') {
         echo $data;
     }
 }

--- a/reference/dom/domdocument/adoptnode.xml
+++ b/reference/dom/domdocument/adoptnode.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 7d5c74c9a561dc63be999694ee65195bef1550a0 Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: ee1ce6a0e1875b6851274f8c373ca2bd48630fa0 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="domdocument.adoptnode" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>


### PR DESCRIPTION
Synchronisation des 32 fichiers FR concernés par la PR de typos php/doc-en#5570. Le hash EN-Revision est bumpé vers `ee1ce6a`.

La plupart des typos EN portaient sur de la prose anglaise déjà correctement traduite en FR (bump du hash uniquement). Le seul changement de contenu FR est la correction d'une coquille dans l'exemple de code de `dio_tcsetattr` (`$date` -> `$data`), elle aussi corrigée côté EN.

Fixes #2893
