### PR TITLE
Sync EN: grapheme_strlen retourne null en cas d'échec d'encodage (#5568)

### DIFF
--- a/reference/intl/grapheme/grapheme-strlen.xml
+++ b/reference/intl/grapheme/grapheme-strlen.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: b548fc8e5592b577d29aabf9cf2e79d5385ae549 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: e7d502fecc2e84d4c57e6451b16f68bec1295ba8 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="function.grapheme-strlen" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -40,9 +40,9 @@
  
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
-   La taille de la chaîne en cas de succès, &return.falseforfailure;.
-  </para>
+  <simpara>
+   La taille de la chaîne en cas de succès, &null; ou &false; en cas d'échec.
+  </simpara>
  </refsect1>
  
  <refsect1 role="examples">


### PR DESCRIPTION
Sync EN de php/doc-en#5568 : la valeur de retour de grapheme_strlen documente désormais &null; ou &false; en cas d'échec (mirroring para -> simpara).

Fixes #2895