### PR TITLE
Sync EN: corrections d'orthographe diverses du manuel (#5571)

### DIFF
--- a/reference/dom/functions/dom-import-simplexml.xml
+++ b/reference/dom/functions/dom-import-simplexml.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 54935fc4b239f498040cc1fa3f7e6eef8f048671 Maintainer: dams Status: ready -->
+<!-- EN-Revision: 940ea8c1b2b727eb0f3f6412305ab699b9b47cc6 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="function.dom-import-simplexml" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -15,13 +15,13 @@
    <type class="union"><type>DOMAttr</type><type>DOMElement</type></type><methodname>dom_import_simplexml</methodname>
    <methodparam><type>object</type><parameter>node</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Cette fonction prend l'attribut ou l'élément donné <parameter>node</parameter> (une
    instance de <classname>SimpleXMLElement</classname>) et crée respectivement un nœud
    <classname>DOMAttr</classname> ou <classname>DOMElement</classname>.
    Le nouveau <classname>DOMNode</classname> fait référence au même nœud XML sous-jacent
    que le <classname>SimpleXMLElement</classname>.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;

--- a/reference/eio/book.xml
+++ b/reference/eio/book.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 4e53894013ec0d223e2723ece46447ba00d5baf5 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 940ea8c1b2b727eb0f3f6412305ab699b9b47cc6 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <book xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="book.eio">
  <?phpdoc extension-membership="pecl" ?>

--- a/reference/eio/constants.xml
+++ b/reference/eio/constants.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 4e53894013ec0d223e2723ece46447ba00d5baf5 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 940ea8c1b2b727eb0f3f6412305ab699b9b47cc6 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <appendix xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="eio.constants">
  &reftitle.constants;

--- a/reference/eio/functions/eio-realpath.xml
+++ b/reference/eio/functions/eio-realpath.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 4e53894013ec0d223e2723ece46447ba00d5baf5 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 940ea8c1b2b727eb0f3f6412305ab699b9b47cc6 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.eio-realpath">
  <refnamediv>
@@ -79,11 +79,11 @@
 <?php
 var_dump(getcwd());
 
-function my_realpath_allback($data, $result) {
+function my_realpath_callback($data, $result) {
     var_dump($result);
 }
 
-eio_realpath("../", EIO_PRI_DEFAULT, "my_realpath_allback");
+eio_realpath("../", EIO_PRI_DEFAULT, "my_realpath_callback");
 eio_event_loop();
 ?>
 ]]>

--- a/reference/enchant/functions/enchant-broker-free-dict.xml
+++ b/reference/enchant/functions/enchant-broker-free-dict.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: a6b55f8de61955b35c83fec32651201cce4aa383 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 940ea8c1b2b727eb0f3f6412305ab699b9b47cc6 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.enchant-broker-free-dict">
  <refnamediv>

--- a/reference/enchant/functions/enchant-broker-request-pwl-dict.xml
+++ b/reference/enchant/functions/enchant-broker-request-pwl-dict.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: a6b55f8de61955b35c83fec32651201cce4aa383 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 940ea8c1b2b727eb0f3f6412305ab699b9b47cc6 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.enchant-broker-request-pwl-dict">
  <refnamediv>

--- a/reference/ev/ev.xml
+++ b/reference/ev/ev.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: b4fbf4434abeca44c58575ff3967e5640f7877d5 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 940ea8c1b2b727eb0f3f6412305ab699b9b47cc6 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <reference xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude" xml:id="class.ev" role="class">
  <title>La classe Ev</title>

--- a/reference/ev/ev/feedsignal.xml
+++ b/reference/ev/ev/feedsignal.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: b4fbf4434abeca44c58575ff3967e5640f7877d5 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 940ea8c1b2b727eb0f3f6412305ab699b9b47cc6 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="ev.feedsignal">
  <refnamediv>

--- a/reference/ev/ev/feedsignalevent.xml
+++ b/reference/ev/ev/feedsignalevent.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: b4fbf4434abeca44c58575ff3967e5640f7877d5 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 940ea8c1b2b727eb0f3f6412305ab699b9b47cc6 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="ev.feedsignalevent">
  <refnamediv>

--- a/reference/ev/evio.xml
+++ b/reference/ev/evio.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: b4fbf4434abeca44c58575ff3967e5640f7877d5 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 940ea8c1b2b727eb0f3f6412305ab699b9b47cc6 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <reference xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude" xml:id="class.evio" role="class">
  <title>La classe EvIo</title>

