### PR TITLE
Sync EN intl: getBestPattern renvoie un motif ICU pour IntlDateFormatter

### DIFF
--- a/reference/intl/intldatepatterngenerator/getbestpattern.xml
+++ b/reference/intl/intldatepatterngenerator/getbestpattern.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 1976eae0d815797af97a1e16c5cd90ffc2868395 Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: 5b6663923676dd3f48bdc916a6a2de651fd959b2 Maintainer: Fan2Shrek Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="intldatepatterngenerator.getbestpattern" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -34,9 +34,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
-   Renvoie un format, accepté par <methodname>DateTimeInterface::format</methodname> en cas de succès, &return.falseforfailure;. 
-  </para>
+  <simpara>
+   Renvoie un motif de date/heure ICU accepté par <classname>IntlDateFormatter</classname> en cas de succès, &return.falseforfailure;.
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">


### PR DESCRIPTION
Sync EN de php/doc-en#5567 : Fixes #2913