### PR TITLE
Nits translation: reference/ (dom to event)

### DIFF
--- a/reference/dom/domnode/c14n.xml
+++ b/reference/dom/domnode/c14n.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="domnode.c14n" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>DOMNode::C14N</refname>
-  <refpurpose>Canonise des nœuds en une chaîne</refpurpose>
+  <refpurpose>Canonicalise des nœuds en une chaîne</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -17,7 +17,7 @@
    <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>nsPrefixes</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
   <para>
-   Canonise des nœuds en une chaîne de caractères.
+   Canonicalise des nœuds en une chaîne de caractères.
   </para>
  </refsect1>
 

--- a/reference/eio/book.xml
+++ b/reference/eio/book.xml
@@ -85,7 +85,7 @@ function my_symlink_done($filename, $result) {
  // Crée une demande eio_rename et l'ajoute au groupe
  $req = eio_rename($filename, "/path/to/new-name");
  eio_grp_add($grp, $req);
- // Vous pouvez vouloir d'autres actions...
+ // Il est possible d'ajouter d'autres demandes...
 }
 
 // Création d'un groupe de demandes

--- a/reference/eio/examples.xml
+++ b/reference/eio/examples.xml
@@ -262,13 +262,13 @@ eio_nop(EIO_PRI_DEFAULT, function () {
   echo "eio_nop\n";
 });
 
-// Ajout les événements
+// Ajoute les événements
 $timer = Event::timer($base, function () {
   echo "2 seconds elapsed\n";
 });
 $timer->add(2);
 
-// Envoi les événements.
+// Envoie les événements.
 $base->dispatch();
 ?>
 ]]></programlisting>

--- a/reference/eio/functions/eio-fdatasync.xml
+++ b/reference/eio/functions/eio-fdatasync.xml
@@ -53,7 +53,7 @@
     <term><parameter>data</parameter></term>
     <listitem>
      <simpara>
-      Variables arbitraires à passer à la fonction de rappel
+      Variable arbitraire à passer à la fonction de rappel
       <parameter>callback</parameter>.
      </simpara>
     </listitem>

--- a/reference/eio/functions/eio-get-event-stream.xml
+++ b/reference/eio/functions/eio-get-event-stream.xml
@@ -63,7 +63,7 @@ var_dump($fd);
 
 eio_nop(EIO_PRI_DEFAULT, "my_res_cb", "nop data");
 eio_mkdir("/tmp/abc-eio-temp", 0750, EIO_PRI_DEFAULT, "my_res_cb", "mkdir data");
-/* quelques appels à eio_* calls ici ... */
+/* quelques autres appels à eio_* ici ... */
 
 
 // Définit les drapeaux des événements

--- a/reference/eio/functions/eio-init.xml
+++ b/reference/eio/functions/eio-init.xml
@@ -18,7 +18,7 @@
    <function>eio_init</function> (re-)initialise Eio.
    Elle alloue la mémoire pour les structures internes
    de la bibliothèque libeio et Eio lui-même.
-   Il faut appeler la fonction <function>eio_init</function>
+   Il est possible d'appeler la fonction <function>eio_init</function>
    avant d'utiliser les fonctions Eio. Sinon, cette fonction sera
    appelée en interne dès lors qu'une fonction Eio sera appelée.
   </simpara>

