### PR TITLE
Sync EN: imagecopyresampled, entrée changelog 8.5.0 sur le type de retour (#5291)

### DIFF
--- a/reference/image/functions/imagecopyresampled.xml
+++ b/reference/image/functions/imagecopyresampled.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: fcd9214294f88b05862a538c6dd94c7872420139 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 16b6c3466bb70f2300b236273003f509638ebb90 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 
 <refentry xml:id="function.imagecopyresampled" xmlns="http://docbook.org/ns/docbook">
@@ -147,6 +147,13 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Le type de retour est désormais &true; ; auparavant, il s'agissait de
+       <type>bool</type>.
+      </entry>
+     </row>
      <row>
       <entry>8.0.0</entry>
       <entry>


### PR DESCRIPTION
Synchronisation avec php/doc-en#5291 : ajout de l'entrée changelog 8.5.0 (le type de retour est désormais &true; ; auparavant <type>bool</type>).

Fixes #2900