### PR TITLE
Sync EN: DelayedTargetValidation, traduction de l'attribut (PHP 8.5) (#5457)

### DIFF
--- a/language/predefined/attributes.xml
+++ b/language/predefined/attributes.xml
@@ -1,17 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 02bee41067ab2822cbffcb4b3b2387f79488dffd Maintainer: pierrick Status: ready -->
+<!-- EN-Revision: efda0bb311990257715bd3a41ab2b04769ce2e4e Maintainer: pierrick Status: ready -->
 <!-- Reviewed: no -->
 <part xml:id="reserved.attributes" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Attributs prédéfinis</title>
 
  <partintro>
-  <para>
+  <simpara>
    PHP fournit des attributs prédéfinis qui peuvent être utilisés.
-  </para>
+  </simpara>
  </partintro>
 
  &language.predefined.attributes.attribute;
  &language.predefined.attributes.allowdynamicproperties;
+ &language.predefined.attributes.delayedtargetvalidation;
  &language.predefined.attributes.deprecated;
  &language.predefined.attributes.nodiscard;
  &language.predefined.attributes.override;

--- a/language/predefined/attributes/delayedtargetvalidation.xml
+++ b/language/predefined/attributes/delayedtargetvalidation.xml
@@ -1,0 +1,139 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: efda0bb311990257715bd3a41ab2b04769ce2e4e Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+<reference xml:id="class.delayedtargetvalidation" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+ <title>L'attribut DelayedTargetValidation</title>
+ <titleabbrev>DelayedTargetValidation</titleabbrev>
+
+ <partintro>
+
+  <section xml:id="delayedtargetvalidation.intro">
+   &reftitle.intro;
+   <simpara>
+    Cet attribut diffère les erreurs de validation de cible des attributs
+    internes, du moment de la compilation à celui où l'attribut est instancié
+    via l'API de Réflexion.
+   </simpara>
+   <simpara>
+    Lorsqu'il est appliqué à une déclaration, toute utilisation invalide
+    d'attributs internes sur la même cible ne déclenche pas d'erreur à la
+    compilation. À la place, la validation est différée et effectuée lorsque
+    l'attribut est instancié via
+    <link linkend="reflectionattribute.newinstance">ReflectionAttribute::newInstance()</link>.
+   </simpara>
+   <simpara>
+    Cela vise principalement la compatibilité ascendante, permettant à du code
+    d'utiliser des attributs susceptibles d'acquérir de nouvelles cibles valides
+    dans de futures versions de PHP, sans casser sur les versions plus anciennes.
+   </simpara>
+  </section>
+
+  <section xml:id="delayedtargetvalidation.synopsis">
+   &reftitle.classsynopsis;
+
+   <classsynopsis class="class">
+    <ooclass>
+     <modifier role="attribute">#[\Attribute]</modifier>
+     <modifier>final</modifier>
+     <classname>DelayedTargetValidation</classname>
+    </ooclass>
+   </classsynopsis>
+
+  </section>
+
+  <section xml:id="delayedtargetvalidation.examples">
+   &reftitle.examples;
+
+   <example>
+    <title>Différer la validation d'une cible invalide</title>
+    <programlisting role="php"><![CDATA[
+<?php
+
+class Base {
+    protected function foo(): void {}
+}
+
+class Child extends Base {
+
+    #[\DelayedTargetValidation]
+    #[\Override]
+    public const NAME = 'child';
+
+    #[\Override]
+    protected function foo(): void {}
+}
+]]></programlisting>
+
+    <simpara>
+     Sur les versions de PHP où <classname>Override</classname> n'est pas
+     autorisé sur les constantes de classe, cela ne produit pas d'erreur à la
+     compilation.
+    </simpara>
+   </example>
+
+   <example>
+    <title>La validation a lieu lors de la réflexion</title>
+    <programlisting role="php"><![CDATA[
+<?php
+
+$reflection = new ReflectionClassConstant(Child::class, 'NAME');
+
+foreach ($reflection->getAttributes() as $attribute) {
+    $attribute->newInstance(); // Peut lever une exception si invalide
+}
+]]></programlisting>
+
+    <simpara>
+     Lorsqu'un attribut quelconque appliqué à la même cible (autre que
+     DelayedTargetValidation lui-même) est instancié via la réflexion à l'aide
+     de <link linkend="reflectionattribute.newinstance">ReflectionAttribute::newInstance()</link>,
+     la validation de cible est effectuée et une exception peut être levée si
+     l'attribut est utilisé sur une cible non prise en charge.
+    </simpara>
+   </example>
+
+  </section>
+
+  <section xml:id="delayedtargetvalidation.notes">
+   &reftitle.notes;
+   <simpara>
+    Cet attribut n'affecte que la validation de cible des attributs internes.
+   </simpara>
+   <simpara>
+    Il ne supprime pas la validation fonctionnelle effectuée par ces attributs.
+    Par exemple, <classname>Override</classname> émettra toujours une erreur si
+    une méthode ne redéfinit pas réellement une méthode parente.
+   </simpara>
+  </section>
+
+  <section xml:id="delayedtargetvalidation.seealso">
+   &reftitle.seealso;
+   <simplelist>
+    <member><link linkend="language.attributes">Vue d'ensemble des attributs</link></member>
+    <member><link linkend="class.override">Override</link></member>
+   </simplelist>
+  </section>
+
+ </partintro>
+
+</reference>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/language/predefined/attributes/delayedtargetvalidation.xml
+++ b/language/predefined/attributes/delayedtargetvalidation.xml
@@ -12,7 +12,7 @@
    <simpara>
     Cet attribut diffère les erreurs de validation de cible des attributs
     internes, du moment de la compilation à celui où l'attribut est instancié
-    via l'API de Réflexion.
+    via l'API de réflexion.
    </simpara>
    <simpara>
     Lorsqu'il est appliqué à une déclaration, toute utilisation invalide
@@ -24,7 +24,7 @@
    <simpara>
     Cela vise principalement la compatibilité ascendante, permettant à du code
     d'utiliser des attributs susceptibles d'acquérir de nouvelles cibles valides
-    dans de futures versions de PHP, sans casser sur les versions plus anciennes.
+    dans de futures versions de PHP, sans échouer sur les versions plus anciennes.
    </simpara>
   </section>
 


### PR DESCRIPTION
Synchronisation avec php/doc-en#5457 : traduction de la page de l'attribut <classname>DelayedTargetValidation</classname> (PHP 8.5) et ajout de la référence dans attributes.xml ; para -> simpara dans l'intro.

Fixes #2899