### PR TITLE
Sync EN: documentation des fonctions SAPI LiteSpeed (#4922)

### DIFF
--- a/appendices/migration74/other-changes.xml
+++ b/appendices/migration74/other-changes.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 90242f8793566eb87ee35a989912310a7c7c132b Maintainer: girgias Status: ready -->
+<!-- EN-Revision: 8a0888aeb20d187289664eb1116fa30228837478 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <sect1 xml:id="migration74.other-changes" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Autres changements</title>
@@ -206,7 +206,7 @@
    </listitem>
 
    <listitem>
-    <simpara>Litespeed :</simpara>
+    <simpara>LiteSpeed :</simpara>
     <itemizedlist>
      <listitem>
       <simpara>

--- a/reference/apache/functions/apache-request-headers.xml
+++ b/reference/apache/functions/apache-request-headers.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 68e52ef14de33f6752a8fdda1ae83c861c5babdb Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 8a0888aeb20d187289664eb1116fa30228837478 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="function.apache-request-headers" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -13,10 +13,10 @@
    <type>array</type><methodname>apache_request_headers</methodname>
    <void/>
   </methodsynopsis>
-  <para>
+  <simpara>
    Récupère tous les en-têtes HTTP de la requête courante.
-   Fonctionne avec les serveurs web Apache, FastCGI, CLI, et FPM.
-  </para>
+   Fonctionne avec les serveurs web Apache, LiteSpeed, FastCGI, CLI, et FPM.
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -26,9 +26,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Un tableau associatif avec tous les en-têtes HTTP de la requête courante.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">
@@ -91,14 +91,14 @@ Connection: Keep-Alive
  <refsect1 role="notes">
   &reftitle.notes;
   <note>
-   <para>
+   <simpara>
     Il est aussi possible d'obtenir les valeurs des variables <acronym>CGI</acronym> communes
     en les lisant dans l'environnement, ce qui fonctionne, que l'on
     soit ou non en module <productname>Apache</productname>. Utiliser
     la fonction <function>phpinfo</function> pour connaître la liste des
     <link linkend="language.variables.predefined">variables d'environnement</link>
     disponibles.
-   </para>
+   </simpara>
   </note>
  </refsect1>
 

--- a/reference/apache/functions/apache-response-headers.xml
+++ b/reference/apache/functions/apache-response-headers.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 68e52ef14de33f6752a8fdda1ae83c861c5babdb Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 8a0888aeb20d187289664eb1116fa30228837478 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="function.apache-response-headers" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -14,10 +14,10 @@
    <type>array</type><methodname>apache_response_headers</methodname>
    <void/>
   </methodsynopsis>
-  <para>
+  <simpara>
    Récupère tous les en-têtes de réponse HTTP.
-   Fonctionne avec les serveurs web Apache, FastCGI, CLI, et FPM.
-  </para>
+   Fonctionne avec les serveurs web Apache, LiteSpeed, FastCGI, CLI, et FPM.
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -27,9 +27,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Un tableau de tous les en-têtes de réponse d'Apache en cas de réussite.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/litespeed/book.xml
+++ b/reference/litespeed/book.xml
@@ -1,26 +1,24 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
 <!-- EN-Revision: 8a0888aeb20d187289664eb1116fa30228837478 Maintainer: lacatoire Status: ready -->
-<!-- Reviewed: yes -->
+<!-- Reviewed: no -->
 
-<book xml:id="book.apache" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+<book xml:id="book.litespeed" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <?phpdoc extension-membership="bundled" ?>
- <title>Apache</title>
+ <title>LiteSpeed</title>
 
- <!-- {{{ preface -->
- <preface xml:id="intro.apache">
+ <preface xml:id="intro.litespeed">
   &reftitle.intro;
   <simpara>
-   Ces fonctions sont disponibles lorsque PHP est exécuté comme module
-   Apache. Certaines fonctions peuvent être disponibles avec d'autres API
-   de serveur web. Consulter la documentation de chaque fonction pour les
-   détails.
+   Une API serveur optimisée pour exécuter PHP avec le serveur web LiteSpeed.
+  </simpara>
+  <simpara>
+   Cette SAPI est fournie avec PHP.
   </simpara>
  </preface>
- <!-- }}} -->
 
- &reference.apache.setup;
- &reference.apache.reference;
+ &reference.litespeed.setup;
+ &reference.litespeed.reference;
 
 </book>
 
@@ -44,4 +42,3 @@ vim600: syn=xml fen fdm=syntax fdl=2 si
 vim: et tw=78 syn=sgml
 vi: ts=1 sw=1
 -->
-

--- a/reference/litespeed/functions/litespeed-finish-request.xml
+++ b/reference/litespeed/functions/litespeed-finish-request.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 8a0888aeb20d187289664eb1116fa30228837478 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+<refentry xml:id="function.litespeed-finish-request" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>litespeed_finish_request</refname>
+  <refpurpose>Envoie toutes les données de la réponse au client</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>bool</type><methodname>litespeed_finish_request</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   Cette fonction envoie toutes les données de la réponse au client et
+   termine la requête. Ceci permet aux tâches consommatrices de temps
+   d'être effectuées sans laisser la connexion avec le client ouverte.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   &return.success;
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>7.2.18</entry>
+      <entry>
+       Cette fonction est devenue disponible.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>fastcgi_finish_request</function></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/litespeed/functions/litespeed-request-headers.xml
+++ b/reference/litespeed/functions/litespeed-request-headers.xml
@@ -1,28 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
 <!-- EN-Revision: 8a0888aeb20d187289664eb1116fa30228837478 Maintainer: lacatoire Status: ready -->
-<!-- Reviewed: yes -->
+<!-- Reviewed: no -->
+<refentry xml:id="function.litespeed-request-headers" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>litespeed_request_headers</refname>
+  <refpurpose>&Alias;
+   <function>apache_request_headers</function>
+  </refpurpose>
+ </refnamediv>
 
-<book xml:id="book.apache" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
- <?phpdoc extension-membership="bundled" ?>
- <title>Apache</title>
-
- <!-- {{{ preface -->
- <preface xml:id="intro.apache">
-  &reftitle.intro;
+ <refsect1 role="description">
+  &reftitle.description;
   <simpara>
-   Ces fonctions sont disponibles lorsque PHP est exécuté comme module
-   Apache. Certaines fonctions peuvent être disponibles avec d'autres API
-   de serveur web. Consulter la documentation de chaque fonction pour les
-   détails.
+   &info.function.alias;
+   <function>apache_request_headers</function>.
   </simpara>
- </preface>
- <!-- }}} -->
-
- &reference.apache.setup;
- &reference.apache.reference;
-
-</book>
+ </refsect1>
+</refentry>
 
 <!-- Keep this comment at the end of the file
 Local variables:
@@ -44,4 +39,3 @@ vim600: syn=xml fen fdm=syntax fdl=2 si
 vim: et tw=78 syn=sgml
 vi: ts=1 sw=1
 -->
-

--- a/reference/litespeed/functions/litespeed-response-headers.xml
+++ b/reference/litespeed/functions/litespeed-response-headers.xml
@@ -1,28 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
 <!-- EN-Revision: 8a0888aeb20d187289664eb1116fa30228837478 Maintainer: lacatoire Status: ready -->
-<!-- Reviewed: yes -->
+<!-- Reviewed: no -->
+<refentry xml:id="function.litespeed-response-headers" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>litespeed_response_headers</refname>
+  <refpurpose>&Alias;
+   <function>apache_response_headers</function>
+  </refpurpose>
+ </refnamediv>
 
-<book xml:id="book.apache" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
- <?phpdoc extension-membership="bundled" ?>
- <title>Apache</title>
-
- <!-- {{{ preface -->
- <preface xml:id="intro.apache">
-  &reftitle.intro;
+ <refsect1 role="description">
+  &reftitle.description;
   <simpara>
-   Ces fonctions sont disponibles lorsque PHP est exécuté comme module
-   Apache. Certaines fonctions peuvent être disponibles avec d'autres API
-   de serveur web. Consulter la documentation de chaque fonction pour les
-   détails.
+   &info.function.alias;
+   <function>apache_response_headers</function>.
   </simpara>
- </preface>
- <!-- }}} -->
-
- &reference.apache.setup;
- &reference.apache.reference;
-
-</book>
+ </refsect1>
+</refentry>
 
 <!-- Keep this comment at the end of the file
 Local variables:
@@ -44,4 +39,3 @@ vim600: syn=xml fen fdm=syntax fdl=2 si
 vim: et tw=78 syn=sgml
 vi: ts=1 sw=1
 -->
-

--- a/reference/litespeed/reference.xml
+++ b/reference/litespeed/reference.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 8a0888aeb20d187289664eb1116fa30228837478 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+
+<reference xml:id="ref.litespeed" xmlns="http://docbook.org/ns/docbook">
+ <title>&Functions; LiteSpeed</title>
+
+ &reference.litespeed.entities.functions;
+
+</reference>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/litespeed/setup.xml
+++ b/reference/litespeed/setup.xml
@@ -1,28 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
 <!-- EN-Revision: 8a0888aeb20d187289664eb1116fa30228837478 Maintainer: lacatoire Status: ready -->
-<!-- Reviewed: yes -->
+<!-- Reviewed: no -->
 
-<book xml:id="book.apache" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
- <?phpdoc extension-membership="bundled" ?>
- <title>Apache</title>
+<chapter xml:id="litespeed.setup" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ &reftitle.setup;
 
- <!-- {{{ preface -->
- <preface xml:id="intro.apache">
-  &reftitle.intro;
+ <!-- {{{ Installation -->
+ <section xml:id="litespeed.installation">
+  &reftitle.install;
   <simpara>
-   Ces fonctions sont disponibles lorsque PHP est exécuté comme module
-   Apache. Certaines fonctions peuvent être disponibles avec d'autres API
-   de serveur web. Consulter la documentation de chaque fonction pour les
-   détails.
+   Pour l'installation de PHP avec LiteSpeed, voir le <link
+   linkend="install.unix.litespeed">chapitre d'installation</link>.
   </simpara>
- </preface>
+ </section>
  <!-- }}} -->
 
- &reference.apache.setup;
- &reference.apache.reference;
-
-</book>
+</chapter>
 
 <!-- Keep this comment at the end of the file
 Local variables:
@@ -44,4 +38,3 @@ vim600: syn=xml fen fdm=syntax fdl=2 si
 vim: et tw=78 syn=sgml
 vi: ts=1 sw=1
 -->
-


### PR DESCRIPTION
Sync EN de php/doc-en#4922 : traduction de l'extension LiteSpeed (litespeed_finish_request, litespeed_request_headers, litespeed_response_headers) et synchronisation des fichiers apache + migration74 (ajout de LiteSpeed aux listes de serveurs, mirroring para -> simpara).

appendices/extensions.xml n'est pas porté par doc-fr (comme les versions.xml), donc non concerné.

Fixes #2896