--- a/reference/ev/evloop/periodic.xml
+++ b/reference/ev/evloop/periodic.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: b4fbf4434abeca44c58575ff3967e5640f7877d5 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 940ea8c1b2b727eb0f3f6412305ab699b9b47cc6 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="evloop.periodic">
  <refnamediv>

--- a/reference/ev/evloop/prepare.xml
+++ b/reference/ev/evloop/prepare.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: b4fbf4434abeca44c58575ff3967e5640f7877d5 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 940ea8c1b2b727eb0f3f6412305ab699b9b47cc6 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="evloop.prepare">
  <refnamediv>

--- a/reference/ev/evtimer/createstopped.xml
+++ b/reference/ev/evtimer/createstopped.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: b4fbf4434abeca44c58575ff3967e5640f7877d5 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 940ea8c1b2b727eb0f3f6412305ab699b9b47cc6 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="evtimer.createstopped">
  <refnamediv>

--- a/reference/ev/examples.xml
+++ b/reference/ev/examples.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 8d666e819852f6b0561b40fcf8689b747568865c Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 940ea8c1b2b727eb0f3f6412305ab699b9b47cc6 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 
 <chapter xml:id="ev.examples" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/reference/event/eventbase.xml
+++ b/reference/event/eventbase.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 23ea6be076881a34e1d454e9680968ece085f7f6 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 940ea8c1b2b727eb0f3f6412305ab699b9b47cc6 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 
 <reference xml:id="class.eventbase" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
@@ -174,10 +174,10 @@
        en la présence d'un fds clôné par dup() ou une de ces variantes.
        Ceci produirait un comportement étrange et très difficile à diagnostiquer.
       </para>
-      <para>
+      <simpara>
        Ce drapeau peut aussi être activé en définissant la variable d'environnement
        <literal>EVENT_EPOLL_USE_CHANGELIST</literal>.
-      </para>
+      </simpara>
       <para>
        Ce drapeau n'a aucun effet si on l'utilise avec un autre backend que
        <literal>epoll</literal>.

--- a/reference/event/eventbuffer/read.xml
+++ b/reference/event/eventbuffer/read.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: a47dff201e3f65c07f6c84a535951632771cf72d Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 940ea8c1b2b727eb0f3f6412305ab699b9b47cc6 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="eventbuffer.read">
  <refnamediv>
@@ -33,9 +33,9 @@
      <parameter>max_bytes</parameter>
     </term>
     <listitem>
-     <para>
+     <simpara>
       Le nombre maximal d'octets à lire depuis le tampon.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>

--- a/reference/event/eventbuffer/readfrom.xml
+++ b/reference/event/eventbuffer/readfrom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: e41806c30bf6975e452c0d4ce35ab0984c2fa68c Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 940ea8c1b2b727eb0f3f6412305ab699b9b47cc6 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="eventbuffer.readfrom" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -46,9 +46,9 @@
      <parameter>howmuch</parameter>
     </term>
     <listitem>
-     <para>
+     <simpara>
       Nombre maximal d'octets à lire.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>

--- a/reference/event/eventbuffer/substr.xml
+++ b/reference/event/eventbuffer/substr.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: e41806c30bf6975e452c0d4ce35ab0984c2fa68c Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 940ea8c1b2b727eb0f3f6412305ab699b9b47cc6 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="eventbuffer.substr" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -23,10 +23,10 @@
     <parameter>length</parameter>
    </methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Soustrait une taille de <parameter>length</parameter> octets
    du tampon, en commençant à la position <parameter>start</parameter>.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;
@@ -36,9 +36,9 @@
      <parameter>start</parameter>
     </term>
     <listitem>
-     <para>
+     <simpara>
       La position de départ des données à soustraire.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
@@ -46,19 +46,19 @@
      <parameter>length</parameter>
     </term>
     <listitem>
-     <para>
+     <simpara>
       Nombre maximal d'octets à soustraire.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retourne les données soustraites sous la forme d'une chaîne de caractères
    en cas de succès, ou bien &false; si une erreur survient.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="seealso">
   &reftitle.seealso;

--- a/reference/event/eventbufferevent/connect.xml
+++ b/reference/event/eventbufferevent/connect.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: da9d81816187b87c03a6cd92a3c3b833f039485c Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 940ea8c1b2b727eb0f3f6412305ab699b9b47cc6 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="eventbufferevent.connect" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -28,10 +28,10 @@
    Si le socket n'est pas assigné au tampon d'événements, cette méthode
    alloue un nouveau socket et le rend non bloquant en interne.
   </para>
