### PR TITLE
Nits translation: reference/ (exec to filesystem)

### DIFF
--- a/reference/exec/functions/escapeshellarg.xml
+++ b/reference/exec/functions/escapeshellarg.xml
@@ -21,8 +21,8 @@
    chaîne. Cela permet de faire passer directement le paramètre
    <parameter>arg</parameter> comme argument Shell, tout en assurant un
    maximum de sécurité. <function>escapeshellarg</function>
-   doit être utilisée pour traiter individuellement chacun des arguments
-   à passer au Shell. Les fonctions Shell sont <function>exec</function>,
+   devrait être utilisée pour traiter individuellement chacun des arguments
+   provenant des entrées utilisateur à passer au Shell. Les fonctions Shell sont <function>exec</function>,
    <function>system</function> et les opérateurs
    <link linkend="language.operators.execution">guillemets obliques</link>.
   </para>

--- a/reference/exec/functions/escapeshellcmd.xml
+++ b/reference/exec/functions/escapeshellcmd.xml
@@ -19,13 +19,13 @@
    <function>escapeshellcmd</function> échappe tous les
    caractères de la chaîne <parameter>command</parameter>
    qui pourraient avoir une signification spéciale dans une
-   commande Shell. Cette fonction permet de s'assurer que la commande sera
-   correctement passée à l'exécuteur de commande Shell
+   commande Shell. Cette fonction devrait être utilisée pour s'assurer que toute
+   donnée provenant des entrées utilisateur est échappée avant d'être passée aux fonctions
    <function>exec</function> et <function>system</function>, ou encore
    à <link linkend="language.operators.execution">guillemets obliques</link>.
   </para>
   <para>
-   Les caractères suivants seront échappés :
+   Les caractères suivants sont précédés d'un antislash :
    <literal>&amp;#;`|*?~&lt;&gt;^()[]{}$\</literal>, <literal>\x0A</literal>
    et <literal>\xFF</literal>. <literal>'</literal> et <literal>"</literal>
    ne sont échappés que s'ils ne sont pas par paire. Sous Windows, tous ces caractères
@@ -82,7 +82,7 @@ system($escaped_command);
   &reftitle.notes;
    <warning xmlns="http://docbook.org/ns/docbook">
     <para>
-     La fonction <function>escapeshellcmd</function> doit être utilisée
+     La fonction <function>escapeshellcmd</function> devrait être utilisée
      sur toute la chaîne de commande, mais elle autorise tout de même
      un attaquant à passer un nombre arbitraire d'arguments.
      Pour échapper un seul argument, la fonction

--- a/reference/exec/functions/exec.xml
+++ b/reference/exec/functions/exec.xml
@@ -40,7 +40,7 @@
       <para>
        Si l'argument <parameter>output</parameter> est présent,
        alors ce tableau sera rempli par les lignes retournées par
-       la commande. Les espaces de début et de fin de chaîne, comme
+       la commande. Les espaces de fin de chaîne, comme
        <literal>\n</literal>, ne seront pas inclus dans ce tableau.
        Il faut noter que si ce tableau contient des
        éléments, <function>exec</function> ajoutera

--- a/reference/exec/functions/proc-close.xml
+++ b/reference/exec/functions/proc-close.xml
@@ -7,7 +7,8 @@
  <refnamediv>
   <refname>proc_close</refname>
   <refpurpose>
-   Ferme un processus ouvert par <function>proc_open</function>
+   Ferme un processus ouvert par <function>proc_open</function> et retourne
+   le code de sortie de ce processus
   </refpurpose>
  </refnamediv>
 

--- a/reference/exec/functions/proc-get-status.xml
+++ b/reference/exec/functions/proc-get-status.xml
@@ -77,7 +77,7 @@
        <entry>signaled</entry>
        <entry>&boolean;</entry>
        <entry>
-        &true; si le processus fils a été terminé par un signal inconnu.
+        &true; si le processus fils a été terminé par un signal non intercepté.
         Toujours défini à &false; sous Windows.
        </entry>
       </row>
@@ -93,7 +93,7 @@
        <entry>exitcode</entry>
        <entry>&integer;</entry>
        <entry>