--- a/reference/eio/functions/eio-mknod.xml
+++ b/reference/eio/functions/eio-mknod.xml
@@ -112,7 +112,7 @@
 <![CDATA[
 
 <?php
-// FIFO name
+// Nom du FIFO
 $temp_filename = "/tmp/eio-temp-fifo";
 
 /* Sera appelé lorsque la fonction eio_mknod() aura terminé */

--- a/reference/eio/functions/eio-npending.xml
+++ b/reference/eio/functions/eio-npending.xml
@@ -5,7 +5,7 @@
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.eio-npending">
  <refnamediv>
   <refname>eio_npending</refname>
-  <refpurpose>Retourne le nombre de requêtes terminées</refpurpose>
+  <refpurpose>Retourne le nombre de requêtes terminées, mais non traitées</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -15,7 +15,7 @@
    <void/>
   </methodsynopsis>
   <simpara>
-   <function>eio_npending</function> retourne le nombre de requêtes terminées.
+   <function>eio_npending</function> retourne le nombre de requêtes terminées, mais non traitées.
   </simpara>
 
  </refsect1>
@@ -28,7 +28,8 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   <function>eio_npending</function> retourne le nombre de requêtes terminées.
+   <function>eio_npending</function> retourne le nombre de requêtes terminées,
+   mais non traitées.
   </simpara>
  </refsect1>
 

--- a/reference/eio/functions/eio-open.xml
+++ b/reference/eio/functions/eio-open.xml
@@ -37,7 +37,7 @@
       Chemin vers le fichier à ouvrir.
       <warning>
        <simpara>
-        Avec quelques APIs (c.-à-d. <emphasis>PHP-FPM</emphasis>), l'appel
+        Avec quelques APIs (par ex. <emphasis>PHP-FPM</emphasis>), l'appel
         peut échouer si l'on ne spécifie pas le chemin complet.
        </simpara>
       </warning>
@@ -132,7 +132,7 @@ function my_file_opened_callback($data, $result) {
 }
 
 // Crée un nouveau fichier pour lecture et écriture
-// N'autorise pas les groupes et autres à faire ce que ce soit avec ce fichier
+// N'autorise pas les groupes et autres à faire quoi que ce soit avec ce fichier
 eio_open($temp_filename, EIO_O_CREAT | EIO_O_RDWR, EIO_S_IRUSR | EIO_S_IWUSR,
   EIO_PRI_DEFAULT, "my_file_opened_callback", $temp_filename);
 eio_event_loop();

--- a/reference/eio/functions/eio-open.xml
+++ b/reference/eio/functions/eio-open.xml
@@ -37,7 +37,7 @@
       Chemin vers le fichier à ouvrir.
       <warning>
        <simpara>
-        Avec quelques APIs (par ex. <emphasis>PHP-FPM</emphasis>), l'appel
+        Avec quelques APIs (c.-à-d. <emphasis>PHP-FPM</emphasis>), l'appel
         peut échouer si l'on ne spécifie pas le chemin complet.
        </simpara>
       </warning>

--- a/reference/eio/functions/eio-read.xml
+++ b/reference/eio/functions/eio-read.xml
@@ -20,7 +20,7 @@
    <methodparam choice="opt"><type>mixed</type><parameter>data</parameter><initializer>NULL</initializer></methodparam>
   </methodsynopsis>
   <simpara>
-   <function>eio_read</function> lit <parameter>length</parameter> octets
+   <function>eio_read</function> lit jusqu'à <parameter>length</parameter> octets
    depuis le descripteur de fichier <parameter>fd</parameter> à la position
    <parameter>offset</parameter>. Les octets lus sont stockés dans l'argument
    <parameter>result</parameter> de la fonction de rappel <parameter>callback</parameter>.

--- a/reference/eio/functions/eio-readdir.xml
+++ b/reference/eio/functions/eio-readdir.xml
@@ -99,7 +99,7 @@
       eio_dirent</literal> - comme un tableau, mais contenant les clés spécifiques suivantes :
       <literal>'name'</literal> - le nom du dossier ;
       <literal>'type'</literal> - une des constantes <emphasis>EIO_DT_*</emphasis> ;
-      <literal>'inode'</literal> - le nombre d'inodes, si disponible, sinon ne sera pas spécifié ;
+      <literal>'inode'</literal> - le numéro d'inode, si disponible, sinon ne sera pas spécifié ;
      </simpara>
     </listitem>
    </varlistentry>
@@ -338,7 +338,7 @@
    <programlisting role="php">
 <![CDATA[
 <?php
-/* Is called when eio_readdir() finishes */
+/* Sera appelé lorsque la fonction eio_readdir() aura terminé */
 function my_readdir_callback($data, $result) {
     echo __FUNCTION__, " called\n";
     echo "donnée : "; var_dump($data);

--- a/reference/eio/functions/eio-set-max-poll-reqs.xml
+++ b/reference/eio/functions/eio-set-max-poll-reqs.xml
@@ -5,7 +5,7 @@
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.eio-set-max-poll-reqs">
  <refnamediv>
   <refname>eio_set_max_poll_reqs</refname>
-  <refpurpose>Définit le nombre maximal de requêtes à exécuter dans une file d'attente</refpurpose>
+  <refpurpose>Définit le nombre maximal de requêtes traitées dans un cycle de scrutation</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/eio/functions/eio-set-max-poll-reqs.xml
+++ b/reference/eio/functions/eio-set-max-poll-reqs.xml
@@ -5,7 +5,7 @@
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.eio-set-max-poll-reqs">
  <refnamediv>
   <refname>eio_set_max_poll_reqs</refname>
-  <refpurpose>Définit le nombre maximal de requêtes traitées dans un cycle de scrutation</refpurpose>
+  <refpurpose>Définit le nombre maximal de requêtes traitées dans un cycle d'interrogation</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/eio/functions/eio-set-max-poll-time.xml
+++ b/reference/eio/functions/eio-set-max-poll-time.xml
@@ -5,7 +5,7 @@
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.eio-set-max-poll-time">
  <refnamediv>
   <refname>eio_set_max_poll_time</refname>
-  <refpurpose>Définit la durée maximale de la file d'attente</refpurpose>
+  <refpurpose>Définit la durée maximale d'une scrutation</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -15,7 +15,7 @@
    <methodparam><type>float</type><parameter>nseconds</parameter></methodparam>
   </methodsynopsis>
   <simpara>
-   La file d'attente s'interrompt si elle prend plus de
+   La scrutation s'interrompt si elle prend plus de
    <parameter>nseconds</parameter> secondes.
   </simpara>
 

--- a/reference/eio/functions/eio-set-max-poll-time.xml
+++ b/reference/eio/functions/eio-set-max-poll-time.xml
@@ -5,7 +5,7 @@
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.eio-set-max-poll-time">
  <refnamediv>
   <refname>eio_set_max_poll_time</refname>
-  <refpurpose>Définit la durée maximale d'une scrutation</refpurpose>
+  <refpurpose>Définit la durée maximale d'une interrogation</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -15,7 +15,7 @@
    <methodparam><type>float</type><parameter>nseconds</parameter></methodparam>
   </methodsynopsis>
   <simpara>
-   La scrutation s'interrompt si elle prend plus de
+   L'interrogation s'interrompt si elle prend plus de
    <parameter>nseconds</parameter> secondes.
   </simpara>
 

--- a/reference/eio/functions/eio-write.xml
+++ b/reference/eio/functions/eio-write.xml
@@ -36,7 +36,7 @@
     <listitem>
      <simpara>
       Un flux, une ressource de socket, ou
-      un descripteur de fichier, c.-à-d. retourné par la
+      un descripteur de fichier, par ex. retourné par la
       fonction <function>eio_open</function>
      </simpara>
     </listitem>

--- a/reference/eio/functions/eio-write.xml
+++ b/reference/eio/functions/eio-write.xml
@@ -36,7 +36,7 @@
     <listitem>
      <simpara>
       Un flux, une ressource de socket, ou
-      un descripteur de fichier, par ex. retourné par la
+      un descripteur de fichier, c.-à-d. retourné par la
       fonction <function>eio_open</function>
      </simpara>
     </listitem>

--- a/reference/enchant/book.xml
+++ b/reference/enchant/book.xml
@@ -15,7 +15,7 @@
    <link xlink:href="&url.enchant;">bibliothèque Enchant</link>. Enchant
    fournit une uniformité et une conformité pour toutes les bibliothèques
    d'orthographe, et implémente certaines fonctionnalités qui peuvent
-   faire défaut dans une bibliothèque. Tout doit "juste fonctionner".
+   faire défaut dans une bibliothèque. Tout devrait "juste fonctionner".
   </simpara>
   <para>
    Enchant supporte les bibliothèques suivantes :
@@ -32,7 +32,7 @@
     </listitem>
     <listitem>
      <simpara>
-      <literal>MySpell/Hunspell (un projet orienté objet, également utilisé par Mozilla)</literal>
+      <literal>MySpell/Hunspell (un projet OpenOffice.org, également utilisé par Mozilla)</literal>
      </simpara>
     </listitem>
     <listitem>

--- a/reference/enchant/configure.xml
+++ b/reference/enchant/configure.xml
@@ -25,7 +25,7 @@
   </simpara>
   <simpara>
    De plus, il est nécessaire de copier au moins un des fournisseurs fournis dans
-   <filename>lib\enchant</filename> vers <filename>\usr\local\lib\enchant-2</filename>,
+   <filename>lib\enchant</filename> vers <filename>\usr\local\lib\enchant-2</filename>
    (qui est un chemin absolu à partir de la racine du <emphasis>disque actuel</emphasis>).
    Antérieur à PHP 8.0.0, c'est-à-dire en utilisant Enchant v1, les fournisseurs devaient être copiés dans
    <filename>C:\enchant_plugins</filename> à la place,

--- a/reference/enchant/functions/enchant-broker-dict-exists.xml
+++ b/reference/enchant/functions/enchant-broker-dict-exists.xml
@@ -26,7 +26,7 @@
     <term><parameter>tag</parameter></term>
     <listitem>
      <simpara>
-      langage, dans un format comme us_US, ch_DE, etc.
+      langue, dans un format comme us_US, ch_DE, etc.
      </simpara>
     </listitem>
    </varlistentry>
@@ -36,7 +36,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   Retourne &true; si le langage existe, &false; sinon.
+   Retourne &true; si la langue existe, &false; sinon.
   </simpara>
  </refsect1>
 

--- a/reference/enchant/functions/enchant-broker-list-dicts.xml
+++ b/reference/enchant/functions/enchant-broker-list-dicts.xml
@@ -58,7 +58,7 @@
  <refsect1 role="examples">
   &reftitle.examples;
   <example>
-   <title>Liste tous les dictionnaires disponibles pour un sponsor</title>
+   <title>Liste tous les dictionnaires disponibles pour un broker</title>
    <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/enchant/functions/enchant-broker-request-dict.xml
+++ b/reference/enchant/functions/enchant-broker-request-dict.xml
@@ -16,7 +16,7 @@
   </methodsynopsis>
   <simpara>
    Crée un nouveau dictionnaire en utilisant le paramètre <parameter>tag</parameter>,
-   représentant le langage dont l'on veut associer le dictionnaire
+   représentant la langue dont l'on veut associer le dictionnaire
    ("en_US", "de_DE", ...).
   </simpara>
  </refsect1>
@@ -28,7 +28,7 @@
     <term><parameter>tag</parameter></term>
     <listitem>
      <simpara>
-      Une balise décrivant le langage, par exemple, en_US, de_DE
+      Une balise décrivant la locale, par exemple, en_US, de_DE
      </simpara>
     </listitem>
    </varlistentry>

--- a/reference/enchant/functions/enchant-broker-set-ordering.xml
+++ b/reference/enchant/functions/enchant-broker-set-ordering.xml
@@ -18,9 +18,9 @@
   <simpara>
    Déclare une préférence pour un dictionnaire à utiliser pour la langue
    spécifiée par le paramètre <parameter>tag</parameter>.
-   L'ordre des langues est une liste séparée par une virgule.
+   L'ordre est une liste de noms de fournisseurs séparée par une virgule.
    Le caractère spécial "*" peut être utilisé comme langue pour déclarer
-   un ordre par défaut pour tous les langages qui ne déclarent pas
+   un ordre par défaut pour toutes les langues qui ne déclarent pas
    explicitement un ordre.
   </simpara>
 
@@ -33,8 +33,8 @@
     <term><parameter>tag</parameter></term>
     <listitem>
      <simpara>
-      La langue. Le caractère "*" peut être utilisé en tant que langage
-      pour déclarer un ordre par défaut pour tous les langages
+      La langue. Le caractère "*" peut être utilisé en tant que langue
+      pour déclarer un ordre par défaut pour toutes les langues
       qui ne déclarent pas explicitement un ordre.
      </simpara>
     </listitem>

--- a/reference/enchant/functions/enchant-dict-add-to-personal.xml
+++ b/reference/enchant/functions/enchant-dict-add-to-personal.xml
@@ -9,7 +9,7 @@
  </refnamediv>
 
  <refsynopsisdiv>
-  &warn.deprecated.function-8-0-0;
+  &warn.deprecated.alias-8-0-0;
  </refsynopsisdiv>
 
  <refsect1 role="description">

--- a/reference/enchant/functions/enchant-dict-get-error.xml
+++ b/reference/enchant/functions/enchant-dict-get-error.xml
@@ -28,7 +28,7 @@
   &reftitle.returnvalues;
   <simpara>
    Retourne le message d'erreur sous la forme d'une chaîne de caractères,
-   ou &false; si une erreur survient.
+   ou &false; si aucune erreur n'est survenue.
   </simpara>
  </refsect1>
 

--- a/reference/enchant/functions/enchant-dict-is-in-session.xml
+++ b/reference/enchant/functions/enchant-dict-is-in-session.xml
@@ -9,7 +9,7 @@
  </refnamediv>
 
  <refsynopsisdiv>
-  &warn.deprecated.function-8-0-0;
+  &warn.deprecated.alias-8-0-0;
  </refsynopsisdiv>
 
  <refsect1 role="description">

--- a/reference/enchant/functions/enchant-dict-quick-check.xml
+++ b/reference/enchant/functions/enchant-dict-quick-check.xml
@@ -16,8 +16,8 @@
    <methodparam choice="opt"><type>array</type><parameter role="reference">suggestions</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
   <simpara>
-   Retourne &true; si le mot est correctement orthographié, &false; si la variable des suggestions est fournie,
-   et la remplit des suggestions possibles.
+   Retourne &true; si le mot est correctement orthographié, &false; sinon ;
+   si la variable des suggestions est fournie, elle est remplie des suggestions possibles.
   </simpara>
  </refsect1>
  <refsect1 role="parameters">

--- a/reference/enchant/functions/enchant-dict-store-replacement.xml
+++ b/reference/enchant/functions/enchant-dict-store-replacement.xml
@@ -16,7 +16,7 @@
    <methodparam><type>string</type><parameter>correct</parameter></methodparam>
   </methodsynopsis>
   <simpara>
-   Ajoute une orthographe pour <parameter>mis</parameter> en utilisant <parameter>cor</parameter>.
+   Ajoute une orthographe pour 'mis' en utilisant 'cor'.
    Il est à noter que si l'on remplace @mis par @cor, alors il est probable que les futures occurrences
    de @mis seront remplacées par @cor. Ainsi, @cor sera ajouté à la liste des suggestions.
   </simpara>

--- a/reference/enchant/functions/enchant-dict-suggest.xml
+++ b/reference/enchant/functions/enchant-dict-suggest.xml
@@ -74,9 +74,7 @@ if (enchant_broker_dict_exists($r,$tag)) {
         echo "Suggestions pour 'soong' : ";
         print_r($suggs);
     }
-    enchant_broker_free_dict($d);
 }
-enchant_broker_free($r);
 ?>
 ]]>
     </programlisting>

--- a/reference/errorfunc/book.xml
+++ b/reference/errorfunc/book.xml
@@ -19,7 +19,7 @@
   <para>
    Avec les fonctions de journal, il est possible d'envoyer des messages
    directement à d'autres machines (ou des e-mails, ou via une passerelle vers pager),
-   vers les logs du système, etc., ainsi, il est possible de sélectionner
+   vers les journaux d'événements du système, etc., ainsi, il est possible de sélectionner
    les messages et surveiller les parties les plus importantes des
    applications et des sites web.
   </para>

--- a/reference/errorfunc/constants.xml
+++ b/reference/errorfunc/constants.xml
@@ -110,8 +110,8 @@
    <listitem>
     <simpara>
      Erreurs fatales qui surviennent lors du démarrage initial de PHP.
-     C'est comme une <constant>E_ERROR</constant>,
-     sauf qu'elle est générée par le cœur de PHP.
+     C'est comme un <constant>E_ERROR</constant>,
+     sauf qu'il est généré par le cœur de PHP.
     </simpara>
     <simpara>
      Valeur de la constante : <literal>16</literal>

--- a/reference/errorfunc/functions/debug-backtrace.xml
+++ b/reference/errorfunc/functions/debug-backtrace.xml
@@ -172,7 +172,7 @@
        <entry>type</entry>
        <entry>&string;</entry>
        <entry>
-        Le type de classe courante. Si une méthode est appelée, "-&gt;" est retourné.
+        Le type d'appel courant. Si une méthode est appelée, "-&gt;" est retourné.
         Si une méthode statique est appelée, "::" est retourné. Si une fonction est appelée,
         rien ne sera retourné.
        </entry>

--- a/reference/errorfunc/functions/error-log.xml
+++ b/reference/errorfunc/functions/error-log.xml
@@ -18,7 +18,7 @@
    <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>additional_headers</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
   <para>
-   Envoie un message d'erreur à l'historique d'erreur
+   Envoie un message d'erreur au journal d'événements
    du serveur web ou à un fichier.
   </para>
  </refsect1>
@@ -50,10 +50,11 @@
           <row>
            <entry>0</entry>
            <entry>
-            <parameter>message</parameter> est envoyé à l'historique
-            PHP, qui est basé sur l'historique système ou un fichier,
-            en fonction de la configuration de <link
-            linkend="ini.error-log">error_log</link>. C'est l'option par défaut.
+            <parameter>message</parameter> est envoyé au journal d'événements
+            système de PHP, en utilisant le mécanisme de journalisation
+            du système d'exploitation ou un fichier, en fonction de la configuration de
+            la directive <link linkend="ini.error-log">error_log</link>.
+            C'est l'option par défaut.
            </entry>
           </row>
           <row>
@@ -158,7 +159,7 @@
     <programlisting role="php">
 <![CDATA[
 <?php
-// Envoie une notification par l'historique du serveur web,
+// Envoie une notification par le journal du serveur web,
 // si la connexion à la base de données est impossible.
 if (!Ora_Logon($username, $password)) {
   error_log("Base Oracle indisponible !", 0);

--- a/reference/errorfunc/functions/error-reporting.xml
+++ b/reference/errorfunc/functions/error-reporting.xml
@@ -57,7 +57,7 @@
   &reftitle.returnvalues;
   <para>
    Retourne le niveau d'<link linkend="ini.error-reporting">error_reporting</link>,
-   <emphasis>avant</emphasis> qu'il ne soit changé en <parameter>error_level</parameter>
+   <emphasis>avant</emphasis> qu'il ne soit changé en <parameter>error_level</parameter>.
   </para>
   <note>
    <simpara>
@@ -105,7 +105,7 @@ error_reporting(0);
 error_reporting(E_ERROR | E_WARNING | E_PARSE);
 
 // Rapporter les E_NOTICE peut vous aider à améliorer vos scripts
-// (variables non initialisées, variables mal orthographiées..)
+// (variables non initialisées, variables mal orthographiées ...)
 error_reporting(E_ERROR | E_WARNING | E_PARSE | E_NOTICE);
 
 // Rapporte toutes les erreurs à part les E_NOTICE

--- a/reference/errorfunc/functions/get-error-handler.xml
+++ b/reference/errorfunc/functions/get-error-handler.xml
@@ -30,7 +30,7 @@
    Si le gestionnaire par défaut est utilisé, &null; est renvoyé.
   </simpara>
   <simpara>
-   Le gestionnaire retourné est la fonction de rappel exacte qui a été passée
+   Le gestionnaire retourné est la valeur callable exacte qui a été passée
    à <function>set_error_handler</function> pour la définir.
   </simpara>
  </refsect1>

--- a/reference/errorfunc/functions/set-error-handler.xml
+++ b/reference/errorfunc/functions/set-error-handler.xml
@@ -54,7 +54,7 @@
   </para>
   <para>
    Si une erreur survient avant que le script ne soit exécuté (par exemple
-   un téléchargement de fichier), le gestionnaire d'erreurs personnalisé ne pourra
+   un téléversement de fichier), le gestionnaire d'erreurs personnalisé ne pourra
    pas être appelé, car il n'est pas encore enregistré.
   </para>
  </refsect1>
@@ -255,7 +255,7 @@ function myErrorHandler($errno, $errstr, $errfile, $errline)
 function scale_by_log($vect, $scale)
 {
     if (!is_numeric($scale) || $scale <= 0) {
-        trigger_error("log(x) pour x <= 0 est indéfini, vous utiliser : scale = $scale", E_USER_ERROR);
+        trigger_error("log(x) pour x <= 0 est indéfini, valeur utilisée : scale = $scale", E_USER_ERROR);
     }
 
     if (!is_array($vect)) {
@@ -284,7 +284,7 @@ print_r($a);
 
 // Générons maintenant un second tableau
 echo "----\nvector b - a notice (b = log(PI) * a)\n";
-/* Valeur à la position $pos n'est pas un nombre, utilisation de 0 (zéro) */
+/* La valeur à la position $pos n'est pas un nombre, utilisation 0 (zéro) */
 $b = scale_by_log($a, M_PI);
 print_r($b);
 
@@ -296,7 +296,7 @@ var_dump($c); // NULL
 
 // Ceci est une erreur critique : le logarithme de zéro ou d'un nombre négatif est indéfini
 echo "----\nvector d - fatal error\n";
-/* log(x) pour x <= 0 est indéfini, vous utiliser : scale = $scale" */
+/* log(x) pour x <= 0 est indéfini, valeur utilisée : scale = $scale" */
 $d = scale_by_log($a, -2.5);
 var_dump($d); // Jamais atteint
 ?>
@@ -317,7 +317,7 @@ Array
 )
 ----
 vector b - a notice (b = log(PI) * a)
-<b>Mon AVERTISSEMENT</b> [1024] La valeur à la position 2 n'est pas un nombre, utilisation de 0 (zéro)<br />
+<b>Mon AVERTISSEMENT</b> [1024] La valeur à la position 2 n'est pas un nombre, utilisation 0 (zéro)<br />
 Array
 (
     [0] => 2.2894597716988
@@ -333,7 +333,7 @@ vector c - a warning
 NULL
 ----
 vector d - fatal error
-<b>Mon ERREUR</b> [256] log(x) pour x <= 0 est indéfini, vous utiliser : scale = -2.5<br />
+<b>Mon ERREUR</b> [256] log(x) pour x <= 0 est indéfini, valeur utilisée : scale = -2.5<br />
   Erreur fatale sur la ligne 36 dans le fichier trigger_error.php, PHP 5.2.1 (Linux)<br />
 Arrêt...<br />
 ]]>

--- a/reference/errorfunc/functions/trigger-error.xml
+++ b/reference/errorfunc/functions/trigger-error.xml
@@ -16,7 +16,7 @@
    <methodparam choice="opt"><type>int</type><parameter>error_level</parameter><initializer><constant>E_USER_NOTICE</constant></initializer></methodparam>
   </methodsynopsis>
   <para>
-   <function>trigger_error</function> est utilisé pour déclencher
+   <function>trigger_error</function> est utilisée pour déclencher
    une erreur utilisateur. Elle peut aussi être utilisée en
    conjonction avec un gestionnaire d'erreurs interne, ou un gestionnaire
    d'erreurs utilisateur qui a été choisi comme gestionnaire

--- a/reference/errorfunc/ini.xml
+++ b/reference/errorfunc/ini.xml
@@ -296,7 +296,7 @@
     <listitem>
      <para>
       Configure la taille maximale des erreurs qui seront enregistrées dans
-      l'historique, en kilooctets. Dans les informations de
+      l'historique, en octets. Dans les informations de
       <link linkend="ini.error-log">error_log</link>, l'origine est ajoutée.
       La valeur par défaut est de 1024. 0 signifie qu'il n'y a pas de limite de
       taille. Cette longueur est appliquée pour enregistrer dans l'historique

--- a/reference/ev/configure.xml
+++ b/reference/ev/configure.xml
@@ -11,7 +11,7 @@
  </simpara>
  <simpara>
   Pour plus d'informations concernant l'installation manuelle,
-  veuillez lire le fichier <filename>INSTALL.md</filename> inclus
+  se reporter au fichier <filename>INSTALL.md</filename> inclus
   dans les sources du paquet.
  </simpara>
 </section>

--- a/reference/ev/ev.xml
+++ b/reference/ev/ev.xml
@@ -323,7 +323,7 @@
         <link xlink:href="&url.ev.signal;">ev_signal</link>
         (et
         <link xlink:href="&url.ev.child;">ev_child</link>).
-        Cette API délivre les signaux de façon asynchrone, ce qui
+        Cette API délivre les signaux de façon synchrone, ce qui
         la rend plus rapide, et peut permettre la récupération des données
         des signaux en attente. Elle peut également simplifier la gestion
         des signaux avec les threads, sachant que les signaux sont des
@@ -717,14 +717,14 @@
       </term>
       <listitem>
        <simpara>
-        Essai tous les backends (y compris les corrompus).
+        Essaie tous les backends (y compris les corrompus).
         Il n'est pas recommandé de l'utiliser explicitement.
         Les opérateurs de bits devraient être appliqués ici
         (c.-à-d. <constant>Ev::BACKEND_ALL</constant> &amp; ~
         <constant>Ev::BACKEND_KQUEUE</constant>).
         Utiliser la méthode
         <methodname>Ev::recommendedBackends</methodname> ou ne
-        spécifiez aucun backend.
+        spécifier aucun backend.
        </simpara>
       </listitem>
      </varlistentry>

--- a/reference/ev/ev/backend.xml
+++ b/reference/ev/ev/backend.xml
@@ -29,7 +29,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   Retourne un entier (masque d'octets) décrivant le backend utilisé par
+   Retourne un entier (masque de bits) décrivant le backend utilisé par
    <emphasis>libev</emphasis>.
   </simpara>
  </refsect1>

--- a/reference/ev/ev/depth.xml
+++ b/reference/ev/ev/depth.xml
@@ -23,7 +23,7 @@
    termes, la profondeur de récursion. En dehors de
    <methodname>Ev::run</methodname>, ce nombre vaut <literal>0</literal>.
    Dans une fonction de rappel, ce nombre vaut <literal>1</literal>,
-   tant que la méthode <methodname>Ev::run</methodname> est invoquée
+   sauf si la méthode <methodname>Ev::run</methodname> est invoquée
    récursivement (ou depuis un autre thread), auquel cas, il sera supérieur.
   </simpara>
  </refsect1>

--- a/reference/ev/ev/embeddablebackends.xml
+++ b/reference/ev/ev/embeddablebackends.xml
@@ -28,9 +28,9 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   Retourne un masque d'octets qui peut contenir les
+   Retourne un masque de bits qui peut contenir les
    <link linkend="ev.constants.watcher-backends">drapeaux de backend</link>
-   combinés avec l'opérateur <emphasis>OR</emphasis>.
+   combinés avec l'opérateur <emphasis>OR</emphasis> bit à bit.
   </simpara>
  </refsect1>
  <refsect1 role="examples">
@@ -41,7 +41,7 @@
 <![CDATA[
 <?php
 /*
-* Vérifie si kqueue est disponible et crée un backend kqueue
+* Vérifie si kqueue est disponible mais non recommandé et crée un backend kqueue
 * pour l'utiliser avec des sockets (qui fonctionne habituellement avec n'importe quelle
 * implémentation de kqueue).
 * Stocke la boucle d'événement kqueue/socket-uniquement dans loop_socket.

--- a/reference/ev/ev/feedsignal.xml
+++ b/reference/ev/ev/feedsignal.xml
@@ -27,7 +27,7 @@
   </simpara>
   <simpara>
    Contrairement à la méthode <methodname>Ev::feedSignalEvent</methodname>,
-   cette méthode fonctionne suivant la boucle qui a enregistré le signal.
+   cette méthode fonctionne quelle que soit la boucle qui a enregistré le signal.
   </simpara>
  </refsect1>
  <refsect1 role="parameters">

--- a/reference/ev/ev/iteration.xml
+++ b/reference/ev/ev/iteration.xml
@@ -31,7 +31,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   Retourne le nombre de sollicitation de la boucle d'événement
+   Retourne le nombre de sollicitations de la boucle d'événement
    par défaut.
   </simpara>
  </refsect1>

--- a/reference/ev/ev/recommendedbackends.xml
+++ b/reference/ev/ev/recommendedbackends.xml
@@ -4,7 +4,7 @@
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="ev.recommendedbackends">
  <refnamediv>
   <refname>Ev::recommendedBackends</refname>
-  <refpurpose>Retourne un masque d'octets de backends recommandés
+  <refpurpose>Retourne un masque de bits de backends recommandés
    pour la plateforme courante</refpurpose>
  </refnamediv>
  <refsect1 role="description">
@@ -37,9 +37,9 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   Retourne un masque d'octets contenant les
+   Retourne un masque de bits contenant les
    <link linkend="ev.constants.watcher-backends">drapeaux des backends</link>
-   combinés en utilisant l'opérateur <emphasis>OR</emphasis>.
+   combinés en utilisant l'opérateur <emphasis>OR</emphasis> bit à bit.
   </simpara>
  </refsect1>
  <refsect1 role="examples">

--- a/reference/ev/ev/run.xml
+++ b/reference/ev/ev/run.xml
@@ -67,7 +67,7 @@
           <entry>
            <constant>Ev::RUN_ONCE</constant>
           </entry>
-          <entry>Bloque au moins un (mise en attente, mais ne boucle plus)</entry>
+          <entry>Bloque au plus un (mise en attente, mais ne boucle plus)</entry>
          </row>
          <row>
           <entry>

--- a/reference/ev/ev/sleep.xml
+++ b/reference/ev/ev/sleep.xml
@@ -33,7 +33,7 @@
     </term>
     <listitem>
      <simpara>
-      Nombre de secondes
+      Nombre fractionnaire de secondes
      </simpara>
     </listitem>
    </varlistentry>

--- a/reference/ev/ev/supportedbackends.xml
+++ b/reference/ev/ev/supportedbackends.xml
@@ -28,9 +28,9 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   Retourne un masque d'octets qui peut contenir les
+   Retourne un masque de bits qui peut contenir les
    <link linkend="ev.constants.watcher-backends">drapeaux de backend</link>
-   combinés en utilisant l'opérateur <emphasis>OR</emphasis>.
+   combinés en utilisant l'opérateur <emphasis>OR</emphasis> bit à bit.
   </simpara>
  </refsect1>
  <refsect1 role="examples">

--- a/reference/ev/evchild/construct.xml
+++ b/reference/ev/evchild/construct.xml
@@ -45,7 +45,7 @@
    paramètre <parameter>trace</parameter> vaut &true;, lorsque le processus
    est stoppé ou continué). En d'autres termes, lorsque le processus
    reçoit un <constant>SIGCHLD</constant>, <emphasis>Ev</emphasis>
-   va récupérer tous les status de sortie/d'attente pour tous les fils
+   va récupérer tous les statuts de sortie/d'attente pour tous les fils
    modifiés/zombies et va appeler la fonction de rappel.
   </simpara>
   <simpara>
@@ -124,7 +124,7 @@
     </term>
     <listitem>
      <simpara>
-      <link linkend="ev.constants.watcher-pri">Fonctions de rappel de l'observateur</link>
+      <link linkend="ev.constants.watcher-pri">Priorité de l'observateur</link>
      </simpara>
     </listitem>
    </varlistentry>

--- a/reference/ev/evembed/sweep.xml
+++ b/reference/ev/evembed/sweep.xml
@@ -17,7 +17,7 @@
   </methodsynopsis>
   <para>
    Balaye, une seule fois, et de façon non bloquante la boucle interne.
-   Fonctionne de la même façon que ce qui suit, mais dans une façon plus
+   Fonctionne de la même façon que ce qui suit, mais d'une façon plus
    appropriée pour les boucles internes :
    <programlisting role="php">
 <![CDATA[

--- a/reference/ev/evfork/construct.xml
+++ b/reference/ev/evfork/construct.xml
@@ -40,7 +40,7 @@
     <listitem>
      <simpara>
       Voir aussi les
-      <link linkend="ev.watcher-callbacks">fonctions de rappels pour
+      <link linkend="ev.watcher-callbacks">fonctions de rappel pour
        les observateurs</link>.
      </simpara>
     </listitem>

--- a/reference/ev/evidle.xml
+++ b/reference/ev/evidle.xml
@@ -22,14 +22,14 @@
     est au ralenti (ou que seuls des watchers ayant une priorité basse ne sont
     en attente), les watchers <classname>EvIdle</classname> seront appelés
     une fois par itération de la boucle d'événements - et ce, tant qu'ils
-    ne sont pas stoppés, ou que le processus ne recoive plus d'événements
+    ne sont pas stoppés, ou que le processus ne reçoive plus d'événements
     et devienne ainsi occupé à gérer les travaux ayant une priorité supérieure.
    </simpara>
    <simpara>
     En plus de maintenir le processus non bloquant (ce qui est utile parfois),
     les watchers <classname>EvIdle</classname> sont un bon endroit
     pour réaliser des <emphasis>"travaux en pseudo-arrière plan"</emphasis>,
-    ou remettre des travaux après que la boucle d'événements n'ait gérée
+    ou remettre des travaux après que la boucle d'événements n'ait géré
     les événements exceptionnels.
    </simpara>
    <simpara>

--- a/reference/ev/evidle/createstopped.xml
+++ b/reference/ev/evidle/createstopped.xml
@@ -4,7 +4,7 @@
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="evidle.createstopped">
  <refnamediv>
   <refname>EvIdle::createStopped</refname>
-  <refpurpose>Crée une instance d'un objet observateur EvIdle</refpurpose>
+  <refpurpose>Crée une instance d'un objet observateur EvIdle arrêté</refpurpose>
  </refnamediv>
  <refsect1 role="description">
   &reftitle.description;

--- a/reference/ev/evio.xml
+++ b/reference/ev/evio.xml
@@ -35,7 +35,7 @@
     de se retrouver dans cette situation. Aussi, il est recommandé de
     toujours utiliser des I/O non bloquants : un <emphasis>read()</emphasis>
     supplémentaire retournant <constant>EAGAIN</constant> (ou similaire)
-    est plus préférable à un programme qui attend l'arrivée de données.
+    est bien préférable à un programme qui attend l'arrivée de données.
    </simpara>
    <simpara>
     Si pour une raison ou une autre, il est impossible d'exécuter le

--- a/reference/ev/evio/createstopped.xml
+++ b/reference/ev/evio/createstopped.xml
@@ -75,7 +75,7 @@
     <listitem>
      <simpara>
       Voir les
-      <link linkend="ev.watcher-callbacks">fonctions de rappels des observateurs</link>.
+      <link linkend="ev.watcher-callbacks">fonctions de rappel des observateurs</link>.
      </simpara>
     </listitem>
    </varlistentry>

--- a/reference/ev/evloop.xml
+++ b/reference/ev/evloop.xml
@@ -187,7 +187,7 @@
        la latence, le stress et l'inexactitude (la fonction de rappel
        du watcher sera appelée plus tard). Les watchers <classname>EvIo</classname>
        ne seront pas affectés. Le fait de définir cette valeur à une valeur non
-       nulle ne va introduire aucune surcharge supplémentaire à
+       nulle ne va introduire aucun surcoût supplémentaire à
        <emphasis>libev</emphasis>. Voir aussi les
        <link xlink:href="http://pod.tst.eu/http://cvs.schmorp.de/libev/ev.pod#FUNCTIONS_CONTROLLING_EVENT_LOOPS">
        fonctions contrôlant les boucles d'événements</link>.

--- a/reference/ev/evloop/construct.xml
+++ b/reference/ev/evloop/construct.xml
@@ -67,7 +67,7 @@
     </term>
     <listitem>
      <simpara>
-      Voir la fonction
+      Voir
       <link linkend="evloop.props.io-interval">io_interval</link>
      </simpara>
     </listitem>
@@ -78,7 +78,7 @@
     </term>
     <listitem>
      <simpara>
-      Voir la fonction
+      Voir
       <link linkend="evloop.props.timeout-interval">timeout_interval</link>
      </simpara>
     </listitem>

--- a/reference/ev/evloop/defaultloop.xml
+++ b/reference/ev/evloop/defaultloop.xml
@@ -72,7 +72,7 @@
     </term>
     <listitem>
      <simpara>
-      Voir la fonction
+      Voir
       <link linkend="evloop.props.io-interval">io_interval</link>
      </simpara>
     </listitem>
@@ -83,7 +83,7 @@
     </term>
     <listitem>
      <simpara>
-      Voir la fonction
+      Voir
       <link linkend="evloop.props.timeout-interval">timeout_interval</link>
      </simpara>
     </listitem>

--- a/reference/ev/evloop/invokepending.xml
+++ b/reference/ev/evloop/invokepending.xml
@@ -5,8 +5,8 @@
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="evloop.invokepending">
  <refnamediv>
   <refname>EvLoop::invokePending</refname>
-  <refpurpose>Invoque tous les watchers en attente pendant que leurs statuts
-   de file d'attente ne soient réinitialisés</refpurpose>
+  <refpurpose>Invoque tous les watchers en attente tout en réinitialisant
+   leur état d'attente</refpurpose>
  </refnamediv>
  <refsect1 role="description">
   &reftitle.description;
@@ -17,8 +17,8 @@
    <void/>
   </methodsynopsis>
   <simpara>
-   Invoque tous les watchers en attente pendant que leurs statuts
-   de file d'attente ne soient réinitialisés.
+   Invoque tous les watchers en attente tout en réinitialisant
+   leur état d'attente.
   </simpara>
  </refsect1>
  <refsect1 role="parameters">

--- a/reference/ev/evloop/now.xml
+++ b/reference/ev/evloop/now.xml
@@ -18,10 +18,10 @@
   <simpara>
    Retourne le "event loop time" courant, qui est la durée pendant
    laquelle la boucle d'événement reçoit des événements et
-   démarre leurs analyses. Ce timestamp ne change pas tant que les
+   démarre leurs analyses. Cet horodatage ne change pas tant que les
    fonctions de rappel sont en cours d'exécution, et c'est aussi le temps
    de base utilisé pour les timers relatifs. Il est possible de le considérer
-   comme le timestamp de l'événement en cours (ou plus exactement,
+   comme l'horodatage de l'événement en cours (ou plus exactement,
    celui utilisé par libev).
   </simpara>
  </refsect1>
@@ -32,7 +32,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   Retourne le timestamp de la boucle d'événement, en secondes.
+   Retourne l'horodatage de la boucle d'événement, en secondes.
   </simpara>
  </refsect1>
  <refsect1 role="seealso">

--- a/reference/ev/evloop/nowupdate.xml
+++ b/reference/ev/evloop/nowupdate.xml
@@ -4,8 +4,8 @@
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="evloop.nowupdate">
  <refnamediv>
   <refname>EvLoop::nowUpdate</refname>
-  <refpurpose>Établit le temps courant en demandant au kernel, et mise à jour
-   du temps retourné par EvLoop::now pendant l'exécution</refpurpose>
+  <refpurpose>Établit le temps courant en demandant au kernel, et met à jour
+   le temps retourné par EvLoop::now pendant l'exécution</refpurpose>
  </refnamediv>
  <refsect1 role="description">
   &reftitle.description;
@@ -16,8 +16,8 @@
    <void/>
   </methodsynopsis>
   <simpara>
-   Établit le temps courant en demandant au kernel, et mise à jour
-   du temps retourné par <methodname>EvLoop::now</methodname> pendant l'exécution.
+   Établit le temps courant en demandant au kernel, et met à jour
+   le temps retourné par <methodname>EvLoop::now</methodname> pendant l'exécution.
    C'est une opération qui est coûteuse en termes de performance et qui
    est habituellement exécutée automatiquement dans la méthode
    <methodname>EvLoop::run</methodname>.

--- a/reference/ev/evloop/run.xml
+++ b/reference/ev/evloop/run.xml
@@ -20,7 +20,7 @@
   </methodsynopsis>
   <simpara>
    Commence à vérifier les événements et à appeler les fonctions de rappel
-   pour la boucle d'événement courant. La méthode s'arrête lorsqu'une
+   pour la boucle d'événements courante. La méthode s'arrête lorsqu'une
    fonction de rappel appelle la méthode <methodname>Ev::stop</methodname>
    ou que les drapeaux sont différents de zéro (auquel cas, la valeur
    retournée est &true;) ou lorsqu'il n'y a aucun watcher actif qui référence

--- a/reference/ev/evloop/signal.xml
+++ b/reference/ev/evloop/signal.xml
@@ -6,7 +6,7 @@
  <refnamediv>
   <refname>EvLoop::signal</refname>
   <refpurpose>Crée un objet EvSignal watcher associé avec l'instance de la
-   boucle d'événement courant</refpurpose>
+   boucle d'événement courante</refpurpose>
  </refnamediv>
  <refsect1 role="description">
   &reftitle.description;
@@ -36,7 +36,7 @@
   </methodsynopsis>
   <simpara>
    Crée un objet EvSignal watcher associé avec l'instance de la
-   boucle d'événement courant.
+   boucle d'événement courante.
   </simpara>
  </refsect1>
  <refsect1 role="parameters">

--- a/reference/ev/evperiodic.xml
+++ b/reference/ev/evperiodic.xml
@@ -27,7 +27,7 @@
     se lancer <emphasis>"dans 10 secondes"</emphasis> (c.-à-d.
     <methodname>EvLoop::now</methodname> + <literal>10.0</literal>,
     c.-à-d. un temps absolu, et non un délai), et que l'horloge système
-    est ré-initialisée à <emphasis>Janvier de l'année dernière</emphasis>,
+    est ré-initialisée à <emphasis>janvier de l'année dernière</emphasis>,
     alors cela prendra une année et plus à lancer l'événement (contrairement
     à <classname>EvTimer</classname> qui sera lancé <literal>10</literal>
     secondes après son démarrage, sachant qu'il utilise un délai maximal d'attente
@@ -36,7 +36,7 @@
    <simpara>
     Comme pour les minuteurs, il est garanti que la fonction de rappel soit
     appelée uniquement lorsque le point dans le temps où il est supposé se lancer
-    ne soit passé. Si plusieurs minuteurs deviennent prêts en même temps
+    est passé. Si plusieurs minuteurs deviennent prêts en même temps
     pendant la même itération de boucle, alors ceux dont les valeurs de délai
     maximal d'attente sont les plus proches seront appelés avant ceux qui ont des
     valeurs de délai maximal d'attente plus éloignées (mais ceci n'est plus
@@ -109,7 +109,7 @@
       <simpara>
        La valeur de l'intervalle courant. Peut être modifié à tout moment,
        mais les modifications ne prennent effet que lorsque le minuteur
-       périodique ne se lance, ou lorsque la méthode
+       périodique se lance, ou lorsque la méthode
        <methodname>EvPeriodic::again</methodname> est appelée.
       </simpara>
      </listitem>

--- a/reference/ev/evsignal.xml
+++ b/reference/ev/evsignal.xml
@@ -19,12 +19,12 @@
    </simpara>
    <simpara>
     Il n'y a aucune limite pour le nombre de watchers pour le même signal,
-    mais seulement dans la même boucle, c.-à-d. un peu surveiller
+    mais seulement dans la même boucle, c.-à-d. il est possible de surveiller
     <constant>SIGINT</constant> dans la boucle par défaut, et pour
     <constant>SIGIO</constant> dans une autre boucle, mais il n'est pas
     autorisé de surveiller <constant>SIGINT</constant> à la fois dans
     la boucle par défaut, et dans une autre boucle au même moment.
-    A ce moment, <constant>SIGCHLD</constant> est lié de façon permanente
+    À ce moment, <constant>SIGCHLD</constant> est lié de façon permanente
     à la boucle par défaut.
    </simpara>
    <simpara>

--- a/reference/ev/evsignal/set.xml
+++ b/reference/ev/evsignal/set.xml
@@ -31,7 +31,7 @@
     </term>
     <listitem>
      <simpara>
-      Numéro du signal. Identique que pour le constructeur
+      Numéro du signal. Identique à celui du constructeur
       <methodname>EvSignal::__construct</methodname>.
      </simpara>
     </listitem>

--- a/reference/ev/evstat.xml
+++ b/reference/ev/evstat.xml
@@ -18,7 +18,7 @@
    </simpara>
    <simpara>
     Le chemin n'a pas besoin d'exister : la modification de "le chemin existe"
-    vers "le chemin n'existe pas est une modification de statut comme un autre.
+    vers "le chemin n'existe pas" est une modification de statut comme un autre.
     La condition "le chemin n'existe pas" est signifiée par la valeur 0 de
     l'élément <literal>'nlink'</literal> (retourné par la méthode
     <methodname>EvStat::attr</methodname>).
@@ -34,7 +34,7 @@
     l'implémentation portable appelle simplement la commande
     <emphasis>stat()</emphasis> sur le chemin pour vérifier les modifications.
     Pour ce cas, un intervalle régulier peut être spécifié. S'il est spécifié,
-    un intervalle de <literal>0.0 </literal> (vivement recommandé) alors
+    un intervalle de <literal>0.0</literal> (vivement recommandé) alors
     une valeur par défaut non spécifiée sera utilisée (aux alentours de 5 secondes,
     et peut être modifiée dynamiquement). <emphasis>libev</emphasis>
     va également imposer un intervalle minimum qui est actuellement aux alentours

--- a/reference/ev/evstat/construct.xml
+++ b/reference/ev/evstat/construct.xml
@@ -57,7 +57,7 @@
     </term>
     <listitem>
      <simpara>
-      Intervalle de détection d'une modification ; doit valoir normalement
+      Intervalle de détection d'une modification ; devrait valoir normalement
       <literal>0.0</literal> pour laisser <emphasis>libev</emphasis>
       choisir la bonne valeur.
      </simpara>

--- a/reference/ev/evtimer.xml
+++ b/reference/ev/evtimer.xml
@@ -16,7 +16,7 @@
    <simpara>
     Les minuteurs sont basés sur un temps réel, aussi, si un minuteur enregistre
     un événement qui se termine après une heure et ré-initialise l'horloge système
-    à <emphasis>Janvier de l'an passé</emphasis>, il sera de nouveau
+    à <emphasis>janvier de l'an passé</emphasis>, il sera de nouveau
     hors délai après une heure (approximativement). "Approximativement"
     car la détection des sauts dans le temps est dure, et certaines inexactitudes
     sont inévitables.
@@ -39,7 +39,7 @@
     à intervalle de <literal>10</literal> secondes exactement.
     Cependant, si le script ne peut pas conserver le minuteur car il prend
     plus de temps que ses <literal>10</literal> secondes, le minuteur
-    ne pourra se lancer pas plus d'une fois par itération de boucle
+    ne pourra pas se lancer plus d'une fois par itération de boucle
     d'événements.
    </simpara>
   </section>
@@ -93,7 +93,7 @@
      <listitem>
       <simpara>
        Si cette propriété vaut <literal>0.0</literal>, alors il sera automatiquement
-       stoppée une fois le délai maximal d'attente atteint. S'il est positif,
+       stoppé une fois le délai maximal d'attente atteint. S'il est positif,
        alors le minuteur sera automatiquement configuré à se lancer à chaque
        seconde en suivant, tant qu'il ne sera pas stoppé manuellement.
       </simpara>
@@ -117,7 +117,7 @@
        à <literal>7.0</literal>, <varname>remaining</varname> retournera
        <literal>5.0</literal>. Lorsque le minuteur est démarré, et qu'une
        seconde se passe, <varname>remaining</varname> retourne
-       <literal>4.0</literal>. lorsque le minuteur expire et qu'il est
+       <literal>4.0</literal>. Lorsque le minuteur expire et qu'il est
        redémarré, il retournera approximativement <literal>7.0</literal>
        (probablement un peu moins sachant que l'invocation de la fonction de rappel
        prend un peu de temps aussi), et ainsi de suite.

--- a/reference/ev/evtimer/again.xml
+++ b/reference/ev/evtimer/again.xml
@@ -16,7 +16,7 @@
    <void/>
   </methodsynopsis>
   <simpara>
-   Cette méthode fonctionne comme si le Timer s'est terminé, et re-commence
+   Cette méthode fonctionne comme si le Timer s'était terminé, et re-commence
    son cycle. La sémantique exacte est :
   </simpara>
   <orderedlist>

--- a/reference/ev/evtimer/construct.xml
+++ b/reference/ev/evtimer/construct.xml
@@ -47,7 +47,7 @@
     </term>
     <listitem>
      <simpara>
-      Configure le time pour lancer le trigger après
+      Configure le timer pour se déclencher après
       <parameter>after</parameter> secondes.
      </simpara>
     </listitem>
@@ -60,9 +60,9 @@
      <simpara>
       Si ce paramètre vaut <literal>0.0</literal>, alors le watcher
       sera automatiquement stoppé lorsque le délai maximal d'attente sera
-      atteint. Si ce paramètre est positif, alors le timer va automatiquement
-      lancer le trigger à chaque seconde suivante, et ce, tant qu'il ne sera
-      pas stoppé manuellement.
+      atteint. Si ce paramètre est positif, alors le timer sera automatiquement
+      configuré pour se déclencher à nouveau toutes les <parameter>repeat</parameter>
+      secondes, tant qu'il ne sera pas stoppé manuellement.
      </simpara>
     </listitem>
    </varlistentry>
@@ -103,7 +103,7 @@
  <refsect1 role="examples">
   &reftitle.examples;
  <example>
-   <title>timers simples</title>
+   <title>Timers simples</title>
    <programlisting role="php">
 <![CDATA[
 <?php
@@ -128,14 +128,14 @@ $w2 = new EvTimer(2, 1, function ($w) {
 $w_stopped = EvTimer::createStopped(10, 5, function($w) {
     echo "Fonction de rappel du timer créé stoppé\n";
 
-    // Stop le watcher après 2 itérations
+    // Stoppe le watcher après 2 itérations
     Ev::iteration() >= 2 and $w->stop();
 });
 
-// Boucle tant que Ev::stop() est appelé ou tant que tous les watchers ne s'arrêtent
+// Boucle jusqu'à ce que Ev::stop() soit appelé ou que tous les watchers s'arrêtent
 Ev::run();
 
-// Démarre et verrouille s'il est en fonctionnement
+// Démarre et regarde si ça fonctionne
 $w_stopped->start();
 echo "Exécution d'une seule itération\n";
 Ev::run(Ev::RUN_ONCE);
@@ -193,7 +193,7 @@ FIN
     <link xlink:href="&url.ev.timer;">ev_timer - répétition d'un délai d'attente maximal</link>
    </member>
    <member>
-    <link xlink:href="&url.ev.timeouts;">Être intelligent avec les délais d'attente maximal</link>
+    <link xlink:href="&url.ev.timeouts;">Être intelligent avec les délais d'attente maximaux</link>
    </member>
   </simplelist>
  </refsect1>

--- a/reference/ev/evtimer/createstopped.xml
+++ b/reference/ev/evtimer/createstopped.xml
@@ -52,7 +52,7 @@
     </term>
     <listitem>
      <simpara>
-      Configure le time pour lancer un trigger après
+      Configure le timer pour lancer un trigger après
       <parameter>after</parameter> secondes.
      </simpara>
     </listitem>

--- a/reference/ev/evtimer/set.xml
+++ b/reference/ev/evtimer/set.xml
@@ -47,7 +47,7 @@
      <simpara>
       Si ce paramètre vaut <literal>0.0</literal>, alors le watcher sera
       automatiquement stoppé si le délai d'attente maximal est atteint.
-      Si ce paramètre est positif, alors le time va automatiquement lancer le
+      Si ce paramètre est positif, alors le timer va automatiquement lancer le
       trigger à chaque seconde suivante, tant qu'il ne sera pas stoppé manuellement.
      </simpara>
     </listitem>

--- a/reference/ev/evwatcher.xml
+++ b/reference/ev/evwatcher.xml
@@ -87,7 +87,7 @@
      </term>
      <listitem>
       <simpara>
-       <emphasis>En lecture seule</emphasis>. Si le watcher est en attente,
+       <emphasis>En lecture seule</emphasis>. &true; si le watcher est en attente,
        c.-à-d. si le watcher a des événements en attente, mais que sa fonction
        de rappel n'a pas encore été appelée, &false; sinon. Tant que le
        watcher est en attente (mais non actif), un autre <emphasis>ne peut pas</emphasis>

--- a/reference/ev/evwatcher/construct.xml
+++ b/reference/ev/evwatcher/construct.xml
@@ -5,7 +5,7 @@
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="evwatcher.construct">
  <refnamediv>
   <refname>EvWatcher::__construct</refname>
-  <refpurpose>Constructeur d'objet observateur</refpurpose>
+  <refpurpose>Constructeur abstrait d'un objet observateur</refpurpose>
  </refnamediv>
  <refsect1 role="description">
   &reftitle.description;
@@ -17,7 +17,7 @@
   </constructorsynopsis>
   <simpara>
    <methodname>EvWatcher::__construct</methodname> est un constructeur
-   d'objet d'observateur, implémenté dans les classes dérivées.
+   abstrait d'un objet observateur, implémenté dans les classes dérivées.
   </simpara>
  </refsect1>
 

--- a/reference/ev/evwatcher/keepalive.xml
+++ b/reference/ev/evwatcher/keepalive.xml
@@ -5,7 +5,7 @@
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="evwatcher.keepalive">
  <refnamediv>
   <refname>EvWatcher::keepalive</refname>
-  <refpurpose>Garde la boucle active</refpurpose>
+  <refpurpose>Configure si la boucle doit être empêchée de se terminer</refpurpose>
  </refnamediv>
  <refsect1 role="description">
   &reftitle.description;
@@ -19,7 +19,7 @@
    </methodparam>
   </methodsynopsis>
   <simpara>
-   Garde la boucle active. Avec un paramètre <parameter>value</parameter>
+   Configure si la boucle doit être empêchée de se terminer. Avec un paramètre <parameter>value</parameter>
    défini à &false;, le Watcher n'empêchera pas les méthodes
    <methodname>Ev::run</methodname>/<methodname>EvLoop::run</methodname>
    de s'arrêter même si le Watcher est actif.
@@ -29,10 +29,10 @@
    <parameter>value</parameter> défini à &true;.
   </simpara>
   <simpara>
-   Le fait de nettoyer le statut "keepalive" est utile lors d'un retour
-   des méthodes <methodname>Ev::run</methodname>/<methodname>EvLoop::run</methodname>,
-   auquel cas le Watcher n'est plus désiré. Ce peut être un Watcher socket UDP
-   qui continue de fonctionner longtemps.
+   Le fait de nettoyer le statut « keepalive » est utile lorsqu'il est
+   indésirable de sortir des méthodes <methodname>Ev::run</methodname>/<methodname>EvLoop::run</methodname>
+   uniquement à cause de ce Watcher. Ce peut être un Watcher socket UDP
+   qui fonctionne longtemps.
   </simpara>
  </refsect1>
  <refsect1 role="parameters">
@@ -61,7 +61,8 @@
  <refsect1 role="examples">
   &reftitle.examples;
   <example>
-   <title>Enregistre un Watcher I/O pour des sockets UDP</title>
+   <title>Enregistre un Watcher I/O pour un socket UDP mais sans maintenir la
+   boucle d'événements active uniquement à cause de ce Watcher.</title>
    <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/ev/periodic-modes.xml
+++ b/reference/ev/periodic-modes.xml
@@ -17,7 +17,7 @@
     L'appel se fera à l'heure d'horloge <parameter>offset</parameter>
     et ne sera pas répété. Il ne sera pas ajusté lorsqu'un bond dans le temps
     surviendra, aussi, s'il doit être exécuté à
-    <emphasis>January 1st 2014</emphasis>, alors il le sera lorsque l'heure
+    <emphasis>1er janvier 2014</emphasis>, alors il le sera lorsque l'heure
     système sera atteinte, ou dépassée.
    </simpara>
   </listitem>

--- a/reference/ev/watcher-callbacks.xml
+++ b/reference/ev/watcher-callbacks.xml
@@ -6,7 +6,7 @@
  <simpara>
   Tous les watchers peuvent être actifs (en attente d'événements) ou inactifs
   (en pause). Seuls les watchers actifs peuvent avoir leurs fonctions de rappel
-  d'appelées. Toutes les fonctions de rappel seront appelées avec au moins deux
+  appelées. Toutes les fonctions de rappel seront appelées avec au moins deux
   arguments :
   <parameter>watcher</parameter> - le watcher, et <parameter>revents</parameter>,
   un masque d'événements reçus.
@@ -48,13 +48,13 @@
    </term>
    <listitem>
     <simpara>
-     <link linkend="ev.constants.watcher-revents">Un watcher recevant les événements</link>.
+     <link linkend="ev.constants.watcher-revents">Les événements reçus par le watcher</link>.
     </simpara>
    </listitem>
   </varlistentry>
  </variablelist>
  <simpara>
-  Chaque type de watcher a un octet d'associé dans
+  Chaque type de watcher a un bit d'associé dans
   <parameter>revents</parameter>, aussi, on peut utiliser la même
   fonction de rappel pour plusieurs watchers. Le masque d'événements
   est nommé après le type, c.-à-d.
@@ -63,7 +63,7 @@
   <methodname>EvLoop::prepare</methodname>) définit <constant>Ev::PREPARE</constant>,
   <classname>EvPeriodic</classname> (ou <methodname>EvLoop::periodic</methodname>)
   définit <constant>Ev::PERIODIC</constant> et ainsi de suite, avec comme exception les
-  événements I/O (qui peuvent définir à la fois les octets
+  événements I/O (qui peuvent définir à la fois les bits
   <constant>Ev::READ</constant> et <constant>Ev::WRITE</constant>).
  </simpara>
 </chapter>

--- a/reference/ev/watchers.xml
+++ b/reference/ev/watchers.xml
@@ -21,16 +21,16 @@ Ev::run(Ev::RUN_ONCE);
  </para>
  <simpara>
   Tous les constructeurs des watchers démarrent automatiquement les watchers.
-  La méthode <literal>createStopped</literal> stoppe un watcher (c.-à-d.
+  Les méthodes <literal>createStopped</literal> créent des watchers stoppés (c.-à-d.
   <methodname>EvIo::createStopped</methodname>).
  </simpara>
  <simpara>
-  Notez qu'un watcher sera automatiquement stoppé lorsque l'objet watcher est
+  Il est à noter qu'un watcher sera automatiquement stoppé lorsque l'objet watcher est
   détruit. Toutefois, les objets watchers retournés par les constructeurs
-  ou les méthodes factorielles seront conservés.
+  ou les méthodes fabriques devraient être conservés.
  </simpara>
  <simpara>
-  Notez également que toutes les méthodes qui modifient les propriétés
+  Il est également à noter que toutes les méthodes qui modifient les propriétés
   d'un watcher (<emphasis>set</emphasis>, <varname>priority</varname> etc.)
   stoppent et redémarrent automatiquement le watcher s'il est actif, ce qui
   signifie que les événements en attente seront perdus.

--- a/reference/event/book.xml
+++ b/reference/event/book.xml
@@ -11,7 +11,7 @@
   <para>
    Ceci est une extension pour planifier efficacement les I/O, les temps
    et les signaux basés sur les événements en utilisant le meilleur
-   mécanisme I/O disponible sur une plateforme spécifique. C'est un portage
+   mécanisme de notification d'I/O disponible sur une plateforme spécifique. C'est un portage
    de libevent pour l'infrastructure PHP.
   </para>
   <note xmlns="http://docbook.org/ns/docbook">

--- a/reference/event/event.callbacks.xml
+++ b/reference/event/event.callbacks.xml
@@ -8,7 +8,7 @@
   sera appelée lorsque l'événement devient actif. Pour associer une fonction
   de rappel avec un événement, il convient de la passer avec un type
   <type>callable</type> à la méthode <methodname>Event::__construct</methodname>,
-  <methodname>Event::set</methodname>, ou toute autre méthode factorielle comme
+  <methodname>Event::set</methodname>, ou toute autre méthode de fabrique comme
   <methodname>Event::timer</methodname>.
  </para>
  <para>
@@ -51,7 +51,7 @@
    </term>
    <listitem>
     <para>
-     Masque d'octets de <emphasis>tous</emphasis> les événements lancés.
+     Masque de bits de <emphasis>tous</emphasis> les événements lancés.
     </para>
    </listitem>
   </varlistentry>

--- a/reference/event/event.constructing.signal.events.xml
+++ b/reference/event/event.constructing.signal.events.xml
@@ -8,7 +8,7 @@
   Un événement peut aussi surveiller les signaux de style POSIX.
   Pour construire un gestionnaire pour un signal, utiliser la méthode
   <methodname>Event::__construct</methodname> avec le drapeau
-  <constant>Event::SIGNAL</constant> ou la méthode factorielle
+  <constant>Event::SIGNAL</constant> ou la méthode de fabrique
   <methodname>Event::signal</methodname>.
  </para>
  <example>
@@ -57,7 +57,7 @@ $base->loop();
  </example>
  <para>
   Il est à noter que les fonctions de rappel d'un signal sont exécutées dans la
-  boucle d'événement après que le signal ne soit survenu, aussi,
+  boucle d'événement après que le signal est survenu, aussi,
   il est plus sûr pour le signal d'appeler des fonctions depuis la boucle
   que l'on n'est pas supposé appeler depuis un gestionnaire de signaux
   POSIX classique.

--- a/reference/event/event.persistence.xml
+++ b/reference/event/event.persistence.xml
@@ -3,7 +3,7 @@
 <!-- Reviewed: no -->
 
 <chapter  xml:id="event.persistence" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
- <title>À propos de la persistence des événements</title>
+ <title>À propos de la persistance des événements</title>
  <para>
   Par défaut, dès qu'un événement en attente devient actif (car son descripteur
   de fichier est prêt à être lu ou écrit, ou parce que son délai d'attente
@@ -14,13 +14,13 @@
  </para>
  <para>
   Si le drapeau <constant>Event::PERSIST</constant> est défini sur l'événement,
-  alors il est <emphasis>persistent</emphasis>. Cela signifie que
+  alors il est <emphasis>persistant</emphasis>. Cela signifie que
   l'événement reste en attente y compris lorsque sa fonction de rappel
   est activée. La méthode <methodname>Event::del</methodname> peut être
   appelée pour le passer en non-attente.
  </para>
  <para>
-  Le délai maximal d'attente sur un événement persistent est réinitialisé
+  Le délai maximal d'attente sur un événement persistant est réinitialisé
   dès lors que sa fonction de rappel est exécutée.
   Aussi, si un événement a comme drapeaux <constant>Event::READ</constant>
   <literal>|</literal> <constant>Event::PERSIST</constant> et un

--- a/reference/event/event.xml
+++ b/reference/event/event.xml
@@ -13,7 +13,7 @@
     La classe <classname>Event</classname> représente et lance un événement
     sur un descripteur de fichier devenu prêt pour une lecture ou une écriture ;
     un descripteur de fichier devient prêt pour une lecture ou une écriture
-    (I/O uniquement) ; un délai d'attente expiré ; un signal survenant ;
+    (I/O edge-triggered uniquement) ; un délai d'attente expiré ; un signal survenant ;
     un événement lancé par l'utilisateur.
    </para>
    <para>
@@ -24,8 +24,8 @@
     tant que l'événement enregistré ne survient pas, le passant ainsi en
     statut <emphasis>actif</emphasis>. Pour gérer les événements, l'utilisateur
     doit enregistrer une fonction de rappel qui sera appelée lorsque l'événement
-    devient actif. Si l'événement est configuré comme <emphasis>persistent</emphasis>,
-    il restera en attente. S'il n'est pas persistent, il ne sera plus en attente
+    devient actif. Si l'événement est configuré comme <emphasis>persistant</emphasis>,
+    il restera en attente. S'il n'est pas persistant, il ne sera plus en attente
     lorsque sa fonction de rappel sera exécutée. La méthode <methodname>Event::del</methodname>
     <emphasis>supprime</emphasis> l'événement, il n'est alors plus en attente.
     En appelant la méthode <methodname>Event::add</methodname>, il sera ajouté
@@ -109,7 +109,7 @@
      <listitem>
       <para>
        Si l'événement est en attente. Voir la section :
-       <link linkend="event.persistence">À propos de la persistence des événements</link>.
+       <link linkend="event.persistence">À propos de la persistance des événements</link>.
       </para>
      </listitem>
     </varlistentry>
@@ -126,8 +126,9 @@
      </term>
      <listitem>
       <para>
-       Indique que l'événement doit être lancé, si la base d'événement
-       sous-jacente supporte ce type d'événement. Ceci affecte la sémantique
+       Indique que l'événement doit être edge-triggered, si le backend de la
+       base d'événement sous-jacente supporte les événements edge-triggered.
+       Ceci affecte la sémantique
        de <constant>Event::READ</constant> et de <constant>Event::WRITE</constant>.
       </para>
      </listitem>
@@ -138,8 +139,8 @@
      </term>
      <listitem>
       <para>
-       Indique que l'événement est persistent. Voir la section :
-       <link linkend="event.persistence">À propos de la persistence des événements</link>.
+       Indique que l'événement est persistant. Voir la section :
+       <link linkend="event.persistence">À propos de la persistance des événements</link>.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/event/event/add.xml
+++ b/reference/event/event/add.xml
@@ -20,8 +20,8 @@
   </methodsynopsis>
   <para>
    Bascule un évènement en attente. Un évènement qui n'a pas le statut en 
-   attente ne se lancera jamais, et le callback de l'évènement ne sera
-   jamais appelé. En utilisant <methodname>Event::del</methodname> un 
+   attente ne se lancera jamais, et la fonction de rappel de l'évènement ne sera
+   jamais appelée. En utilisant <methodname>Event::del</methodname> un 
    évènement peut être re-planifié par l'utilisateur quand il veut.
   </para>
   <para>

--- a/reference/event/event/add.xml
+++ b/reference/event/event/add.xml
@@ -21,7 +21,7 @@
   <para>
    Bascule un évènement en attente. Un évènement qui n'a pas le statut en 
    attente ne se lancera jamais, et la fonction de rappel de l'évènement ne sera
-   jamais appelée. En utilisant <methodname>Event::del</methodname> un 
+   jamais appelée. En utilisant <methodname>Event::del</methodname> un
    évènement peut être re-planifié par l'utilisateur quand il veut.
   </para>
   <para>

--- a/reference/event/event/construct.xml
+++ b/reference/event/event/construct.xml
@@ -95,8 +95,8 @@
     </term>
     <listitem>
      <para>
-      Données personnalisées. Si spécifié, elles seront passées à la fonction
-      de rappel lorsque l'événement aura lancé les triggers.
+      Données personnalisées. Si spécifiées, elles seront passées à la fonction
+      de rappel lorsque l'événement se déclenche.
      </para>
     </listitem>
    </varlistentry>

--- a/reference/event/event/del.xml
+++ b/reference/event/event/del.xml
@@ -17,7 +17,8 @@
    <void />
   </methodsynopsis>
   <para>
-   Supprime un événement du jeu d'événements surveillés.
+   Supprime un événement du jeu d'événements surveillés, c.-à-d. le passe en
+   non-attente.
   </para>
  </refsect1>
  <refsect1 role="parameters">

--- a/reference/event/event/settimer.xml
+++ b/reference/event/event/settimer.xml
@@ -63,8 +63,8 @@
     </term>
     <listitem>
      <para>
-      Données personnalisées. Si spécifié, elles seront passées à la fonction
-      de rappel lorsque l'événement lancera les triggers.
+      Données personnalisées. Si spécifiées, elles seront passées à la fonction
+      de rappel lorsque l'événement se déclenche.
      </para>
     </listitem>
    </varlistentry>

--- a/reference/event/event/signal.xml
+++ b/reference/event/event/signal.xml
@@ -78,8 +78,8 @@
     </term>
     <listitem>
      <para>
-      Données personnalisées. Si spécifié, elles seront passées à la fonction
-      de rappel lorsque l'événement lancera les triggers.
+      Données personnalisées. Si spécifiées, elles seront passées à la fonction
+      de rappel lorsque l'événement se déclenche.
      </para>
     </listitem>
    </varlistentry>

--- a/reference/event/event/timer.xml
+++ b/reference/event/event/timer.xml
@@ -64,8 +64,8 @@
     </term>
     <listitem>
      <para>
-      Données personnalisées. Si spécifié, elles seront passées à la fonction
-      de rappel lorsque l'événement lancera les triggers.
+      Données personnalisées. Si spécifiées, elles seront passées à la fonction
+      de rappel lorsque l'événement se déclenche.
      </para>
     </listitem>
    </varlistentry>

--- a/reference/event/eventbase.xml
+++ b/reference/event/eventbase.xml
@@ -170,8 +170,8 @@
       </para>
       <para>
        Le fait de définir ce drapeau rend le code plus rapide, mais il peut
-       se confronter à un bogue Linux : il n'est pas sécurisé d'utiliser ce drapeau
-       en la présence d'un fds clôné par dup() ou une de ces variantes.
+       déclencher un bogue Linux : il n'est pas sécurisé d'utiliser ce drapeau
+       en présence d'un fds cloné par dup() ou une de ces variantes.
        Ceci produirait un comportement étrange et très difficile à diagnostiquer.
       </para>
       <simpara>

--- a/reference/event/eventbase/getfeatures.xml
+++ b/reference/event/eventbase/getfeatures.xml
@@ -49,9 +49,9 @@ $base = new EventBase($cfg);
 
 echo "fonctionnalités :\n";
 $features = $base->getFeatures();
-($features & EventConfig::FEATURE_ET) and print "ET - edge-triggered IO\n";
-($features & EventConfig::FEATURE_O1) and print "O1 - O(1) operation for adding/deleting events\n";
-($features & EventConfig::FEATURE_FDS) and print "FDS - arbitrary file descriptor types, and not just sockets\n";
+($features & EventConfig::FEATURE_ET) and print "ET - E/S déclenchées par front\n";
+($features & EventConfig::FEATURE_O1) and print "O1 - opération O(1) pour l'ajout/suppression d'événements\n";
+($features & EventConfig::FEATURE_FDS) and print "FDS - type de descripteur de fichiers arbitraire, et non uniquement les sockets\n";
 ?>
 ]]>
    </programlisting>

--- a/reference/event/eventbase/gettimeofdaycached.xml
+++ b/reference/event/eventbase/gettimeofdaycached.xml
@@ -6,7 +6,7 @@
 <refentry xml:id="eventbase.gettimeofdaycached" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>EventBase::getTimeOfDayCached</refname>
-  <refpurpose>Retourne le temps de l'événement courant</refpurpose>
+  <refpurpose>Retourne le temps de l'événement de base courant</refpurpose>
  </refnamediv>
  <refsect1 role="description">
   &reftitle.description;
@@ -33,7 +33,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Retourne le temps de <emphasis>l'événement</emphasis>.
+   Retourne le temps de l'<emphasis>événement de base</emphasis> courant.
    En cas d'échec, retourne &null;.
   </para>
  </refsect1>

--- a/reference/event/eventbase/reinit.xml
+++ b/reference/event/eventbase/reinit.xml
@@ -18,7 +18,7 @@
   </methodsynopsis>
   <para>
    Re-initialise l'événement de base.
-   Doit être appelée après un fork.
+   Devrait être appelée après un fork.
   </para>
  </refsect1>
  <refsect1 role="parameters">

--- a/reference/event/eventbuffer.xml
+++ b/reference/event/eventbuffer.xml
@@ -129,9 +129,10 @@
      </term>
      <listitem>
       <para>
-       La fin de ligne est une séquence de nombres représentant un retour chariot
-       et une nouvelle ligne. Ce format n'est pas très utile ; il existe encore
-       seulement pour des raisons de compatibilité ascendante.
+       La fin de ligne est une séquence quelconque d'un nombre quelconque de
+       caractères de retour chariot et de saut de ligne. Ce format n'est pas
+       très utile ; il existe principalement pour des raisons de compatibilité
+       ascendante.
       </para>
      </listitem>
     </varlistentry>
@@ -194,8 +195,8 @@
        Identique à <constant>EventBuffer::PTR_SET</constant>,
        sauf que ce drapeau fait que la méthode
        <methodname>EventBuffer::setPosition</methodname>
-       se déplace à une position en arrière par rapport au numéro
-       d'octets spécifié (au lieu de définir une position absolue).
+       se déplace en avant jusqu'au nombre d'octets spécifié
+       (au lieu de définir une position absolue).
       </para>
      </listitem>
     </varlistentry>

--- a/reference/event/eventbuffer/addbuffer.xml
+++ b/reference/event/eventbuffer/addbuffer.xml
@@ -22,7 +22,7 @@
    Déplace toutes les données du tampon fourni par le paramètre
    <parameter>buf</parameter> à la fin de l'<classname>EventBuffer</classname>
    courant. C'est un ajout destructeur. Les données du premier tampon
-   sont déplacées dans l'autre. Cependant, aucune copie mémoire ne survient.
+   sont déplacées dans l'autre. Cependant, aucune copie mémoire inutile ne survient.
   </para>
  </refsect1>
  <refsect1 role="parameters">

--- a/reference/event/eventbuffer/copyout.xml
+++ b/reference/event/eventbuffer/copyout.xml
@@ -25,7 +25,7 @@
   <para>
    Fonctionne de la même façon que la méthode
    <methodname>EventBuffer::read</methodname>, mais ne vide pas les
-   données du tampon. c.-à-d. la méthode copie les premiers
+   données du tampon. C.-à-d. que la méthode copie les premiers
    <parameter>max_bytes</parameter> octets depuis le début du tampon
    dans le paramètre <parameter>data</parameter>. S'il y a moins de
    <parameter>max_bytes</parameter> octets disponibles, la méthode

--- a/reference/event/eventbuffer/enablelocking.xml
+++ b/reference/event/eventbuffer/enablelocking.xml
@@ -21,7 +21,7 @@
    par plusieurs threads à la fois. Lorsque le verrouillage est activé,
    le verrou sera placé lorsque les fonctions de rappel seront appelées.
    Ce comportement peut conduire à des verrous morts si l'on n'est pas
-   attentif.
+   attentif. Il faut donc anticiper en conséquence.
   </para>
  </refsect1>
  <refsect1 role="parameters">

--- a/reference/event/eventbuffer/lock.xml
+++ b/reference/event/eventbuffer/lock.xml
@@ -21,7 +21,7 @@
    <methodname>EventBuffer::unlock</methodname> pour réaliser un jeu
    d'opérations atomiques, c.-à-d. thread-safe. Il est à noter qu'il n'est pas nécessaire
    de verrouiller les buffers pour les opérations <emphasis>individuelles</emphasis>.
-   Lorsque le verrou est actif, (voir <methodname>EventBuffer::enableLocking</methodname>)
+   Lorsque le verrou est actif (voir <methodname>EventBuffer::enableLocking</methodname>),
    les opérations individuelles sur les buffers d'événements sont déjà atomiques.
   </para>
  </refsect1>

--- a/reference/event/eventbuffer/pullup.xml
+++ b/reference/event/eventbuffer/pullup.xml
@@ -6,7 +6,7 @@
 <refentry xml:id="eventbuffer.pullup" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>EventBuffer::pullup</refname>
-  <refpurpose>Sérialise les données du buffer et retourne le contenu du
+  <refpurpose>Linéarise les données du buffer et retourne le contenu du
    buffer sous la forme d'une chaîne</refpurpose>
  </refnamediv>
  <refsect1 role="description">
@@ -21,9 +21,9 @@
    </methodparam>
   </methodsynopsis>
   <para>
-   Sérialise les premiers <parameter>size</parameter> octets du buffer,
+   Linéarise les premiers <parameter>size</parameter> octets du buffer,
    les copie ou les bouge comme nécessaire pour assurer qu'ils soient contigus
-   et le fait d'occuper la même partie de la mémoire. Si la taille
+   et occupent la même partie de la mémoire. Si la taille
    est négative, la fonction linéarise la totalité du buffer.
   </para>
   <warning>

--- a/reference/event/eventbuffer/search.xml
+++ b/reference/event/eventbuffer/search.xml
@@ -93,7 +93,7 @@
    <programlisting role="php">
 <![CDATA[
 <?php
-// Compte le nombre d'occurrence de la chaîne 'str' dans le tampon 'buf'
+// Compte le nombre d'occurrences de la chaîne 'str' dans le tampon 'buf'
 function count_instances($buf, $str) {
     $total = 0;
     $p     = 0;

--- a/reference/event/eventbufferevent.about.callbacks.xml
+++ b/reference/event/eventbufferevent.about.callbacks.xml
@@ -8,7 +8,7 @@
   représente un <emphasis>buffer d'événements</emphasis>.
   La nature asynchrone d'I/O réalisée par Libevent implique qu'un socket
   (ou tout autre type de descripteur de fichiers) n'est pas toujours
-  disponible. Event invoque les fonctions de rappel correspondant lorsque
+  disponible. Event invoque les fonctions de rappel correspondantes lorsque
   la ressource devient disponible pour une lecture ou une écriture,
   ou lorsque des événements surviennent (c.-à-d. une erreur, une fin de ligne,
   etc.).

--- a/reference/event/eventbufferevent.xml
+++ b/reference/event/eventbufferevent.xml
@@ -20,7 +20,7 @@
    <orderedlist>
     <listitem>
      <para>
-      On décide que l'on veut écrire des données dans une connexion ; placez
+      On décide que l'on veut écrire des données dans une connexion ; on place
       ces données dans un buffer.
      </para>
     </listitem>
@@ -269,7 +269,7 @@
      <listitem>
       <para>
        Une erreur survient pendant une opération bufferevent. Pour plus
-       d'informations sur l'erreur, appelez la méthode
+       d'informations sur l'erreur, appeler la méthode
        <methodname>EventUtil::getLastSocketErrno</methodname> et/ou
        <methodname>EventUtil::getLastSocketError</methodname>.
       </para>

--- a/reference/event/eventbufferevent/connect.xml
+++ b/reference/event/eventbufferevent/connect.xml
@@ -131,7 +131,7 @@ if (!$output->add(
     exit("Échec lors de l'ajout de la demande dans le tampon de sortie\n");
 }
 
-/* Connexion à l'hôte de façon asynchrone.
+/* Connexion à l'hôte de façon synchrone.
  * Nous connaissons l'IP, et donc, nous n'avons pas besoin de résolution DNS. */
 if (!$bev->connect("127.0.0.1:80")) {
     exit("Impossible de se connecter à l'hôte\n");

--- a/reference/event/eventbufferevent/connecthost.xml
+++ b/reference/event/eventbufferevent/connecthost.xml
@@ -5,7 +5,7 @@
 <refentry xml:id="eventbufferevent.connecthost" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>EventBufferEvent::connectHost</refname>
-  <refpurpose>Connexion à un hôte</refpurpose>
+  <refpurpose>Connexion à un hôte avec résolution DNS optionnellement asynchrone</refpurpose>
  </refnamediv>
  <refsect1 role="description">
   &reftitle.description;
@@ -44,7 +44,7 @@
    Le paramètre <parameter>dns_base</parameter> est optionnel.
    Il peut valoir &null;, ou bien un objet créé avec la méthode
    <methodname>EventDnsBase::__construct</methodname>.
-   Pour une résolution de nom d'hôte asynchrone, passez une ressource
+   Pour une résolution de nom d'hôte asynchrone, il faut passer une ressource
    d'événement de base DNS valide. Sinon, la résolution du nom d'hôte
    sera bloquante.
   </simpara>

--- a/reference/event/eventbufferevent/createpair.xml
+++ b/reference/event/eventbufferevent/createpair.xml
@@ -51,7 +51,7 @@
     <listitem>
      <para>
       Constantes <link>EventBufferEvent::OPT_*</link>
-      combinées avec l'opérateur <literal>OR</literal>.
+      combinées avec l'opérateur <literal>OR</literal> bit à bit.
      </para>
     </listitem>
    </varlistentry>

--- a/reference/event/eventbufferevent/getinput.xml
+++ b/reference/event/eventbufferevent/getinput.xml
@@ -21,7 +21,7 @@
    Un tampon d'entrée est un stockage pour les données à lire.
   </para>
   <para>
-   Notez qu'il y a aussi des propriétés d'
+   Il est à noter qu'il y a aussi des propriétés d'
    <literal><link
   linkend="eventbufferevent.props.input">entrée</link>
    </literal> pour la classe <classname>EventBufferEvent</classname>.

--- a/reference/event/eventbufferevent/getoutput.xml
+++ b/reference/event/eventbufferevent/getoutput.xml
@@ -23,7 +23,7 @@
    à écrire.
   </para>
   <para>
-   Notez qu'il y a aussi des propriétés de
+   Il est à noter qu'il y a aussi des propriétés de
    <literal><link
   linkend="eventbufferevent.props.output">sortie</link>
    </literal> pour la classe <classname>EventBufferEvent</classname>.

--- a/reference/event/eventbufferevent/read.xml
+++ b/reference/event/eventbufferevent/read.xml
@@ -20,7 +20,7 @@
    </methodparam>
   </methodsynopsis>
   <para>
-   Supprime les <parameter>size</parameter> octets du tampon
+   Supprime jusqu'à <parameter>size</parameter> octets du tampon
    d'entrée. Retourne une chaîne de données lues
    depuis le tampon d'entrée.
   </para>

--- a/reference/event/eventbufferevent/settimeouts.xml
+++ b/reference/event/eventbufferevent/settimeouts.xml
@@ -6,7 +6,7 @@
 <refentry xml:id="eventbufferevent.settimeouts" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>EventBufferEvent::setTimeouts</refname>
-  <refpurpose>Définit le mode lecture et écriture pour le délai d'attente maximal d'un tampon d'événement</refpurpose>
+  <refpurpose>Définit le délai d'attente en lecture et en écriture d'un tampon d'événement</refpurpose>
  </refnamediv>
  <refsect1 role="description">
   &reftitle.description;
@@ -24,7 +24,7 @@
    </methodparam>
   </methodsynopsis>
   <para>
-   Définit le mode lecture et écriture pour le délai d'attente maximal d'un tampon d'événement.
+   Définit le délai d'attente en lecture et en écriture d'un tampon d'événement.
   </para>
  </refsect1>
  <refsect1 role="parameters">
@@ -36,7 +36,7 @@
     </term>
     <listitem>
      <para>
-      La lecture du délai d'attente maximal
+      Le délai d'attente en lecture
      </para>
     </listitem>
    </varlistentry>
@@ -46,7 +46,7 @@
     </term>
     <listitem>
      <para>
-      L'écriture du délai d'attente maximal
+      Le délai d'attente en écriture
      </para>
     </listitem>
    </varlistentry>

--- a/reference/event/eventbufferevent/setwatermark.xml
+++ b/reference/event/eventbufferevent/setwatermark.xml
@@ -5,7 +5,7 @@
 <refentry xml:id="eventbufferevent.setwatermark" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>EventBufferEvent::setWatermark</refname>
-  <refpurpose>Active la lecture, et/ou l'écriture des filigranes</refpurpose>
+  <refpurpose>Ajuste les filigranes de lecture et/ou d'écriture</refpurpose>
  </refnamediv>
  <refsect1 role="description">
   &reftitle.description;
@@ -27,8 +27,8 @@
    </methodparam>
   </methodsynopsis>
   <para>
-   Active la lecture, l'écriture ou les deux pour les <emphasis>filigranes</emphasis>
-   d'un tampon d'événement.
+   Ajuste les filigranes de lecture, les <emphasis>filigranes</emphasis> d'écriture,
+   ou les deux, d'un unique tampon d'événement.
   </para>
   <simpara>
    Un filigrane de tampon d'événement est une portion, une valeur spécifiant

--- a/reference/event/eventbufferevent/sslerror.xml
+++ b/reference/event/eventbufferevent/sslerror.xml
@@ -51,7 +51,7 @@ function ssl_event_cb($bev, $events, $ctx) {
     if ($events & EventBufferEvent::ERROR) {
         // Récupère les erreurs depuis la pile des erreurs SSL
         while ($err = $bev->sslError()) {
-            fprintf(STDERR, "Bufferevent error %s.\n", $err);
+            fprintf(STDERR, "Erreur Bufferevent %s.\n", $err);
         }
     }
 

--- a/reference/event/eventbufferevent/sslrenegotiate.xml
+++ b/reference/event/eventbufferevent/sslrenegotiate.xml
@@ -24,8 +24,8 @@
     L'appel à cette méthode demande à SSL une renégociation, et au tampon
     d'événement d'appeler la fonction de rappel appropriée. C'est une méthode
     très avancée ; elle ne doit être appelée que si l'on sait parfaitement
-    ce que l'on fait, tout spécialement depuis quelques versions SSL où
-    des failles de sécurité ont été mises à jour lors de renégociation.
+    ce que l'on fait, tout spécialement depuis que de nombreuses versions SSL
+    ont présenté des failles de sécurité connues liées à la renégociation.
    </para>
   </warning>
  </refsect1>

--- a/reference/event/eventbufferevent/sslsocket.xml
+++ b/reference/event/eventbufferevent/sslsocket.xml
@@ -5,7 +5,7 @@
 <refentry xml:id="eventbufferevent.sslsocket" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>EventBufferEvent::sslSocket</refname>
-  <refpurpose>Crée un nouveau tampon SSL dont ces données seront envoyées via un socket SSL</refpurpose>
+  <refpurpose>Crée un nouveau tampon SSL dont ses données seront envoyées via un socket SSL</refpurpose>
  </refnamediv>
  <refsect1 role="description">
   &reftitle.description;
@@ -61,7 +61,7 @@
      <para>
       Socket à utiliser pour ce SSL. Peut être un flux, une ressource
       de socket, un descripteur numérique de fichier, ou &null;. Si le
-      paramètre <parameter>socket</parameter> vaut &null;, on imagine
+      paramètre <parameter>socket</parameter> vaut &null;, on suppose
       que le descripteur de fichier pour ce socket sera assigné ultérieurement
       via la méthode <methodname>EventBufferEvent::connectHost</methodname>.
      </para>

--- a/reference/event/eventbufferevent/write.xml
+++ b/reference/event/eventbufferevent/write.xml
@@ -6,7 +6,7 @@
 <refentry xml:id="eventbufferevent.write" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>EventBufferEvent::write</refname>
-  <refpurpose>Ajoute des données dans un tampon d'événement de sortie</refpurpose>
+  <refpurpose>Ajoute des données dans le tampon de sortie d'un tampon d'événement</refpurpose>
  </refnamediv>
  <refsect1 role="description">
   &reftitle.description;
@@ -20,7 +20,7 @@
    </methodparam>
   </methodsynopsis>
   <para>
-   Ajoute des données dans un tampon d'événement de sortie.
+   Ajoute des données dans le tampon de sortie d'un tampon d'événement.
   </para>
  </refsect1>
  <refsect1 role="parameters">

--- a/reference/event/eventbufferevent/writebuffer.xml
+++ b/reference/event/eventbufferevent/writebuffer.xml
@@ -6,7 +6,7 @@
 <refentry xml:id="eventbufferevent.writebuffer" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>EventBufferEvent::writeBuffer</refname>
-  <refpurpose>Ajoute le contenu entier d'un tampon dans un tampon d'événement de sortie</refpurpose>
+  <refpurpose>Ajoute le contenu entier d'un tampon dans le tampon de sortie d'un tampon d'événement</refpurpose>
  </refnamediv>
  <refsect1 role="description">
   &reftitle.description;
@@ -20,7 +20,7 @@
    </methodparam>
   </methodsynopsis>
   <para>
-   Ajoute le contenu entier d'un tampon dans un tampon d'événement de sortie.
+   Ajoute le contenu entier d'un tampon dans le tampon de sortie d'un tampon d'événement.
   </para>
  </refsect1>
  <refsect1 role="parameters">

--- a/reference/event/eventconfig.xml
+++ b/reference/event/eventconfig.xml
@@ -76,7 +76,7 @@
      <listitem>
       <para>
        Requiert une méthode du backend où ajouter ou supprimer un seul événement,
-       ou d'avoir un seul événement qui devient actif.
+       ou avoir un seul événement qui devient actif, est une opération en O(1).
       </para>
      </listitem>
     </varlistentry>
@@ -86,8 +86,8 @@
      </term>
      <listitem>
       <para>
-       Requiert une méthode du backend qui peut supporter des types de
-       descripteur de fichier arbitraire, et non pas seulement des sockets.
+       Requiert une méthode du backend qui peut supporter des types arbitraires
+       de descripteur de fichier, et non pas seulement des sockets.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/event/eventconfig/requirefeatures.xml
+++ b/reference/event/eventconfig/requirefeatures.xml
@@ -64,7 +64,7 @@ if ($cfg->requireFeatures(EventConfig::FEATURE_FDS)) {
 
     $base = new EventBase($cfg);
     ($base->getFeatures() & EventConfig::FEATURE_FDS)
-        and print "FDS - types arbitraire de descripteur de fichier et non pas juste des sockets\n";
+        and print "FDS - types arbitraires de descripteur de fichier et non pas juste des sockets\n";
 }
 ?>
 ]]>
@@ -73,7 +73,7 @@ if ($cfg->requireFeatures(EventConfig::FEATURE_FDS)) {
    <screen>
 <![CDATA[
 fonctionnalité FDS demandée
-FDS - types arbitraire de descripteur de fichier et non pas juste des sockets
+FDS - types arbitraires de descripteur de fichier et non pas juste des sockets
 ]]>
    </screen>
   </example>

--- a/reference/event/eventconfig/setflags.xml
+++ b/reference/event/eventconfig/setflags.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="eventconfig.setflags" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>EventConfig::setFlags</refname>
-  <refpurpose>Définit un ou plusieurs indicateurs pour configurer l'initialisation éventuelle de l'EventBase</refpurpose>
+  <refpurpose>Définit un ou plusieurs indicateurs pour configurer l'événement de base éventuel</refpurpose>
  </refnamediv>
  <refsect1 role="description">
   &reftitle.description;
@@ -18,8 +18,8 @@
    </methodparam>
   </methodsynopsis>
   <para>
-   Définit un ou plusieurs indicateurs pour configurer les parties 
-   de l'initialisation éventuelle de l'EventBase qui seront initialisées, et comment elles fonctionneront.
+   Définit un ou plusieurs indicateurs pour configurer quelles parties
+   de l'événement de base éventuel seront initialisées, et comment elles fonctionneront.
   </para>
  </refsect1>
  <refsect1 role="parameters">

--- a/reference/event/eventdnsbase/loadhosts.xml
+++ b/reference/event/eventdnsbase/loadhosts.xml
@@ -19,7 +19,8 @@
    </methodparam>
   </methodsynopsis>
   <para>
-   Charge un fichier hosts (au même format que /etc/hosts).
+   Charge un fichier hosts (au même format que
+   <literal>/etc/hosts</literal>).
   </para>
  </refsect1>
  <refsect1 role="parameters">

--- a/reference/event/eventhttp/bind.xml
+++ b/reference/event/eventhttp/bind.xml
@@ -40,7 +40,9 @@
     </term>
     <listitem>
      <para>
-      Une chaîne de caractères contenant l'adresse IP à écouter.
+      Une chaîne de caractères contenant l'adresse IP sur laquelle
+      <literal>listen(2)</literal>
+      écoute.
      </para>
     </listitem>
    </varlistentry>
@@ -79,7 +81,6 @@ if (!$http->bind("127.0.0.1", 8088)) {
 };
 if (!$http->bind("127.0.0.1", 8089)) {
     exit("bind(2) a échoué\n");
-
 };
 
 $http->setCallback("/about", function($req) {
@@ -118,7 +119,7 @@ Connection: close
 <html><head><title>404 Not Found</title></head><body><h1>Not Found</h1><p>The requested URL /unknown was not found on this server.</p></body></html>
 
 Server:
-URI: /about
+URI : /about
 OK
 ]]>
    </screen>

--- a/reference/event/eventhttp/construct.xml
+++ b/reference/event/eventhttp/construct.xml
@@ -144,44 +144,44 @@ function _http_dump($req, $data) {
     static $max_requests = 2;
 
     if (++$counter >= $max_requests)  {
-        echo "Counter reached max requests $max_requests. Exiting\n";
+        echo "Le compteur a atteint le maximum de requêtes $max_requests. Sortie\n";
         exit();
     }
 
-    echo __METHOD__, " called\n";
-    echo "request:"; var_dump($req);
-    echo "data:"; var_dump($data);
+    echo __METHOD__, " appelée\n";
+    echo "requête :"; var_dump($req);
+    echo "données :"; var_dump($data);
 
     echo "\n===== DUMP =====\n";
-    echo "Command:", $req->getCommand(), PHP_EOL;
-    echo "URI:", $req->getUri(), PHP_EOL;
-    echo "Input headers:"; var_dump($req->getInputHeaders());
-    echo "Output headers:"; var_dump($req->getOutputHeaders());
+    echo "Commande :", $req->getCommand(), PHP_EOL;
+    echo "URI :", $req->getUri(), PHP_EOL;
+    echo "En-têtes d'entrée :"; var_dump($req->getInputHeaders());
+    echo "En-têtes de sortie :"; var_dump($req->getOutputHeaders());
 
-    echo "\n >> Sending reply ...";
+    echo "\n >> Envoi de la réponse ...";
     $req->sendReply(200, "OK");
     echo "OK\n";
 
-    echo "\n >> Reading input buffer ...\n";
+    echo "\n >> Lecture du buffer d'entrée ...\n";
     $buf = $req->getInputBuffer();
     while ($s = $buf->readLine(EventBuffer::EOL_ANY)) {
         echo $s, PHP_EOL;
     }
-    echo "No more data in the buffer\n";
+    echo "Plus de données dans le buffer\n";
 }
 
 function _http_about($req) {
     echo __METHOD__, PHP_EOL;
-    echo "URI: ", $req->getUri(), PHP_EOL;
-    echo "\n >> Sending reply ...";
+    echo "URI : ", $req->getUri(), PHP_EOL;
+    echo "\n >> Envoi de la réponse ...";
     $req->sendReply(200, "OK");
     echo "OK\n";
 }
 
 function _http_default($req, $data) {
     echo __METHOD__, PHP_EOL;
-    echo "URI: ", $req->getUri(), PHP_EOL;
-    echo "\n >> Sending reply ...";
+    echo "URI : ", $req->getUri(), PHP_EOL;
+    echo "\n >> Envoi de la réponse ...";
     $req->sendReply(200, "OK");
     echo "OK\n";
 }
@@ -191,7 +191,7 @@ if ($argc > 1) {
     $port = (int) $argv[1];
 }
 if ($port <= 0 || $port > 65535) {
-    exit("Invalid port");
+    exit("Port invalide");
 }
 
 $base = new EventBase();
@@ -200,7 +200,7 @@ $http->setAllowedMethods(EventHttpRequest::CMD_GET | EventHttpRequest::CMD_POST)
 
 $http->setCallback("/dump", "_http_dump", array(4, 8));
 $http->setCallback("/about", "_http_about");
-$http->setDefaultCallback("_http_default", "custom data value");
+$http->setDefaultCallback("_http_default", "valeur de données personnalisée");
 
 $http->bind("0.0.0.0", 8010);
 $base->loop();

--- a/reference/event/eventhttp/setcallback.xml
+++ b/reference/event/eventhttp/setcallback.xml
@@ -145,44 +145,44 @@ function _http_dump($req, $data) {
     static $max_requests = 2;
 
     if (++$counter >= $max_requests)  {
-        echo "Counter reached max requests $max_requests. Exiting\n";
+        echo "Le compteur a atteint le maximum de requêtes $max_requests. Sortie\n";
         exit();
     }
 
-    echo __METHOD__, " called\n";
-    echo "request:"; var_dump($req);
-    echo "data:"; var_dump($data);
+    echo __METHOD__, " appelée\n";
+    echo "requête :"; var_dump($req);
+    echo "données :"; var_dump($data);
 
     echo "\n===== DUMP =====\n";
-    echo "Command:", $req->getCommand(), PHP_EOL;
-    echo "URI:", $req->getUri(), PHP_EOL;
-    echo "Input headers:"; var_dump($req->getInputHeaders());
-    echo "Output headers:"; var_dump($req->getOutputHeaders());
+    echo "Commande :", $req->getCommand(), PHP_EOL;
+    echo "URI :", $req->getUri(), PHP_EOL;
+    echo "En-têtes d'entrée :"; var_dump($req->getInputHeaders());
+    echo "En-têtes de sortie :"; var_dump($req->getOutputHeaders());
 
-    echo "\n >> Sending reply ...";
+    echo "\n >> Envoi de la réponse ...";
     $req->sendReply(200, "OK");
     echo "OK\n";
 
-    echo "\n >> Reading input buffer ...\n";
+    echo "\n >> Lecture du buffer d'entrée ...\n";
     $buf = $req->getInputBuffer();
     while ($s = $buf->readLine(EventBuffer::EOL_ANY)) {
         echo $s, PHP_EOL;
     }
-    echo "No more data in the buffer\n";
+    echo "Plus de données dans le buffer\n";
 }
 
 function _http_about($req) {
     echo __METHOD__, PHP_EOL;
-    echo "URI: ", $req->getUri(), PHP_EOL;
-    echo "\n >> Sending reply ...";
+    echo "URI : ", $req->getUri(), PHP_EOL;
+    echo "\n >> Envoi de la réponse ...";
     $req->sendReply(200, "OK");
     echo "OK\n";
 }
 
 function _http_default($req, $data) {
     echo __METHOD__, PHP_EOL;
-    echo "URI: ", $req->getUri(), PHP_EOL;
-    echo "\n >> Sending reply ...";
+    echo "URI : ", $req->getUri(), PHP_EOL;
+    echo "\n >> Envoi de la réponse ...";
     $req->sendReply(200, "OK");
     echo "OK\n";
 }
@@ -192,7 +192,7 @@ if ($argc > 1) {
     $port = (int) $argv[1];
 }
 if ($port <= 0 || $port > 65535) {
-    exit("Invalid port");
+    exit("Port invalide");
 }
 
 $base = new EventBase();
@@ -201,7 +201,7 @@ $http->setAllowedMethods(EventHttpRequest::CMD_GET | EventHttpRequest::CMD_POST)
 
 $http->setCallback("/dump", "_http_dump", array(4, 8));
 $http->setCallback("/about", "_http_about");
-$http->setDefaultCallback("_http_default", "custom data value");
+$http->setDefaultCallback("_http_default", "valeur de données personnalisée");
 
 $http->bind("0.0.0.0", 8010);
 $base->loop();

--- a/reference/event/eventhttp/setdefaultcallback.xml
+++ b/reference/event/eventhttp/setdefaultcallback.xml
@@ -37,7 +37,7 @@
     <listitem>
      <para>
       La fonction de rappel de type <type>callable</type>.
-      Elle doit correspondre au prototype suivant :
+      Elle devrait correspondre au prototype suivant :
      </para>
      <methodsynopsis>
       <type>void</type>

--- a/reference/event/eventhttpconnection/construct.xml
+++ b/reference/event/eventhttpconnection/construct.xml
@@ -47,7 +47,7 @@
     </term>
     <listitem>
      <para>
-      Base d'événement associé.
+      Événement de base associé.
      </para>
     </listitem>
    </varlistentry>
@@ -57,7 +57,9 @@
     </term>
     <listitem>
      <para>
-      Si vaut &null;, la résolution du nom d'hôte sera bloquante.
+      Si
+      <parameter>dns_base</parameter>
+      vaut &null;, la résolution du nom d'hôte sera bloquante.
      </para>
     </listitem>
    </varlistentry>

--- a/reference/event/eventhttpconnection/getbase.xml
+++ b/reference/event/eventhttpconnection/getbase.xml
@@ -6,7 +6,7 @@
 <refentry xml:id="eventhttpconnection.getbase" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>EventHttpConnection::getBase</refname>
-  <refpurpose>Retourne la base d'événement associée avec la connexion</refpurpose>
+  <refpurpose>Retourne l'événement de base associé avec la connexion</refpurpose>
  </refnamediv>
  <refsect1 role="description">
   &reftitle.description;
@@ -17,7 +17,7 @@
    <void />
   </methodsynopsis>
   <para>
-   Retourne la base d'événement associée avec la connexion.
+   Retourne l'événement de base associé avec la connexion.
   </para>
  </refsect1>
  <refsect1 role="parameters">
@@ -28,7 +28,7 @@
   &reftitle.returnvalues;
   <para>
    Retourne l'objet <classname>EventBase</classname> associé avec
-   la connexion en cas de succès, &false; sinon.
+   la connexion en cas de succès. &false; sinon.
   </para>
  </refsect1>
 </refentry>

--- a/reference/event/eventhttpconnection/makerequest.xml
+++ b/reference/event/eventhttpconnection/makerequest.xml
@@ -86,14 +86,14 @@ function _request_handler($req, $base) {
     echo __FUNCTION__, PHP_EOL;
 
     if (is_null($req)) {
-        echo "Timed out\n";
+        echo "Délai d'attente maximal atteint\n";
     } else {
         $response_code = $req->getResponseCode();
 
         if ($response_code == 0) {
             echo "Connexion refusée\n";
         } elseif ($response_code != 200) {
-            echo "Réponse inatendue : $response_code\n";
+            echo "Réponse inattendue : $response_code\n";
         } else {
             echo "Succès : $response_code\n";
             $buf = $req->getInputBuffer();

--- a/reference/event/eventhttpconnection/setclosecallback.xml
+++ b/reference/event/eventhttpconnection/setclosecallback.xml
@@ -36,7 +36,7 @@
     <listitem>
      <para>
       Fonction de rappel à appeler lors de la fermeture de la connexion.
-      Doit correspondre au prototype suivant :
+      Devrait correspondre au prototype suivant :
      </para>
      <methodsynopsis>
       <type>void</type>
@@ -72,22 +72,22 @@
 <![CDATA[
 <?php
 /*
- * Setting up close-connection callback
+ * Configuration de la fonction de rappel de fermeture de connexion
  *
- * The script handles closed connections using HTTP API.
+ * Le script gère les connexions fermées en utilisant l'API HTTP.
  *
- * Usage:
- * 1) Launch the server:
+ * Utilisation :
+ * 1) Lancez le serveur :
  * $ php examples/http_closecb.php 4242
  *
- * 2) Launch a client in another terminal. Telnet-like
- * session should look like the following:
+ * 2) Lancez un client dans un autre terminal. La session
+ * de type Telnet devrait ressembler à ceci :
  *
  * $ nc -t 127.0.0.1 4242
  * GET / HTTP/1.0
  * Connection: close
  *
- * The server will output something similar to the following:
+ * Le serveur devrait afficher quelque chose de similaire à :
  *
  * HTTP/1.0 200 OK
  * Content-Type: multipart/x-mixed-replace;boundary=boundarydonotcross
@@ -95,14 +95,14 @@
  *
  * <html>
  *
- * 3) Terminate the client connection abruptly,
- * i.e. kill the process, or just press Ctrl-C.
+ * 3) Terminez la connexion client brusquement,
+ * par exemple en tuant le processus, ou en appuyant sur Ctrl-C.
  *
- * 4) Check if the server called _close_callback.
- * The script should output "_close_callback" string to standard output.
+ * 4) Vérifiez si le serveur a appelé _close_callback.
+ * Le script devrait afficher la chaîne "_close_callback" sur la sortie standard.
  *
- * 5) Check if the server's process has no orphaned connections,
- * e.g. with `lsof` utility.
+ * 5) Vérifiez que le processus serveur n'a pas de connexions orphelines,
+ * par exemple avec l'utilitaire `lsof`.
  */
 
 function _close_callback($conn)
@@ -116,22 +116,22 @@ function _http_default($req, $dummy)
     $conn->setCloseCallback('_close_callback', NULL);
 
     /*
-    By enabling Event::READ we protect the server against unclosed conections.
-    This is a peculiarity of Libevent. The library disables Event::READ events
-     on this connection, and the server is not notified about terminated
-    connections.
+    En activant Event::READ, on protège le serveur contre les connexions non fermées.
+    C'est une particularité de Libevent. La bibliothèque désactive les événements
+    Event::READ sur cette connexion, et le serveur n'est pas notifié des connexions
+    terminées.
 
-    So each time client terminates connection abruptly, we get an orphaned
-    connection. For instance, the following is a part of `lsof -p $PID | grep TCP`
-    command after client has terminated connection:
+    Ainsi, chaque fois qu'un client termine brusquement la connexion, on obtient une
+    connexion orpheline. Par exemple, voici une partie de la commande
+    `lsof -p $PID | grep TCP` après que le client a terminé la connexion :
 
     57-php     15057 ruslan  6u  unix 0xffff8802fb59c780   0t0  125187 socket
     58:php     15057 ruslan  7u  IPv4             125189   0t0     TCP *:4242 (LISTEN)
     59:php     15057 ruslan  8u  IPv4             124342   0t0     TCP localhost:4242->localhost:37375 (CLOSE_WAIT)
 
-    where $PID is our process ID.
+    où $PID est l'identifiant du processus.
 
-    The following block of code fixes such kind of orphaned connections.
+    Le bloc de code suivant corrige ce type de connexions orphelines.
      */
     $bev = $req->getBufferEvent();
     $bev->enable(Event::READ);
@@ -159,7 +159,7 @@ if ($argc > 1) {
     $port = (int) $argv[1];
 }
 if ($port <= 0 || $port > 65535) {
-    exit("Invalid port");
+    exit("Port invalide");
 }
 
 $base = new EventBase();

--- a/reference/event/eventhttprequest.xml
+++ b/reference/event/eventhttprequest.xml
@@ -202,7 +202,7 @@
      </term>
      <listitem>
       <para>
-       Demande le type d'en-tête d'entrée.
+       Type d'en-tête d'entrée de la requête.
       </para>
      </listitem>
     </varlistentry>
@@ -212,7 +212,7 @@
      </term>
      <listitem>
       <para>
-       Demande le type d'en-tête de sortie.
+       Type d'en-tête de sortie de la requête.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/event/eventhttprequest/cancel.xml
+++ b/reference/event/eventhttprequest/cancel.xml
@@ -20,14 +20,14 @@
    Annule une requête HTTP en attente.
   </para>
   <para>
-   Annule une requête HTTP entrante. La fonction de rappel associée avec
+   Annule une requête HTTP en cours. La fonction de rappel associée avec
    cette requête ne sera pas exécutée, et l'objet de la requête, libéré.
    Si la requête est en cours de traitement, l'objet <classname>EventHttpConnection</classname>
    correspondant sera ré-initialisé.
   </para>
   <para>
    Une requête ne peut être annulée si sa fonction de rappel a déjà été exécutée.
-   Une requête peut être annulée depuis sa fonction de rappel.
+   Une requête peut être annulée de manière réentrante depuis sa fonction de rappel chunked.
   </para>
  </refsect1>
  <refsect1 role="parameters">

--- a/reference/event/eventhttprequest/clearheaders.xml
+++ b/reference/event/eventhttprequest/clearheaders.xml
@@ -6,7 +6,7 @@
 <refentry xml:id="eventhttprequest.clearheaders" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>EventHttpRequest::clearHeaders</refname>
-  <refpurpose>Supprime tous les en-têtes depuis la liste des en-têtes de la requête</refpurpose>
+  <refpurpose>Supprime tous les en-têtes de sortie depuis la liste des en-têtes de la requête</refpurpose>
  </refnamediv>
  <refsect1 role="description">
   &reftitle.description;
@@ -17,7 +17,7 @@
    <void />
   </methodsynopsis>
   <para>
-   Supprime tous les en-têtes depuis la liste des en-têtes de la requête.
+   Supprime tous les en-têtes de sortie depuis la liste des en-têtes de la requête.
   </para>
  </refsect1>
  <refsect1 role="parameters">

--- a/reference/event/eventhttprequest/construct.xml
+++ b/reference/event/eventhttprequest/construct.xml
@@ -39,7 +39,7 @@
     <listitem>
      <para>
       Fonction de rappel appelée avec le chemin demandé.
-      Doit correspondre au prototype suivant :
+      Devrait correspondre au prototype suivant :
      </para>
      <methodsynopsis>
       <type>void</type>
@@ -92,11 +92,11 @@ function _request_handler($req, $base) {
         if ($response_code == 0) {
             echo "Connexion refusée\n";
         } elseif ($response_code != 200) {
-            echo "Réponse innatendue : $response_code\n";
+            echo "Réponse inattendue : $response_code\n";
         } else {
             echo "Succès : $response_code\n";
             $buf = $req->getInputBuffer();
-            echo "Body:\n";
+            echo "Corps :\n";
             while ($s = $buf->readLine(EventBuffer::EOL_ANY)) {
                 echo $s, PHP_EOL;
             }

--- a/reference/event/eventhttprequest/getbufferevent.xml
+++ b/reference/event/eventhttprequest/getbufferevent.xml
@@ -25,7 +25,7 @@
     Le compteur de référence de l'objet retourné sera incrémenté d'un pour
     protéger les structures internes contre des destructions prématurées quand
     la méthode est appelée depuis une fonction de rappel. L'objet
-    <classname>EventBufferEvent</classname> doit donc être libéré explicitement
+    <classname>EventBufferEvent</classname> devrait donc être libéré explicitement
     via la méthode <methodname>EventBufferEvent::free</methodname>.
     Sinon il y aura une fuite de mémoire.
    </para>

--- a/reference/event/eventhttprequest/getresponsecode.xml
+++ b/reference/event/eventhttprequest/getresponsecode.xml
@@ -27,7 +27,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Retourne le code de la réponse.
+   Retourne le code de la réponse de la requête.
   </para>
  </refsect1>
  <refsect1 role="seealso">

--- a/reference/event/eventhttprequest/sendreplychunk.xml
+++ b/reference/event/eventhttprequest/sendreplychunk.xml
@@ -6,7 +6,7 @@
 <refentry xml:id="eventhttprequest.sendreplychunk" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>EventHttpRequest::sendReplyChunk</refname>
-  <refpurpose>Envoie un autre bloc de données comme partie d'un bloc de réponse entrant</refpurpose>
+  <refpurpose>Envoie un autre bloc de données comme partie d'une réponse fragmentée en cours</refpurpose>
  </refnamediv>
  <refsect1 role="description">
   &reftitle.description;
@@ -20,7 +20,7 @@
    </methodparam>
   </methodsynopsis>
   <para>
-   Envoie un autre bloc de données comme partie d'un bloc de réponse entrant.
+   Envoie un autre bloc de données comme partie d'une réponse fragmentée en cours.
    Après l'appel de cette méthode, le paramètre <parameter>buf</parameter>
    sera vide.
   </para>

--- a/reference/event/eventhttprequest/sendreplyend.xml
+++ b/reference/event/eventhttprequest/sendreplyend.xml
@@ -6,7 +6,7 @@
 <refentry xml:id="eventhttprequest.sendreplyend" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>EventHttpRequest::sendReplyEnd</refname>
-  <refpurpose>Complète un bloc de réponse, en libérant la requête</refpurpose>
+  <refpurpose>Complète une réponse fragmentée, en libérant la requête le cas échéant</refpurpose>
  </refnamediv>
  <refsect1 role="description">
   &reftitle.description;
@@ -17,7 +17,7 @@
    <void />
   </methodsynopsis>
   <para>
-   Complète un bloc de réponse, en libérant la requête.
+   Complète une réponse fragmentée, en libérant la requête le cas échéant.
   </para>
  </refsect1>
  <refsect1 role="parameters">

--- a/reference/event/eventhttprequest/sendreplystart.xml
+++ b/reference/event/eventhttprequest/sendreplystart.xml
@@ -5,7 +5,7 @@
 <refentry xml:id="eventhttprequest.sendreplystart" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>EventHttpRequest::sendReplyStart</refname>
-  <refpurpose>Initialise un bloc de réponse</refpurpose>
+  <refpurpose>Initialise une réponse fragmentée</refpurpose>
  </refnamediv>
  <refsect1 role="description">
   &reftitle.description;

--- a/reference/event/eventlistener/construct.xml
+++ b/reference/event/eventlistener/construct.xml
@@ -4,7 +4,7 @@
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="eventlistener.construct">
  <refnamediv>
   <refname>EventListener::__construct</refname>
-  <refpurpose>Crée un nouvel écouteur de connexion associé avec la base d'événement</refpurpose>
+  <refpurpose>Crée un nouvel écouteur de connexion associé avec l'événement de base</refpurpose>
  </refnamediv>
  <refsect1 role="description">
   &reftitle.description;
@@ -37,7 +37,7 @@
    </methodparam>
   </methodsynopsis>
   <para>
-   Crée un nouvel écouteur de connexion associé avec la base d'événement.
+   Crée un nouvel écouteur de connexion associé avec l'événement de base.
   </para>
  </refsect1>
  <refsect1 role="parameters">
@@ -49,7 +49,7 @@
     </term>
     <listitem>
      <para>
-      Base d'événement associée.
+      Événement de base associé.
      </para>
     </listitem>
    </varlistentry>
@@ -94,7 +94,7 @@
     <listitem>
      <para>
       Contrôle le nombre maximal de connexions en attente que la pile réseau
-      autorise à patienter dans un statut "non encore accepté" ; voir la documentation
+      devrait autoriser à patienter dans un statut "non encore accepté" ; voir la documentation
       de la fonction <literal>listen</literal> du système pour plus
       de détails. Si le paramètre <parameter>backlog</parameter> est négatif,
       Libevent tente de récupérer une bonne valeur pour ce paramètre ;
@@ -152,11 +152,11 @@
  * Un simple serveur d'écho, basé sur un écouteur de connexion libevent.
  *
  * Utilisation :
- * 1) Dans un terminal Windows, exécutez :
+ * 1) Dans une fenêtre de terminal, exécutez :
  *
  * $ php listener.php 9881
  *
- * 2) Dans un autre terminal Windows, ouvrez la connexion suivante :
+ * 2) Dans une autre fenêtre de terminal, ouvrez la connexion suivante :
  *
  * $ nc 127.0.0.1 9881
  *

--- a/reference/event/eventlistener/getbase.xml
+++ b/reference/event/eventlistener/getbase.xml
@@ -6,7 +6,7 @@
 <refentry xml:id="eventlistener.getbase" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>EventListener::getBase</refname>
-  <refpurpose>Retourne la base d'événement associée avec l'écouteur d'événements</refpurpose>
+  <refpurpose>Retourne l'événement de base associé avec l'écouteur d'événements</refpurpose>
  </refnamediv>
  <refsect1 role="description">
   &reftitle.description;
@@ -17,7 +17,7 @@
    <void />
   </methodsynopsis>
   <para>
-   Retourne la base d'événement associée avec l'écouteur d'événements.
+   Retourne l'événement de base associé avec l'écouteur d'événements.
   </para>
  </refsect1>
  <refsect1 role="parameters">
@@ -27,7 +27,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Retourne la base d'événement associée avec l'écouteur d'événements.
+   Retourne l'événement de base associé avec l'écouteur d'événements.
   </para>
  </refsect1>
 </refentry>

--- a/reference/event/eventlistener/setcallback.xml
+++ b/reference/event/eventlistener/setcallback.xml
@@ -41,7 +41,7 @@
       Ignoré si vaut &null;.
      </para>
      <para>
-      Doit correspondre au prototype suivant :
+      Devrait correspondre au prototype suivant :
      </para>
      <methodsynopsis>
       <type>void</type>

--- a/reference/event/eventlistener/seterrorcallback.xml
+++ b/reference/event/eventlistener/seterrorcallback.xml
@@ -31,7 +31,7 @@
     </term>
     <listitem>
      <para>
-      La fonction de rappel pour l'erreur. Doit correspondre au prototype suivant :
+      La fonction de rappel pour l'erreur. Devrait correspondre au prototype suivant :
      </para>
      <methodsynopsis>
       <type>void</type>

--- a/reference/event/eventsslcontext.xml
+++ b/reference/event/eventsslcontext.xml
@@ -328,7 +328,7 @@
       <para>
        Clé pour un élément du tableau contenant les options, utilisé
        dans la méthode <methodname>EventSslContext::__construct</methodname>.
-       Représente le chemin dans lequel on doit chercher le fichier
+       Représente le chemin dans lequel devrait être cherché le fichier
        de l'autorité du certificat.
       </para>
      </listitem>

--- a/reference/event/eventutil.xml
+++ b/reference/event/eventutil.xml
@@ -10,7 +10,7 @@
   <section xml:id="eventutil.intro">
    &reftitle.intro;
    <simpara>
-    La classe <classname>EventUtil</classname> est un squelette avec des
+    La classe <classname>EventUtil</classname> est un singleton avec des
     méthodes et des constantes supplémentaires.
    </simpara>
   </section>
@@ -236,7 +236,7 @@
       <para>
        Option du socket. Indique que les règles utilisées dans la
        validation des adresses fournies dans un appel à
-       <literal>bind(2)</literal> doivent autoriser la ré-utilisation
+       <literal>bind(2)</literal> devraient autoriser la ré-utilisation
        des adresses locales. Voir la page de manuel sur
        <literal>socket(7)</literal>. (Ajouté en event-1.6.0.)
       </para>
@@ -249,7 +249,8 @@
      <listitem>
       <para>
        Option du socket. Active l'envoi de messages keep-alive sur les
-       sockets de connexion. Attend un entier. Voir la page de manuel sur
+       sockets de connexion. Attend un drapeau booléen sous forme d'entier.
+       Voir la page de manuel sur
        <literal>socket(7)</literal>. (Ajouté en event-1.6.0.)
       </para>
      </listitem>
@@ -398,7 +399,7 @@
      </term>
      <listitem>
       <para>
-       Option du socket. Voir la page du manuel sur
+       Niveau d'option du socket. Voir la page du manuel sur
        <literal>socket(7)</literal>. (Ajouté en event-1.6.0.)
       </para>
      </listitem>
@@ -409,7 +410,7 @@
      </term>
      <listitem>
       <para>
-       Option du socket. Voir la page du manuel sur
+       Niveau d'option du socket. Voir la page du manuel sur
        <literal>socket(7)</literal>. (Ajouté en event-1.6.0.)
       </para>
      </listitem>
@@ -420,7 +421,7 @@
      </term>
      <listitem>
       <para>
-       Option du socket. Voir la page du manuel sur
+       Niveau d'option du socket. Voir la page du manuel sur
        <literal>socket(7)</literal>. (Ajouté en event-1.6.0.)
       </para>
      </listitem>

--- a/reference/event/eventutil/construct.xml
+++ b/reference/event/eventutil/construct.xml
@@ -6,7 +6,7 @@
 <refentry xml:id="eventutil.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>EventUtil::__construct</refname>
-  <refpurpose>Le constructeur</refpurpose>
+  <refpurpose>Le constructeur abstrait</refpurpose>
  </refnamediv>
  <refsect1 role="description">
   &reftitle.description;
@@ -17,7 +17,7 @@
    <void />
   </methodsynopsis>
   <para>
-   <classname>EventUtil</classname> est un squelette.
+   <classname>EventUtil</classname> est un singleton.
    Aussi, le constructeur est abstrait, et il est donc impossible
    de créer des objets en se basant sur cette classe.
   </para>

--- a/reference/event/eventutil/setsocketoption.xml
+++ b/reference/event/eventutil/setsocketoption.xml
@@ -73,7 +73,7 @@
     </term>
     <listitem>
      <para>
-      Nom de l'option (type). À la même signification que le paramètre correspondant
+      Nom de l'option (type). A la même signification que le paramètre correspondant
       de la fonction <function>socket_get_option</function>. Voir aussi les
       <link linkend="eventutil.constants">constantes EventUtil</link>.
      </para>

--- a/reference/event/examples.xml
+++ b/reference/event/examples.xml
@@ -28,7 +28,7 @@ function eventcb($bev, $events, $base) {
         echo "Connecté.\n";
     } elseif ($events & (EventBufferEvent::ERROR | EventBufferEvent::EOF)) {
         if ($events & EventBufferEvent::ERROR) {
-            echo "erreur DNS : ", $bev->getDnsErrorString(), PHP_EOL;
+            echo "Erreur DNS : ", $bev->getDnsErrorString(), PHP_EOL;
         }
 
         echo "Fermeture\n";
@@ -267,7 +267,7 @@ class MyListener {
     public function __construct($port) {
         $this->base = new EventBase();
         if (!$this->base) {
-            echo "Impossible d'ouvrir la base de l'événement";
+            echo "Impossible d'ouvrir l'événement de base";
             exit(1);
         }
 
@@ -312,7 +312,7 @@ class MyListener {
     public function accept_error_cb($listener, $ctx) {
         $base = $this->base;
 
-        fprintf(STDERR, "On recoit une erreur %d (%s) sur l'écouteur. "
+        fprintf(STDERR, "On reçoit une erreur %d (%s) sur l'écouteur. "
             ."Arrêt.\n",
             EventUtil::getLastSocketErrno(),
             EventUtil::getLastSocketError());
@@ -368,7 +368,7 @@ class MySslEchoServer {
 
         $this->base = new EventBase();
         if (!$this->base) {
-            exit("Impossible d'ouvrir la base de l'événement\n");
+            exit("Impossible d'ouvrir l'événement de base\n");
         }
 
         $this->listener = new EventListener($this->base,
@@ -441,7 +441,7 @@ class MySslEchoServer {
     // Initialise les structures SSL ; crée un EventSslContext
     // Optionnellement, crée des certificats autosignés
     function init_ssl() {
-        // Nous *devons* avoir l'entropie. Sinon, il n'y a aucun intérêt à crypter.
+        // Nous *devons* avoir l'entropie. Sinon, il n'y a aucun intérêt à chiffrer.
         if (!EventUtil::sslRandPoll()) {
             exit("Échec de EventUtil::sslRandPoll\n");
         }
@@ -450,7 +450,7 @@ class MySslEchoServer {
         $local_pk   = __DIR__."/privkey.pem";
 
         if (!file_exists($local_cert) || !file_exists($local_pk)) {
-            echo "Impossible de lire $local_cert ni $local_pk file. Pour générer une clé\n",
+            echo "Impossible de lire le fichier $local_cert ou $local_pk. Pour générer une clé\n",
                 "et un certificat autosigné, exécutez :\n",
                 "  openssl genrsa -out $local_pk 2048\n",
                 "  openssl req -new -key $local_pk -out cert.req\n",
@@ -560,7 +560,7 @@ eio_mkdir($dir, 0750, EIO_PRI_DEFAULT, "my_nop_cb");
 
 $event = new Event($base, eio_get_event_stream(),
     Event::READ | Event::PERSIST, function ($fd, $events, $base) {
-    echo "step 5\n";
+    echo "étape 5\n";
 
     while (eio_nreqs()) {
         eio_poll();
@@ -605,9 +605,9 @@ echo "Méthode d'événement utilisée : ", $base->getMethod(), PHP_EOL;
 
 echo "fonctionnalités :\n";
 $features = $base->getFeatures();
-($features & EventConfig::FEATURE_ET) and print "ET - edge-triggered IO\n";
-($features & EventConfig::FEATURE_O1) and print "O1 - O(1) operation for adding/deleting events\n";
-($features & EventConfig::FEATURE_FDS) and print "FDS - arbitrary file descriptor types, and not just sockets\n";
+($features & EventConfig::FEATURE_ET) and print "ET - E/S déclenchées par front\n";
+($features & EventConfig::FEATURE_O1) and print "O1 - opération O(1) pour l'ajout/suppression d'événements\n";
+($features & EventConfig::FEATURE_FDS) and print "FDS - type de descripteur de fichiers arbitraire, et non uniquement les sockets\n";
 
 // Nécessite la fonctionnalité FDS
 if ($cfg->requireFeatures(EventConfig::FEATURE_FDS)) {
@@ -652,7 +652,7 @@ $base->loop();
  * 1) Exécutez-le sur le port de votre choix, i.e. :
  * $ php examples/http.php 8010
  * 2) Dans un autre terminal, connectez-vous sur une adresse de ce port
- * et effectuez des requêtes GET ou POST (les autres types sont désactivées dans cet exemple), i.e. :
+ * et effectuez des requêtes GET ou POST (les autres types sont désactivés dans cet exemple), i.e. :
  * $ nc -t 127.0.0.1 8010
  * POST /about HTTP/1.0
  * Content-Type: text/plain
@@ -696,11 +696,11 @@ function _http_dump($req, $data) {
     static $max_requests = 2;
 
     if (++$counter >= $max_requests)  {
-        echo "Le compteur a atteint le nombre maximal de requête ($max_requests). Sortie !\n";
+        echo "Le compteur a atteint le nombre maximal de requêtes ($max_requests). Sortie !\n";
         exit();
     }
 
-    echo __METHOD__, " called\n";
+    echo __METHOD__, " appelée\n";
     echo "Requête :"; var_dump($req);
     echo "Données :"; var_dump($data);
 
@@ -732,7 +732,7 @@ function _http_about($req) {
 
 function _http_default($req, $data) {
     echo __METHOD__, PHP_EOL;
-    echo "URI: ", $req->getUri(), PHP_EOL;
+    echo "URI : ", $req->getUri(), PHP_EOL;
     echo "\n >> Envoi de la réponse ...";
     $req->sendReply(200, "OK");
     echo "OK\n";
@@ -831,7 +831,7 @@ function _http_about($req) {
 
 function _http_default($req, $data) {
     echo __METHOD__, PHP_EOL;
-    echo "URI: ", $req->getUri(), PHP_EOL;
+    echo "URI : ", $req->getUri(), PHP_EOL;
     echo "\n >> Envoi de la réponse ...";
     $req->sendReply(200, "OK");
     echo "OK\n";
@@ -944,7 +944,7 @@ if (!$ctx) {
 
 $base = new EventBase();
 if (!$base) {
-    trigger_error("Échec dans l'initialisation de la base d'événement", E_USER_ERROR);
+    trigger_error("Échec dans l'initialisation de l'événement de base", E_USER_ERROR);
 }
 
 $conn = new EventHttpConnection($base, NULL, $host, $port, $ctx);
@@ -1040,7 +1040,7 @@ PHP, date:
  *
  * $ socat - GOPEN:/tmp/1.sock
  *
- * 3) Commencez à taper. Le serveur doit répéter les entrées.
+ * 3) Commencez à taper. Le serveur devrait répéter les entrées.
  */
 
 class MyListenerConnection {
@@ -1096,7 +1096,7 @@ class MyListener {
     public function __construct($sock_path) {
         $this->base = new EventBase();
         if (!$this->base) {
-            echo "Impossible d'ouvrir la base de l'événement";
+            echo "Impossible d'ouvrir l'événement de base";
             exit(1);
         }
 
@@ -1131,7 +1131,7 @@ class MyListener {
         $base = $this->base;
 
         fprintf(STDERR, "On reçoit une erreur %d (%s) sur l'écouteur. "
-            ."Shutting down.\n",
+            ."Arrêt.\n",
             EventUtil::getLastSocketErrno(),
             EventUtil::getLastSocketError());
 
@@ -1183,7 +1183,7 @@ class Handler {
 
         $this->base = new EventBase();
         if (!$this->base) {
-            exit("Impossible d'ouvrir la base de l'événement\n");
+            exit("Impossible d'ouvrir l'événement de base\n");
         }
 
         if (!$this->listener = new EventListener($this->base,


### PR DESCRIPTION
Corrections de langue et de traduction dans reference/, de dom à event (orthographe, grammaire, fidélité à l'anglais).