-  <para>
+  <simpara>
    Pour résoudre les noms DNS (de façon asynchrone), utiliser la méthode
    <methodname>EventBufferEvent::connectHost</methodname>.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;

--- a/reference/event/eventbufferevent/connecthost.xml
+++ b/reference/event/eventbufferevent/connecthost.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 23ea6be076881a34e1d454e9680968ece085f7f6 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 940ea8c1b2b727eb0f3f6412305ab699b9b47cc6 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="eventbufferevent.connecthost" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -40,14 +40,14 @@
    une tentative de connexion sera émise, tout comme le fait la méthode
    <methodname>EventBufferEvent::connect</methodname>.
   </para>
-  <para>
+  <simpara>
    Le paramètre <parameter>dns_base</parameter> est optionnel.
    Il peut valoir &null;, ou bien un objet créé avec la méthode
    <methodname>EventDnsBase::__construct</methodname>.
    Pour une résolution de nom d'hôte asynchrone, passez une ressource
    d'événement de base DNS valide. Sinon, la résolution du nom d'hôte
    sera bloquante.
-  </para>
+  </simpara>
   <note>
    <para>
     <classname>EventDnsBase</classname> n'est disponible que si
@@ -73,10 +73,10 @@
      <parameter>dns_base</parameter>
     </term>
     <listitem>
-     <para>
+     <simpara>
       Objet <classname>EventDnsBase</classname> dans le cas
       où le DNS doit être résolu de façon asynchrone. Sinon, &null;.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>

--- a/reference/event/eventbufferevent/setwatermark.xml
+++ b/reference/event/eventbufferevent/setwatermark.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 23ea6be076881a34e1d454e9680968ece085f7f6 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 940ea8c1b2b727eb0f3f6412305ab699b9b47cc6 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="eventbufferevent.setwatermark" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -30,7 +30,7 @@
    Active la lecture, l'écriture ou les deux pour les <emphasis>filigranes</emphasis>
    d'un tampon d'événement.
   </para>
-  <para>
+  <simpara>
    Un filigrane de tampon d'événement est une portion, une valeur spécifiant
    le nombre d'octets à lire ou à écrire avant d'appeler la fonction de rappel.
    Par défaut, chaque événement de lecture/écriture lance une fonction de
@@ -38,7 +38,7 @@
    <link
   xlink:href="http://www.wangafu.net/~nickm/libevent-book/Ref6_bufferevent.html#_callbacks_and_watermarks">Fast
  portable non-blocking network programming with Libevent: Callbacks and watermarks</link>
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;

--- a/reference/event/eventdnsbase/construct.xml
+++ b/reference/event/eventdnsbase/construct.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: a47dff201e3f65c07f6c84a535951632771cf72d Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 940ea8c1b2b727eb0f3f6412305ab699b9b47cc6 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="eventdnsbase.construct">
  <refnamediv>
@@ -43,11 +43,11 @@
      <parameter>initialize</parameter>
     </term>
     <listitem>
-     <para>
+     <simpara>
       Si <parameter>initialize</parameter> est &true;, il tente d'utiliser les paramètres par défaut du système d'exploitation sous-jacent pour configurer judicieusement la base DNS.
       Si c'est &false;, la base DNS est laissée non configurée, sans serveurs de noms ni options définies.
       Dans ce dernier cas, la base DNS doit être configurée manuellement, par exemple avec la méthode <methodname>EventDnsBase::parseResolvConf</methodname>.
-     </para>
+     </simpara>
      <para>
       Si <parameter>initialize</parameter> est un entier, il doit être l'un des drapeaux suivants:
       <informaltable>

--- a/reference/event/eventlistener/getsocketname.xml
+++ b/reference/event/eventlistener/getsocketname.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: da9d81816187b87c03a6cd92a3c3b833f039485c Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 940ea8c1b2b727eb0f3f6412305ab699b9b47cc6 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="eventlistener.getsocketname" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -24,9 +24,9 @@
     <parameter role="reference">port</parameter>
    </methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Récupère l'adresse courante pour laquelle le socket d'écoute est lié.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;

--- a/reference/event/eventutil.xml
+++ b/reference/event/eventutil.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 23ea6be076881a34e1d454e9680968ece085f7f6 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 940ea8c1b2b727eb0f3f6412305ab699b9b47cc6 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 
 <reference xml:id="class.eventutil" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