-        Le code retourné par le processus (uniquement si l'élément
+        Le code retourné par le processus (significatif uniquement si l'élément
         <literal>running</literal> vaut &false;).
         Avant PHP 8.3.0, seul le premier appel de cette fonction retournait la vraie valeur, les appels suivants retournaient <literal>-1</literal>.</entry>
      </row>

--- a/reference/exec/functions/proc-open.xml
+++ b/reference/exec/functions/proc-open.xml
@@ -61,7 +61,7 @@
       </para>
       <note>
        <para>
-        Sur Windows, l'échappement des arguments des éléments du &array; assume
+        Sur Windows, l'échappement des arguments des éléments du &array; suppose
         que le traitement de la ligne de commande de la commande exécutée est
         compatible avec le traitement d'arguments de ligne de commande fait par
         le runtime VC.
@@ -177,7 +177,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Retourne une ressource représentant le processus, qui pourra être utilisé par 
+   Retourne une ressource représentant le processus, qui devrait être libérée à l'aide de
    la fonction <function>proc_close</function> lorsqu'on n'en aura plus besoin.
    En cas d'échec, &false; sera retourné.
   </para>
@@ -281,7 +281,7 @@ if (is_resource($process)) {
 <![CDATA[
 Array
 (
-    [some_option] => aeiou
+    [quelques_options] => aeiou
     [PWD] => /tmp
     [SHLVL] => 1
     [_] => /usr/local/bin/php

--- a/reference/exec/functions/proc-terminate.xml
+++ b/reference/exec/functions/proc-terminate.xml
@@ -21,7 +21,7 @@
   <para>
    <function>proc_terminate</function> envoie un signal au processus 
    <parameter>process</parameter> (créé avec <function>proc_open</function>) 
-   pour lui indiquer qu'il doit se terminer. <function>proc_terminate</function> 
+   pour lui indiquer qu'il devrait se terminer. <function>proc_terminate</function>
    se termine immédiatement après, et n'attend pas l'arrêt réel du processus.
   </para>
   <para>

--- a/reference/exec/functions/shell-exec.xml
+++ b/reference/exec/functions/shell-exec.xml
@@ -57,7 +57,7 @@
     Cette fonction peut retourner &null; lorsqu'une erreur survient
     mais aussi lorsque le programme ne produit aucune sortie. Il n'est pas possible
     de détecter les échecs d'exécution en utilisant cette fonction. La fonction
-    <function>exec</function> doit être utilisée lorsqu'on souhaite récupérer
+    <function>exec</function> devrait être utilisée lorsqu'on souhaite récupérer
     le code de sortie du programme.
    </para>
   </note>

--- a/reference/exec/reference.xml
+++ b/reference/exec/reference.xml
@@ -13,7 +13,7 @@
    <warning>
     <para>
      Les fichiers ouverts avec un verrou (tout spécialement les sessions ouvertes)
-     doivent être fermés avant l'exécution d'un programme en arrière-plan.
+     devraient être fermés avant l'exécution d'un programme en arrière-plan.
     </para>
    </warning>
   </section>

--- a/reference/exif/book.xml
+++ b/reference/exif/book.xml
@@ -11,10 +11,10 @@
  <preface xml:id="intro.exif">
   &reftitle.intro;
   <simpara>
-   Avec l'extension exif, il est possible de travailler sur les données
-   méta des images. Par exemple, il faut utiliser les fonctions
-   exif pour lire les données méta des images prises par des
-   appareils numériques, stockées dans l'en-tête. Elles sont communément
+   Avec l'extension exif, il est possible de travailler sur les
+   métadonnées des images. Par exemple, il est possible d'utiliser les fonctions
+   exif pour lire les métadonnées des images prises par des
+   appareils numériques, stockées dans les en-têtes. Elles sont communément
    présentes dans les images <acronym>JPEG</acronym> et <acronym>TIFF</acronym>.
   </simpara>
  </preface>

--- a/reference/exif/constants.xml
+++ b/reference/exif/constants.xml
@@ -22,7 +22,7 @@
  </variablelist>
  <simpara>
   La fonction <function>exif_imagetype</function> liste plusieurs constantes
-  connexes.
+  intégrées connexes.
  </simpara>
 </appendix>
 <!-- Keep this comment at the end of the file

--- a/reference/exif/functions/exif-read-data.xml
+++ b/reference/exif/functions/exif-read-data.xml
@@ -19,13 +19,13 @@
   <simpara>
    <function>exif_read_data</function> lit les en-têtes <acronym>EXIF</acronym>
    des images.
-   Avec cette fonction, il est possible de lire les données méta générées par les appareils photos
+   Avec cette fonction, il est possible de lire les métadonnées générées par les appareils photos
    numériques.
   </simpara>
   <simpara>
    Les en-têtes <acronym>EXIF</acronym> tendent à être présents dans les images
    JPEG/TIFF générées par les appareils photos numériques, mais malheureusement,
-   chaque appareil photo numérique a une idée différente de la façon dont
+   chaque fabricant d'appareil photo numérique a une idée différente de la façon dont
    leurs images doivent être marquées, donc, il n'est pas possible de toujours compter
    sur un en-tête EXIF spécifique, bien que présent.
   </simpara>
@@ -37,17 +37,17 @@
    utilisée dans une balise image <acronym>HTML</acronym> classique.
   </simpara>
   <simpara>
-   Lorsqu'un en-tête EXIF contient une note de Copyright, cet en-tête
-   peut alors contenir lui-même deux valeurs. Comme cette solution est
+   Lorsqu'un en-tête EXIF contient une note de Copyright, cette note
+   peut elle-même contenir deux valeurs. Comme cette solution est
    incohérente avec les standards EXIF 2.10, la section <literal>COMPUTED</literal>
    retournera les deux en-têtes, <literal>Copyright.Photographer</literal>
    et <literal>Copyright.Editor</literal>, tandis que les sections <literal>IFD0</literal>
-   contiennent le tableau d'octets avec des caractères NULL pour séparer les deux entrées ;
+   contiennent le tableau d'octets avec le caractère NULL séparant les deux entrées ;
    ou bien, juste la première entrée si le type de données était erroné
    (comportement par défaut d'EXIF). La section <literal>COMPUTED</literal> va aussi
    contenir une entrée <literal>Copyright</literal>, qui sera soit la chaîne originale
-   de copyright, soit une liste de valeurs séparées par des virgules de
-   photos et de copyright de l'auteur.
+   de copyright, soit une liste séparée par des virgules du copyright
+   du photographe et de l'éditeur.
   </simpara>
   <simpara>
    La balise <literal>UserComment</literal> présente le même problème que la balise Copyright.
@@ -72,7 +72,7 @@
     <listitem>
      <simpara>
       L'emplacement du fichier image. Il peut s'agir soit d'un chemin d'accès
-      au fichier (les enveloppes de flux sont également prises en charge comme
+      au fichier (les enveloppes de flux sont également supportées comme
       d'habitude), soit d'un flux <type>resource</type>.
      </simpara>
     </listitem>
@@ -81,8 +81,8 @@
     <term><parameter>required_sections</parameter></term>
     <listitem>
      <para>
-      Liste de valeurs séparées par des virgules
-      des sections qui devront être présentées dans le tableau de résultat.
+      Liste séparée par des virgules
+      de sections devant être présentes dans le fichier pour produire un tableau de résultat.
       Si aucune des sections demandées n'est trouvée, la valeur retournée
       est &false;.
       <informaltable>
@@ -98,8 +98,8 @@
           <entry>
            Attribut HTML, largeur, hauteur, couleur ou noir et blanc et plus si disponible.
            La largeur et la hauteur sont calculées de la même façon que la fonction
-           <function>getimagesize</function>, donc, leurs valeurs ne
-           devraient jamais différer. De même, l'index
+           <function>getimagesize</function>, donc leurs valeurs ne doivent
+           faire partie d'aucun en-tête retourné. De même, l'index
           <literal>html</literal> est la représentation textuelle de la hauteur/largeur
           utilisée dans une balise image <acronym>HTML</acronym> classique.
           </entry>
@@ -107,7 +107,7 @@
          <row>
           <entry>ANY_TAG</entry>
           <entry>
-           Toutes les informations concernant cette balise, comme
+           Toute information ayant un Tag, comme
            <literal>IFD0</literal>, <literal>EXIF</literal>, ...
           </entry>
          </row>

--- a/reference/exif/functions/exif-tagname.xml
+++ b/reference/exif/functions/exif-tagname.xml
@@ -5,7 +5,7 @@
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.exif-tagname">
  <refnamediv>
   <refname>exif_tagname</refname>
-  <refpurpose>Lit le nom d'en-tête EXIF d'un index</refpurpose>
+  <refpurpose>Récupère le nom d'en-tête EXIF d'un index</refpurpose>
  </refnamediv>
  <refsect1 role="description">
   &reftitle.description;

--- a/reference/exif/functions/exif-thumbnail.xml
+++ b/reference/exif/functions/exif-thumbnail.xml
@@ -5,7 +5,7 @@
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.exif-thumbnail">
  <refnamediv>
   <refname>exif_thumbnail</refname>
-  <refpurpose>Récupère la miniature d'une image</refpurpose>
+  <refpurpose>Récupère la miniature embarquée d'une image</refpurpose>
  </refnamediv>
  <refsect1 role="description">
   &reftitle.description;
@@ -20,8 +20,8 @@
    <function>exif_thumbnail</function> lit la miniature de l'image.
   </simpara>
   <simpara>
-   Pour afficher des miniatures avec cette fonction, il faut
-   envoyer le bon type MIME avec la fonction <function>header</function>.
+   Pour afficher des miniatures avec cette fonction, il est recommandé
+   d'envoyer le bon type MIME avec la fonction <function>header</function>.
   </simpara>
   <simpara>
    Il est possible que la fonction <function>exif_thumbnail</function>

--- a/reference/exif/ini.xml
+++ b/reference/exif/ini.xml
@@ -6,8 +6,8 @@
  &reftitle.runtime;
  &extension.runtime;
  <para>
-  EXIF supporte automatiquement la conversion depuis Unicode
-  et JIS, lorsque le module <link linkend="ref.mbstring">mbstring</link>
+  EXIF supporte automatiquement la conversion pour les encodages
+  Unicode et JIS des commentaires utilisateurs, lorsque le module <link linkend="ref.mbstring">mbstring</link>
   est compilé avec PHP. Cela se fait en décodant le commentaire avec
   le jeu de caractères spécifié. Le résultat est ensuite codé avec
   un autre jeu de caractères, compatible avec la sortie
@@ -79,7 +79,7 @@
     <literal>exif.encode_unicode</literal> définit la
     méthode de gestion des commentaires écrits en Unicode.
     La valeur par défaut est <literal>ISO-8859-15</literal>,
-    qui devrait fonctionner dans tous les pays non-asiatiques.
+    qui devrait fonctionner pour la plupart des pays non-asiatiques.
     Cette directive peut être laissée vide, ou prendre un
     des jeux de caractères supporté par mbstring. Si elle
     est vide, le jeu de caractères interne de mbstring sera
@@ -114,7 +114,7 @@
      <literal>exif.decode_unicode_intel</literal> définit
      le jeu de caractères de remplacement pour les commentaires
      utilisateurs écrits en Unicode, si l'ordre des bits
-     est celui de Intel (little-endian). Cette directive ne
+     est celui d'Intel (little-endian). Cette directive ne
      peut être laissée vide, et doit être un des jeux de
      caractères supportés par l'extension mbstring. La valeur
      par défaut est <literal>UCS-2LE</literal>.
@@ -162,7 +162,7 @@
      <literal>exif.decode_jis_intel</literal> définit
      le jeu de caractères de remplacement pour les commentaires
      utilisateurs écrits en JIS, si l'ordre des bits
-     est celui de Intel (little-endian). Cette directive ne
+     est celui d'Intel (little-endian). Cette directive ne
      peut être laissée vide, et doit être un des jeux de
      caractères supportés par l'extension mbstring. La valeur
      par défaut est <literal>JIS</literal>.

--- a/reference/expect/book.xml
+++ b/reference/expect/book.xml
@@ -13,7 +13,7 @@
    Cette extension autorise l'interaction avec des processus à travers PTY.
    Il est possible d'utiliser l'<link linkend="wrappers.expect">enveloppe <literal>expect://</literal></link>
    avec les <link linkend="ref.filesystem">fonctions de système de
-   fichiers</link> ce qui fournit une interface simple et plus intuitive.
+   fichiers</link> ce qui fournit une interface plus simple et plus intuitive.
   </simpara>
  </preface>
  <!-- }}} -->

--- a/reference/expect/functions/expect-expectl.xml
+++ b/reference/expect/functions/expect-expectl.xml
@@ -147,7 +147,7 @@ ini_set("expect.timeout", 30);
 $stream = fopen("expect://scp user@remotehost:/var/log/messages /home/user/messages.txt", "r");
 
 $cases = array(
-    // array(masque, valeur à retourner si le masque correspond)
+    // array(motif, valeur à retourner si le motif correspond)
     array("password:", "asked for password"),
     array("yes/no)?",  "asked for yes/no")
 );

--- a/reference/expect/functions/expect-popen.xml
+++ b/reference/expect/functions/expect-popen.xml
@@ -48,7 +48,7 @@
    <programlisting role="php">
 <![CDATA[
 <?php
-// Identification au répertoire CVS de PHP.net
+// Identification au dépôt CVS de PHP.net
 $stream = expect_popen ("cvs -d :pserver:anonymous@cvs.php.net:/repository login");
 sleep (3);
 fwrite ($stream, "phpfi\n");

--- a/reference/fann/book.xml
+++ b/reference/fann/book.xml
@@ -11,7 +11,7 @@
   <para>
    Le support PHP pour la bibliothèque FANN (Fast Artificial Neural Network) qui implémente des réseaux
    de neurones artificiels multicouches avec support pour les réseaux entièrement connectés et les réseaux
-   connectés de manière éparses. Il inclut un cadre pour la manipulation facile des ensembles de données
+   connectés de manière éparse. Il inclut un cadre pour la manipulation facile des ensembles de données
    d'entraînement. Il est facile à utiliser, polyvalent, bien documenté et rapide.
   </para>
  </preface>

--- a/reference/fann/constants.xml
+++ b/reference/fann/constants.xml
@@ -6,7 +6,7 @@
  &extension.constants;
  <para>
   <variablelist xml:id="constants.fann-train">
-   <title>Training algorithms</title>
+   <title>Algorithmes d'entraînement</title>
    <varlistentry xml:id="constant.fann-train-incremental">
     <term>
      <constant>FANN_TRAIN_INCREMENTAL</constant>
@@ -16,8 +16,8 @@
      <simpara>
       L'algorithme standard de rétropropagation, où les poids sont mis à jour après chaque motif d'entraînement.
       Cela signifie que les poids sont mis à jour de nombreuses fois pendant une seule époque. Pour cette raison,
-      certains problèmes se formeront très rapidement avec cet algorithme, tandis que d'autres problèmes plus avancés
-      ne se formeront pas très bien.
+      certains problèmes s'entraîneront très rapidement avec cet algorithme, tandis que d'autres problèmes plus avancés
+      ne s'entraîneront pas très bien.
      </simpara>
     </listitem>
    </varlistentry>
@@ -30,7 +30,7 @@
      <simpara>
       L'algorithme standard de rétropropagation, où les poids sont mis à jour après avoir calculé l'erreur quadratique
       moyenne pour l'ensemble d'entraînement. Cela signifie que les poids ne sont mis à jour qu'une seule fois pendant
-      une époque. Pour cette raison, certains problèmes se formeront plus lentement avec cet algorithme. Mais comme
+      une époque. Pour cette raison, certains problèmes s'entraîneront plus lentement avec cet algorithme. Mais comme
       l'erreur quadratique moyenne est calculée plus correctement que dans l'entraînement incrémentiel, certains problèmes
       atteindront de meilleures solutions avec cet algorithme.
      </simpara>
@@ -48,7 +48,7 @@
       peuvent être définis pour changer la façon dont l'algorithme d'entraînement RPROP fonctionne, mais il est uniquement recommandé
       pour les utilisateurs ayant une connaissance de la façon dont l'algorithme d'entraînement RPROP fonctionne. L'algorithme
       d'entraînement RPROP est décrit par [Riedmiller et Braun, 1993], mais l'algorithme d'apprentissage réel utilisé ici est
-      l'algorithme d'entraînement iRPROP décrit par [Igel et Husken, 2000] qui est une variété de l'algorithme d'entraînement RPROP standard.
+      l'algorithme d'entraînement iRPROP- décrit par [Igel et Husken, 2000] qui est une variété de l'algorithme d'entraînement RPROP standard.
      </simpara>
     </listitem>
    </varlistentry>
@@ -73,13 +73,13 @@
     </term>
     <listitem>
      <simpara>
-      Un algorithme d'entraînement encore plus avancé. Seulement pour la version 2.2. 
+      Un algorithme d'entraînement encore plus avancé. Seulement pour la version 2.2.
      </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
   <variablelist xml:id="constants.fann-activation-funcs">
-   <title>Activation functions</title>
+   <title>Fonctions d'activation</title>
    <varlistentry xml:id="constant.fann-linear">
     <term>
      <constant>FANN_LINEAR</constant>
@@ -328,7 +328,7 @@
      <simpara>
       Les critères d'arrêt du nombre de bits qui échouent. Le nombre de bits signifie le nombre de neurones de sortie qui diffèrent
       de plus que la limite de défaillance de bits (voir fann_get_bit_fail_limit, fann_set_bit_fail_limit). Les bits sont comptés
-      dans tous les données d'entraînement, donc ce nombre peut être plus élevé que le nombre de données d'entraînement.
+      dans toutes les données d'entraînement, donc ce nombre peut être plus élevé que le nombre de données d'entraînement.
      </simpara>
     </listitem>
    </varlistentry>
@@ -359,7 +359,7 @@
    </varlistentry>
    </variablelist>
   <variablelist xml:id="constants.fann-e">
-   <title>Errors</title>
+   <title>Erreurs</title>
    <varlistentry xml:id="constant.fann-e-no-error">
     <term>
      <constant>FANN_E_NO_ERROR</constant>

--- a/reference/fann/examples.xml
+++ b/reference/fann/examples.xml
@@ -4,7 +4,7 @@
 <chapter xml:id="fann.examples" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.examples;
  <section xml:id="fann.examples-1">
-  <title>XOR training</title>
+  <title>Entraînement XOR</title>
   <para>
    Cet exemple montre comment entraîner des données pour la fonction XOR
    <example>
@@ -62,11 +62,11 @@ if ($ann) {
 <?php
 $train_file = (dirname(__FILE__) . "/xor_float.net");
 if (!is_file($train_file))
-    die("The file xor_float.net has not been created! Please run simple_train.php to generate it");
+    die("Le fichier xor_float.net n'a pas été créé ! Veuillez exécuter simple_train.php pour le générer");
 
 $ann = fann_create_from_file($train_file);
 if (!$ann)
-    die("ANN could not be created");
+    die("Le réseau de neurones n'a pas pu être créé");
 
 $input = array(-1, 1);
 $calc_out = fann_run($ann, $input);

--- a/reference/fann/functions/fann-cascadetrain-on-data.xml
+++ b/reference/fann/functions/fann-cascadetrain-on-data.xml
@@ -19,7 +19,7 @@
   </methodsynopsis>
   <para>
    La fraction de changement de sortie en cascade est un nombre compris entre 0 et 1 déterminant quelle fraction
-   la valeur de <function>fann_get_MSE</function> doit changer dans <function>fann_get_cascade_output_stagnation_epochs</function>
+   la valeur de <function>fann_get_MSE</function> devrait changer dans <function>fann_get_cascade_output_stagnation_epochs</function>
    pendant l'entraînement des connexions de sortie, afin que l'entraînement ne stagne pas. Si l'entraînement stagne,
    l'entraînement des connexions de sortie sera terminé et de nouveaux candidats seront préparés.
   </para>
@@ -59,7 +59,7 @@
     <term><parameter>neurons_between_reports</parameter></term>
     <listitem>
      <para>
-      Le nombre de neurones entre l'impression d'un rapport d'état. Une valeur de zéro signifie qu'aucun rapport ne doit être affiché.
+      Le nombre de neurones entre l'impression d'un rapport d'état. Une valeur de zéro signifie qu'aucun rapport ne devrait être affiché.
      </para>
     </listitem>
    </varlistentry>

--- a/reference/fann/functions/fann-cascadetrain-on-file.xml
+++ b/reference/fann/functions/fann-cascadetrain-on-file.xml
@@ -51,7 +51,7 @@
     <term><parameter>neurons_between_reports</parameter></term>
     <listitem>
      <para>
-      Le nombre de neurones entre l'impression d'un rapport d'état. Une valeur de zéro signifie qu'aucun rapport ne doit être affiché.
+      Le nombre de neurones entre l'impression d'un rapport d'état. Une valeur de zéro signifie qu'aucun rapport ne devrait être affiché.
      </para>
     </listitem>
    </varlistentry>

--- a/reference/fann/functions/fann-copy.xml
+++ b/reference/fann/functions/fann-copy.xml
@@ -35,7 +35,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Retourne une copie du réseau neuronal en cas de succès, ou &false;
+   Retourne une copie du réseau de neurones en cas de succès, ou &false;
    si une erreur survient.
   </para>
  </refsect1>

--- a/reference/fann/functions/fann-create-from-file.xml
+++ b/reference/fann/functions/fann-create-from-file.xml
@@ -5,7 +5,7 @@
 <refentry xml:id="function.fann-create-from-file" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>fann_create_from_file</refname>
-  <refpurpose>Construit une propagation de retour du réseau neuronal depuis un fichier
+  <refpurpose>Construit un réseau de neurones de rétropropagation à partir d'un fichier
    de configuration</refpurpose>
  </refnamediv>
 
@@ -16,8 +16,8 @@
    <methodparam><type>string</type><parameter>configuration_file</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Construit une propagation de retour du réseau neuronal depuis un fichier
-   de configuration, qui a été sauvegardée par la fonction <function>fann_save</function>.
+   Construit un réseau de neurones de rétropropagation à partir d'un fichier
+   de configuration, qui a été sauvegardé par la fonction <function>fann_save</function>.
   </para>
  </refsect1>
 

--- a/reference/fann/functions/fann-create-shortcut-array.xml
+++ b/reference/fann/functions/fann-create-shortcut-array.xml
@@ -7,7 +7,7 @@
 <refentry xml:id="function.fann-create-shortcut-array" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>fann_create_shortcut_array</refname>
-  <refpurpose>Crée une propagation de retour standard de réseau neuronal
+  <refpurpose>Crée un réseau de neurones de rétropropagation standard
    qui n'est pas totalement connecté, et a des connexions raccourcies</refpurpose>
  </refnamediv>
 
@@ -19,7 +19,7 @@
    <methodparam><type>array</type><parameter>layers</parameter></methodparam>
   </methodsynopsis>
   <simpara>
-   Crée une propagation de retour standard de réseau neuronal
+   Crée un réseau de neurones de rétropropagation standard
    qui n'est pas totalement connecté, et a des connexions raccourcies
    en utilisant un tableau de tailles de couches.
   </simpara>
@@ -50,7 +50,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Retourne une ressource représentant le réseau neuronal en cas de succès,
+   Retourne une ressource représentant le réseau de neurones en cas de succès,
    ou &false; si une erreur survient.
   </para>
  </refsect1>

--- a/reference/fann/functions/fann-create-train-from-callback.xml
+++ b/reference/fann/functions/fann-create-train-from-callback.xml
@@ -74,7 +74,7 @@
       </simplelist>
      </para>
      <para>
-      La fonction doit retourner un tableau associatif avec les clés
+      La fonction devrait retourner un tableau associatif avec les clés
       <literal>input</literal> et <literal>output</literal> et deux
       valeurs de tableaux pour les entrées et les sorties.
      </para>

--- a/reference/fann/functions/fann-descale-input.xml
+++ b/reference/fann/functions/fann-descale-input.xml
@@ -32,7 +32,7 @@
     <term><parameter>input_vector</parameter></term>
     <listitem>
      <para>
-      Vecteur d'entrée qui sera mis à l'échelle
+      Vecteur d'entrée dont l'échelle sera inversée
      </para>
     </listitem>
    </varlistentry>

--- a/reference/fann/functions/fann-descale-output.xml
+++ b/reference/fann/functions/fann-descale-output.xml
@@ -32,7 +32,7 @@
     <term><parameter>output_vector</parameter></term>
     <listitem>
      <para>
-      Vecteur de sortie qui sera mis à l'échelle
+      Vecteur de sortie dont l'échelle sera inversée
      </para>
     </listitem>
    </varlistentry>

--- a/reference/fann/functions/fann-descale-train.xml
+++ b/reference/fann/functions/fann-descale-train.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="function.fann-descale-train" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>fann_descale_train</refname>
-  <refpurpose>Redimensionne les données d'entrée et de sortie en fonction des paramètres calculés précédemment.</refpurpose> 
+  <refpurpose>Inverse l'échelle des données d'entrée et de sortie en fonction des paramètres calculés précédemment</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -15,7 +15,7 @@
    <methodparam><type>resource</type><parameter>train_data</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Redimensionne les données d'entrée et de sortie en fonction des paramètres calculés précédemment.
+   Inverse l'échelle des données d'entrée et de sortie en fonction des paramètres calculés précédemment.
   </para>
  </refsect1>
 

--- a/reference/fann/functions/fann-get-activation-steepness.xml
+++ b/reference/fann/functions/fann-get-activation-steepness.xml
@@ -27,7 +27,7 @@
    du minimum au maximum. Une valeur élevée pour la fonction d'activation donnera également un entraînement plus agressif.
   </para>
   <para>
-   Lors de l'entraînement des réseaux de neurones où les valeurs de sortie doivent être aux extrêmes
+   Lors de l'entraînement des réseaux de neurones où les valeurs de sortie devraient être aux extrêmes
    (généralement 0 et 1, selon la fonction d'activation), une fonction d'activation raide peut être utilisée (par exemple 1.0).
   </para>
   <para>

--- a/reference/fann/functions/fann-get-cascade-activation-functions.xml
+++ b/reference/fann/functions/fann-get-cascade-activation-functions.xml
@@ -17,7 +17,7 @@
    Le tableau des fonctions d'activation en cascade est un tableau des différentes fonctions d'activation utilisées par les candidats.
   </para>
   <para>
-   Voir <function>fann_get_cascade_activation_functions_count</function> pour une description des fonctions d'activation qui seront générées par ce tableau.
+   Voir <function>fann_get_cascade_num_candidates</function> pour une description des neurones candidats qui seront générés par ce tableau.
   </para>
   <para>
    Les fonctions d'activations par défaut sont <constant>FANN_SIGMOID</constant>, <constant>FANN_SIGMOID_SYMMETRIC</constant>,

--- a/reference/fann/functions/fann-get-cascade-activation-steepnesses.xml
+++ b/reference/fann/functions/fann-get-cascade-activation-steepnesses.xml
@@ -17,7 +17,7 @@
    Les raideurs d'activation en cascade sont un tableau des différentes fonctions d'activation utilisées par les candidats.
   </para>
   <para>
-   Voir <function>fann_get_cascade_activation_steepnesses_count</function> pour une description des raideurs d'activation qui seront générées par ce tableau.
+   Voir <function>fann_get_cascade_num_candidates</function> pour une description des neurones candidats qui seront générés par ce tableau.
   </para>
   <para>
    Les raideurs d'activations par défaut sont {0.25, 0.50, 0.75, 1.00}.

--- a/reference/fann/functions/fann-get-quickprop-mu.xml
+++ b/reference/fann/functions/fann-get-quickprop-mu.xml
@@ -17,7 +17,7 @@
   </methodsynopsis>
   <para>
    Le facteur mu est utilisé pour accroître et décroitre la taille de l'étape
-   durant l'entraînement quickprop. Le facteur mu doit toujours être inférieur
+   durant l'entraînement quickprop. Le facteur mu devrait toujours être supérieur
    à 1, sachant que sinon, il va décroitre la taille de l'étape alors qu'il
    est supposé l'accroitre.
   </para>

--- a/reference/fann/functions/fann-get-total-neurons.xml
+++ b/reference/fann/functions/fann-get-total-neurons.xml
@@ -17,7 +17,7 @@
   </methodsynopsis>
   <para>
    Récupère le nombre total de neurones dans la totalité du réseau.
-   Ce nombre n'inclut pas les neurones de polarisation -
+   Ce nombre inclut aussi les neurones de polarisation -
    un réseau 2-4-2 a 2+4+2 +2(polarisants) = 10 neurones.
   </para>
  </refsect1>

--- a/reference/fann/functions/fann-get-training-algorithm.xml
+++ b/reference/fann/functions/fann-get-training-algorithm.xml
@@ -24,7 +24,7 @@
    Il est à noter que cet algorithme est également utilisé pendant
    <function>fann_cascadetrain_on_data</function>, bien que seules les
    constantes <constant>FANN_TRAIN_RPROP</constant> et <constant>FANN_TRAIN_QUICKPROP</constant>
-   sont autorisées pendant l'entraînement en cascade.
+   soient autorisées pendant l'entraînement en cascade.
   </para>
  </refsect1>
 

--- a/reference/fann/functions/fann-reset-mse.xml
+++ b/reference/fann/functions/fann-reset-mse.xml
@@ -19,7 +19,7 @@
    Réinitialise l'erreur quadratique moyenne du réseau.
   </para>
   <para>
-   Cette fonction réinitialise également le nombre d'octets en échec.
+   Cette fonction réinitialise également le nombre de bits en échec.
   </para>
  </refsect1>
 

--- a/reference/fann/functions/fann-set-activation-function-output.xml
+++ b/reference/fann/functions/fann-set-activation-function-output.xml
@@ -6,7 +6,7 @@
 <refentry xml:id="function.fann-set-activation-function-output" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>fann_set_activation_function_output</refname>
-  <refpurpose>Définit la fonction d'activation pour la couche d'entrée</refpurpose>
+  <refpurpose>Définit la fonction d'activation pour la couche de sortie</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -17,7 +17,7 @@
    <methodparam><type>int</type><parameter>activation_function</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Définit la fonction d'activation pour la couche d'entrée.
+   Définit la fonction d'activation pour la couche de sortie.
   </para>
  </refsect1>
 

--- a/reference/fann/functions/fann-set-bit-fail-limit.xml
+++ b/reference/fann/functions/fann-set-bit-fail-limit.xml
@@ -6,7 +6,7 @@
 <refentry xml:id="function.fann-set-bit-fail-limit" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>fann_set_bit_fail_limit</refname>
-  <refpurpose>Définit le bit sûr limite, utilisé pendant l'entraînement</refpurpose>
+  <refpurpose>Définit la limite d'échec de bit, utilisée pendant l'entraînement</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -17,7 +17,7 @@
    <methodparam><type>float</type><parameter>bit_fail_limit</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Définit le bit sûr limite, utilisé pendant l'entraînement.
+   Définit la limite d'échec de bit, utilisée pendant l'entraînement.
   </para>
  </refsect1>
 
@@ -34,7 +34,7 @@
     <term><parameter>bit_fail_limit</parameter></term>
     <listitem>
      <para>
-      Le bit sûr limite.
+      La limite d'échec de bit.
      </para>
     </listitem>
    </varlistentry>

--- a/reference/fann/functions/fann-set-weight.xml
+++ b/reference/fann/functions/fann-set-weight.xml
@@ -52,7 +52,7 @@
     <term><parameter>weight</parameter></term>
     <listitem>
      <para>
-      Taille de la connexion
+      Poids de la connexion
      </para>
     </listitem>
    </varlistentry>

--- a/reference/fann/functions/fann-test-data.xml
+++ b/reference/fann/functions/fann-test-data.xml
@@ -22,7 +22,7 @@
    et calcule le MSE pour ces données.
   </para>
   <para>
-   Cette fonction met à jour le MSE à sa valeur la plus sûre.
+   Cette fonction met à jour le MSE et les valeurs de bits échoués.
   </para>
  </refsect1>
 

--- a/reference/fann/functions/fann-train-epoch.xml
+++ b/reference/fann/functions/fann-train-epoch.xml
@@ -19,7 +19,7 @@
   <para>
    Effectue un entraînement avec un jeu de données d'entraînement.
    Une époque correspond au fait que toutes les données d'entraînement
-   sont considérées comme étant exactement uniques.
+   sont considérées exactement une fois.
   </para>
   <para>
    Cette fonction retourne l'erreur MSE sachant qu'elle est calculée

--- a/reference/fann/functions/fann-train.xml
+++ b/reference/fann/functions/fann-train.xml
@@ -21,7 +21,7 @@
   <para>
    Effectue un entraînement sur une itération avec un jeu d'entrées,
    et un jeu de sorties désirées. Cet entraînement est toujours un
-   entraînement incrémental, sachant que seulement un masque est présenté.
+   entraînement incrémental, sachant que seulement un motif est présenté.
   </para>
  </refsect1>
 

--- a/reference/fann/setup.xml
+++ b/reference/fann/setup.xml
@@ -82,7 +82,7 @@ $ sudo pecl install fann
 
   <section xml:id="fann.installation.manual">
 
-   <title>Manuel d'installation</title>
+   <title>Installation manuelle</title>
 
    <para>
     Pour les développeurs et les personnes intéressées par les derniers changements, l'on

--- a/reference/fdf/examples.xml
+++ b/reference/fdf/examples.xml
@@ -35,9 +35,9 @@ if (fdf_get_value($fdf, "show_publisher") == "On") {
   
 if (fdf_get_value($fdf, "show_preparer") == "On") {
   $preparer = fdf_get_value($fdf, "preparer");
-  echo 'La valeur du champ Preparer était  "<b>' . $preparer . '</b>"<br />';
+  echo 'La valeur du champ Preparer était "<b>' . $preparer . '</b>"<br />';
 } else
-  echo 'La valeur du champ Preparer ne doit pas être affiché.<br />';
+  echo 'La valeur du champ Preparer ne doit pas être affichée.<br />';
 fdf_close($fdf);
 ?>
 ]]>

--- a/reference/fdf/functions/fdf-add-doc-javascript.xml
+++ b/reference/fdf/functions/fdf-add-doc-javascript.xml
@@ -49,8 +49,8 @@
     <term><parameter>script_code</parameter></term>
     <listitem>
      <simpara>
-      Le code du script. Il est fortement recommandé d'utiliser '\r' comme
-      séparateur de lignes dans le code <parameter>script_code</parameter>.
+      Le code du script. Il est fortement recommandé d'utiliser <literal>\r</literal>
+      comme séparateur de lignes dans le code <parameter>script_code</parameter>.
      </simpara>
     </listitem>
    </varlistentry>

--- a/reference/fdf/functions/fdf-error.xml
+++ b/reference/fdf/functions/fdf-error.xml
@@ -15,7 +15,8 @@
    <methodparam choice="opt"><type>int</type><parameter>error_code</parameter><initializer>-1</initializer></methodparam>
   </methodsynopsis>
   <simpara>
-   Retourne le message d'erreur FDF.
+   Retourne une description textuelle du code d'erreur FDF fourni dans
+   <parameter>error_code</parameter>.
   </simpara>
  </refsect1>
 

--- a/reference/fdf/functions/fdf-get-attachment.xml
+++ b/reference/fdf/functions/fdf-get-attachment.xml
@@ -5,7 +5,7 @@
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.fdf-get-attachment">
  <refnamediv>
   <refname>fdf_get_attachment</refname>
-  <refpurpose>Extrait un fichier intégré dans un document FDF</refpurpose>
+  <refpurpose>Extrait un fichier téléversé intégré dans un document FDF</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -18,7 +18,7 @@
   </methodsynopsis>
   <simpara>
    Extrait le fichier <parameter>fieldname</parameter>
-   téléchargé par le biais du champ <literal>"file selection"</literal>,
+   téléversé par le biais du champ <literal>"file selection"</literal>,
    puis le stocke dans le fichier <parameter>savepath</parameter>.
   </simpara>
  </refsect1>
@@ -49,12 +49,12 @@
     <listitem>
      <simpara>
       Peut être le nom d'un fichier ou bien un dossier dans lequel le
-      fichier téléchargé sera créé sous son nom original. Tout fichier
+      fichier téléversé sera créé sous son nom original. Tout fichier
       déjà existant avec le même nom sera écrasé.
      </simpara>
      <note>
       <simpara>
-       Il semble qu'il n'y ait pas d'autre moyen pour connaître le nom du fichier téléchargé
+       Il semble qu'il n'y ait pas d'autre moyen pour connaître le nom du fichier téléversé
        que de le stocker dans un dossier avec <parameter>savepath</parameter> puis
        de lire son nom dans le dossier.
       </simpara>
@@ -70,7 +70,7 @@
    Le tableau retourné contient les champs suivants :
    <itemizedlist>
     <listitem>
-     <simpara><parameter>path</parameter> - chemin de stockage du dossier</simpara>
+     <simpara><parameter>path</parameter> - chemin où le fichier a été stocké</simpara>
     </listitem>
     <listitem>
      <simpara><parameter>size</parameter> - taille du fichier stocké en octets</simpara>
@@ -85,13 +85,13 @@
  <refsect1 role="examples">
   &reftitle.examples;
   <example>
-   <title>Enregistrement d'un fichier téléchargé</title>
+   <title>Enregistrement d'un fichier téléversé</title>
    <programlisting role="php">
 <![CDATA[
 <?php
 $fdf = fdf_open_string($HTTP_FDF_DATA);
 $data = fdf_get_attachment($fdf, "filename", "/tmpdir");
-echo "Le fichier téléchargé est stocké dans $data[path]";
+echo "Le fichier téléversé est stocké dans $data[path]";
 ?>
 ]]>
    </programlisting>

--- a/reference/fdf/functions/fdf-get-encoding.xml
+++ b/reference/fdf/functions/fdf-get-encoding.xml
@@ -40,7 +40,7 @@
   &reftitle.returnvalues;
   <simpara>
    Retourne l'encodage, sous la forme d'une &string;. Une chaîne vide
-   est retournée si le schéma <literal>PDFDocEncoding/Unicode</literal>
+   est retournée si le schéma par défaut <literal>PDFDocEncoding/Unicode</literal>
    est utilisé.
   </simpara>
  </refsect1>

--- a/reference/fdf/functions/fdf-get-version.xml
+++ b/reference/fdf/functions/fdf-get-version.xml
@@ -5,7 +5,7 @@
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.fdf-get-version">
  <refnamediv>
   <refname>fdf_get_version</refname>
-  <refpurpose>Lit le numéro de version de l'API FDF</refpurpose>
+  <refpurpose>Lit le numéro de version de l'API ou du fichier FDF</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -16,8 +16,8 @@
   </methodsynopsis>
   <simpara>
    Retourne le numéro de version FDF pour le document
-   <parameter>fdf_document</parameter>, pour l'API
-   si aucun paramètre n'est donné.
+   <parameter>fdf_document</parameter>, ou le numéro de version de l'API
+   du toolkit si aucun paramètre n'est donné.
   </simpara>
  </refsect1>
 

--- a/reference/fdf/functions/fdf-open-string.xml
+++ b/reference/fdf/functions/fdf-open-string.xml
@@ -15,7 +15,7 @@
    <methodparam><type>string</type><parameter>fdf_data</parameter></methodparam>
   </methodsynopsis>
   <simpara>
-   Lit un document FDF à partir d'une &string;.
+   Lit les données de formulaire à partir d'une &string;.
   </simpara>
   <simpara>
    Il est possible d'utiliser <function>fdf_open_string</function> avec la variable

--- a/reference/fdf/functions/fdf-open.xml
+++ b/reference/fdf/functions/fdf-open.xml
@@ -15,7 +15,7 @@
    <methodparam><type>string</type><parameter>filename</parameter></methodparam>
   </methodsynopsis>
   <simpara>
-   Ouvre un document FDF.
+   Ouvre un fichier contenant des données de formulaire.
   </simpara>
   <simpara>
    Il est également possible d'utiliser la fonction

--- a/reference/fdf/functions/fdf-set-encoding.xml
+++ b/reference/fdf/functions/fdf-set-encoding.xml
@@ -43,8 +43,8 @@
       "<literal>GBK</literal>" et "<literal>BigFive</literal>".
      </simpara>
      <simpara>
-      Une &string; vide replace la valeur par défaut de l'encodage au
-      schéma <literal>PDFDocEncoding/Unicode</literal>.
+      Une &string; vide réinitialise l'encodage au
+      schéma <literal>PDFDocEncoding/Unicode</literal> par défaut.
      </simpara>
     </listitem>
    </varlistentry>

--- a/reference/fdf/functions/fdf-set-file.xml
+++ b/reference/fdf/functions/fdf-set-file.xml
@@ -5,7 +5,7 @@
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.fdf-set-file">
  <refnamediv>
   <refname>fdf_set_file</refname>
-  <refpurpose>Crée un document PDF pour y afficher des données FDF</refpurpose>
+  <refpurpose>Définit le document PDF dans lequel afficher les données FDF</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -17,7 +17,8 @@
    <methodparam choice="opt"><type>string</type><parameter>target_frame</parameter></methodparam>
   </methodsynopsis>
   <simpara>
-   Crée un document PDF pour y afficher des données FDF.
+   Sélectionne un document PDF différent de celui dont le formulaire est
+   issu, afin d'y afficher les résultats du formulaire.
   </simpara>
  </refsect1>
 

--- a/reference/fdf/functions/fdf-set-submit-form-action.xml
+++ b/reference/fdf/functions/fdf-set-submit-form-action.xml
@@ -5,7 +5,7 @@
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.fdf-set-submit-form-action">
  <refnamediv>
   <refname>fdf_set_submit_form_action</refname>
-  <refpurpose>Modifie l'action d'un formulaire</refpurpose>
+  <refpurpose>Définit une action de soumission de formulaire pour un champ</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -19,7 +19,7 @@
    <methodparam><type>int</type><parameter>flags</parameter></methodparam>
   </methodsynopsis>
   <simpara>
-   Modifie l'action d'un formulaire.
+   Définit une action de soumission de formulaire pour le champ donné.
   </simpara>
  </refsect1>
 

--- a/reference/fdf/functions/fdf-set-value.xml
+++ b/reference/fdf/functions/fdf-set-value.xml
@@ -48,8 +48,8 @@
     <term><parameter>value</parameter></term>
     <listitem>
      <simpara>
-      Ce paramètre devra être stocké comme une chaîne de caractères
-      même si c'est un tableau. Dans ce cas, tous les éléments du tableau
+      Ce paramètre sera stocké comme une chaîne de caractères
+      sauf si c'est un tableau. Dans ce cas, tous les éléments du tableau
       seront stockés comme un tableau de valeurs.
      </simpara>
     </listitem>
@@ -60,11 +60,11 @@
      <note>
       <simpara>
        Dans les anciennes versions de la suite FDF, le dernier paramètre déterminait si la valeur
-       du champ devait être convertie en un nom PDF (<parameter>isname</parameter> = 1)
-       ou positionnée comme une chaîne de caractères (<parameter>isname</parameter> = 0).
+       du champ devait être convertie en un nom PDF (<parameter>isName</parameter> = 1)
+       ou positionnée comme une chaîne de caractères (<parameter>isName</parameter> = 0).
       </simpara>
       <simpara>
-       La valeur n'est plus dans la suite actuelle, version 5.0. Pour des raisons de compatibilité,
+       La valeur n'est plus utilisée dans la suite actuelle, version 5.0. Pour des raisons de compatibilité,
        cela est toujours supporté comme un paramètre optionnel, mais ignoré en
        interne.
       </simpara>

--- a/reference/fdf/functions/fdf-set-version.xml
+++ b/reference/fdf/functions/fdf-set-version.xml
@@ -42,7 +42,7 @@
     <term><parameter>version</parameter></term>
     <listitem>
      <simpara>
-      Le numéro de version. Pour le toolkit FDF courant, ce peut être
+      Le numéro de version. Pour le toolkit FDF courant 5.0, ce peut être
       <literal>1.2</literal>, <literal>1.3</literal> ou
       <literal>1.4</literal>.
      </simpara>

--- a/reference/fdf/setup.xml
+++ b/reference/fdf/setup.xml
@@ -29,7 +29,7 @@
   <simpara>
    La plupart des fonctions FDF nécessitent une ressource de type
    <parameter>fdf</parameter> comme premier argument. Une ressource
-   <parameter>fdf</parameter> est une structure qui représente un
+   <parameter>fdf</parameter> est un gestionnaire vers un
    fichier FDF ouvert. Il est possible de créer des ressources <parameter>fdf</parameter>
    avec les fonctions <function>fdf_create</function>,
    <function>fdf_open</function> et <function>fdf_open_string</function>.

--- a/reference/ffi/ffi.cdata.xml
+++ b/reference/ffi/ffi.cdata.xml
@@ -58,8 +58,7 @@
      </listitem>
      <listitem>
       <simpara>
-       Les pointeurs C peuvent être incrémentés et décrémentés à l'aide des opérations ordinaires ( <code>+</code>/<code>-</code>/ / ).
-       <code>++</code>/<code>--</code>, par exemple <code>$cdata += 5</code>
+       Les pointeurs C peuvent être incrémentés et décrémentés à l'aide des opérations ordinaires <code>+</code>/<code>-</code>/<code>++</code>/<code>--</code>, par exemple <code>$cdata += 5</code>
       </simpara>
      </listitem>
      <listitem>

--- a/reference/ffi/ffi.exception.xml
+++ b/reference/ffi/ffi.exception.xml
@@ -5,7 +5,7 @@
 <reference xml:id="class.ffi-exception" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>Exceptions FFI</title>
- <titleabbrev>Exceptions FFI</titleabbrev>
+ <titleabbrev>FFI\Exception</titleabbrev>
 
  <partintro>
 

--- a/reference/ffi/ffi/alignof.xml
+++ b/reference/ffi/ffi/alignof.xml
@@ -27,7 +27,7 @@
     <term><parameter>ptr</parameter></term>
     <listitem>
      <simpara>
-      L'identifiant de la donnée ou du type C.
+      Le gestionnaire de la donnée ou du type C.
      </simpara>
     </listitem>
    </varlistentry>

--- a/reference/ffi/ffi/cdef.xml
+++ b/reference/ffi/ffi/cdef.xml
@@ -33,7 +33,7 @@
      </simpara>
      <note>
       <simpara>
-       Les directives du préprocesseur C ne sont pas prises en charge, c'est-à-dire <code>#include</code>,
+       Les directives du préprocesseur C ne sont pas supportées, c'est-à-dire <code>#include</code>,
        <code>#define</code> et les macros CPP ne fonctionnent pas.
       </simpara>
      </note>

--- a/reference/ffi/ffi/scope.xml
+++ b/reference/ffi/ffi/scope.xml
@@ -18,7 +18,7 @@
    Instancie un objet FFI avec les déclarations C analysées lors du préchargement.
   </simpara>
   <simpara>
-   La méthode <methodname>FFI::scope</methodname> peut être appelée plusieurs fois pour la même portée. Plusieurs références à la
+   La méthode <methodname>FFI::scope</methodname> peut être appelée sans risque plusieurs fois pour la même portée. Plusieurs références à la
    même portée peuvent être chargées en même temps.
   </simpara>
  </refsect1>

--- a/reference/fileinfo/functions/finfo-open.xml
+++ b/reference/fileinfo/functions/finfo-open.xml
@@ -61,7 +61,7 @@
   &reftitle.returnvalues;
   <simpara>
    (Uniquement en mode procédural)
-   Retourne une instance de <classname>finfo</classname> en cas de succès, &return.falseforfailure;.
+   Retourne une instance de <classname>finfo</classname> en cas de succès,&return.falseforfailure;.
   </simpara>
  </refsect1>
 
@@ -80,7 +80,7 @@
       <entry>8.1.0</entry>
       <entry>
        Retourne désormais une instance de <classname>finfo</classname> ;
-       auparavant, une &resource; était attendue.
+       antérieurement, une &resource; était retournée.
       </entry>
      </row>
      <row>

--- a/reference/filesystem/constants.xml
+++ b/reference/filesystem/constants.xml
@@ -265,7 +265,7 @@
     </term>
     <listitem>
      <simpara>
-      Les barres obliques inverses ne citent pas les métacaractères.
+      Les barres obliques inverses ne protègent pas les métacaractères.
      </simpara>
     </listitem>
    </varlistentry>
@@ -456,7 +456,7 @@
   </varlistentry>
  </variablelist>
  <variablelist xml:id="filesystem.constants.upload">
-  <title>Constantes de Téléversement de Fichiers PHP</title>
+  <title>Constantes de téléversement de fichiers PHP</title>
   <varlistentry xml:id="constant.upload-err-cant-write">
    <term>
     <constant>UPLOAD_ERR_CANT_WRITE</constant>
@@ -476,7 +476,7 @@
    </term>
    <listitem>
     <para>
-     Une extension PHP a interrompu le téléchargement du fichier. PHP ne fournit pas de moyen de savoir quelle extension a provoqué l'arrêt du téléchargement du fichier ; examiner la liste des extensions chargées avec la fonction <function>phpinfo</function> peut aider.
+     Une extension PHP a interrompu le téléversement du fichier. PHP ne fournit pas de moyen de savoir quelle extension a provoqué l'arrêt du téléversement du fichier ; examiner la liste des extensions chargées avec la fonction <function>phpinfo</function> peut aider.
      La valeur de la constante est <literal>8</literal>.
     </para>
    </listitem>
@@ -488,7 +488,7 @@
    </term>
    <listitem>
     <para>
-     Le fichier téléchargé dépasse la directive <emphasis>MAX_FILE_SIZE</emphasis> spécifiée dans le formulaire HTML.
+     Le fichier téléversé dépasse la directive <emphasis>MAX_FILE_SIZE</emphasis> spécifiée dans le formulaire HTML.
      La valeur de la constante est <literal>2</literal>.
     </para>
    </listitem>
@@ -500,7 +500,7 @@
    </term>
    <listitem>
     <para>
-     Le fichier téléchargé dépasse la directive <link linkend="ini.upload-max-filesize">upload_max_filesize</link> spécifiée dans le fichier &php.ini;.
+     Le fichier téléversé dépasse la directive <link linkend="ini.upload-max-filesize">upload_max_filesize</link> spécifiée dans le fichier &php.ini;.
      La valeur de la constante est <literal>1</literal>.
     </para>
    </listitem>
@@ -512,7 +512,7 @@
    </term>
    <listitem>
     <para>
-     Aucun fichier n'a été téléchargé.
+     Aucun fichier n'a été téléversé.
      La valeur de la constante est <literal>4</literal>.
     </para>
    </listitem>
@@ -536,7 +536,7 @@
    </term>
    <listitem>
     <para>
-     Aucune erreur, le fichier a été téléchargé avec succès.
+     Aucune erreur, le fichier a été téléversé avec succès.
      La valeur de la constante est <literal>0</literal>.
     </para>
    </listitem>
@@ -548,7 +548,7 @@
    </term>
    <listitem>
     <para>
-     Le fichier téléchargé n'a été que partiellement téléchargé.
+     Le fichier téléversé n'a été que partiellement téléversé.
      La valeur de la constante est <literal>3</literal>.
     </para>
    </listitem>

--- a/reference/filesystem/functions/basename.xml
+++ b/reference/filesystem/functions/basename.xml
@@ -48,7 +48,7 @@
        Un chemin.
       </para>
       <para>
-       Sous Windows, les caractères (<literal>/</literal>) et antislash
+       Sous Windows, le caractère slash (<literal>/</literal>) et l'antislash
        (<literal>\</literal>) sont utilisés comme séparateurs de
        dossier. Sous les autres OS, seul le caractère slash
        (<literal>/</literal>) est utilisé.
@@ -59,7 +59,8 @@
      <term><parameter>suffix</parameter></term>
      <listitem>
       <para>
-       Si <parameter>suffix</parameter> est fourni, le suffixe sera aussi supprimé.
+       Si le nom de la composante se termine par <parameter>suffix</parameter>,
+       celui-ci sera aussi supprimé.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/filesystem/functions/chgrp.xml
+++ b/reference/filesystem/functions/chgrp.xml
@@ -21,7 +21,7 @@
   </para>
   <para>
    Seul le super-utilisateur (root) peut changer le groupe
-   propriétaire d'un fichier arbitrairement; les utilisateurs
+   propriétaire d'un fichier arbitrairement ; les utilisateurs
    classiques ne peuvent changer le groupe propriétaire d'un
    fichier que si l'utilisateur propriétaire du fichier est
    membre du groupe.

--- a/reference/filesystem/functions/copy.xml
+++ b/reference/filesystem/functions/copy.xml
@@ -86,7 +86,7 @@ $file = 'example.txt';
 $newfile = 'example.txt.bak';
 
 if (!copy($file, $newfile)) {
-    echo "La copie $file du fichier a échoué...\n";
+    echo "La copie du fichier $file a échoué...\n";
 }
 ?>
 ]]>

--- a/reference/filesystem/functions/dirname.xml
+++ b/reference/filesystem/functions/dirname.xml
@@ -22,13 +22,13 @@
   <note>
    <para>
     <function>dirname</function> agit naïvement sur la chaîne en entrée et
-    n'est pas au courant du système de fichiers courant ou d'éventuels
+    n'est pas au courant du système de fichiers réel ou d'éventuels
     composants comme "<literal>..</literal>".
    </para>
   </note>
   <caution>
    <para>
-    Sur Windows, <function>dirname</function> assume que la codepage actuellement
+    Sur Windows, <function>dirname</function> suppose la codepage actuellement
     définie, donc pour qu'il puisse voir le nom de dossier correct avec des
     caractères multioctets dans le chemin, la codepage correspondante doit
     être définie.
@@ -37,7 +37,7 @@
     est indéfini.
    </para>
    <para>
-    Sur d'autres systèmes, <function>dirname</function> assume que <parameter>path</parameter>
+    Sur d'autres systèmes, <function>dirname</function> suppose que <parameter>path</parameter>
     est encodé dans un encodage compatible ASCII. Sinon, le comportement de la
     fonction est indéfini.
    </para>

--- a/reference/filesystem/functions/feof.xml
+++ b/reference/filesystem/functions/feof.xml
@@ -50,7 +50,7 @@
     par le serveur, <function>feof</function> se bloquera.
     Pour contourner ce comportement, se reporter à l'exemple ci-dessous :
     <example>
-     <title>Gestion des délais d'attente dépassés <function>feof</function></title>
+     <title>Gestion des délais d'attente dépassés avec <function>feof</function></title>
      <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/filesystem/functions/fgets.xml
+++ b/reference/filesystem/functions/fgets.xml
@@ -50,10 +50,9 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Retourne une &string; contenant les <parameter>length</parameter> premiers
-   caractères, moins 1 octet depuis le pointeur de fichier
-   <parameter>stream</parameter>. &false; est retourné s'il n'y a plus de
-   données à lire.
+   Retourne une &string; d'au plus <parameter>length</parameter> - 1 octets lus
+   depuis le fichier pointé par <parameter>stream</parameter>. &false; est
+   retourné s'il n'y a plus de données à lire.
   </para>
   <para>
    Si une erreur survient, la fonction retourne &false;.

--- a/reference/filesystem/functions/fgetss.xml
+++ b/reference/filesystem/functions/fgetss.xml
@@ -23,10 +23,10 @@
   </methodsynopsis>
   <para>
    Identique à <function>fgets</function>, sauf que
-   la fonction <function>fgetss</function> supprime tous les octets nuls,
-   toutes les balises HTML et PHP qu'il trouve dans le texte lu.
+   la fonction <function>fgetss</function> tente de supprimer tous les octets nuls,
+   toutes les balises HTML et PHP qu'elle trouve dans le texte lu.
    La fonction conserve l'état de l'analyse d'appel en appel, et ainsi n'est
-   pas équivalent à l'appel de <function>strip_tags</function> sur la valeur de
+   pas équivalente à l'appel de <function>strip_tags</function> sur la valeur de
    retour de <function>fgets</function>.
   </para>
  </refsect1>
@@ -69,7 +69,7 @@
   <para>
    Retourne une chaîne de taille <parameter>length</parameter> - 1 octet
    lu depuis le fichier pointé par <parameter>handle</parameter>,
-   dont les balises HTML et PHP ont été échappées.
+   dont les balises HTML et PHP ont été supprimées.
   </para>
   <para>
    Si une erreur survient, la fonction retourne &false;.

--- a/reference/filesystem/functions/file-exists.xml
+++ b/reference/filesystem/functions/file-exists.xml
@@ -32,7 +32,7 @@
       <para>
        Sous Windows, il convient d'utiliser le format de chemin
        <filename>//computername/share/filename</filename> ou
-       <filename>\\\\computername\share\filename</filename> pour vérifier qu'un
+       <filename>\\computername\share\filename</filename> pour vérifier qu'un
        fichier est disponible sur le partage réseau.
       </para>
      </listitem>

--- a/reference/filesystem/functions/file-get-contents.xml
+++ b/reference/filesystem/functions/file-get-contents.xml
@@ -89,7 +89,7 @@
       <para>
        Le déplacement dans le fichier (<parameter>offset</parameter>) n'est
        pas supporté sur des fichiers distants. Toute tentative de se déplacer
-       dans un fichier qui n'est pas local, cela peut fonctionner sur
+       dans un fichier qui n'est pas local peut fonctionner sur
        les petits déplacements, mais le comportement peut ne pas être attendu
        car le processus utilise le flux du buffer.
       </para>

--- a/reference/filesystem/functions/file-put-contents.xml
+++ b/reference/filesystem/functions/file-put-contents.xml
@@ -167,7 +167,7 @@ file_put_contents($file, $current);
 $file = 'people.txt';
 // Une nouvelle personne à ajouter
 $person = "Jean Dupond\n";
-// Ecrit le contenu dans le fichier, en utilisant le drapeau
+// Écrit le contenu dans le fichier, en utilisant le drapeau
 // FILE_APPEND pour rajouter à la suite du fichier et
 // LOCK_EX pour empêcher quiconque d'autre d'écrire dans le fichier
 // en même temps

--- a/reference/filesystem/functions/file.xml
+++ b/reference/filesystem/functions/file.xml
@@ -125,7 +125,7 @@
    comme <constant>FILE_APPEND</constant>.
   </simpara>
   <para>
-   Émet une erreur de niveau <constant>E_WARNING</constant> si le fichier 
+   Émet une erreur de niveau <constant>E_WARNING</constant> si le fichier
    n'existe pas.
   </para>
  </refsect1>

--- a/reference/filesystem/functions/filectime.xml
+++ b/reference/filesystem/functions/filectime.xml
@@ -77,10 +77,10 @@ if (file_exists($filename)) {
   &reftitle.notes;
   <note>
    <para>
-    Sur la plupart des serveurs UNIX, un fichier est considéré
+    Sur la plupart des systèmes de fichiers UNIX, un fichier est considéré
     comme modifié si les données de son inode sont modifiées.
-    C'est-à-dire lorsque les permissions (utilisateur, groupe ou autre) ont
-    été modifiées. Voir aussi <function>filemtime</function>
+    C'est-à-dire lorsque les permissions, le propriétaire, le groupe ou
+    d'autres métadonnées de l'inode sont mis à jour. Voir aussi <function>filemtime</function>
     (qu'il sera possible d'utiliser lorsqu'on créera des indications
     telles que "Dernière modification : " sur les pages web) et
     <function>fileatime</function>.
@@ -88,8 +88,8 @@ if (file_exists($filename)) {
   </note>
   <note>
    <para>
-    Il est à noter que sur certains systèmes UNIX, le <literal>ctime</literal>
-    d'un fichier texte est considéré comme sa date de création. Cela est faux !
+    Il est à noter que dans certains ouvrages Unix, le <literal>ctime</literal>
+    d'un fichier est considéré comme sa date de création. Cela est faux !
     Il n'y a pas de date de création de fichier sous la plupart
     des systèmes UNIX.
    </para>

--- a/reference/filesystem/functions/filegroup.xml
+++ b/reference/filesystem/functions/filegroup.xml
@@ -5,7 +5,7 @@
 <refentry xml:id="function.filegroup" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>filegroup</refname>
-  <refpurpose>Lire le nom du groupe</refpurpose>
+  <refpurpose>Lit le groupe d'un fichier</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -15,7 +15,7 @@
    <methodparam><type>string</type><parameter>filename</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Lit le nom du groupe. L'identifiant de groupe est retourné au format numérique,
+   Lit le groupe du fichier. L'identifiant de groupe est retourné au format numérique,
    il convient d'utiliser <function>posix_getgrgid</function> pour retrouver le nom du groupe.
   </para>
  </refsect1>

--- a/reference/filesystem/functions/fileperms.xml
+++ b/reference/filesystem/functions/fileperms.xml
@@ -40,7 +40,7 @@
   <para>
    Retourne les permissions du fichier sous forme numérique. Les bits de poids
    faible sont les mêmes que ceux des permissions dans <function>chmod</function>,
-   cependant certaines plateformes incluent dans le retour des informations sur
+   cependant la plupart des plateformes incluent dans le retour des informations sur
    le type de fichier donné dans <parameter>filename</parameter>. Les exemples
    qui suivent montrent comment tester la valeur de retour concernant les
    permissions et le type de fichier sur des systèmes POSIX comme Linux ou macOS.
@@ -100,7 +100,7 @@ switch ($perms & 0xF000) {
     case 0x8000: // Régulier
         $info = 'r';
         break;
-    case 0x6000: // Block special
+    case 0x6000: // Bloc spécial
         $info = 'b';
         break;
     case 0x4000: // dossier

--- a/reference/filesystem/functions/filetype.xml
+++ b/reference/filesystem/functions/filetype.xml
@@ -40,7 +40,7 @@
   <para>
    Retourne le type du fichier. Les réponses possibles sont :
    <literal>fifo</literal>, <literal>char</literal>, <literal>dir</literal>,
-   <literal>block</literal>, <literal>link</literal>, <literal>file</literal>
+   <literal>block</literal>, <literal>link</literal>, <literal>file</literal>,
    <literal>socket</literal> et <literal>unknown</literal>.
   </para>
   <para>

--- a/reference/filesystem/functions/fnmatch.xml
+++ b/reference/filesystem/functions/fnmatch.xml
@@ -125,7 +125,7 @@
     <listitem>
      <para>
       La valeur de <parameter>flags</parameter> peut être une combinaison
-      des drapeaux suivants, joins avec l'
+      des drapeaux suivants, joints avec l'
       <link linkend="language.operators.bitwise">opérateur binaire OR (|)</link>.
       <table>
        <title>
@@ -179,7 +179,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Retourne &true; s'il y a des résultats, &false; sinon.
+   Retourne &true; s'il y a une correspondance, &false; sinon.
   </para>
  </refsect1>
 

--- a/reference/filesystem/functions/fopen.xml
+++ b/reference/filesystem/functions/fopen.xml
@@ -225,7 +225,7 @@ $handle = fopen("c:\\folder\\resource.txt", "r");
         <literal>\r\n</literal> lors du travail sur le fichier.
         À l'inverse, il est possible d'utiliser l'option <literal>'b'</literal> pour forcer
         le fichier à être écrit en mode binaire, sans traduction des données.
-        Pour utiliser ces options, ajoutez <literal>'b'</literal> ou <literal>'t'</literal>
+        Pour utiliser ces options, il faut ajouter <literal>'b'</literal> ou <literal>'t'</literal>
         comme dernier caractère du paramètre <parameter>mode</parameter>.
        </para>
        <para>

--- a/reference/filesystem/functions/fputcsv.xml
+++ b/reference/filesystem/functions/fputcsv.xml
@@ -19,8 +19,8 @@
    <methodparam choice="opt"><type>string</type><parameter>eol</parameter><initializer>"\n"</initializer></methodparam>
   </methodsynopsis>
   <para>
-   <function>fputcsv</function> formate la ligne passée sous forme de
-   <parameter>fields</parameter> tableau) en tant que <acronym>CSV</acronym> et l'écrit
+   <function>fputcsv</function> formate la ligne (passée sous forme de
+   tableau <parameter>fields</parameter>) en tant que <acronym>CSV</acronym> et l'écrit
    (terminé par un <parameter>eol</parameter>) dans le <parameter>stream</parameter> spécifié.
   </para>
  </refsect1>

--- a/reference/filesystem/functions/fread.xml
+++ b/reference/filesystem/functions/fread.xml
@@ -129,7 +129,7 @@ fclose($handle);
       comme des flux retournés lors de la lecture de
       <link linkend="features.remote-files">fichiers distants</link> ou depuis
       <function>popen</function> et <function>fsockopen</function>, la lecture
-      s'arrête après la réception d'un paquet. Il faut donc faire des 
+      s'arrête après la réception d'un paquet. Il faut donc faire des
       boucles pour collecter les données par paquet, comme présenté
       ci-dessous.
      </para>

--- a/reference/filesystem/functions/fscanf.xml
+++ b/reference/filesystem/functions/fscanf.xml
@@ -19,7 +19,7 @@
   <para>
    La fonction <function>fscanf</function> est similaire à la fonction
    <function>sscanf</function>, sauf qu'elle prend un fichier en entrée,
-   représentée par la ressource <parameter>stream</parameter> et interprète
+   représenté par la ressource <parameter>stream</parameter> et interprète
    l'entrée en fonction du format <parameter>format</parameter> spécifié.
   </para>
   <para>

--- a/reference/filesystem/functions/fseek.xml
+++ b/reference/filesystem/functions/fseek.xml
@@ -23,9 +23,9 @@
    à la position <parameter>whence</parameter>.
   </para>
    <para>
-   En général, il est possible de se déplacer au-delà de la fin du flux (eof); si des
-   données sont écrites dans ce cas, l'espace entre la fin du flux et
-   la position courante sera rempli d'octets nuls. Cependant, certains flux ne supportent
+   En général, il est possible de se déplacer au-delà de la fin du flux (eof) ; si des
+   données sont alors écrites, la lecture de toute zone non écrite entre la fin du flux et
+   la position visée renverra des octets de valeur 0. Cependant, certains flux ne supportent
    pas ce comportement, en particulier lorsque l'espace de stockage sous-jacent est de
    taille fixe.
   </para>
@@ -118,7 +118,8 @@ fseek($fp, 0);
    <para>
     Si l'on ouvre le fichier avec le mode <literal>a</literal> ou
     <literal>a+</literal>, toutes les données que l'on écrira dans le fichier
-    seront toujours ajoutées, sans se soucier de la position dans le fichier.
+    seront toujours ajoutées, sans se soucier de la position dans le fichier,
+    et le résultat de l'appel à <function>fseek</function> sera indéterminé.
    </para>
   </note>
   <note>

--- a/reference/filesystem/functions/fstat.xml
+++ b/reference/filesystem/functions/fstat.xml
@@ -64,7 +64,7 @@ $fstat = fstat($fp);
 // ferme le fichier
 fclose($fp);
 
-// affiche le résultat
+// affiche uniquement la partie associative
 print_r(array_slice($fstat, 13));
 
 ?>

--- a/reference/filesystem/functions/fwrite.xml
+++ b/reference/filesystem/functions/fwrite.xml
@@ -114,7 +114,7 @@ if (is_writable($filename)) {
          exit;
     }
 
-    // Ecrivons quelque chose dans notre fichier.
+    // Écrivons quelque chose dans notre fichier.
     if (fwrite($fp, $somecontent) === FALSE) {
         echo "Impossible d'écrire dans le fichier ($filename)";
         exit;
@@ -138,7 +138,7 @@ if (is_writable($filename)) {
   &reftitle.notes;
   <note>
    <para>
-    Le fait d'écrire dans un flux peut se terminer avant que la chaîne complète ne soit
+    Le fait d'écrire dans un flux réseau peut se terminer avant que la chaîne complète ne soit
     écrite. La valeur retournée par la fonction
     <function>fwrite</function> peut être vérifiée comme ceci :
     <programlisting role="php">

--- a/reference/filesystem/functions/is-dir.xml
+++ b/reference/filesystem/functions/is-dir.xml
@@ -63,7 +63,7 @@
 var_dump(is_dir('a_file.txt'));
 var_dump(is_dir('bogus_dir/abc'));
 
-var_dump(is_dir('..')); // un dossier au dessus
+var_dump(is_dir('..')); // un dossier au-dessus
 ?>
 ]]>
     </programlisting>

--- a/reference/filesystem/functions/is-executable.xml
+++ b/reference/filesystem/functions/is-executable.xml
@@ -80,7 +80,7 @@ if (is_executable($file)) {
    <simpara>
     Sur Windows, un fichier est considéré exécutable, si c'est un fichier
     proprement exécutable tel que rapporté par l'API Win
-    <literal>GetBinaryType()</literal>; pour des raisons de rétro-compatibilité,
+    <literal>GetBinaryType()</literal>; pour des raisons de rétrocompatibilité,
     les fichiers qui ont comme extension <filename>.bat</filename> ou
     <filename>.cmd</filename> sont aussi considérés comme exécutables.
     Antérieur à PHP 7.4.0, tout fichier non vide avec une extension

--- a/reference/filesystem/functions/lchgrp.xml
+++ b/reference/filesystem/functions/lchgrp.xml
@@ -22,7 +22,7 @@
   </para>
   <para>
    Seul le super-utilisateur peut changer le groupe d'un lien symbolique
-   arbitrairement; les autres utilisateurs peuvent changer le groupe d'un
+   arbitrairement ; les autres utilisateurs peuvent changer le groupe d'un
    lien symbolique vers un groupe auquel cet utilisateur est membre.
   </para>
  </refsect1>

--- a/reference/filesystem/functions/lchown.xml
+++ b/reference/filesystem/functions/lchown.xml
@@ -18,7 +18,7 @@
   <para>
    Essaie de remplacer le propriétaire du lien symbolique
    <parameter>filename</parameter> par l'utilisateur
-   <parameter>user</parameter>
+   <parameter>user</parameter>.
   </para>
   <para>
    Seul le super-utilisateur peut changer le propriétaire d'un lien symbolique.

--- a/reference/filesystem/functions/link.xml
+++ b/reference/filesystem/functions/link.xml
@@ -6,7 +6,7 @@
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.link">
  <refnamediv>
   <refname>link</refname>
-  <refpurpose>Crée un lien</refpurpose>
+  <refpurpose>Crée un lien physique</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -17,7 +17,7 @@
    <methodparam><type>string</type><parameter>link</parameter></methodparam>
   </methodsynopsis>
   <para>
-   <function>link</function> crée un lien.
+   <function>link</function> crée un lien physique.
   </para>
  </refsect1>
 
@@ -66,7 +66,7 @@
   &reftitle.examples;
   <para>
    <example>
-    <title>Création d'un lien</title>
+    <title>Création d'un lien physique simple</title>
     <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/filesystem/functions/lstat.xml
+++ b/reference/filesystem/functions/lstat.xml
@@ -15,7 +15,8 @@
    <methodparam><type>string</type><parameter>filename</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Retourne les informations sur un fichier ou un lien symbolique.
+   Rassemble les statistiques du fichier ou du lien symbolique désigné par
+   <parameter>filename</parameter>.
   </para>
  </refsect1>
 

--- a/reference/filesystem/functions/move-uploaded-file.xml
+++ b/reference/filesystem/functions/move-uploaded-file.xml
@@ -98,11 +98,11 @@ foreach ($_FILES["pictures"]["error"] as $key => $error) {
   &reftitle.notes;
   <note>
    <para>
-    <function>move_uploaded_file</function> n'est pas affectée par
+    <function>move_uploaded_file</function> tient compte de
     l'<link linkend="ini.open-basedir">open_basedir</link>.
     Cependant, les restrictions sont placées uniquement sur le
     paramètre <parameter>to</parameter> qui permet le
-    déplacement des fichiers chargés dans lesquels 
+    déplacement des fichiers chargés dans lesquels
     <parameter>from</parameter> peut entrer en conflit avec ces
     restrictions. <function>move_uploaded_file</function> permet de
     s'assurer de la sécurité de cette opération en autorisant le

--- a/reference/filesystem/functions/parse-ini-file.xml
+++ b/reference/filesystem/functions/parse-ini-file.xml
@@ -55,7 +55,8 @@
       <para>
        En passant le paramètre <parameter>process_sections</parameter>
        à &true;, le résultat sera
-       un tableau multidimensionnel avec les noms des sections.
+       un tableau multidimensionnel, incluant les noms des sections et
+       les configurations.
        La valeur par défaut de ce paramètre est &false;
       </para>
      </listitem>
@@ -189,6 +190,7 @@ Array
                     [2] => 5.2
                     [3] => 5.3
                 )
+
             [urls] => Array
                 (
                     [svn] => http://svn.php.net
@@ -248,19 +250,19 @@ echo '(chargé ) magic_quotes_gpc = ' . yesno(get_cfg_var('magic_quotes_gpc')) .
     </para>
     <programlisting>
 <![CDATA[
-; | is used for bitwise OR
+; | est utilisé pour le OU bit à bit
 three = 2|3
 
-; & is used for bitwise AND
+; & est utilisé pour le ET bit à bit
 four = 6&5
 
-; ^ is used for bitwise XOR
+; ^ est utilisé pour le OU exclusif bit à bit
 five = 3^6
 
-; ~ is used for bitwise negate
+; ~ est utilisé pour la négation bit à bit
 negative_two = ~1
 
-; () is used for grouping
+; () est utilisé pour le regroupement
 seven = (8|7)&(6|5)
 
 ; Interpoler la variable d'environnement PATH
@@ -283,8 +285,8 @@ configured_memory_limit = ${memory_limit}
     </para>
     <programlisting>
 <![CDATA[
-quoted = "She said \"Exactly my point\"." ; Results in a string with quote marks in it.
-hint = "Use \\\" to escape double quote" ; Results in: Use \" to escape double quote
+quoted = "She said \"Exactly my point\"." ; Donne une chaîne contenant des guillemets.
+hint = "Use \\\" to escape double quote" ; Donne : Use \" to escape double quote
 ]]>
     </programlisting>
     <para>
@@ -304,7 +306,7 @@ save_path = "C:\Temp\"
     <programlisting>
 <![CDATA[
 long_text = "Lorem \"ipsum\"""
- dolor" ; Results in: Lorem "ipsum"\n dolor
+ dolor" ; Donne : Lorem "ipsum"\n dolor
 ]]>
     </programlisting>
     <para>
@@ -344,7 +346,7 @@ code = "\${test}"
   <note>
    <para>
     Si une valeur du fichier ini contient des
-    données non-alphanumériques, il faut la protéger en la plaçant 
+    données non-alphanumériques, il faut la protéger en la plaçant
     entre guillemets doubles (").
    </para>
   </note>

--- a/reference/filesystem/functions/parse-ini-string.xml
+++ b/reference/filesystem/functions/parse-ini-string.xml
@@ -83,8 +83,8 @@
   &reftitle.notes;
   <note>
    <simpara>
-    Il y a plusieurs mots réservés que ne doivent pas être
-    utilisés comme clé dans les fichiers .ini. Cela inclut : 
+    Il y a plusieurs mots réservés qui ne doivent pas être
+    utilisés comme clé dans les fichiers .ini. Cela inclut :
     <literal>null</literal>, <literal>yes</literal>, <literal>no</literal>, 
     <literal>true</literal>, <literal>false</literal>, <literal>on</literal>,
     <literal>off</literal>, <literal>none</literal>.

--- a/reference/filesystem/functions/pathinfo.xml
+++ b/reference/filesystem/functions/pathinfo.xml
@@ -115,8 +115,8 @@
    </para>
   </note>
   <para>
-   Si <parameter>flags</parameter> est utilisé, cette fonction retourne
-   une &string; contenant les éléments.
+   Si <parameter>flags</parameter> est présent, cette fonction retourne
+   une &string; contenant l'élément demandé.
   </para>
  </refsect1>
 
@@ -150,7 +150,7 @@ lib.inc
   </para>
   <para>
    <example>
-    <title>Exemple <function>pathinfo</function> sans extension</title>
+    <title>Exemple <function>pathinfo</function> montrant la différence entre null et l'absence d'extension</title>
     <programlisting role="php">
 <![CDATA[
 <?php
@@ -175,7 +175,7 @@ NULL
   </para>
   <para>
    <example>
-    <title>Exemple avec <function>pathinfo</function></title>
+    <title>Exemple <function>pathinfo</function> pour un fichier caché (dot-file)</title>
     <programlisting role="php">
 <![CDATA[
 <?php
@@ -206,20 +206,20 @@ Array
      la déstructuration de tableau comme ceci :
     </para>
     <programlisting role="php">
-     <![CDATA[
-     <?php
-     ['basename' => $basename, 'dirname' => $dirname] = pathinfo('/www/htdocs/inc/lib.inc.php');
-     var_dump($basename, $dirname);
-     ?>
-     ]]>
+<![CDATA[
+<?php
+['basename' => $basename, 'dirname' => $dirname] = pathinfo('/www/htdocs/inc/lib.inc.php');
+
+var_dump($basename, $dirname);
+?>
+]]>
     </programlisting>
     &example.outputs.similar;
     <screen>
-
-     <![CDATA[
-     string(11) "lib.inc.php"
-     string(15) "/www/htdocs/inc"
-     ]]>
+<![CDATA[
+string(11) "lib.inc.php"
+string(15) "/www/htdocs/inc"
+]]>
     </screen>
    </example>
   </para>

--- a/reference/filesystem/functions/pclose.xml
+++ b/reference/filesystem/functions/pclose.xml
@@ -6,7 +6,7 @@
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.pclose">
  <refnamediv>
   <refname>pclose</refname>
-  <refpurpose>Ferme un processus de pointeur de fichier</refpurpose>
+  <refpurpose>Ferme un pointeur de fichier de processus</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -16,7 +16,7 @@
    <methodparam><type>resource</type><parameter>handle</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Ferme un processus de pointeur de fichier ouvert avec la fonction
+   Ferme un pointeur de fichier vers un pipe ouvert par la fonction
    <function>popen</function>.
   </para>
  </refsect1>

--- a/reference/filesystem/functions/popen.xml
+++ b/reference/filesystem/functions/popen.xml
@@ -5,7 +5,7 @@
 <refentry xml:id="function.popen" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>popen</refname>
-  <refpurpose>Crée un processus de pointeur de fichier</refpurpose>
+  <refpurpose>Ouvre un pointeur de fichier de processus</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -16,7 +16,7 @@
    <methodparam><type>string</type><parameter>mode</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Crée un processus de pointeur de fichier, exécuté en effectuant un fork
+   Ouvre un pipe vers un processus exécuté en effectuant un fork
    de la commande fournie par le paramètre <parameter>command</parameter>.
   </para>
  </refsect1>
@@ -89,7 +89,7 @@ $handle = popen("/bin/ls", "r");
   <para>
    Si la commande à exécuter n'a pu être trouvée, une ressource
    valide sera retournée. Cela semble étrange, mais c'est pratique.
-   cela permet d'accéder aux messages d'erreur qui ont été
+   Cela permet d'accéder aux messages d'erreur qui ont été
    retournés par le Shell :
    <example>
     <title>Exemple avec <function>popen</function></title>

--- a/reference/filesystem/functions/readlink.xml
+++ b/reference/filesystem/functions/readlink.xml
@@ -44,7 +44,7 @@
   <note>
    <simpara>
     La fonction échoue si le paramètre <parameter>path</parameter>
-    n'est pas un lien symbolique, sauf sous Windows, où le chemin personnalisé
+    n'est pas un lien symbolique, sauf sous Windows, où le chemin normalisé
     sera retourné.
    </simpara>
   </note>

--- a/reference/filesystem/functions/realpath.xml
+++ b/reference/filesystem/functions/realpath.xml
@@ -72,8 +72,8 @@
   </note>
   <note>
    <para>
-    La fonction <function>realpath</function> ne fonctionnera pas pour un 
-    fichier qui se trouve à l'intérieur d'un phar car ce chemin serait un 
+    La fonction <function>realpath</function> ne fonctionnera pas pour un
+    fichier qui se trouve à l'intérieur d'un Phar car ce chemin serait un
     chemin d'accès virtuel, pas un vrai.
    </para>
   </note>

--- a/reference/filesystem/functions/rename.xml
+++ b/reference/filesystem/functions/rename.xml
@@ -37,9 +37,9 @@
       </para>
       <note>
        <para>
-        Le gestionnaire utilisé dans le paramètre
+        L'enveloppe utilisée dans le paramètre
         <parameter>from</parameter> <emphasis>DOIT</emphasis>
-        être le même que celui utilisé dans <parameter>to</parameter>.
+        être la même que celle utilisée dans <parameter>to</parameter>.
        </para>
       </note>
      </listitem>

--- a/reference/filesystem/functions/rewind.xml
+++ b/reference/filesystem/functions/rewind.xml
@@ -55,7 +55,7 @@
   &reftitle.examples;
   <para>
    <example>
-    <title>Exemple avec <function>rewind</function></title>
+    <title>Exemple d'écrasement avec <function>rewind</function></title>
     <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/filesystem/functions/stat.xml
+++ b/reference/filesystem/functions/stat.xml
@@ -55,8 +55,8 @@
     <tgroup cols="3">
      <thead>
       <row>
-       <entry>Numéro</entry>
-       <entry>Nom</entry>
+       <entry>Numérique</entry>
+       <entry>Associatif</entry>
        <entry>Description</entry>
       </row>
      </thead>
@@ -244,7 +244,7 @@
       <entry>
        Les valeurs statiques <literal>size</literal>, <literal>atime</literal>,
        <literal>mtime</literal> et <literal>ctime</literal> des liens symboliques
-       sont toujours ceux de la cible. Ce n'était précédemment pas le cas
+       sont toujours celles de la cible. Ce n'était précédemment pas le cas
        pour les builds <abbrev>NTS</abbrev> sous Windows.
       </entry>
      </row>

--- a/reference/filesystem/functions/touch.xml
+++ b/reference/filesystem/functions/touch.xml
@@ -43,7 +43,7 @@
      <term><parameter>mtime</parameter></term>
      <listitem>
       <para>
-       La date de création. Si <parameter>mtime</parameter> est omis,
+       La date de modification. Si <parameter>mtime</parameter> est omis,
        c'est l'heure courante <function>time</function> qui est utilisée.
       </para>
      </listitem>

--- a/reference/filesystem/ini.xml
+++ b/reference/filesystem/ini.xml
@@ -115,8 +115,7 @@
     </term>
     <listitem>
      <para>
-      Définit le type d'"user agent" (Définition du navigateur web) utilisé par
-      PHP.
+      Définit le user agent que PHP doit envoyer.
      </para>
     </listitem>
    </varlistentry>
@@ -141,7 +140,7 @@
     </term>
     <listitem>
      <para>
-      L'adresse mail à utiliser pour les connexions FTP non-autorisées
+      L'adresse mail à utiliser pour les connexions FTP non-authentifiées
       ou encore pour fournir une valeur au champ "From" sur une connexion HTTP.
      </para>
     </listitem>


### PR DESCRIPTION
Corrections de langue et de traduction dans reference/, de exec to filesystem (orthographe, grammaire, fidélité à l'anglais).