@@ -9,10 +9,10 @@
 <!-- {{{ EventUtil intro -->
   <section xml:id="eventutil.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     La classe <classname>EventUtil</classname> est un squelette avec des
     méthodes et des constantes supplémentaires.
-   </para>
+   </simpara>
   </section>
 <!-- }}} -->
   <section xml:id="eventutil.synopsis">

--- a/reference/event/eventutil/getsocketname.xml
+++ b/reference/event/eventutil/getsocketname.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: da9d81816187b87c03a6cd92a3c3b833f039485c Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 940ea8c1b2b727eb0f3f6412305ab699b9b47cc6 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="eventutil.getsocketname" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -28,9 +28,9 @@
     <parameter role="reference">port</parameter>
    </methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Récupère l'adresse courante liée au <parameter>socket</parameter>.
-  </para>
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;

--- a/reference/event/examples.xml
+++ b/reference/event/examples.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: ac397fd0da4d814b5a2f4ba49254f9b6093315e1 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 940ea8c1b2b727eb0f3f6412305ab699b9b47cc6 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 
 <chapter xml:id="event.examples" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/reference/fann/fannconnection/getfromneuron.xml
+++ b/reference/fann/fannconnection/getfromneuron.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: dd07341fae2c414adc1f700be0890ff32e8daab4 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 940ea8c1b2b727eb0f3f6412305ab699b9b47cc6 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="fannconnection.getfromneuron" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -15,9 +15,9 @@
    <modifier>public</modifier> <type>int</type><methodname>FANNConnection::getFromNeuron</methodname>
    <void />
   </methodsynopsis>
-  <para>
+  <simpara>
    Retourne la position du neurone de départ.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -27,9 +27,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    La position du neurone de départ.
-  </para>
+  </simpara>
  </refsect1>
 
 

--- a/reference/fann/fannconnection/gettoneuron.xml
+++ b/reference/fann/fannconnection/gettoneuron.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: d3b8e3393716cef21fa6dc370c68ca67890d5575 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 940ea8c1b2b727eb0f3f6412305ab699b9b47cc6 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="fannconnection.gettoneuron" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -27,9 +27,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    La position du neurone de fin.
-  </para>
+  </simpara>
  </refsect1>
 
 

--- a/reference/fann/functions/fann-create-shortcut-array.xml
+++ b/reference/fann/functions/fann-create-shortcut-array.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: e41806c30bf6975e452c0d4ce35ab0984c2fa68c Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 940ea8c1b2b727eb0f3f6412305ab699b9b47cc6 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <!-- CREDITS: DavidA -->
 
@@ -18,11 +18,11 @@
    <methodparam><type>int</type><parameter>num_layers</parameter></methodparam>
    <methodparam><type>array</type><parameter>layers</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Crée une propagation de retour standard de réseau neuronal
    qui n'est pas totalement connecté, et a des connexions raccourcies
    en utilisant un tableau de tailles de couches.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">

--- a/reference/fann/functions/fann-create-shortcut.xml
+++ b/reference/fann/functions/fann-create-shortcut.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e41806c30bf6975e452c0d4ce35ab0984c2fa68c Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: 940ea8c1b2b727eb0f3f6412305ab699b9b47cc6 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="function.fann-create-shortcut" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>

--- a/reference/fann/functions/fann-get-cascade-candidate-change-fraction.xml
+++ b/reference/fann/functions/fann-get-cascade-candidate-change-fraction.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e41806c30bf6975e452c0d4ce35ab0984c2fa68c Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: 940ea8c1b2b727eb0f3f6412305ab699b9b47cc6 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="function.fann-get-cascade-candidate-change-fraction" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -27,9 +27,9 @@
   <para>
    Si la fraction de changement de candidat en cascade est faible, les neurones candidats seront entraînés davantage et si la fraction est élevée, ils seront moins entraînés.
   </para>
-  <para>
+  <simpara>
    La fraction de changement de candidat en cascade par défaut est de 0.01, ce qui est équivalent à un changement de 1% dans le MSE.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">

--- a/reference/yaf/yaf_view_simple/eval.xml
+++ b/reference/yaf/yaf_view_simple/eval.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: a023d0b2477a34b665318759194f64e4eeaa2262 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 940ea8c1b2b727eb0f3f6412305ab699b9b47cc6 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes Maintainer: yannick -->
 
 <refentry xml:id="yaf-view-simple.eval" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -16,9 +16,9 @@
    <methodparam><type>string</type><parameter>tpl_content</parameter></methodparam>
    <methodparam choice="opt"><type>array</type><parameter>tpl_vars</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Évalue un template et retourne le résultat.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">

--- a/reference/yaf/yaf_view_simple/setscriptpath.xml
+++ b/reference/yaf/yaf_view_simple/setscriptpath.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 94f2f851f015535e58fd84bc2accac402f21a48e Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 940ea8c1b2b727eb0f3f6412305ab699b9b47cc6 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes Maintainer: yannick -->
 
 <refentry xml:id="yaf-view-simple.setscriptpath" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/reference/yar/examples.xml
+++ b/reference/yar/examples.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 914b97130aed191518791045b93b6f858ef5a139 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 940ea8c1b2b727eb0f3f6412305ab699b9b47cc6 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 
 <chapter xml:id="yar.examples" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -17,8 +17,8 @@ class Operator {
 
     /**
      * Ajout de deux opérandes
-     * @param interge 
-     * @return interge
+     * @param integer 
+     * @return integer
      */
     public function add($a, $b) {
         return $this->_add($a, $b);
@@ -40,8 +40,8 @@ class Operator {
 
     /**
      * Les méthodes protégées ne seront pas exposées
-     * @param interge 
-     * @return interge
+     * @param integer 
+     * @return integer
      */
     protected function _add($a, $b) {
         return $a + $b;

--- a/reference/yar/yar_concurrent_client/loop.xml
+++ b/reference/yar/yar_concurrent_client/loop.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 331fbfeac522d4ad00de1e043cc11610d66b88f9 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 940ea8c1b2b727eb0f3f6412305ab699b9b47cc6 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="yar-concurrent-client.loop" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -16,9 +16,9 @@
    <methodparam choice="opt"><type>callable</type><parameter>callback</parameter></methodparam>
    <methodparam choice="opt"><type>callable</type><parameter>error_callback</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Envoi tous les appels distants RPC enregistrés.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">

--- a/reference/zookeeper/ini.xml
+++ b/reference/zookeeper/ini.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 373591548f2bb7cc35e46242ea4faa0adcf7febc Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 940ea8c1b2b727eb0f3f6412305ab699b9b47cc6 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 
 <section xml:id="zookeeper.configuration" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -81,12 +81,12 @@
      <type>int</type>
     </term>
     <listitem>
-     <para>
+     <simpara>
       Temps d'attente en microsecondes pour les tentatives de verrouillage de la session PHP.
-      Soyez prudent lors de la définition de cette valeur. Les valeurs valides sont des entiers, 
+      Soyez prudent lors de la définition de cette valeur. Les valeurs valides sont des entiers,
       où 0 est interprété comme la valeur par défaut.
       Les valeurs négatives entraînent un verrouillage réduit à une tentative de verrouillage.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
 

--- a/reference/zookeeper/zookeeper.xml
+++ b/reference/zookeeper/zookeeper.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: eadc8dd73577ca16f7a1520634d5f3656e9bd4d3 Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: 940ea8c1b2b727eb0f3f6412305ab699b9b47cc6 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <reference xml:id="class.zookeeper"
  role="class"
@@ -470,7 +470,7 @@
      <varlistentry xml:id="zookeeper.constants.log-level-error">
       <term><constant>Zookeeper::LOG_LEVEL_ERROR</constant></term>
       <listitem>
-       <para>Sortie des messages d'erreur uniquement</para>
+       <simpara>Sortie des messages d'erreur uniquement</simpara>
       </listitem>
      </varlistentry>
      <varlistentry xml:id="zookeeper.constants.log-level-warn">

--- a/reference/zookeeper/zookeeper/getchildren.xml
+++ b/reference/zookeeper/zookeeper/getchildren.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 16f729a56f0dabc39c93b27315f36d6838f00027 Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: 940ea8c1b2b727eb0f3f6412305ab699b9b47cc6 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="zookeeper.getchildren" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -69,7 +69,7 @@
 <![CDATA[
 <?php
 
-$zookeeper = new Zookeeper('locahost:2181');
+$zookeeper = new Zookeeper('localhost:2181');
 $path = '/zookeeper';
 $r = $zookeeper->getchildren($path);
 


### PR DESCRIPTION
Synchronisation avec php/doc-en#5571 (corrections de fautes d'orthographe dans le manuel). Bump du hash EN-Revision sur les 38 fichiers, miroir des conversions para vers simpara, et correction des fautes uniquement là où elles figurent dans du code FR (eio-realpath, yar/examples, zookeeper/getchildren). Les fautes en prose anglaise sont déjà traduites côté FR, donc non concernées.

Fixes #2903