### PR TITLE
Nits translation: reference/ (filter to ibm_db2)

### DIFF
--- a/reference/filter/book.xml
+++ b/reference/filter/book.xml
@@ -37,7 +37,7 @@
    adresse email valide.
   </simpara>
   <simpara>
-   La plupart des filtres prennent en charge des <emphasis>options</emphasis>
+   La plupart des filtres supportent des <emphasis>options</emphasis>
    sous forme de drapeaux permettant d’ajuster leur comportement.
    Ces drapeaux sont identifiés par les constantes
    <constant>FILTER_FLAG_<replaceable>*</replaceable></constant>.

--- a/reference/filter/constants.xml
+++ b/reference/filter/constants.xml
@@ -754,87 +754,88 @@
          <member><literal>169.254.0.0/16</literal></member>
          <member><literal>127.0.0.0/8</literal></member>
          <member><literal>240.0.0.0/4</literal></member>
-         </simplelist>.
-        </para>
-        <para>
-         Et pour IPv6, cela correspond aux plages suivantes :
-         <simplelist type="inline">
-          <member><literal>::1/128</literal></member>
-          <member><literal>::/128</literal></member>
-          <member><literal>::FFFF:0:0/96</literal></member>
-          <member><literal>FE80::/10</literal></member>
-          </simplelist>.
-         </para>
-        </listitem>
-       </varlistentry>
-       <varlistentry xml:id="constant.filter-flag-no-priv-range">
-        <term>
-         <constant>FILTER_FLAG_NO_PRIV_RANGE</constant>
-         (<type>int</type>)
-        </term>
-        <listitem>
-         <simpara>
-          Refuser les adresses privées.
-         </simpara>
-         <para>
-          Ce sont des adresses IPv4 qui se trouvent dans les plages suivantes :
-          <simplelist type="inline">
-           <member><literal>10.0.0.0/8</literal></member>
-           <member><literal>172.16.0.0/12</literal></member>
-           <member><literal>192.168.0.0/16</literal></member>
-           </simplelist>.
-          </para>
-          <simpara>
-           Ce sont des adresses IPv6 commençant par
-           <literal>FD</literal> ou <literal>FC</literal>.
-          </simpara>
-         </listitem>
-        </varlistentry>
-        <varlistentry xml:id="constant.filter-flag-global-range">
-         <term>
-          <constant>FILTER_FLAG_GLOBAL_RANGE</constant>
-          (<type>int</type>)
-         </term>
-         <listitem>
-          <simpara>
-           N'autoriser que les adresses globales.
-           Celles-ci peuvent être trouvées dans
-           <link xlink:href="&url.rfc;6890">RFC 6890</link>
-           où l'attribut <literal>Global</literal> est <literal>True</literal>.
-           Disponible à partir de PHP 8.2.0.
-          </simpara>
-         </listitem>
-        </varlistentry>
-       </variablelist>
+        </simplelist>.
+       </para>
+       <para>
+        Et pour IPv6, cela correspond aux plages suivantes :
+        <simplelist type="inline">
+         <member><literal>::1/128</literal></member>
+         <member><literal>::/128</literal></member>
+         <member><literal>::FFFF:0:0/96</literal></member>
+         <member><literal>FE80::/10</literal></member>
+        </simplelist>.
+       </para>
       </listitem>
      </varlistentry>
-
-     <varlistentry xml:id="constant.filter-validate-mac">
+     <varlistentry xml:id="constant.filter-flag-no-priv-range">
       <term>
-       <constant>FILTER_VALIDATE_MAC</constant>
+       <constant>FILTER_FLAG_NO_PRIV_RANGE</constant>
        (<type>int</type>)
       </term>
       <listitem>
        <simpara>
-        Valide si la valeur est une adresse MAC.
+        Refuser les adresses privées.
        </simpara>
-
-       <variablelist xml:id="filter.constants.validation.mac.options">
-        <title>Options disponibles</title>
-        <varlistentry>
-         <term><literal>default</literal></term>
-         <listitem>
-          <simpara>
-           Valeur à retourner en cas d'échec du filtre.
-          </simpara>
-         </listitem>
-        </varlistentry>
-       </variablelist>
+       <para>
+        Ce sont des adresses IPv4 qui se trouvent dans les plages suivantes :
+        <simplelist type="inline">
+         <member><literal>10.0.0.0/8</literal></member>
+         <member><literal>172.16.0.0/12</literal></member>
+         <member><literal>192.168.0.0/16</literal></member>
+        </simplelist>.
+       </para>
+       <simpara>
+        Ce sont des adresses IPv6 commençant par
+        <literal>FD</literal> ou <literal>FC</literal>.
+       </simpara>
+      </listitem>
+     </varlistentry>
+     <varlistentry xml:id="constant.filter-flag-global-range">
+      <term>
+       <constant>FILTER_FLAG_GLOBAL_RANGE</constant>
+       (<type>int</type>)
+      </term>
+      <listitem>
+       <simpara>
+        N'autoriser que les adresses globales.
+        Celles-ci peuvent être trouvées dans
+        <link xlink:href="&url.rfc;6890">RFC 6890</link>
+        où l'attribut <literal>Global</literal> est <literal>True</literal>.
+        Disponible à partir de PHP 8.2.0.
+       </simpara>
       </listitem>
      </varlistentry>
     </variablelist>
-    <variablelist xml:id="filter.constants.sanitization">
-     <title>Filtres de Sanitisation</title>
+   </listitem>
+  </varlistentry>
+
+  <varlistentry xml:id="constant.filter-validate-mac">
+   <term>
+    <constant>FILTER_VALIDATE_MAC</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Valide si la valeur est une adresse MAC.
+    </simpara>
+
+    <variablelist xml:id="filter.constants.validation.mac.options">
+     <title>Options disponibles</title>
+     <varlistentry>
+      <term><literal>default</literal></term>
+      <listitem>
+       <simpara>
+        Valeur à retourner en cas d'échec du filtre.
+       </simpara>
+      </listitem>
+     </varlistentry>
+    </variablelist>
+   </listitem>
+  </varlistentry>
+ </variablelist>
+
+ <variablelist xml:id="filter.constants.sanitization">
+  <title>Filtres de Sanitisation</title>
      <varlistentry xml:id="constant.filter-unsafe-raw">
       <term>
        <constant>FILTER_UNSAFE_RAW</constant>
@@ -874,7 +875,7 @@
        </simpara>
        <simpara>
         Optionnellement, il peut supprimer ou encoder des caractères spécifiés s'il est utilisé avec les
-        filtres de sanitarisation <constant>FILTER_FLAG_STRIP_<replaceable>*</replaceable></constant>
+        filtres de sanitation <constant>FILTER_FLAG_STRIP_<replaceable>*</replaceable></constant>
         et <constant>FILTER_FLAG_ENCODE_<replaceable>*</replaceable></constant>.
        </simpara>
        <simpara>
@@ -1030,13 +1031,13 @@
       </term>
       <listitem>
        <simpara>
-        Assainir la chaîne en supprimant tous les caractères sauf les chiffres
+        Assainit la chaîne en supprimant tous les caractères sauf les chiffres
         (<literal>[0-9]</literal>), le signe plus (<literal>+</literal>)
         et le signe moins (<literal>-</literal>).
        </simpara>
 
        <variablelist xml:id="filter.constants.sanitization.float.flags">
-        <title>Options Facultatives</title>
+        <title>Options facultatives</title>
         <varlistentry xml:id="constant.filter-flag-allow-fraction">
          <term>
           <constant>FILTER_FLAG_ALLOW_FRACTION</constant>
@@ -1168,7 +1169,7 @@ string(5) "12.34"
        </para>
        <note>
         <simpara>
-         La valeur retournée par le callback sera la valeur retournée par la
+         La valeur retournée par la fonction de rappel sera la valeur retournée par la
          fonction de filtre invoquée.
         </simpara>
        </note>

--- a/reference/filter/examples.xml
+++ b/reference/filter/examples.xml
@@ -74,18 +74,18 @@ $options = array(
     )
 );
 if (filter_var($int_a, FILTER_VALIDATE_INT, $options) !== FALSE) {
-    echo "L'entier A 'int_a' est considéré comme valide (entre 0 et 3).\n";
+    echo "L'entier A '$int_a' est considéré comme valide (entre 0 et 3).\n";
 }
 if (filter_var($int_b, FILTER_VALIDATE_INT, $options) !== FALSE) {
-    echo "L'entier B 'int_b' est considéré comme valide (entre 0 et 3).\n";
+    echo "L'entier B '$int_b' est considéré comme valide (entre 0 et 3).\n";
 }
 if (filter_var($int_c, FILTER_VALIDATE_INT, $options) !== FALSE) {
-    echo "L'entier C 'int_c' est considéré comme valide (entre 0 et 3).\n";
+    echo "L'entier C '$int_c' est considéré comme valide (entre 0 et 3).\n";
 }
 
 $options['options']['default'] = 1;
 if (($int_c = filter_var($int_c, FILTER_VALIDATE_INT, $options)) !== FALSE) {
-    echo "L'entier C 'int_c' est considéré comme valide (entre 0 et 3).";
+    echo "L'entier C '$int_c' est considéré comme valide (entre 0 et 3).";
 }
 ?>
 ]]>

--- a/reference/filter/functions/filter-input-array.xml
+++ b/reference/filter/functions/filter-input-array.xml
@@ -66,12 +66,12 @@
    retourné si <parameter>add_empty</parameter> est &true;.
    Auquel cas, les entrées manquantes seront définies à &null;,
    sauf si le drapeau <constant>FILTER_NULL_ON_FAILURE</constant> est utilisé,
-   dans quel cas ce sera &false;.
+   auquel cas ce sera &false;.
   </simpara>
   <simpara>
    Une entrée dans le &array; retourné sera &false; si le filtre échoue,
    sauf si le drapeau <constant>FILTER_NULL_ON_FAILURE</constant> est utilisé,
-   dans ce cas ça sera &null;.
+   auquel cas il sera &null;.
   </simpara>
  </refsect1>
 

--- a/reference/filter/functions/filter-input.xml
+++ b/reference/filter/functions/filter-input.xml
@@ -31,7 +31,7 @@
        Le contenu de la superglobale qui est filtrée est le contenu original
        "brut" fourni par le <acronym>SAPI</acronym>,
        avant toute modification utilisateur de la superglobale.
-       Pour filtrer une superglobale modifiée utiliser
+       Pour filtrer une superglobale modifiée, utiliser
        <function>filter_var</function> à la place.
       </simpara>
      </warning>

--- a/reference/filter/functions/filter-var-array.xml
+++ b/reference/filter/functions/filter-var-array.xml
@@ -40,7 +40,7 @@
     <term><parameter>options</parameter></term>
     <listitem>
      <simpara>
-      Soit un <type>array</type> associatif d'option,
+      Soit un <type>array</type> associatif d'options,
       soit un filtre à appliquer à chaque entrée,
       qui peut être un filtre de validation en utilisant une des constantes
       <constant>FILTER_VALIDATE_<replaceable>*</replaceable></constant>,

--- a/reference/filter/functions/filter-var.xml
+++ b/reference/filter/functions/filter-var.xml
@@ -68,7 +68,7 @@
     <term><parameter>options</parameter></term>
     <listitem>
      <simpara>
-      Soit un <type>array</type> associatif d'option,
+      Soit un <type>array</type> associatif d'options,
       soit un masque de bit des constantes des drapeaux de filtrage
       <constant>FILTER_FLAG_<replaceable>*</replaceable></constant>.
      </simpara>

--- a/reference/fpm/functions/fastcgi-finish-request.xml
+++ b/reference/fpm/functions/fastcgi-finish-request.xml
@@ -4,7 +4,7 @@
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.fastcgi-finish-request">
  <refnamediv>
   <refname>fastcgi_finish_request</refname>
-  <refpurpose>Affiche toutes les données de la réponse au client</refpurpose>
+  <refpurpose>Envoie toutes les données de la réponse au client</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -14,7 +14,7 @@
    <void/>
   </methodsynopsis>
   <simpara>
-   Cette fonction affiche toutes les données de la réponse au client et
+   Cette fonction envoie toutes les données de la réponse au client et
    termine la requête. Ceci permet aux tâches consommatrices de temps
    d'être effectuées sans laisser la connexion avec le client ouverte.
   </simpara>

--- a/reference/fpm/status.xml
+++ b/reference/fpm/status.xml
@@ -126,7 +126,7 @@
      </row>
      <row>
       <entry>start since</entry>
-      <entry>Temps en secondes écoulées depuis le dernier démarrage du pool de processus.</entry>
+      <entry>Temps en secondes écoulé depuis le dernier démarrage du pool de processus.</entry>
      </row>
      <row>
       <entry>accepted conn</entry>
@@ -249,7 +249,7 @@
       <entry>
        Le %cpu de la dernière requête. Ce sera 0 si le processus n'est pas au repos car le
        calcul est effectué lorsque le traitement de la requête est terminé.
-       La valeur peut dépasser 100 %, car l'indicateur indiquera le pourcentage total du temps CPU utilisé lors de la dernière requête -
+       La valeur peut dépasser 100 %, car l'indicateur indiquera le pourcentage total du temps CPU utilisé lors de la dernière requête :
        prend en compte les processus sur tous les cœurs, alors que le 100 % est pour un seul cœur.
       </entry>
      </row>

--- a/reference/ftp/book.xml
+++ b/reference/ftp/book.xml
@@ -14,7 +14,7 @@
    <link xlink:href="&url.rfc;959">&url.rfc;959</link>.
    Cette extension permet un accès détaillé au serveur FTP fournissant
    un éventail de commandes pour les scripts. Pour seulement
-   lire ou écrire un fichier sur un serveur FTP, il est préférable d'utiliser le gestionnaire
+   lire ou écrire un fichier sur un serveur FTP, il est préférable d'utiliser l'enveloppe
    <link linkend="wrappers.ftp"><literal>ftp://</literal></link>
    avec les <link linkend="ref.filesystem">fonctions de système de fichiers</link>
    qui fournissent une interface simple et intuitive.

--- a/reference/ftp/functions/ftp-fget.xml
+++ b/reference/ftp/functions/ftp-fget.xml
@@ -90,8 +90,8 @@
      <row>
       <entry>7.3.0</entry>
       <entry>
-       Le paramètre <parameter>mode</parameter> est maintenant optionnel. Précédemment il
-       était obligatoire.
+       Le paramètre <parameter>mode</parameter> est maintenant optionnel. Antérieur à cette version,
+       il était obligatoire.
       </entry>
      </row>
     </tbody>

--- a/reference/ftp/functions/ftp-fget.xml
+++ b/reference/ftp/functions/ftp-fget.xml
@@ -90,8 +90,8 @@
      <row>
       <entry>7.3.0</entry>
       <entry>
-       Le paramètre <parameter>mode</parameter> est maintenant optionnel. Antérieur à cette version,
-       il était obligatoire.
+       Le paramètre <parameter>mode</parameter> est maintenant optionnel. Précédemment il
+       était obligatoire.
       </entry>
      </row>
     </tbody>

--- a/reference/ftp/functions/ftp-fput.xml
+++ b/reference/ftp/functions/ftp-fput.xml
@@ -17,8 +17,8 @@
    <methodparam choice="opt"><type>int</type><parameter>offset</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
   <para>
-   <function>ftp_fput</function> charge les données issues du fichier
-   identifié par <parameter>stream</parameter> jusqu'à la fin du fichier.
+   <function>ftp_fput</function> charge les données depuis un pointeur de fichier
+   vers un fichier distant sur le serveur FTP.
   </para>
  </refsect1>
  <refsect1 role="parameters">
@@ -91,8 +91,8 @@
      <row>
       <entry>7.3.0</entry>
       <entry>
-       Le paramètre <parameter>mode</parameter> est maintenant optionnel. Précédemment il
-       était obligatoire.
+       Le paramètre <parameter>mode</parameter> est maintenant optionnel. Antérieur à
+       cette version, il était obligatoire.
       </entry>
      </row>
     </tbody>

--- a/reference/ftp/functions/ftp-fput.xml
+++ b/reference/ftp/functions/ftp-fput.xml
@@ -91,8 +91,8 @@
      <row>
       <entry>7.3.0</entry>
       <entry>
-       Le paramètre <parameter>mode</parameter> est maintenant optionnel. Antérieur à
-       cette version, il était obligatoire.
+       Le paramètre <parameter>mode</parameter> est maintenant optionnel. Précédemment il
+       était obligatoire.
       </entry>
      </row>
     </tbody>

--- a/reference/ftp/functions/ftp-get.xml
+++ b/reference/ftp/functions/ftp-get.xml
@@ -90,8 +90,8 @@
      <row>
       <entry>7.3.0</entry>
       <entry>
-       Le paramètre <parameter>mode</parameter> est maintenant optionnel. Précédemment il
-       était obligatoire.
+       Le paramètre <parameter>mode</parameter> est maintenant optionnel. Antérieur à
+       cette version, il était obligatoire.
       </entry>
      </row>
     </tbody>

--- a/reference/ftp/functions/ftp-get.xml
+++ b/reference/ftp/functions/ftp-get.xml
@@ -90,8 +90,8 @@
      <row>
       <entry>7.3.0</entry>
       <entry>
-       Le paramètre <parameter>mode</parameter> est maintenant optionnel. Antérieur à
-       cette version, il était obligatoire.
+       Le paramètre <parameter>mode</parameter> est maintenant optionnel. Précédemment il
+       était obligatoire.
       </entry>
      </row>
     </tbody>

--- a/reference/ftp/functions/ftp-login.xml
+++ b/reference/ftp/functions/ftp-login.xml
@@ -14,7 +14,7 @@
    <methodparam><type>string</type><parameter>username</parameter></methodparam>
    <methodparam><modifier role="attribute">#[\SensitiveParameter]</modifier><type>string</type><parameter>password</parameter></methodparam>
   </methodsynopsis>
-  <para> 
+  <para>
    <function>ftp_login</function> identifie la connexion FTP sur le serveur,
    avec le nom d'utilisateur <parameter>username</parameter> et le mot 
    de passe <parameter>password</parameter>.

--- a/reference/ftp/functions/ftp-mdtm.xml
+++ b/reference/ftp/functions/ftp-mdtm.xml
@@ -55,7 +55,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Retourne la date de dernière modification en tant qu'un horodatage
+   Retourne la date de dernière modification en tant qu'horodatage
    <emphasis>local</emphasis> Unix en cas de succès, ou -1 si
    une erreur survient.
   </para>

--- a/reference/ftp/functions/ftp-nb-continue.xml
+++ b/reference/ftp/functions/ftp-nb-continue.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="function.ftp-nb-continue" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>ftp_nb_continue</refname>
-  <refpurpose>Reprend le téléchargement d'un fichier (non bloquant)</refpurpose>
+  <refpurpose>Reprend le téléchargement ou l'envoi d'un fichier (non bloquant)</refpurpose>
  </refnamediv>
  <refsect1 role="description">
   &reftitle.description;

--- a/reference/ftp/functions/ftp-nb-fget.xml
+++ b/reference/ftp/functions/ftp-nb-fget.xml
@@ -96,8 +96,8 @@
      <row>
       <entry>7.3.0</entry>
       <entry>
-       Le paramètre <parameter>mode</parameter> est maintenant optionnel. Précédemment il
-       était obligatoire.
+       Le paramètre <parameter>mode</parameter> est maintenant optionnel. Antérieur à cette version,
+       il était obligatoire.
       </entry>
      </row>
     </tbody>

--- a/reference/ftp/functions/ftp-nb-fget.xml
+++ b/reference/ftp/functions/ftp-nb-fget.xml
@@ -96,8 +96,8 @@
      <row>
       <entry>7.3.0</entry>
       <entry>
-       Le paramètre <parameter>mode</parameter> est maintenant optionnel. Antérieur à cette version,
-       il était obligatoire.
+       Le paramètre <parameter>mode</parameter> est maintenant optionnel. Précédemment il
+       était obligatoire.
       </entry>
      </row>
     </tbody>

--- a/reference/ftp/functions/ftp-nb-fput.xml
+++ b/reference/ftp/functions/ftp-nb-fput.xml
@@ -98,8 +98,8 @@
      <row>
       <entry>7.3.0</entry>
       <entry>
-       Le paramètre <parameter>mode</parameter> est maintenant optionnel. Précédemment il
-       était obligatoire.
+       Le paramètre <parameter>mode</parameter> est maintenant optionnel. Antérieur à cette version,
+       il était obligatoire.
       </entry>
      </row>
     </tbody>

--- a/reference/ftp/functions/ftp-nb-fput.xml
+++ b/reference/ftp/functions/ftp-nb-fput.xml
@@ -98,8 +98,8 @@
      <row>
       <entry>7.3.0</entry>
       <entry>
-       Le paramètre <parameter>mode</parameter> est maintenant optionnel. Antérieur à cette version,
-       il était obligatoire.
+       Le paramètre <parameter>mode</parameter> est maintenant optionnel. Précédemment il
+       était obligatoire.
       </entry>
      </row>
     </tbody>

--- a/reference/ftp/functions/ftp-nb-get.xml
+++ b/reference/ftp/functions/ftp-nb-get.xml
@@ -22,7 +22,7 @@
    dans un fichier local. 
   </para>
   <para>
-   La différence entre cette fonction et <function>ftp_fget</function> est
+   La différence entre cette fonction et <function>ftp_get</function> est
    que cette fonction peut lire le fichier de manière asynchrone, afin
    que le programme fasse autre chose pendant que le fichier
    est téléchargé.

--- a/reference/ftp/functions/ftp-nb-put.xml
+++ b/reference/ftp/functions/ftp-nb-put.xml
@@ -97,7 +97,7 @@
      <row>
       <entry>7.3.0</entry>
       <entry>
-       Le paramètre <parameter>mode</parameter> est maintenant optionnel. Précédemment il
+       Le paramètre <parameter>mode</parameter> est maintenant optionnel. Antérieur à cette version, il
        était obligatoire.
       </entry>
      </row>

--- a/reference/ftp/functions/ftp-nb-put.xml
+++ b/reference/ftp/functions/ftp-nb-put.xml
@@ -97,7 +97,7 @@
      <row>
       <entry>7.3.0</entry>
       <entry>
-       Le paramètre <parameter>mode</parameter> est maintenant optionnel. Antérieur à cette version, il
+       Le paramètre <parameter>mode</parameter> est maintenant optionnel. Précédemment il
        était obligatoire.
       </entry>
      </row>

--- a/reference/ftp/functions/ftp-put.xml
+++ b/reference/ftp/functions/ftp-put.xml
@@ -90,8 +90,8 @@
      <row>
       <entry>7.3.0</entry>
       <entry>
-       Le paramètre <parameter>mode</parameter> est maintenant optionnel. Précédemment il
-       était obligatoire.
+       Le paramètre <parameter>mode</parameter> est maintenant optionnel. Antérieur à cette version,
+       il était obligatoire.
       </entry>
      </row>
     </tbody>

--- a/reference/ftp/functions/ftp-put.xml
+++ b/reference/ftp/functions/ftp-put.xml
@@ -90,8 +90,8 @@
      <row>
       <entry>7.3.0</entry>
       <entry>
-       Le paramètre <parameter>mode</parameter> est maintenant optionnel. Antérieur à cette version,
-       il était obligatoire.
+       Le paramètre <parameter>mode</parameter> est maintenant optionnel. Précédemment il
+       était obligatoire.
       </entry>
      </row>
     </tbody>

--- a/reference/ftp/functions/ftp-rawlist.xml
+++ b/reference/ftp/functions/ftp-rawlist.xml
@@ -57,7 +57,7 @@
   </para>
   <para>
    La sortie n'est jamais analysée. L'identifiant du type système retourné par
-   la fonction <function>ftp_systype</function> peut être utilisée pour
+   la fonction <function>ftp_systype</function> peut être utilisé pour
    déterminer comment les résultats doivent être interprétés.
   </para>
  </refsect1>

--- a/reference/ftp/functions/ftp-set-option.xml
+++ b/reference/ftp/functions/ftp-set-option.xml
@@ -59,9 +59,9 @@
           <row>
            <entry><constant>FTP_USEPASVADDRESS</constant></entry>
            <entry>
-            Lorsqu'il est désactivé, PHP ignore l'adresse IP retournée par le 
-            serveur FTP en réponse à la commande PASV et utilise plutôt 
-            l'adresse IP fournie dans le ftp_connect(). 
+            Lorsqu'il est désactivé, PHP ignore l'adresse IP retournée par le
+            serveur FTP en réponse à la commande PASV et utilise plutôt
+            l'adresse IP fournie dans le ftp_connect().
             <parameter>value</parameter> doit être une valeur booléenne.
            </entry>
           </row>
@@ -75,7 +75,7 @@
      <term><parameter>value</parameter></term>
      <listitem>
       <para>
-       Ce paramètre dépend de l'option <parameter>option</parameter> 
+       Ce paramètre dépend de l'option <parameter>option</parameter>
        que l'on veut modifier.
       </para>
      </listitem>

--- a/reference/funchand/functions/call-user-func-array.xml
+++ b/reference/funchand/functions/call-user-func-array.xml
@@ -152,7 +152,7 @@ call_user_func_array(array(__NAMESPACE__ .'\Foo', 'test'), array('Philip'));
 ?>
 ]]>
     </programlisting>
-    &example.outputs;
+    &example.outputs.similar;
     <screen>
 <![CDATA[
 Bonjour Hannes!

--- a/reference/funchand/functions/create-function.xml
+++ b/reference/funchand/functions/create-function.xml
@@ -5,7 +5,7 @@
 <refentry xml:id="function.create-function" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>create_function</refname>
-  <refpurpose>Crée une fonction anonyme</refpurpose>
+  <refpurpose>Crée une fonction dynamiquement en évaluant une chaîne de code</refpurpose>
  </refnamediv>
 
  <refsynopsisdiv>
@@ -29,7 +29,7 @@
     <function>eval</function> et donc les exigences en termes
     de sécurité sont identiques à celles de la fonction <function>eval</function>.
     De plus, les performances ne sont pas au rendez-vous et l'usage mémoire
-    est significatif.
+    est significatif, car les fonctions créées sont globales et ne peuvent pas être libérées.
    </para>
    <para>
     Une <link linkend="functions.anonymous">fonction anonyme</link> native
@@ -40,13 +40,11 @@
  <refsect1 role="parameters">
   &reftitle.parameters;
   <para>
-   Généralement, les arguments <parameter>args</parameter> sont
-   présentés sous la forme d'une chaîne à guillemets simples, et la même
-   recommandation vaut pour <parameter>code</parameter>.
-   La raison de l'utilisation des guillemets simples est de protéger
-   les noms de variables du remplacement par leur valeur. Si l'on utilise
-   les guillemets doubles, n'oubliez pas d'échapper les noms
-   de variables (c.-à-d. <literal>\$avar</literal>).
+   Il est normalement conseillé de passer ces paramètres sous forme de chaînes à
+   <link linkend="language.types.string.syntax.single">guillemets simples</link>.
+   Si des <link linkend="language.types.string.syntax.double">guillemets doubles</link>
+   sont utilisés, les noms de variables dans le code doivent être échappés avec soin,
+   c.-à-d. <literal>\$somevar</literal>.
    <variablelist>
     <varlistentry>
      <term><parameter>args</parameter></term>
@@ -274,7 +272,7 @@ Array
     <programlisting role="php">
 <![CDATA[
 <?php
-$sv = array("petite", "une longue chaîne", "longue", "une phrase toute entière");
+$sv = array("petite", "une longue chaîne", "longue", "une phrase tout entière");
 echo "Original :\n";
 print_r($sv);
 echo "Trié :\n";
@@ -289,7 +287,7 @@ print_r($sv);
     <programlisting role="php">
 <![CDATA[
 <?php
-$sv = array("petite", "une longue chaîne", "longue", "une phrase toute entière");
+$sv = array("petite", "une longue chaîne", "longue", "une phrase tout entière");
 echo "Original :\n";
 print_r($sv);
 echo "Trié :\n";
@@ -307,12 +305,12 @@ Array
   [0] => petite
   [1] => une longue chaîne
   [2] => longue
-  [3] => une phrase toute entière
+  [3] => une phrase tout entière
 )
 Trié :
 Array
 (
-  [0] => une phrase toute entière
+  [0] => une phrase tout entière
   [1] => une longue chaîne
   [2] => longue
   [3] => petite

--- a/reference/funchand/functions/forward-static-call-array.xml
+++ b/reference/funchand/functions/forward-static-call-array.xml
@@ -60,7 +60,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Retourne le résultat de la fonction, et &false; en cas d'erreur.
+   Retourne le résultat de la fonction, ou &false; en cas d'erreur.
   </para>
  </refsect1>
 

--- a/reference/funchand/functions/func-get-arg.xml
+++ b/reference/funchand/functions/func-get-arg.xml
@@ -138,7 +138,7 @@ Après changement  : 'baz'
   &reftitle.seealso;
   <para>
    <simplelist>
-    <member>La syntaxe <link linkend="functions.variable-arg-list"><literal>...</literal></link></member>
+    <member><link linkend="functions.variable-arg-list">La syntaxe <literal>...</literal></link></member>
     <member><function>func_get_args</function></member>
     <member><function>func_num_args</function></member>
    </simplelist>

--- a/reference/funchand/functions/register-shutdown-function.xml
+++ b/reference/funchand/functions/register-shutdown-function.xml
@@ -120,7 +120,7 @@ register_shutdown_function('shutdown');
    <para>
     Les fonctions d'arrêt s'exécutent séparément du temps suivi par
     <link linkend="ini.max-execution-time">max_execution_time</link>. Cela signifie
-    que même si un processus est terminé pour avoir fonctionné trop longtemps, les 
+    que même si un processus est terminé pour avoir fonctionné trop longtemps, les
     fonctions d'arrêt sont toujours appelées. De plus, si le
     <literal>max_execution_time</literal> atteint sa limite pendant qu'une fonction
     d'arrêt est en cours d'exécution, elle n'est pas interrompue.

--- a/reference/gearman/examples.xml
+++ b/reference/gearman/examples.xml
@@ -33,20 +33,20 @@ do
   switch($gmclient->returnCode())
   {
     case GEARMAN_WORK_DATA:
-      echo "Data: $result\n";
+      echo "Données : $result\n";
       break;
     case GEARMAN_WORK_STATUS:
       list($numerator, $denominator)= $gmclient->doStatus();
-      echo "Status: $numerator/$denominator complete\n";
+      echo "Statut : $numerator/$denominator terminé\n";
       break;
     case GEARMAN_WORK_FAIL:
-      echo "Failed\n";
+      echo "Échec\n";
       exit;
     case GEARMAN_SUCCESS:
-      echo "Success: $result\n";
+      echo "Succès : $result\n";
       break;
     default:
-      echo "RET: " . $gmclient->returnCode() . "\n";
+      echo "RET : " . $gmclient->returnCode() . "\n";
       exit;
   }
 }
@@ -59,7 +59,7 @@ while($gmclient->returnCode() != GEARMAN_SUCCESS);
 <![CDATA[
 <?php
 
-echo "Starting\n";
+echo "Début\n";
 
 # Crée un nouvel agent.
 $gmworker= new GearmanWorker();
@@ -71,7 +71,7 @@ $gmworker->addServer();
 # de l'agent en "reverse_fn_fast" pour en améliorer la rapidité avec aucun affichage.
 $gmworker->addFunction("reverse", "reverse_fn");
 
-print "Waiting for job...\n";
+print "Attente d'un travail...\n";
 while($gmworker->work())
 {
   if ($gmworker->returnCode() != GEARMAN_SUCCESS)
@@ -83,23 +83,23 @@ while($gmworker->work())
 
 function reverse_fn($job)
 {
-  echo "Received job: " . $job->handle() . "\n";
+  echo "Travail reçu : " . $job->handle() . "\n";
 
   $workload = $job->workload();
   $workload_size = $job->workloadSize();
 
-  echo "Workload: $workload ($workload_size)\n";
+  echo "Charge de travail : $workload ($workload_size)\n";
 
   # Cette boucle n'est pas nécessaire, mais montre simplement le fonctionnement
   for ($x= 0; $x < $workload_size; $x++)
   {
-    echo "Sending status: " . ($x + 1) . "/$workload_size complete\n";
+    echo "Envoi du statut : " . ($x + 1) . "/$workload_size terminé\n";
     $job->sendStatus($x, $workload_size);
     sleep(1);
   }
 
   $result= strrev($workload);
-  echo "Result: $result\n";
+  echo "Résultat : $result\n";
 
   # On retourne ce que l'on veut au client.
   return $result;
@@ -118,31 +118,31 @@ function reverse_fn_fast($job)
    <screen>
 <![CDATA[
 % php reverse_worker.php
-Starting
-Waiting for job...
-Received job: H:foo.local:36
-Workload: Hello! (6)
-Sending status: 1/6 complete
-Sending status: 2/6 complete
-Sending status: 3/6 complete
-Sending status: 4/6 complete
-Sending status: 5/6 complete
-Sending status: 6/6 complete
-Result: !olleH
+Début
+Attente d'un travail...
+Travail reçu : H:foo.local:36
+Charge de travail : Hello! (6)
+Envoi du statut : 1/6 terminé
+Envoi du statut : 2/6 terminé
+Envoi du statut : 3/6 terminé
+Envoi du statut : 4/6 terminé
+Envoi du statut : 5/6 terminé
+Envoi du statut : 6/6 terminé
+Résultat : !olleH
 ]]>
    </screen>
    <screen>
 <![CDATA[
 % php reverse_client.php
-Starting
-Sending job
-Status: 1/6 complete
-Status: 2/6 complete
-Status: 3/6 complete
-Status: 4/6 complete
-Status: 5/6 complete
-Status: 6/6 complete
-Success: !olleH
+Début
+Envoi de la tâche
+Statut : 1/6 terminé
+Statut : 2/6 terminé
+Statut : 3/6 terminé
+Statut : 4/6 terminé
+Statut : 5/6 terminé
+Statut : 6/6 terminé
+Succès : !olleH
 ]]>
    </screen>
   </example>
@@ -155,8 +155,7 @@ Success: !olleH
     Cet exemple montre un client et un agent simple. Le client envoie une &string;
     au serveur de travaux en tant que travail d'arrière-plan, et l'agent
     renverse la &string;. Il est à noter que vu l'exécution asynchrone de l'agent, le
-    client n'attend pas la fin et qu'il sort (y compris lorsqu'il ne
-    reçoit pas les résultats).
+    client n'attend pas la fin et qu'il sort (et donc le client ne reçoit jamais les résultats).
    </simpara>
    <programlisting role="php">
 <![CDATA[
@@ -186,7 +185,7 @@ echo "done!\n";
 <![CDATA[
 <?php
 
-echo "Starting\n";
+echo "Début\n";
 
 # Crée un nouvel agent
 $gmworker= new GearmanWorker();
@@ -203,30 +202,30 @@ while($gmworker->work())
 {
   if ($gmworker->returnCode() != GEARMAN_SUCCESS)
   {
-    echo "return_code: " . $gmworker->returnCode() . "\n";
+    echo "return_code : " . $gmworker->returnCode() . "\n";
     break;
   }
 }
 
 function reverse_fn($job)
 {
-  echo "Received job: " . $job->handle() . "\n";
+  echo "Travail reçu : " . $job->handle() . "\n";
 
   $workload = $job->workload();
   $workload_size = $job->workloadSize();
 
-  echo "Workload: $workload ($workload_size)\n";
+  echo "Charge de travail : $workload ($workload_size)\n";
 
   # Cette boucle n'est pas nécessaire, mais nous l'utilisons pour en comprendre le fonctionnement
   for ($x= 0; $x < $workload_size; $x++)
   {
-    echo "Sending status: " . ($x + 1) . "/$workload_size complete\n";
+    echo "Envoi du statut : " . ($x + 1) . "/$workload_size terminé\n";
     $job->sendStatus($x, $workload_size);
     sleep(1);
   }
 
   $result= strrev($workload);
-  echo "Result: $result\n";
+  echo "Résultat : $result\n";
 
   # Retourne ce que l'on veut au client.
   return $result;
@@ -245,25 +244,25 @@ function reverse_fn_fast($job)
    <screen>
 <![CDATA[
 % php reverse_worker.php
-Starting
-Waiting for job...
-Received job: H:foo.local:41
-Workload: this is a test (14)
-1/14 complete
-2/14 complete
-3/14 complete
-4/14 complete
-5/14 complete
-6/14 complete
-7/14 complete
-8/14 complete
-9/14 complete
-10/14 complete
-11/14 complete
-12/14 complete
-13/14 complete
-14/14 complete
-Result: tset a si siht
+Début
+Attente d'un travail...
+Travail reçu : H:foo.local:41
+Charge de travail : this is a test (14)
+Envoi du statut : 1/14 terminé
+Envoi du statut : 2/14 terminé
+Envoi du statut : 3/14 terminé
+Envoi du statut : 4/14 terminé
+Envoi du statut : 5/14 terminé
+Envoi du statut : 6/14 terminé
+Envoi du statut : 7/14 terminé
+Envoi du statut : 8/14 terminé
+Envoi du statut : 9/14 terminé
+Envoi du statut : 10/14 terminé
+Envoi du statut : 11/14 terminé
+Envoi du statut : 12/14 terminé
+Envoi du statut : 13/14 terminé
+Envoi du statut : 14/14 terminé
+Résultat : tset a si siht
 ]]>
    </screen>
    <screen>

--- a/reference/gearman/gearmanclient/addoptions.xml
+++ b/reference/gearman/gearmanclient/addoptions.xml
@@ -27,7 +27,7 @@
      <simpara>
       Les options à ajouter.
       Une des constantes suivantes ou la combinaison de constantes en utilisant
-      l'opérateur de manipulation de bit (<quote>|</quote>):
+      l'opérateur OU bit à bit (<quote>|</quote>):
       <constant>GEARMAN_CLIENT_GENERATE_UNIQUE</constant>,
       <constant>GEARMAN_CLIENT_NON_BLOCKING</constant>,
       <constant>GEARMAN_CLIENT_UNBUFFERED_RESULT</constant> ou

--- a/reference/gearman/gearmanclient/addtask.xml
+++ b/reference/gearman/gearmanclient/addtask.xml
@@ -20,7 +20,7 @@
    Ajoute une tâche à exécuter en parallèle d'autres tâches. Appelez cette
    méthode pour toutes les tâches à exécuter en parallèle, puis, appelez
    la méthode <methodname>GearmanClient::runTasks</methodname> pour exécuter les
-   tâches. Notez qu'il est nécessaire d'avoir assez d'agents disponibles pour exécuter
+   tâches. Il est à noter qu'il est nécessaire d'avoir assez d'agents disponibles pour exécuter
    en parallèle toutes les tâches.
   </simpara>
  </refsect1>

--- a/reference/gearman/gearmanclient/addtaskbackground.xml
+++ b/reference/gearman/gearmanclient/addtaskbackground.xml
@@ -166,7 +166,7 @@ function reverse_fn($job)
   # Cette boucle n'est pas nécessaire, mais permet de comprendre le fonctionnement
   for ($x= 0; $x < $workload_size; $x++)
   {
-    echo "Envoi du statut : " . ($x + 1) . "/$workload_size complete\n";
+    echo "Envoi du statut : " . ($x + 1) . "/$workload_size terminé\n";
     $job->sendStatus($x+1, $workload_size);
     $job->sendData(substr($workload, $x, 1));
     sleep(1);
@@ -189,32 +189,32 @@ function reverse_fn($job)
 <![CDATA[
 Travail reçu : H:foo.local:65
 Charge de l'agent : !dlroW olleH (12)
-1/12 complete
+1/12 terminé
 Travail reçu : H:foo.local:66
 Charge de l'agent : Hello World! (12)
-Envoi du statut : 1/12 complete
-Envoi du statut : 2/12 complete
-Envoi du statut : 2/12 complete
-Envoi du statut : 3/12 complete
-Envoi du statut : 3/12 complete
-Envoi du statut : 4/12 complete
-Envoi du statut : 4/12 complete
-Envoi du statut : 5/12 complete
-Envoi du statut : 5/12 complete
-Envoi du statut : 6/12 complete
-Envoi du statut : 6/12 complete
-Envoi du statut : 7/12 complete
-Envoi du statut : 7/12 complete
-Envoi du statut : 8/12 complete
-Envoi du statut : 8/12 complete
-Envoi du statut : 9/12 complete
-Envoi du statut : 9/12 complete
-Envoi du statut : 10/12 complete
-Envoi du statut : 10/12 complete
-Envoi du statut : 11/12 complete
-Envoi du statut : 11/12 complete
-Envoi du statut : 12/12 complete
-Envoi du statut : 12/12 complete
+Envoi du statut : 1/12 terminé
+Envoi du statut : 2/12 terminé
+Envoi du statut : 2/12 terminé
+Envoi du statut : 3/12 terminé
+Envoi du statut : 3/12 terminé
+Envoi du statut : 4/12 terminé
+Envoi du statut : 4/12 terminé
+Envoi du statut : 5/12 terminé
+Envoi du statut : 5/12 terminé
+Envoi du statut : 6/12 terminé
+Envoi du statut : 6/12 terminé
+Envoi du statut : 7/12 terminé
+Envoi du statut : 7/12 terminé
+Envoi du statut : 8/12 terminé
+Envoi du statut : 8/12 terminé
+Envoi du statut : 9/12 terminé
+Envoi du statut : 9/12 terminé
+Envoi du statut : 10/12 terminé
+Envoi du statut : 10/12 terminé
+Envoi du statut : 11/12 terminé
+Envoi du statut : 11/12 terminé
+Envoi du statut : 12/12 terminé
+Envoi du statut : 12/12 terminé
 Résultat : !dlroW olleH
 Résultat : Hello World!
 ]]>

--- a/reference/gearman/gearmanclient/addtaskhigh.xml
+++ b/reference/gearman/gearmanclient/addtaskhigh.xml
@@ -20,7 +20,7 @@
    Ajoute une tâche de forte priorité à effectuer en parallèle d'autres tâches.
    Appelez cette méthode pour que toutes les tâches soient menées de front, puis appelez
    <methodname>GearmanClient::runTasks</methodname> pour faire le travail. Les tâches avec une forte priorité
-   seront sélectionnées dans la queue avant celle de priorité plus faible.
+   seront sélectionnées dans la queue avant celles de priorité normale ou plus faible.
   </simpara>
  </refsect1>
 

--- a/reference/gearman/gearmanclient/addtaskhighbackground.xml
+++ b/reference/gearman/gearmanclient/addtaskhighbackground.xml
@@ -20,7 +20,7 @@
    Ajoute une tâche de fond de forte priorité à effectuer en parallèle d'autres tâches.
    Appelez cette méthode pour que toutes les tâches soient menées de front, puis appelez
    <methodname>GearmanClient::runTasks</methodname> pour faire le travail. Les tâches avec une forte priorité
-   seront sélectionnées dans la queue avant celle de priorité plus faible.
+   seront sélectionnées dans la queue avant celles de priorité normale ou plus faible.
   </simpara>
  </refsect1>
 

--- a/reference/gearman/gearmanclient/addtasklow.xml
+++ b/reference/gearman/gearmanclient/addtasklow.xml
@@ -20,7 +20,7 @@
    Ajoute une tâche de faible priorité à effectuer en parallèle d'autres tâches.
    Appelez cette méthode pour que toutes les tâches soient menées de front, puis appelez
    <methodname>GearmanClient::runTasks</methodname> pour faire le travail. Les tâches avec une faible priorité
-   seront sélectionnées dans la queue après celle de priorité plus forte.
+   seront sélectionnées dans la queue après celles de priorité normale ou haute.
   </simpara>
  </refsect1>
 

--- a/reference/gearman/gearmanclient/addtasklowbackground.xml
+++ b/reference/gearman/gearmanclient/addtasklowbackground.xml
@@ -20,7 +20,7 @@
    Ajoute une tâche de fond de faible priorité à effectuer en parallèle d'autres tâches.
    Appelez cette méthode pour que toutes les tâches soient menées de front, puis appelez
    <methodname>GearmanClient::runTasks</methodname> pour faire le travail. Les tâches avec une faible priorité
-   seront sélectionnées dans la queue après celle de priorité plus forte.
+   seront sélectionnées dans la queue après celles de priorité normale ou haute.
   </simpara>
  </refsect1>
 

--- a/reference/gearman/gearmanclient/addtaskstatus.xml
+++ b/reference/gearman/gearmanclient/addtaskstatus.xml
@@ -15,8 +15,8 @@
    <methodparam choice="opt"><type>mixed</type><parameter>context</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
   <simpara>
-   Utilisé pour demander le statut au serveur Gearman, qui appellera le retour de statut
-   spécifié (grâce à <methodname>GearmanClient::setStatusCallback</methodname>).
+   Utilisé pour demander le statut au serveur Gearman, qui appellera la fonction de rappel de statut
+   spécifiée (grâce à <methodname>GearmanClient::setStatusCallback</methodname>).
   </simpara>
  </refsect1>
 
@@ -35,7 +35,7 @@
     <term><parameter>context</parameter></term>
     <listitem>
      <simpara>
-      Les données à passer au retour de statut, généralement une référence à un tableau ou à un objet
+      Les données à passer à la fonction de rappel de statut, généralement une référence à un tableau ou à un objet
      </simpara>
     </listitem>
    </varlistentry>

--- a/reference/gearman/gearmanclient/context.xml
+++ b/reference/gearman/gearmanclient/context.xml
@@ -28,7 +28,7 @@
   &reftitle.returnvalues;
   <simpara>
    Les données de contexte identiques à celles définies
-   avec la fonction <methodname>GearmanClient::setContext</methodname>
+   avec la méthode <methodname>GearmanClient::setContext</methodname>
   </simpara>
  </refsect1>
 

--- a/reference/gearman/gearmanclient/do.xml
+++ b/reference/gearman/gearmanclient/do.xml
@@ -136,10 +136,10 @@ Succès : !olleH
     <title>Soumission d'un travail et récupération incrémentale du statut</title>
     <simpara>
      Un travail est soumis et le script boucle pour récupérer les informations
-     de statut. L'agent a un délai artificiel pour récupérer les résultats
-     lors d'une exécution longue d'un travail mais aussi l'envoi des statuts
-     et des données. Chaque sous-séquence appelle la méthode
-     <methodname>GearmanClient::do</methodname> permettant de produire des
+     de statut. L'agent a un délai artificiel qui résulte en un travail
+     de longue durée et envoie le statut et les données au fur et à mesure
+     du traitement. Chaque appel suivant à la méthode
+     <methodname>GearmanClient::do</methodname> produit des
      informations de statut sur le travail en cours.
     </simpara>
     <programlisting role="php">
@@ -169,7 +169,7 @@ do
       break;
     case GEARMAN_WORK_STATUS:
       list($numerator, $denominator)= $gmclient->doStatus();
-      echo "Statut : $numerator/$denominator complete\n";
+      echo "Statut : $numerator/$denominator terminé\n";
       break;
     case GEARMAN_WORK_FAIL:
       echo "Échec\n";
@@ -229,7 +229,7 @@ function reverse_fn($job)
   # Cette boucle n'est pas nécessaire, mais montre le fonctionnement
   for ($x= 0; $x < $workload_size; $x++)
   {
-    echo "Envoi du statut : " + $x + 1 . "/$workload_size complete\n";
+    echo "Envoi du statut : " + $x + 1 . "/$workload_size terminé\n";
     $job->sendStatus($x+1, $workload_size);
     $job->sendData(substr($workload, $x, 1));
     sleep(1);
@@ -255,12 +255,12 @@ Début
 Attente d'un travail...
 Travail reçu : H:foo.local:106
 Charge de l'agent : Hello! (6)
-1/6 complete
-2/6 complete
-3/6 complete
-4/6 complete
-5/6 complete
-6/6 complete
+1/6 terminé
+2/6 terminé
+3/6 terminé
+4/6 terminé
+5/6 terminé
+6/6 terminé
 Résultat : !olleH
 ]]>
     </screen>
@@ -271,17 +271,17 @@ Résultat : !olleH
 <![CDATA[
 Début
 Envoi d'un travail
-Statut : 1/6 complete
+Statut : 1/6 terminé
 Données : H
-Statut : 2/6 complete
+Statut : 2/6 terminé
 Données : e
-Statut : 3/6 complete
+Statut : 3/6 terminé
 Données : l
-Statut : 4/6 complete
+Statut : 4/6 terminé
 Données : l
-Statut : 5/6 complete
+Statut : 5/6 terminé
 Données : o
-Statut : 6/6 complete
+Statut : 6/6 terminé
 Données : !
 Succès : !olleH
 ]]>

--- a/reference/gearman/gearmanclient/dohigh.xml
+++ b/reference/gearman/gearmanclient/dohigh.xml
@@ -20,7 +20,7 @@
    du résultat sous la forme d'une &string;. C'est aux fonctions
    <classname>GearmanClient</classname> et <classname>GearmanWorker</classname> d'accorder
    le format du résultat. Les tâches en priorités hautes seront exécutées avant celles
-   dont la priorité est normale, voire, basse dans la file d'attente.
+   dont la priorité est normale, voire basse dans la file d'attente.
   </simpara>
  </refsect1>
 

--- a/reference/gearman/gearmanclient/donormal.xml
+++ b/reference/gearman/gearmanclient/donormal.xml
@@ -189,7 +189,7 @@ do
 }
 while($gmclient->returnCode() != GEARMAN_SUCCESS);
 
-echo "Success: $result\n";
+echo "Succès : $result\n";
 
 ?>
 ]]>
@@ -228,9 +228,9 @@ function reverse_fn($job)
   $workload = $job->workload();
   $workload_size = $job->workloadSize();
 
-  echo "Workload : $workload ($workload_size)\n";
+  echo "Charge de travail : $workload ($workload_size)\n";
 
-  # This status loop is not needed, just showing how it works
+  # Cette boucle de statut n'est pas nécessaire, elle montre juste le fonctionnement
   for ($x= 0; $x < $workload_size; $x++)
   {
     echo "Envoi du statut : " + $x + 1 . "/$workload_size terminé\n";
@@ -251,14 +251,14 @@ function reverse_fn($job)
     </programlisting>
     &example.outputs.similar;
     <simpara>
-     Worker output:
+     Sortie du worker :
     </simpara>
     <screen>
 <![CDATA[
 Début
 Attente d'une tâche...
 Tâche reçue : H:foo.local:106
-Workload : Hello! (6)
+Charge de travail : Hello! (6)
 1/6 terminé
 2/6 terminé
 3/6 terminé
@@ -283,7 +283,7 @@ Statut : 3/6 terminé
 Données : l
 Statut : 4/6 terminé
 Données : l
-Status: 5/6 terminé
+Statut : 5/6 terminé
 Données : o
 Statut : 6/6 terminé
 Données : !

--- a/reference/gearman/gearmanclient/dostatus.xml
+++ b/reference/gearman/gearmanclient/dostatus.xml
@@ -69,7 +69,7 @@ do
     case GEARMAN_WORK_STATUS:
       # Récupère le statut du travail en cours
       list($numerator, $denominator)= $gmclient->doStatus();
-      echo "Statut : $numerator/$denominator complete\n";
+      echo "Statut : $numerator/$denominator terminé\n";
       break;
     case GEARMAN_WORK_FAIL:
       echo "Échec \n";

--- a/reference/gearman/gearmanclient/setdata.xml
+++ b/reference/gearman/gearmanclient/setdata.xml
@@ -21,7 +21,7 @@
   <note>
    <simpara>
     Cette méthode a été remplacée par la méthode
-    <methodname>GearmanClient::setContext</methodname> depuis la version
+    <methodname>GearmanClient::setContext</methodname> à partir de la version
     0.6.0 de l'extension Gearman.
    </simpara>
   </note>

--- a/reference/gearman/gearmanjob/fail.xml
+++ b/reference/gearman/gearmanjob/fail.xml
@@ -16,8 +16,7 @@
   </methodsynopsis>
   <simpara>
    Envoie un statut d'échec pour ce travail, indiquant que le travail a échoué
-   de façon inattendue (a contrario d'un échec avec une émission d'une exception
-   donnée).
+   de façon prévue (a contrario d'un échec dû à l'émission d'une exception).
   </simpara>
   <note>
    <simpara>

--- a/reference/gearman/gearmanjob/sendfail.xml
+++ b/reference/gearman/gearmanjob/sendfail.xml
@@ -15,7 +15,7 @@
   </methodsynopsis>
   <simpara>
    Envoie un statut d'échec pour ce travail, indiquant que le travail a échoué
-   de façon inattendue (a contrario d'une erreur émettant une exception).
+   de façon prévue (a contrario d'un échec dû à l'émission d'une exception).
   </simpara>
  </refsect1>
 

--- a/reference/gearman/gearmanworker/error.xml
+++ b/reference/gearman/gearmanworker/error.xml
@@ -4,7 +4,7 @@
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="gearmanworker.error">
  <refnamediv>
   <refname>GearmanWorker::error</refname>
-  <refpurpose> Récupère la dernière erreur survenue</refpurpose>
+  <refpurpose>Récupère la dernière erreur survenue</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/gearman/gearmanworker/setid.xml
+++ b/reference/gearman/gearmanworker/setid.xml
@@ -4,7 +4,7 @@
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="gearmanworker.setid">
  <refnamediv>
   <refname>GearmanWorker::setId</refname>
-  <refpurpose>Définit un identifiant au worker</refpurpose>
+  <refpurpose>Définit un identifiant à l'agent</refpurpose>
  </refnamediv>
 
  <refsect1 role="description"><!-- {{{ -->
@@ -14,8 +14,8 @@
    <methodparam><type>string</type><parameter>id</parameter></methodparam>
   </methodsynopsis>
   <simpara>
-   Assigne au worker un identifiant, permettant ainsi qu'il soit identifiable lorsque
-   gearman demande la liste des workers disponibles.
+   Assigne à l'agent un identifiant, permettant ainsi qu'il soit identifiable lorsque
+   gearman demande la liste des agents disponibles.
   </simpara>
  </refsect1><!-- }}} -->
 

--- a/reference/geoip/book.xml
+++ b/reference/geoip/book.xml
@@ -15,7 +15,7 @@
   </simpara>
   <warning>
    <simpara>
-    Cette extension ne prend pas en charge les bases de données "GeoIP2"
+    Cette extension ne supporte pas les bases de données "GeoIP2"
     actuelles de MaxMind, uniquement les fichiers de base de données "GeoIP Legacy".
    </simpara>
   </warning>

--- a/reference/gettext/functions/textdomain.xml
+++ b/reference/gettext/functions/textdomain.xml
@@ -14,8 +14,8 @@
    <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>domain</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
   <para>
-   Cette fonction définit le domaine de recherche à utiliser lors des appels
-   à <function>gettext</function> sont effectués. Ce 
+   Cette fonction définit le domaine de recherche à utiliser lorsque des appels
+   à <function>gettext</function> sont effectués. Ce
    domaine dépend généralement de l'application.
   </para>
  </refsect1>
@@ -40,8 +40,8 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Cette fonction retourne le message courant du domaine en cas de succès,
-   après une possible modification.
+   Cette fonction retourne le domaine de messages courant en cas de succès,
+   après une éventuelle modification.
   </para>
  </refsect1>
 

--- a/reference/gettext/setup.xml
+++ b/reference/gettext/setup.xml
@@ -10,7 +10,7 @@
  <section xml:id="gettext.requirements">
   &reftitle.required;
   <para>
-   Pour utiliser ces fonctions, il faut télécharger et installer les bibliothèques 
+   Pour utiliser ces fonctions, il faut télécharger et installer les bibliothèques
    GNU gettext depuis <link xlink:href="&url.gettext;">&url.gettext;</link>.
   </para>
  </section>

--- a/reference/gmagick/gmagick/annotateimage.xml
+++ b/reference/gmagick/gmagick/annotateimage.xml
@@ -72,7 +72,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   L'objet <classname>GmagickDraw</classname> contenant l'annotation.
+   L'objet <classname>Gmagick</classname> contenant l'annotation.
   </simpara>
  </refsect1>
 

--- a/reference/gmagick/gmagick/drawimage.xml
+++ b/reference/gmagick/gmagick/drawimage.xml
@@ -37,7 +37,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   L'objet <classname>GmagickDraw</classname> dessiné.
+   L'objet <classname>Gmagick</classname> dessiné.
   </simpara>
  </refsect1>
 

--- a/reference/gmagick/gmagick/edgeimage.xml
+++ b/reference/gmagick/gmagick/edgeimage.xml
@@ -16,8 +16,8 @@
   </methodsynopsis>
   <simpara>
    Améliore les bords intérieurs de l'image avec un filtre de convolution
-   utilisant le rayon fourni. En utilisant un rayon de 0 et la méthode le choisira
-   pour.
+   utilisant le rayon fourni. En utilisant un rayon de 0, la méthode le choisira
+   automatiquement.
   </simpara>
 
 

--- a/reference/gmagick/gmagick/levelimage.xml
+++ b/reference/gmagick/gmagick/levelimage.xml
@@ -61,7 +61,7 @@
      <simpara>
       Une constante de canaux valide pour le mode de canal utilisé.
       Pour l'appliquer à plus d'un canal, combinez les constantes
-      de type de canaux en utilisant un opérateur de jonction.
+      de type de canaux en utilisant un opérateur bit à bit.
       Se reporter à la liste des <link linkend="gmagick.constants.channel">constantes de canaux</link>.
      </simpara>
     </listitem>

--- a/reference/gmagick/gmagick/reducenoiseimage.xml
+++ b/reference/gmagick/gmagick/reducenoiseimage.xml
@@ -19,8 +19,8 @@
    informations des coins. L'algorithme fonctionne en
    remplaçant chaque pixel avec son voisin le plus proche
    de sa valeur. Un voisin est défini par son rayon.
-   En utilisant un rayon de 0 et la méthode <methodname>Gmagick::reducenoiseimage</methodname>
-   sélectionnera un rayon approprié pour.
+   En utilisant un rayon de 0, la méthode <methodname>Gmagick::reducenoiseimage</methodname>
+   sélectionnera un rayon approprié automatiquement.
   </simpara>
  </refsect1>
 

--- a/reference/gmagick/gmagick/setimagechanneldepth.xml
+++ b/reference/gmagick/gmagick/setimagechanneldepth.xml
@@ -36,7 +36,7 @@
     <term><parameter>depth</parameter></term>
     <listitem>
      <simpara>
-      La profondeur de l'image, en octets.
+      La profondeur de l'image, en bits.
      </simpara>
     </listitem>
    </varlistentry>

--- a/reference/gmagick/gmagick/setimagedepth.xml
+++ b/reference/gmagick/gmagick/setimagedepth.xml
@@ -27,7 +27,7 @@
     <term><parameter>depth</parameter></term>
     <listitem>
      <simpara>
-      La profondeur de l'image, en octets : 8, 16, ou 32.
+      La profondeur de l'image, en bits : 8, 16, ou 32.
      </simpara>
     </listitem>
    </varlistentry>

--- a/reference/gmagick/gmagickdraw/settextencoding.xml
+++ b/reference/gmagick/gmagickdraw/settextencoding.xml
@@ -17,7 +17,7 @@
   <simpara>
    Spécifie le code du jeu de caractères à utiliser pour le texte des annotations.
    Le seul jeu de caractères qui peut être actuellement spécifié est "UTF-8"
-   pour représenter l'Unicode comme séquence de bits. En spécifiant une chaîne vide
+   pour représenter l'Unicode comme séquence d'octets. En spécifiant une chaîne vide
    pour définir l'encodage du texte conformément à celui du système.
    Un texte utilisant l'Unicode sera représenté correctement lors de l'utilisation
    d'une police de caractères qui supporte l'Unicode.

--- a/reference/gmp/functions/gmp-and.xml
+++ b/reference/gmp/functions/gmp-and.xml
@@ -5,7 +5,7 @@
 <refentry xml:id="function.gmp-and" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>gmp_and</refname>
-  <refpurpose>ET logique</refpurpose>
+  <refpurpose>ET bit à bit</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -16,7 +16,7 @@
    <methodparam><type class="union"><type>GMP</type><type>int</type><type>string</type></type><parameter>num2</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Calcule le ET logique de 2 nombres GMP.
+   Calcule le ET bit à bit de 2 nombres GMP.
   </para>
  </refsect1>
 
@@ -43,7 +43,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Un nombre GMP représentant le ET logique (<literal>AND</literal>)
+   Un nombre GMP représentant le ET bit à bit (<literal>AND</literal>)
    des 2 arguments.
   </para>
  </refsect1>

--- a/reference/gmp/functions/gmp-clrbit.xml
+++ b/reference/gmp/functions/gmp-clrbit.xml
@@ -39,7 +39,7 @@
      <listitem>
       <para>
        L'index du bit à annuler. L'index 0 représente
-       le dernier bit significatif.
+       le bit de poids faible.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/gmp/functions/gmp-div-r.xml
+++ b/reference/gmp/functions/gmp-div-r.xml
@@ -19,7 +19,7 @@
   <para>
    Calcule le reste de la division entière
    de <parameter>num1</parameter> par <parameter>num2</parameter>. Le reste
-   a le même signe que <parameter>n</parameter>, s'il est différent de zéro.
+   a le même signe que <parameter>num1</parameter>, s'il est différent de zéro.
   </para>
  </refsect1>
 

--- a/reference/gmp/functions/gmp-hamdist.xml
+++ b/reference/gmp/functions/gmp-hamdist.xml
@@ -18,7 +18,7 @@
   <para>
    Retourne la distance de Hamming entre <parameter>num1</parameter>
    et <parameter>num2</parameter>. Les deux paramètres doivent être
-   strictement positifs.
+   non négatifs.
   </para>
  </refsect1>
 

--- a/reference/gmp/functions/gmp-or.xml
+++ b/reference/gmp/functions/gmp-or.xml
@@ -5,7 +5,7 @@
 <refentry xml:id="function.gmp-or" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>gmp_or</refname>
-  <refpurpose>OU logique</refpurpose>
+  <refpurpose>OU bit à bit</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -16,7 +16,7 @@
    <methodparam><type class="union"><type>GMP</type><type>int</type><type>string</type></type><parameter>num2</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Calcule le OU logique de deux nombres GMP.
+   Calcule le OU bit à bit de deux nombres GMP.
   </para>
  </refsect1>
 
@@ -31,8 +31,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>num2
-     </parameter></term>
+     <term><parameter>num2</parameter></term>
      <listitem>
       &gmp.parameter;
      </listitem>

--- a/reference/gmp/functions/gmp-sign.xml
+++ b/reference/gmp/functions/gmp-sign.xml
@@ -56,7 +56,7 @@
 // positif
 echo gmp_sign("500") . "\n";
 
-// negatif
+// négatif
 echo gmp_sign("-500") . "\n";
 
 // zéro

--- a/reference/gmp/functions/gmp-xor.xml
+++ b/reference/gmp/functions/gmp-xor.xml
@@ -5,7 +5,7 @@
 <refentry xml:id="function.gmp-xor" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>gmp_xor</refname>
-  <refpurpose>OU exclusif logique</refpurpose>
+  <refpurpose>OU exclusif bit à bit</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -16,7 +16,7 @@
    <methodparam><type class="union"><type>GMP</type><type>int</type><type>string</type></type><parameter>num2</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Calcule le OU exclusif logique (XOR) de deux nombres GMP.
+   Calcule le OU exclusif bit à bit (XOR) de deux nombres GMP.
   </para>
  </refsect1>
 

--- a/reference/gnupg/functions/gnupg-decrypt.xml
+++ b/reference/gnupg/functions/gnupg-decrypt.xml
@@ -44,7 +44,8 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   &return.success;
+   En cas de succès, cette fonction retourne le texte déchiffré.
+   En cas d'échec, cette fonction retourne &false;.
   </simpara>
  </refsect1>
 

--- a/reference/gnupg/functions/gnupg-setsignmode.xml
+++ b/reference/gnupg/functions/gnupg-setsignmode.xml
@@ -37,7 +37,7 @@
      </simpara>
      <simpara>
       <parameter>signmode</parameter> prend une constante indiquant quel type de
-      signature qui doit être produite. Les valeurs possibles sont :
+      signature doit être produit. Les valeurs possibles sont :
       <constant>GNUPG_SIG_MODE_NORMAL</constant>,
       <constant>GNUPG_SIG_MODE_DETACH</constant> et
       <constant>GNUPG_SIG_MODE_CLEAR</constant>.

--- a/reference/gnupg/reference.xml
+++ b/reference/gnupg/reference.xml
@@ -24,7 +24,7 @@
     <simpara>
      En tant qu'alternative aux fonctions utilisant explicitement les
      <type>resource</type>, il est également possible d'utiliser un style orienté
-     objet à l'aide d'objets <classname>GnuPG</classname> .
+     objet à l'aide d'objets <classname>gnupg</classname>.
     </simpara>
    </note>
   </partintro>

--- a/reference/hash/functions/hash-equals.xml
+++ b/reference/hash/functions/hash-equals.xml
@@ -50,7 +50,7 @@
     <term><parameter>user_string</parameter></term>
     <listitem>
      <para>
-      La chaîne fournie par l'utilisateur à comparer contre.
+      La chaîne fournie par l'utilisateur à comparer.
      </para>
     </listitem>
    </varlistentry>

--- a/reference/hash/functions/hash-hkdf.xml
+++ b/reference/hash/functions/hash-hkdf.xml
@@ -95,8 +95,8 @@
   &reftitle.errors;
   <para>
    Lève une exception <classname>ValueError</classname> si <parameter>key</parameter>
-   est vide, <parameter>algo</parameter> est inconnue/pas cryptographique,
-   <parameter>length</parameter> est moins que <literal>0</literal> ou trop grand
+   est vide, <parameter>algo</parameter> est inconnu/non cryptographique,
+   <parameter>length</parameter> est inférieur à <literal>0</literal> ou trop grand
    (plus grand que 255 fois la taille de la fonction de hachage).
   </para>
  </refsect1>

--- a/reference/hash/functions/hash-hmac-file.xml
+++ b/reference/hash/functions/hash-hmac-file.xml
@@ -48,7 +48,7 @@
      <term><parameter>key</parameter></term>
      <listitem>
       <para>
-       Clé secrète partagée utilisée pour générer la variance HMAC de
+       Clé secrète partagée utilisée pour générer la variante HMAC de
        l'empreinte numérique.
       </para>
      </listitem>

--- a/reference/hash/functions/hash-hmac.xml
+++ b/reference/hash/functions/hash-hmac.xml
@@ -47,7 +47,7 @@
      <term><parameter>key</parameter></term>
      <listitem>
       <para>
-       Clé secrète partagée utilisée pour générer la variance HMAC de
+       Clé secrète partagée utilisée pour générer la variante HMAC de
        l'empreinte numérique.
       </para>
      </listitem>

--- a/reference/hash/functions/hash-init.xml
+++ b/reference/hash/functions/hash-init.xml
@@ -51,7 +51,7 @@
      <term><parameter>key</parameter></term>
      <listitem>
       <para>
-       Lorsque <constant>HASH_HMAC</constant> est spécifiée pour <parameter>flags</parameter>,
+       Lorsque <constant>HASH_HMAC</constant> est spécifié pour <parameter>flags</parameter>,
        une clé secrète partagée qui sera utilisée avec la méthode de hachage
        HMAC doit être fournie dans ce paramètre.
       </para>
@@ -123,10 +123,6 @@
        <entry>Le paramètre <parameter>options</parameter> a été ajouté.</entry>
       </row>
       <row>
-       <entry>7.2.0</entry>
-       <entry>L'usage de fonction de hachage non-cryptographique (adler32, crc32, crc32b, fnv132, fnv1a32, fnv164, fnv1a64, joaat) avec <constant>HASH_HMAC</constant> a été désactivé.</entry>
-      </row>
-      <row>
        <entry>8.0.0</entry>
        <entry>
         Lève une exception <classname>ValueError</classname> dorénavant si le
@@ -136,6 +132,10 @@
         Précédemment, &false; était retourné et un message
         <constant>E_WARNING</constant> était émis.
        </entry>
+      </row>
+      <row>
+       <entry>7.2.0</entry>
+       <entry>L'usage de fonction de hachage non-cryptographique (adler32, crc32, crc32b, fnv132, fnv1a32, fnv164, fnv1a64, joaat) avec <constant>HASH_HMAC</constant> a été désactivé.</entry>
       </row>
       <row>
        <entry>7.2.0</entry>

--- a/reference/hash/functions/hash-pbkdf2.xml
+++ b/reference/hash/functions/hash-pbkdf2.xml
@@ -29,11 +29,11 @@
      <term><parameter>algo</parameter></term>
      <listitem>
       <para>
-       Nom de l'algorithme d'hachage sélectionné (par exemple : <literal>"sha256"</literal>).
+       Nom de l'algorithme de hachage sélectionné (par exemple : <literal>"sha256"</literal>).
        Pour une liste des algorithmes supportés voir <function>hash_hmac_algos</function>.
        <note>
         <para>
-         Les fonctions d'hachage non cryptographiques ne sont pas autorisées.
+         Les fonctions de hachage non cryptographiques ne sont pas autorisées.
         </para>
        </note>
       </para>
@@ -74,7 +74,7 @@
        correspondra à la longueur, en octets, de la clé dérivée ; si
        le paramètre <parameter>binary</parameter> vaut &false;,
        il correspondra à deux fois la longueur, en octets, de la clé
-       dérivée (vu que chaque octet de la clé est retournée sur
+       dérivée (vu que chaque octet de la clé est retourné sur
        deux hexits).
       </para>
       <para>
@@ -87,9 +87,8 @@
      <term><parameter>binary</parameter></term>
      <listitem>
       <para>
-       Lorsque défini à &true;, la fonction affiche les données
-       binaires brutes. Si vaut &false;, l'affichage se fera
-       en minuscule.
+       Lorsque &true;, retourne les données binaires brutes.
+       Lorsque &false;, retourne des chiffres hexadécimaux en minuscule.
       </para>
      </listitem>
     </varlistentry>
@@ -120,7 +119,7 @@
  <refsect1 role="errors"><!-- {{{ -->
   &reftitle.errors;
   <para>
-   Une exception <classname>ValueError</classname> si 
+   Lève une exception <classname>ValueError</classname> si
    l'algorithme n'est pas connu, si le paramètre <parameter>iterations</parameter>
    est inférieur ou égal à <literal>0</literal>, si la longueur
    <parameter>length</parameter> est inférieure à <literal>0</literal>
@@ -153,7 +152,7 @@
       <row>
        <entry>7.2.0</entry>
        <entry>
-        L'utilisation de fonctions d'hachage non cryptographiques (adler32,
+        L'utilisation de fonctions de hachage non cryptographiques (adler32,
         crc32, crc32b, fnv132, fnv1a32, fnv164, fnv1a64, joaat) a été désactivée.
        </entry>
       </row>

--- a/reference/hash/functions/hash-update-stream.xml
+++ b/reference/hash/functions/hash-update-stream.xml
@@ -32,7 +32,7 @@
      <term><parameter>stream</parameter></term>
      <listitem>
       <para>
-       Identifiant de fichier ouvert comme retourné par n'importe quelle
+       Gestionnaire de fichier ouvert comme retourné par n'importe quelle
        fonction de création de flux.
       </para>
      </listitem>
@@ -41,7 +41,7 @@
      <term><parameter>length</parameter></term>
      <listitem>
       <para>
-       Taille maximale de caractères à copier de <parameter>stream</parameter>
+       Nombre maximum de caractères à copier de <parameter>stream</parameter>
        dans le contexte de hachage.
       </para>
      </listitem>
@@ -53,7 +53,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Nombre actuel d'octets ajoutés au contexte de hachage de
+   Nombre effectif d'octets ajoutés au contexte de hachage de
    <parameter>stream</parameter>.
   </para>
  </refsect1>

--- a/reference/hrtime/hrtime-performancecounter/getticks.xml
+++ b/reference/hrtime/hrtime-performancecounter/getticks.xml
@@ -5,7 +5,7 @@
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="hrtime-performancecounter.getticks">
  <refnamediv>
   <refname>HRTime\PerformanceCounter::getTicks</refname>
-  <refpurpose>Ticks courant depuis le système</refpurpose>
+  <refpurpose>Ticks courants depuis le système</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/ibase/book.xml
+++ b/reference/ibase/book.xml
@@ -29,7 +29,7 @@
   </simpara>
   <simpara>
    Firebird est un projet commercialement indépendant (fondation) de programmeurs C++,
-   conseillés techniques, supportant le développement et assurant la
+   conseillers techniques, supportant le développement et assurant la
    compatibilité multi-plate-forme de la base de données relationnelle basée sur le
    code source offert par Inprise Corp. (maintenant connu sous le nom de Embarcadero)
    sous la licence "InterBase Public License v.1.0 le 25 Juillet 2000".

--- a/reference/ibase/functions/ibase-trans.xml
+++ b/reference/ibase/functions/ibase-trans.xml
@@ -5,7 +5,7 @@
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.ibase-trans">
  <refnamediv>
   <refname>ibase_trans</refname>
-  <refpurpose>Prépare une transaction interBase</refpurpose>
+  <refpurpose>Démarre une transaction interBase</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -21,7 +21,7 @@
    <methodparam choice="opt"><type>int</type><parameter>trans_args</parameter></methodparam>
   </methodsynopsis>
   <simpara>
-   Prépare une transaction interBase.
+   Démarre une transaction interBase.
   </simpara>
   <note>
    <simpara>

--- a/reference/ibm_db2/book.xml
+++ b/reference/ibm_db2/book.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 020edc73be983e8e2aca04782ff7c901da4afad7 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 020edc73be983e8e2aca04782ff7c901da4afad7 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <book xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="book.ibm-db2">
  <?phpdoc extension-membership="pecl" ?>
@@ -11,9 +11,9 @@
  <preface xml:id="intro.ibm-db2">
   &reftitle.intro;
   <simpara>
-   Ces fonctions permettent un accès aux IBM DB2 Universal Database,
-   IBM Cloudscape et Apache Derby qui utilisent
-   <literal>DB2 Call Level Interface</literal> (CLI).
+   Ces fonctions permettent d'accéder aux bases de données IBM DB2 Universal Database,
+   IBM Cloudscape et Apache Derby en utilisant l'interface
+   DB2 Call Level Interface (DB2 CLI).
   </simpara>
  </preface>
  <!-- }}} -->

--- a/reference/ibm_db2/configure.xml
+++ b/reference/ibm_db2/configure.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 020edc73be983e8e2aca04782ff7c901da4afad7 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 020edc73be983e8e2aca04782ff7c901da4afad7 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <section xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="ibm-db2.installation">
  &reftitle.install;
@@ -35,7 +35,7 @@ bash$ ./configure --with-IBM_DB2=/chemin/vers/DB2
   <filename class="directory">/opt/IBM/db2/V8.1</filename>.
  </para>
  <note>
-  <title>Note pour les utilisateurs de IIS</title>
+  <title>Note pour les utilisateurs d'IIS</title>
   <simpara>
    Si le driver ibm_db2 est utilisé avec IIS (Microsoft Internet Information Server),
    il pourrait être nécessaire de prendre les mesures suivantes :

--- a/reference/ibm_db2/constants.xml
+++ b/reference/ibm_db2/constants.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 86e6094e86b84a51d00ab217ac50ce8dde33d82a Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 86e6094e86b84a51d00ab217ac50ce8dde33d82a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 
 <appendix xml:id="ibm-db2.constants" xmlns="http://docbook.org/ns/docbook">
@@ -14,7 +14,7 @@
    </term>
    <listitem>
     <simpara>
-     Spécifie que les données binaires seront retournées comme elles sont.
+     Spécifie que les données binaires seront retournées telles quelles.
      Ceci est le mode par défaut.
     </simpara>
    </listitem>
@@ -48,9 +48,9 @@
      (<type>int</type>)
    </term>
    <listitem>
-    <simpara> 
-     Spécifie le curseur flottant pour une déclaration de ressource. Ce
-     mode permet un accès aléatoire aux lignes du jeu de résultats, mais
+    <simpara>
+     Spécifie un curseur de défilement pour une ressource de requête. Ce
+     mode permet un accès aléatoire aux lignes d'un jeu de résultats, mais
      présentement, il est supporté seulement par IBM DB2 Universal Database.
     </simpara>
    </listitem>
@@ -62,9 +62,9 @@
    </term>
    <listitem>
     <simpara>
-     Spécifie un curseur d'avancement seul pour une déclaration de ressource.
-     Il s'agit de la valeur par défaut de ce type de curseur, et il est
-     supporté par tous les serveurs de base de données.
+     Spécifie un curseur unidirectionnel pour une ressource de requête.
+     Il s'agit du type de curseur par défaut, supporté sur tous les
+     serveurs de base de données.
     </simpara>
    </listitem>
   </varlistentry>
@@ -75,8 +75,8 @@
    </term>
    <listitem>
     <simpara>
-     Spécifie que la variable PHP doit être liée comme étant un paramètre
-     ENTRANT pour une procédure d'enregistrement.
+     Spécifie que la variable PHP devrait être liée comme paramètre
+     ENTRANT pour une procédure stockée.
     </simpara>
    </listitem>
   </varlistentry>
@@ -87,8 +87,8 @@
    </term>
    <listitem>
     <simpara>
-     Spécifie que la variable PHP doit être liée comme étant un paramètre
-     SORTANT pour une procédure d'enregistrement.
+     Spécifie que la variable PHP devrait être liée comme paramètre
+     SORTANT pour une procédure stockée.
     </simpara>
    </listitem>
   </varlistentry>
@@ -99,8 +99,8 @@
    </term>
    <listitem>
     <simpara>
-     Spécifie que la variable PHP doit être liée comme étant un paramètre
-     ENTRANT/SORTANT pour une procédure d'enregistrement.
+     Spécifie que la variable PHP devrait être liée comme paramètre
+     ENTRANT/SORTANT pour une procédure stockée.
     </simpara>
    </listitem>
   </varlistentry>
@@ -111,7 +111,7 @@
    </term>
    <listitem>
     <simpara>
-     Spécifie que la colonne doit être liée directement à un fichier pour
+     Spécifie que la colonne devrait être liée directement à un fichier en
      entrée.
     </simpara>
    </listitem>
@@ -123,7 +123,7 @@
    </term>
    <listitem>
     <simpara>
-     Spécifie que autocommit doit être activé.
+     Spécifie que l'autocommit devrait être activé.
     </simpara>
    </listitem>
   </varlistentry>
@@ -134,7 +134,7 @@
    </term>
    <listitem>
     <simpara>
-     Spécifie que autocommit doit être désactivé.
+     Spécifie que l'autocommit devrait être désactivé.
     </simpara>
    </listitem>
   </varlistentry>
@@ -145,7 +145,7 @@
    </term>
    <listitem>
     <simpara>
-     Spécifie que la variable doit être liée à un type DOUBLE, FLOAT ou REAL.
+     Spécifie que la variable devrait être liée à un type DOUBLE, FLOAT ou REAL.
     </simpara>
    </listitem>
   </varlistentry>
@@ -156,7 +156,7 @@
    </term>
    <listitem>
     <simpara>
-     Spécifie que la variable doit être liée à un type SMALLINT, INTEGER ou
+     Spécifie que la variable devrait être liée à un type SMALLINT, INTEGER ou
      BIGINT.
     </simpara>
    </listitem>
@@ -168,40 +168,40 @@
    </term>
    <listitem>
     <simpara>
-     Spécifie que la variable doit être liée à un type CHAR ou VARCHAR
+     Spécifie que la variable devrait être liée à un type CHAR ou VARCHAR.
     </simpara>
    </listitem>
   </varlistentry>
   <varlistentry xml:id="constant.db2-case-natural">
    <term>
     <constant>DB2_CASE_NATURAL</constant>
-    (<type>int</type>)
+     (<type>int</type>)
    </term>
    <listitem>
     <simpara>
-     Spécifie que les noms de colonnes doivent être retournés dans leurs casses naturelles.
+     Spécifie que les noms de colonnes seront retournés dans leur casse naturelle.
     </simpara>
    </listitem>
   </varlistentry>
   <varlistentry xml:id="constant.db2-case-lower">
    <term>
     <constant>DB2_CASE_LOWER</constant>
-    (<type>int</type>)
+     (<type>int</type>)
    </term>
    <listitem>
     <simpara>
-     Spécifie que les noms de colonnes doivent être retournés en minuscule.
+     Spécifie que les noms de colonnes seront retournés en minuscules.
     </simpara>
    </listitem>
   </varlistentry>
   <varlistentry xml:id="constant.db2-case-upper">
    <term>
     <constant>DB2_CASE_UPPER</constant>
-    (<type>int</type>)
+     (<type>int</type>)
    </term>
    <listitem>
     <simpara>
-     Spécifie que les noms de colonnes doivent être retournés en majuscule.
+     Spécifie que les noms de colonnes seront retournés en majuscules.
     </simpara>
    </listitem>
   </varlistentry>
@@ -212,7 +212,7 @@
    </term>
    <listitem>
     <simpara>
-     Spécifie que la préparation différée doit être active pour la ressource de requête spécifiée.
+     Spécifie que la préparation différée devrait être activée pour la ressource de requête spécifiée.
     </simpara>
    </listitem>
   </varlistentry>
@@ -223,7 +223,7 @@
    </term>
    <listitem>
     <simpara>
-     Spécifie que la préparation différée doit être désactivée pour la ressource de requête spécifiée.
+     Spécifie que la préparation différée devrait être désactivée pour la ressource de requête spécifiée.
     </simpara>
    </listitem>
   </varlistentry>

--- a/reference/ibm_db2/functions/db2-bind-param.xml
+++ b/reference/ibm_db2/functions/db2-bind-param.xml
@@ -23,11 +23,11 @@
   </methodsynopsis>
 
   <simpara>
-   Associe une variable PHP à un paramètre dans la requête SQL
-   retournée par <function>db2_prepare</function>. Cette fonction donne
-   plus de contrôle sur les types des paramètres, les types des données, la
-   précision, et l'échelle pour le paramètre qu'en lui passant simplement une
-   variable à l'intérieur du tableau d'entrée optionnel de la fonction
+   Associe une variable PHP à un paramètre d'une requête SQL dans une
+   ressource de requête retournée par <function>db2_prepare</function>. Cette
+   fonction donne plus de contrôle sur le type de paramètre, le type de
+   données, la précision et l'échelle du paramètre que le simple fait de
+   passer la variable comme élément du tableau d'entrée optionnel de
    <function>db2_execute</function>.
   </simpara>
 
@@ -81,9 +81,8 @@
     <term><parameter>data_type</parameter></term>
     <listitem>
      <simpara>
-      Une constante spécifiant le type de données SQL que la variable PHP
-      devrait être associée. Le paramètre doit prendre une des valeurs
-      suivantes : <constant>DB2_BINARY</constant>,
+      Une constante spécifiant le type de données SQL auquel la variable PHP
+      devrait être associée : l'une des valeurs <constant>DB2_BINARY</constant>,
       <constant>DB2_CHAR</constant>, <constant>DB2_DOUBLE</constant> ou
       <constant>DB2_LONG</constant>.
      </simpara>
@@ -96,7 +95,7 @@
       Spécifie la précision à laquelle la variable devrait être associée à
       la base de données. Ce paramètre peut également être utilisé pour
       récupérer des valeurs de sortie XML pour les procédures stockées.
-      Une valeur non-négative spécifie la taille maximale des données XML
+      Une valeur non négative spécifie la taille maximale des données XML
       qui seront récupérées depuis la base de données. Si ce paramètre n'est
       pas utilisé, une taille par défaut de 1 Mo sera définie pour récupérer
       les valeurs de sortie XML depuis la procédure stockée.
@@ -128,22 +127,23 @@
     <title>Association de variables PHP à une requête préparée</title>
     <simpara>
      La requête SQL dans l'exemple suivant utilise deux paramètres d'entrée
-     dans la section WHERE. Nous appelons <function>db2_bind_param</function>
-     pour associer deux variables qui n'ont pas été déclarées ou assignées
-     avant l'appel de <function>db2_bind_param</function>; dans cet exemple,
-     <literal>$lower_limit</literal> est assignée avant d'être appelée à
+     dans la clause WHERE. Nous appelons <function>db2_bind_param</function>
+     pour associer deux variables PHP aux paramètres SQL correspondants. Il
+     est à noter que les variables PHP n'ont pas besoin d'être déclarées ou
+     assignées avant l'appel à <function>db2_bind_param</function> ; dans cet
+     exemple, <literal>$lower_limit</literal> est assignée avant l'appel à
      <function>db2_bind_param</function>, mais <literal>$upper_limit</literal>
-     est assignée après l'appel de <function>db2_bind_param</function>. Les
-     variables doivent être associées et, pour les paramètres qui acceptent les
-     entrées, nous devons leur assigner une valeur avant d'appeler
+     est assignée après l'appel à <function>db2_bind_param</function>. Les
+     variables doivent être associées et, pour les paramètres qui acceptent
+     une entrée, une valeur doit leur être assignée, avant d'appeler
      <function>db2_execute</function>.
     </simpara>
     <programlisting role="php">
 <![CDATA[
 <?php
 
-$sql = 'SELECT nom, race, poids FROM animaux
-    WHERE poids > ? AND poids < ?';
+$sql = 'SELECT name, breed, weight FROM animals
+    WHERE weight > ? AND weight < ?';
 $conn = db2_connect($database, $user, $password);
 $stmt = db2_prepare($conn, $sql);
 
@@ -167,17 +167,17 @@ if (db2_execute($stmt)) {
     &example.outputs;
     <screen>
 <![CDATA[
-Pook, chat, 3.2
-Rickety Ride, chèvre, 9.7
-Peaches, chien, 12.3
+Pook, cat, 3.2
+Rickety Ride, goat, 9.7
+Peaches, dog, 12.3
 ]]>
     </screen>
    </example>
    <example>
-    <title>Appel de procédures d'enregistrement avec les paramètres IN et OUT</title>
+    <title>Appel de procédures stockées avec des paramètres IN et OUT</title>
     <para>
-     La procédure d'enregistrement concorde_animal dans l'exemple suivant
-     accepte trois différents paramètres :
+     La procédure stockée match_animal dans l'exemple suivant accepte trois
+     paramètres différents :
      <orderedlist>
       <listitem>
        <simpara>
@@ -188,8 +188,8 @@ Peaches, chien, 12.3
       <listitem>
        <simpara>
         un paramètre d'entrée-sortie (INOUT) qui accepte le nom du second
-        animal en entrée et retourne une &string; &true; si un
-        animal dans la base de données correspond à ce nom
+        animal en entrée et retourne la chaîne <literal>TRUE</literal> si un
+        animal de la base de données correspond à ce nom
        </simpara>
       </listitem>
       <listitem>
@@ -199,34 +199,33 @@ Peaches, chien, 12.3
        </simpara>
       </listitem>
      </orderedlist>
-     De plus, la procédure d'enregistrement retourne un jeu de résultats
-     contenant les animaux listés en ordre alphabétique en commençant avec
-     l'animal correspondant à la valeur d'entrée du premier paramètre et en
-     terminant avec l'animal correspondant à la valeur d'entrée du deuxième
-     paramètre.
+     De plus, la procédure stockée retourne un jeu de résultats contenant les
+     animaux listés par ordre alphabétique, en commençant par l'animal
+     correspondant à la valeur d'entrée du premier paramètre et en terminant
+     par l'animal correspondant à la valeur d'entrée du second paramètre.
     </para>
     <programlisting role="php">
 <![CDATA[
 <?php
 
-$sql = 'CALL concorde_animal(?, ?, ?)';
+$sql = 'CALL match_animal(?, ?, ?)';
 $conn = db2_connect($database, $user, $password);
 $stmt = db2_prepare($conn, $sql);
 
-$nom = "Peaches";
-$second_nom = "Rickety Ride";
-$poids = 0;
+$name = "Peaches";
+$second_name = "Rickety Ride";
+$weight = 0;
 
-db2_bind_param($stmt, 1, "nom", DB2_PARAM_IN);
-db2_bind_param($stmt, 2, "second_nom", DB2_PARAM_INOUT);
-db2_bind_param($stmt, 3, "poids", DB2_PARAM_OUT);
+db2_bind_param($stmt, 1, "name", DB2_PARAM_IN);
+db2_bind_param($stmt, 2, "second_name", DB2_PARAM_INOUT);
+db2_bind_param($stmt, 3, "weight", DB2_PARAM_OUT);
 
-print "Valeurs des paramètres _avant_ CALL :\n";
-print "  1: {$nom} 2: {$second_nom} 3: {$poids}\n\n";
+print "Valeurs des paramètres associés _avant_ CALL :\n";
+print "  1: {$name} 2: {$second_name} 3: {$weight}\n\n";
 
 if (db2_execute($stmt)) {
-    print "Valeurs des paramètres _après_ CALL :\n";
-    print "  1: {$nom} 2: {$second_nom} 3: {$poids}\n\n";
+    print "Valeurs des paramètres associés _après_ CALL :\n";
+    print "  1: {$name} 2: {$second_name} 3: {$weight}\n\n";
 
     print "Résultats :\n";
     while ($row = db2_fetch_array($stmt)) {
@@ -239,16 +238,16 @@ if (db2_execute($stmt)) {
     &example.outputs;
     <screen>
 <![CDATA[
-Valeurs des paramètres _avant_ CALL :
+Valeurs des paramètres associés _avant_ CALL :
   1: Peaches 2: Rickety Ride 3: 0
 
-Valeurs des paramètres _après_ CALL :
+Valeurs des paramètres associés _après_ CALL :
   1: Peaches 2: TRUE 3: 22
 
 Résultats :
-  Peaches, chien, 12.3
-  Pook, chat, 3.2
-  Rickety Ride, chèvre, 9.7
+  Peaches, dog, 12.3
+  Pook, cat, 3.2
+  Rickety Ride, goat, 9.7
 ]]>
     </screen>
    </example>
@@ -266,7 +265,7 @@ Résultats :
     <programlisting role="php">
 <![CDATA[
 <?php
-$stmt = db2_prepare($conn, "INSERT INTO animal_pictures(photo) VALUES (?)");
+$stmt = db2_prepare($conn, "INSERT INTO animal_pictures(picture) VALUES (?)");
 
 $picture = "/opt/albums/spook/grooming.jpg";
 $rc = db2_bind_param($stmt, 1, "picture", DB2_PARAM_FILE);

--- a/reference/ibm_db2/functions/db2-client-info.xml
+++ b/reference/ibm_db2/functions/db2-client-info.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 020edc73be983e8e2aca04782ff7c901da4afad7 Maintainer: jsgoupil Status: ready -->
+<!-- EN-Revision: 020edc73be983e8e2aca04782ff7c901da4afad7 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.db2-client-info">
  <refnamediv>
@@ -23,7 +23,7 @@
     <tgroup cols="3">
      <thead>
       <row>
-       <entry>Nom Propriété</entry>
+       <entry>Nom de la propriété</entry>
        <entry>Type de retour</entry>
        <entry>Description</entry>
       </row>
@@ -32,7 +32,7 @@
       <row>
        <entry>APPL_CODEPAGE</entry>
        <entry>&integer;</entry>
-       <entry>L'application est un code page.</entry>
+       <entry>Le code page de l'application.</entry>
       </row>
       <row>
        <entry>CONN_CODEPAGE</entry>
@@ -42,7 +42,7 @@
       <row>
        <entry>DATA_SOURCE_NAME</entry>
        <entry>&string;</entry>
-       <entry>Le nom source de la donnée (DSN) utilisé pour créer la connexion
+       <entry>Le nom de la source de données (DSN) utilisé pour créer la connexion
         courante à la base de données.</entry>
       </row>
       <row>
@@ -74,7 +74,7 @@
        <entry>ODBC_SQL_CONFORMANCE</entry>
        <entry>&string;</entry>
        <entry>
-        <para>Le niveau de grammaire supporté par le client :
+        <para>Le niveau de grammaire SQL ODBC supporté par le client :
          <variablelist>
           <varlistentry>
            <term>MINIMUM</term>
@@ -166,7 +166,7 @@ if ($client) {
 }
 else {
     echo "Erreur de récupération des informations du client.
-     Peut-être que votre connexion à la base de données était invalide.";
+     Peut-être que la connexion à la base de données était invalide.";
 }
 db2_close($conn);
 

--- a/reference/ibm_db2/functions/db2-column-privileges.xml
+++ b/reference/ibm_db2/functions/db2-column-privileges.xml
@@ -61,8 +61,8 @@
     <term><parameter>table_name</parameter></term>
     <listitem>
      <simpara>
-      Le nom de la table. Pour obtenir toutes les tables dans la base de
-      données, passez &null; ou une chaîne vide.
+      Le nom de la table ou de la vue. Pour obtenir toutes les tables dans la
+      base de données, passez &null; ou une chaîne vide.
      </simpara>
     </listitem>
    </varlistentry>
@@ -103,7 +103,7 @@
       </row>
       <row>
        <entry>TABLE_NAME</entry>
-       <entry>Nom de la table.</entry>
+       <entry>Nom de la table ou de la vue.</entry>
       </row>
       <row>
        <entry>COLUMN_NAME</entry>
@@ -124,7 +124,7 @@
       </row>
       <row>
        <entry>IS_GRANTABLE</entry>
-       <entry>Si GRANTEE est permis pour donner ce privilège à d'autres
+       <entry>Si GRANTEE a la permission d'accorder ce privilège à d'autres
        utilisateurs.</entry>
       </row>
      </tbody>

--- a/reference/ibm_db2/functions/db2-columns.xml
+++ b/reference/ibm_db2/functions/db2-columns.xml
@@ -61,8 +61,8 @@
     <term><parameter>table_name</parameter></term>
     <listitem>
      <simpara>
-      Le nom de la table. Pour obtenir toutes les tables dans la base de
-      données, passez &null; ou une chaîne vide.
+      Le nom de la table ou de la vue. Pour obtenir toutes les tables dans
+      la base de données, passez &null; ou une chaîne vide.
      </simpara>
     </listitem>
    </varlistentry>
@@ -81,8 +81,8 @@
   &reftitle.returnvalues;
   <para>
    Retourne une ressource avec le jeu de résultats contenant les lignes qui
-   décrivent les privilèges des colonnes concordant avec les paramètres
-   spécifiés. Les lignes sont composées des colonnes suivantes :
+   décrivent les colonnes concordant avec les paramètres spécifiés. Les
+   lignes sont composées des colonnes suivantes :
    <informaltable>
     <tgroup cols="2">
      <thead>
@@ -103,7 +103,7 @@
       </row>
       <row>
        <entry>TABLE_NAME</entry>
-       <entry>Nom de la table.</entry>
+       <entry>Nom de la table ou de la vue.</entry>
       </row>
       <row>
        <entry>COLUMN_NAME</entry>
@@ -124,19 +124,19 @@
       </row>
       <row>
        <entry>BUFFER_LENGTH</entry>
-       <entry>Nombre d'octets maximaux nécessaires pour enregistrer des données
+       <entry>Nombre maximal d'octets nécessaires pour enregistrer des données
        de cette colonne.</entry>
       </row>
       <row>
        <entry>DECIMAL_DIGITS</entry>
-       <entry>L'échelle de la colonne ou &null; où l'échelle n'est pas
+       <entry>L'échelle de la colonne ou &null; lorsque l'échelle n'est pas
        applicable.</entry>
       </row>
       <row>
        <entry>NUM_PREC_RADIX</entry>
        <entry>Un entier pouvant être <literal>10</literal> (représentant un
        type de données numérique exact), <literal>2</literal> (représentant un
-       type de données numériques approximé) ou &null; (représentant un type
+       type de données numérique approximatif) ou &null; (représentant un type
        de données pour lequel la base n'est pas applicable).</entry>
       </row>
       <row>
@@ -159,14 +159,14 @@
        <entry>SQL_DATETIME_SUB</entry>
        <entry>Retourne un entier représentant un code de sous-type
        <literal>datetime</literal> ou
-       &null; si les types de données SQL n'appliquent pas.</entry>
+       &null; pour les types de données SQL auxquels cela ne s'applique pas.</entry>
       </row>
       <row>
        <entry>CHAR_OCTET_LENGTH</entry>
-       <entry>Grandeur maximale en octets pour les types de données d'un
-       caractère de la colonne, qui concorde avec COLUMN_SIZE pour un seul
-       octet de données ou &null; pour un type de données qui n'est pas des
-       caractères.</entry>
+       <entry>Longueur maximale en octets pour une colonne de type
+       caractère, qui concorde avec COLUMN_SIZE pour les données d'un jeu
+       de caractères sur un octet, ou &null; pour les types de données
+       non-caractères.</entry>
       </row>
       <row>
        <entry>ORDINAL_POSITION</entry>
@@ -174,8 +174,8 @@
       </row>
       <row>
        <entry>IS_NULLABLE</entry>
-       <entry>Une chaîne dont la valeur est 'YES' signifie que la colonne est
-       nulle et 'NO' signifie que la colonne ne peut être nulle.</entry>
+       <entry>Une chaîne dont la valeur 'YES' signifie que la colonne peut
+       être nulle et 'NO' signifie que la colonne ne peut être nulle.</entry>
       </row>
      </tbody>
     </tgroup>

--- a/reference/ibm_db2/functions/db2-commit.xml
+++ b/reference/ibm_db2/functions/db2-commit.xml
@@ -17,11 +17,11 @@
   </methodsynopsis>
 
   <simpara>
-   Envoie une requête en cours sur la ressource de connexion spécifiée et
+   Valide une transaction en cours sur la ressource de connexion spécifiée et
    commence une nouvelle transaction. Les applications PHP ont normalement
-   pour valeur par défaut AUTOCOMMIT d'activé, alors
+   le mode AUTOCOMMIT activé par défaut, donc
    <function>db2_commit</function> n'est pas nécessaire tant que AUTOCOMMIT
-   n'est pas désactivée pour la ressource de connexion.
+   n'est pas désactivé pour la ressource de connexion.
   </simpara>
 
  </refsect1>
@@ -32,7 +32,7 @@
     <term><parameter>connection</parameter></term>
     <listitem>
      <simpara>
-      Une variable ressource de connexion valide retournée par
+      Une variable ressource de connexion à la base de données valide retournée par
       <function>db2_connect</function> ou <function>db2_pconnect</function>.
      </simpara>
     </listitem>

--- a/reference/ibm_db2/functions/db2-conn-error.xml
+++ b/reference/ibm_db2/functions/db2-conn-error.xml
@@ -20,10 +20,10 @@
   <simpara>
    <function>db2_conn_error</function> retourne la valeur de SQLSTATE
    représentant la raison pour laquelle la dernière tentative de connexion à
-   la base de données a échoué. Lorsque <function>db2_connect</function>
-   retourne &false; en cas d'une tentative de connexion échouée, ne passez
-   aucun paramètre à <function>db2_conn_error</function> pour obtenir la
-   valeur de SQLSTATE.
+   la base de données a échoué. Comme <function>db2_connect</function>
+   retourne &false; en cas de tentative de connexion échouée, il ne faut
+   passer aucun paramètre à <function>db2_conn_error</function> pour obtenir
+   la valeur de SQLSTATE.
   </simpara>
   <simpara>
    Si par contre la connexion était réussie mais est devenue invalide avec le

--- a/reference/ibm_db2/functions/db2-conn-errormsg.xml
+++ b/reference/ibm_db2/functions/db2-conn-errormsg.xml
@@ -20,11 +20,11 @@
   <simpara>
    <function>db2_conn_errormsg</function> retourne un message d'erreur et la
    valeur de SQLCODE représentant la raison pour laquelle la dernière tentative
-   de connexion à la base de données a échoué. Lorsque
+   de connexion à la base de données a échoué. Comme
    <function>db2_connect</function> retourne &false; en cas d'une tentative de
-   connexion échouée, ne passez aucun paramètre à
+   connexion échouée, il ne faut passer aucun paramètre à
    <function>db2_conn_errormsg</function> pour obtenir le message d'erreur et
-   la valeur de SQLCODE.
+   la valeur de SQLCODE associés.
   </simpara>
   <simpara>
    Si par contre la connexion était réussie mais est devenue invalide avec le
@@ -69,7 +69,7 @@
    <programlisting role="php">
 <![CDATA[
 <?php
-$conn = db2_connect('mauvaisnom', 'mauvaisutilisateur', 'mauvaismotdepasse');
+$conn = db2_connect('badname', 'baduser', 'badpassword');
 if (!$conn) {
     print db2_conn_errormsg();
 }
@@ -80,7 +80,7 @@ if (!$conn) {
    <screen>
 <![CDATA[
 [IBM][CLI Driver] SQL1013N  The database alias name
-or database name "MAUVAISNOM" could not be found.  SQLSTATE=42705
+or database name "BADNAME" could not be found.  SQLSTATE=42705
  SQLCODE=-1013
 ]]>
    </screen>

--- a/reference/ibm_db2/functions/db2-connect.xml
+++ b/reference/ibm_db2/functions/db2-connect.xml
@@ -139,8 +139,8 @@
           sur cette connexion.
          </simpara>
          <simpara>
-          La valeur <constant>DB2_AUTOCOMMIT_OFF</constant> désactive le
-          autocommit pour cette connexion.
+          La valeur <constant>DB2_AUTOCOMMIT_OFF</constant> désactive
+          l'autocommit pour cette connexion.
          </simpara>
         </listitem>
        </varlistentry>
@@ -171,7 +171,7 @@
          </simpara>
          <simpara>
           Passer la valeur <constant>DB2_SCROLLABLE</constant> spécifie un
-          curseur scrollable pour une ressource de requête. Ce mode permet
+          curseur défilant pour une ressource de requête. Ce mode permet
           un accès aléatoire aux lignes dans un jeu de résultats, mais actuellement,
           n'est supporté que par la base de données IBM DB2 Universal.
          </simpara>
@@ -188,8 +188,8 @@
         <listitem>
          <simpara>
           Le fait de passer la valeur DB2_TRUSTED_CONTEXT_ENABLE active le contexte
-          pour ce gestionnaire de connexion. Ce paramètre ne peut être défini avec
-          la fonction <function>db2_set_option</function>.
+          de confiance pour ce gestionnaire de connexion. Ce paramètre ne peut
+          être défini avec la fonction <function>db2_set_option</function>.
          </simpara>
          <simpara>
           Cette clé fonctionne uniquement si la base de données est cataloguée
@@ -226,56 +226,57 @@ db2set DB2COMM=TCPIP</literallayout>
         <term><parameter>i5_naming</parameter></term>
         <listitem>
          <simpara>
-          La valeur <literal>DB2_I5_NAMING_ON</literal> active DB2 UDB Cli
-          iSeries mode système de nom. Les fichiers sont qualifiés en
+          La valeur <literal>DB2_I5_NAMING_ON</literal> active le mode de
+          nommage système iSeries de DB2 UDB CLI. Les fichiers sont qualifiés en
           utilisant le délimiteur slash (/). Les fichiers non qualifiés sont
           résolus en utilisant la liste de bibliothèque pour le travail.
          </simpara>
          <simpara>
-          La valeur <literal>DB2_I5_NAMING_OFF</literal> désactive DB2 UDB
-          CLI mode de nom par défaut, qui est l'écriture SQL. Les fichiers
+          La valeur <literal>DB2_I5_NAMING_OFF</literal> désactive le
+          mode de nommage par défaut de DB2 UDB CLI, qui est le nommage SQL. Les fichiers
           sont qualifiés en utilisant le délimiteur point (.). Les fichiers
           non qualifiés sont résolus en utilisant soit la bibliothèque par
-          défaut ou l'ID de l'usager courant.
+          défaut, soit l'ID de l'utilisateur courant.
          </simpara>
         </listitem>
        </varlistentry>
        <varlistentry>
         <term><parameter>i5_commit</parameter></term>
         <listitem>
-         <simpara>
+         <para>
           L'attribut <parameter>i5_commit</parameter> devrait être fixé avant
           l'appel à <function>db2_connect</function>. Si la valeur est
-          changée après que la connexion ait été établie et que la connexion
+          changée après que la connexion a été établie et que la connexion
           est à une source de données distante, le changement ne prendra
-          effet qu'au prochain appel de <function>db2_connect</function>.
-         </simpara>
-         <note>
+          effet qu'au prochain appel réussi de <function>db2_connect</function>
+          pour le gestionnaire de connexion.
+          <note>
            <simpara>
            La configuration php.ini <parameter>ibm_db2.i5_allow_commit</parameter>==0
            ou <literal>DB2_I5_TXN_NO_COMMIT</literal> est par défaut, mais
-           peut être dérivée avec l'option <parameter>i5_commit</parameter>.
+           peut être remplacée avec l'option <parameter>i5_commit</parameter>.
            </simpara>
-         </note>
+          </note>
+         </para>
          <simpara>
-          <literal>DB2_I5_TXN_NO_COMMIT</literal> : contrôle d'envoi n'est pas utilisé.
+          <literal>DB2_I5_TXN_NO_COMMIT</literal> : le contrôle de validation n'est pas utilisé.
          </simpara>
          <simpara>
-          <literal>DB2_I5_TXN_READ_UNCOMMITTED</literal> : lecture ancienne,
-          lecture non répétitive et fictive est possible.
+          <literal>DB2_I5_TXN_READ_UNCOMMITTED</literal> : Les lectures sales,
+          non répétables et fantômes sont possibles.
          </simpara>
          <simpara>
-          <literal>DB2_I5_TXN_READ_COMMITTED</literal> : lecture ancienne non
-          possible. La lecture répétitive et fictive est possible.
+          <literal>DB2_I5_TXN_READ_COMMITTED</literal> : Les lectures sales ne
+          sont pas possibles. Les lectures non répétables et fantômes sont possibles.
          </simpara>
          <simpara>
-          <literal>DB2_I5_TXN_REPEATABLE_READ</literal> : lecture ancienne et
-          non répétitive n'est pas possible. Lecture fictive est possible.
+          <literal>DB2_I5_TXN_REPEATABLE_READ</literal> : Les lectures sales et
+          non répétables ne sont pas possibles. Les lectures fantômes sont possibles.
          </simpara>
          <simpara>
           <literal>DB2_I5_TXN_SERIALIZABLE</literal> : les transactions sont
-          sérialisées. Lecture ancienne, non répétitive et fictive n'est
-          pas possible.
+          sérialisées. Les lectures sales, non répétables et fantômes ne sont
+          pas possibles.
          </simpara>
         </listitem>
        </varlistentry>
@@ -285,20 +286,20 @@ db2set DB2COMM=TCPIP</literallayout>
          <simpara>
            <literal>DB2_FIRST_IO</literal> Toutes les requêtes sont
            optimisées avec le but de retourner la première page aussi vite
-           que possible. Ce but fonctionne bien lorsque l'affichage est
-           contrôlé par un utilisateur qui peut annuler une requête après
+           que possible. Ce but fonctionne bien lorsque les données de sortie sont
+           contrôlées par un utilisateur qui est le plus susceptible d'annuler une requête après
            avoir vu la première page des données. Les requêtes sont codées
-           avec une clause <literal>"OPTIMIZE nnn ROWS"</literal> afin de
-           réussir le but spécifié par la clause.
+           avec une clause <literal>"OPTIMIZE FOR nnn ROWS"</literal> afin de
+           honorer le but spécifié par la clause.
          </simpara>
          <simpara>
           <literal>DB2_ALL_IO</literal> Toutes les requêtes sont optimisées
-          avec le but de retourner l'entière requête dans le plus petit
-          intervalle de temps. Ceci est une bonne option lorsque l'affichage
-          d'une requête est en train d'être écrit vers un fichier ou un
-          rapport ou encore lorsque l'interface met en queue les données. Les
+          avec le but d'exécuter la requête entière jusqu'à la fin dans le plus petit
+          intervalle de temps. C'est une bonne option lorsque les données de sortie
+          d'une requête sont en train d'être écrites vers un fichier ou un
+          rapport ou encore lorsque l'interface met en file d'attente les données. Les
           requêtes sont codées avec une clause <literal>"OPTIMIZE FOR nnn ROWS"</literal> afin de
-          réussir le but spécifié par la clause. Ceci est l'opération par
+          honorer le but spécifié par la clause. C'est la valeur par
           défaut.
          </simpara>
         </listitem>
@@ -308,18 +309,19 @@ db2set DB2COMM=TCPIP</literallayout>
         <listitem>
          <simpara>
           La valeur <literal>DB2_I5_DBCS_ALLOC_ON</literal> active le canevas
-          d'allocation DB2 6X pour l'accroissement des tailles des colonnes.
+          d'allocation DB2 6X pour l'accroissement des tailles des colonnes
+          en traduction DBCS.
          </simpara>
          <simpara>
           La valeur <literal>DB2_I5_DBCS_ALLOC_OFF</literal> désactive le
           canevas d'allocation DB2 6X pour l'accroissement des tailles des
-          colonnes.
+          colonnes en traduction DBCS.
          </simpara>
          <simpara>
           Note : la configuration &php.ini;
           <parameter>ibm_db2.i5_dbcs_alloc</parameter>==0 ou
           <literal>DB2_I5_DBCS_ALLOC_OFF</literal> est par défaut mais peut
-          être dérivée avec l'option <parameter>i5_dbcs_alloc</parameter>.
+          être remplacée avec l'option <parameter>i5_dbcs_alloc</parameter>.
          </simpara>
         </listitem>
        </varlistentry>
@@ -336,12 +338,12 @@ db2set DB2COMM=TCPIP</literallayout>
           États-Unis <literal>"mm/dd/yyyy"</literal> est utilisé.
          </simpara>
          <simpara>
-          <literal>DB2_I5_FMT_EUR</literal> : le format de date Européen
+          <literal>DB2_I5_FMT_EUR</literal> : le format de date européen
           <literal>"dd.mm.yyyy"</literal> est utilisé.
          </simpara>
          <simpara>
           <literal>DB2_I5_FMT_JIS</literal> : le format de date de
-          l'industrie japonaise des standards <literal>"yyyy-mm-dd"</literal> est utilisé.
+          la norme industrielle japonaise (JIS) <literal>"yyyy-mm-dd"</literal> est utilisé.
          </simpara>
          <simpara>
           <literal>DB2_I5_FMT_MDY</literal> : le format de date <literal>"mm/dd/yyyy"</literal>
@@ -356,7 +358,7 @@ db2set DB2COMM=TCPIP</literallayout>
           utilisé.
          </simpara>
          <simpara>
-          <literal>DB2_I5_FMT_JUL</literal> : le format de date Julien <literal>"yy/ddd"</literal>
+          <literal>DB2_I5_FMT_JUL</literal> : le format de date julien <literal>"yy/ddd"</literal>
           est utilisé.
          </simpara>
          <simpara>
@@ -399,7 +401,7 @@ db2set DB2COMM=TCPIP</literallayout>
         <listitem>
          <simpara>
           <literal>DB2_I5_FMT_ISO</literal> : le format de l'heure de
-          l'organisation internationale de normalisation <literal>"hh.mm.ss"</literal> est
+          l'organisation internationale de normalisation (ISO) <literal>"hh.mm.ss"</literal> est
           utilisé. Ceci est la valeur par défaut.
          </simpara>
          <simpara>
@@ -408,12 +410,12 @@ db2set DB2COMM=TCPIP</literallayout>
           vaut <literal>"AM"</literal> ou <literal>"PM"</literal>.
          </simpara>
          <simpara>
-          <literal>DB2_I5_FMT_EUR</literal> : le format de l'heure Européen
+          <literal>DB2_I5_FMT_EUR</literal> : le format de l'heure européen
           <literal>"hh.mm.ss"</literal> est utilisé.
          </simpara>
          <simpara>
           <literal>DB2_I5_FMT_JIS</literal> : le format de l'heure de
-          l'industrie japonaise des standards <literal>"hh:mm:ss"</literal> est utilisé.
+          la norme industrielle japonaise <literal>"hh:mm:ss"</literal> est utilisé.
          </simpara>
          <simpara>
           <literal>DB2_I5_FMT_HMS</literal> : le format <literal>"hh:mm:ss"</literal> est utilisé.
@@ -425,20 +427,20 @@ db2set DB2COMM=TCPIP</literallayout>
         <listitem>
          <simpara>
           <literal>DB2_I5_SEP_COLON</literal> : un deux-points ( : ) est
-          utilisé en tant que séparateur de temps. Ceci est la valeur par
+          utilisé en tant que séparateur d'heure. Ceci est la valeur par
           défaut.
          </simpara>
          <simpara>
           <literal>DB2_I5_SEP_PERIOD</literal> : un point ( . ) est utilisé
-          en tant que séparateur de temps.
+          en tant que séparateur d'heure.
          </simpara>
          <simpara>
           <literal>DB2_I5_SEP_COMMA</literal> : une virgule ( , ) est
-          utilisée en tant que séparateur de temps.
+          utilisée en tant que séparateur d'heure.
          </simpara>
          <simpara>
           <literal>DB2_I5_SEP_BLANK</literal> : un espace blanc est utilisé
-          en tant que séparateur de temps.
+          en tant que séparateur d'heure.
          </simpara>
          <simpara>
           <literal>DB2_I5_SEP_JOB</literal> : la valeur par défaut est
@@ -466,21 +468,21 @@ db2set DB2COMM=TCPIP</literallayout>
       </variablelist>
      </para>
      <para>
-      La nouvelle option i5/OS suivante est disponible depuis la version ibm_db2
-      1.8.0 et suivantes.
+      La nouvelle option i5/OS suivante est disponible à partir de la version ibm_db2
+      1.8.0.
       <variablelist>
        <varlistentry>
         <term><parameter>i5_libl</parameter></term>
         <listitem>
          <simpara>
-          Une chaîne indiquant la liste à utiliser pour résoudre les références
+          Une chaîne indiquant la liste de bibliothèques à utiliser pour résoudre les références
           de fichiers non qualifiés. Spécifier la liste en séparant les
           valeurs par un espace, comme ceci : 'i5_libl'=&gt;"MYLIB YOURLIB ANYLIB".
          </simpara>
          <note>
           <simpara>
            <parameter>i5_libl</parameter> appelle <literal>qsys2/qcmdexc('cmd',cmdlen)</literal>,
-           qui n'est disponible que depuis i5/OS V5R4.
+           qui n'est disponible qu'à partir de i5/OS V5R4.
           </simpara>
          </note>
         </listitem>
@@ -508,7 +510,7 @@ db2set DB2COMM=TCPIP</literallayout>
     <simpara>
      Les connexions cataloguées nécessitent que l'on ait préalablement
      catalogué la base de données spécifiée à l'aide du processeur de ligne de
-     commandes DB2 (<literal>"Command Line Processor"</literal> : cLP) ou avec l'assistant de
+     commandes DB2 (<literal>"Command Line Processor"</literal> : CLP) ou avec l'assistant de
      configuration de DB2.
     </simpara>
     <programlisting role="php">
@@ -617,9 +619,9 @@ Autocommit est désactivé.
    <example>
     <title>Meilleure performance i5/OS</title>
     <simpara>
-     Pour réussir à utiliser les meilleures performance du i5/OS ibm_db2
-     1.5.1, l'application PHP utilise l'hôte par défaut, le userid et le mot
-     de passe pour le <function>db2_connect</function>.
+     Pour obtenir les meilleures performances de l'application PHP i5/OS
+     ibm_db2 1.5.1, utiliser l'hôte par défaut, l'identifiant utilisateur et
+     le mot de passe pour l'appel à <function>db2_connect</function>.
     </simpara>
     <programlisting role="php">
 <![CDATA[
@@ -645,9 +647,9 @@ PICTURES
     </screen>
    </example>
    <example>
-    <title>Utilisation du contexte</title>
+    <title>Utilisation du contexte de confiance</title>
     <simpara>
-     L'exemple suivant montre comment activer le contexte, changer d'utilisateur
+     L'exemple suivant montre comment activer le contexte de confiance, changer d'utilisateur
      et récupérer l'ID de l'utilisateur courant.
     </simpara>
     <programlisting role="php">
@@ -669,14 +671,14 @@ $options = array ("trustedcontext" => DB2_TRUSTED_CONTEXT_ENABLE);
 
 $tc_conn = db2_connect($dsn, "", "", $options);
 if($tc_conn) {
-    echo "Explicit trusted connection succeeded.\n";
+    echo "Connexion explicite de confiance réussie.\n";
 
     if(db2_get_option($tc_conn, "trustedcontext")) {
         $userBefore = db2_get_option($tc_conn, "trusted_user");
 
         //Code en tant qu'utilisateur 1.
 
-        //Modification en l'utilisateur de confiance.
+        //Passage à l'utilisateur de confiance.
         $parameters = array("trusted_user" => $tc_user,
           "trusted_password" => $tcuser_pass);
         $res = db2_set_option ($tc_conn, $parameters, 1);
@@ -692,7 +694,7 @@ if($tc_conn) {
     db2_close($tc_conn);
 }
 else {
-    echo "Le changement de contexte de connexion a échoué.\n";
+    echo "La connexion explicite de confiance a échoué.\n";
 }
 ?>
 
@@ -701,7 +703,7 @@ else {
     &example.outputs;
     <screen>
 <![CDATA[
-Le changement de contexte de connexion a échoué.
+Connexion explicite de confiance réussie.
 L'utilisateur a changé.
 ]]>
     </screen>

--- a/reference/ibm_db2/functions/db2-cursor-type.xml
+++ b/reference/ibm_db2/functions/db2-cursor-type.xml
@@ -6,7 +6,7 @@
  <refnamediv>
   <refname>db2_cursor_type</refname>
   <refpurpose>
-   Retourne le type de curseur utilisé par une ressource
+   Retourne le type de curseur utilisé par une ressource d'instruction
   </refpurpose>
  </refnamediv>
  <refsect1 role="description">
@@ -17,9 +17,9 @@
   </methodsynopsis>
 
   <simpara>
-   Retourne le type de curseur utilisé par une ressource. Cette fonction
-   permet de déterminer si l'on travaille avec un curseur à avancement
-   seul ou un curseur flottant.
+   Retourne le type de curseur utilisé par une ressource d'instruction.
+   Cette fonction permet de déterminer si l'on travaille avec un curseur
+   à avance seul ou un curseur flottant.
   </simpara>
 
  </refsect1>
@@ -30,7 +30,7 @@
     <term><parameter>stmt</parameter></term>
     <listitem>
      <simpara>
-      Une ressource valide.
+      Une ressource d'instruction valide.
      </simpara>
     </listitem>
    </varlistentry>
@@ -39,9 +39,9 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   Retourne <constant>DB2_FORWARD_ONLY</constant> si la ressource utilise un
-   curseur à avance seul ou <constant>DB2_SCROLLABLE</constant> si la ressource
-   utilise un curseur flottant.
+   Retourne <constant>DB2_FORWARD_ONLY</constant> si la ressource d'instruction
+   utilise un curseur à avance seul ou <constant>DB2_SCROLLABLE</constant>
+   si la ressource d'instruction utilise un curseur flottant.
   </simpara>
  </refsect1>
 

--- a/reference/ibm_db2/functions/db2-escape-string.xml
+++ b/reference/ibm_db2/functions/db2-escape-string.xml
@@ -31,7 +31,7 @@
       Une &string; qui contient des caractères spéciaux qui doivent être modifiés.
       Les caractères qui sont transformés à l'aide d'un antislash sont <literal>\x00</literal>,
       <literal>\n</literal>, <literal>\r</literal>, <literal>\</literal>,
-      <literal>'</literal> <literal>"</literal> et <literal>\x1a</literal>.
+      <literal>'</literal>, <literal>"</literal> et <literal>\x1a</literal>.
      </simpara>
     </listitem>
    </varlistentry>

--- a/reference/ibm_db2/functions/db2-exec.xml
+++ b/reference/ibm_db2/functions/db2-exec.xml
@@ -64,8 +64,8 @@
     <term><parameter>options</parameter></term>
     <listitem>
      <simpara>
-      Un tableau associatif contenant les options de la requête. Il est possible de
-      utiliser ce paramètre pour demander un curseur flottant sur les
+      Un tableau associatif contenant les options de la requête. Il est possible
+      d'utiliser ce paramètre pour demander un curseur flottant sur les
       serveurs de base de données qui supportent cette fonctionnalité.
      </simpara>
      <simpara>
@@ -217,9 +217,9 @@ db2_close($conn);
     <title>Exécuter un "JOIN" avec des données XML</title>
     <simpara>
      L'exemple suivant fonctionne avec des documents enregistrés dans deux
-     colonnes différentes dans la base de données SAMPLE. Cela crée deux
-     tables temporaires provenant des documents XML de deux différentes
-     colonnes XML et retourne un ResultSet SQL avec les informations contenant
+     colonnes XML différentes de la base de données SAMPLE. Cela crée deux
+     tables temporaires provenant des documents XML de deux colonnes XML
+     différentes et retourne un ResultSet SQL avec les informations contenant
      le statut de livraison pour un client.
     </simpara>
     <programlisting role="php">

--- a/reference/ibm_db2/functions/db2-execute.xml
+++ b/reference/ibm_db2/functions/db2-execute.xml
@@ -23,14 +23,14 @@
   </simpara>
   <simpara>
    Si la requête SQL retourne un jeu de résultats, par exemple, une requête
-   SELECT ou CALL à une procédure d'enregistrement retourne un ou
+   SELECT ou un CALL à une procédure stockée retournant un ou
    plusieurs jeux de résultats, il est possible de récupérer une ligne en tant que
    tableau à partir de la ressource <literal>stmt</literal> en utilisant
    <function>db2_fetch_assoc</function>,
    <function>db2_fetch_both</function> ou
    <function>db2_fetch_array</function>. Alternativement, il est possible d'utiliser
-   <function>db2_fetch_row</function> pour déplacer le pointeur à
-   la ligne suivante et récupérer une colonne à la fois de cette ligne avec la
+   <function>db2_fetch_row</function> pour déplacer le pointeur du jeu de résultats
+   à la ligne suivante et récupérer une colonne à la fois de cette ligne avec la
    fonction <function>db2_result</function>.
   </simpara>
   <simpara>
@@ -83,9 +83,9 @@
     <programlisting role="php">
 <![CDATA[
 <?php
-$pet = array(0, 'chat', 'Pook', 3.2);
+$pet = array(0, 'cat', 'Pook', 3.2);
 
-$insert = 'INSERT INTO animaux (id, race, nom, poids)
+$insert = 'INSERT INTO animals (id, breed, name, weight)
     VALUES (?, ?, ?, ?)';
 
 $stmt = db2_prepare($conn, $insert);
@@ -106,7 +106,7 @@ Ajout d'un nouvel animal réussi.
     </screen>
    </example>
    <example>
-    <title>Appel d'une procédure d'enregistrement avec un paramètre de SORTIE</title>
+    <title>Appel d'une procédure stockée avec un paramètre de SORTIE</title>
     <simpara>
      L'exemple suivant prépare une requête CALL qui accepte un marqueur qui
      représente un paramètre de SORTIE, lie la variable PHP <literal>$my_pets</literal>
@@ -115,7 +115,7 @@ Ajout d'un nouvel animal réussi.
      <function>db2_execute</function> pour exécuter la requête
      CALL. Une fois que la requête CALL a été exécutée, la valeur de
      <literal>$num_pets</literal> change pour refléter la valeur retournée
-     par la procédure d'enregistrement pour ce paramètre de SORTIE.
+     par la procédure stockée pour ce paramètre de SORTIE.
     </simpara>
     <programlisting role="php">
 <![CDATA[

--- a/reference/ibm_db2/functions/db2-fetch-array.xml
+++ b/reference/ibm_db2/functions/db2-fetch-array.xml
@@ -42,8 +42,8 @@
     <listitem>
      <simpara>
       Demande une ligne spécifique indexée numériquement qui commence par la
-      valeur 1 au jeu de résultat. En fournissant ce paramètre,
-      une alerte PHP sera générée si le jeu de résultat
+      valeur 1 au jeu de résultats. En fournissant ce paramètre,
+      une alerte PHP sera générée si le jeu de résultats
       utilise un curseur d'avancement seul.
      </simpara>
     </listitem>

--- a/reference/ibm_db2/functions/db2-fetch-assoc.xml
+++ b/reference/ibm_db2/functions/db2-fetch-assoc.xml
@@ -41,8 +41,8 @@
     <listitem>
      <simpara>
       Demande une ligne spécifique indexée numériquement qui commence par la
-      valeur 1 au jeu de résultat. En fournissant ce paramètre,
-      une alerte PHP sera générée si le jeu de résultat
+      valeur 1 dans le jeu de résultats. En fournissant ce paramètre,
+      une alerte PHP sera générée si le jeu de résultats
       utilise un curseur d'avancement seul.
      </simpara>
     </listitem>

--- a/reference/ibm_db2/functions/db2-fetch-both.xml
+++ b/reference/ibm_db2/functions/db2-fetch-both.xml
@@ -45,9 +45,8 @@
     <listitem>
      <simpara>
       Demande une ligne spécifique indexée numériquement qui commence par la
-      valeur 1 au jeu de résultat. En fournissant ce paramètre,
-      une alerte PHP sera générée si le jeu de résultat
-      utilise un curseur d'avancement seul.
+      valeur 1 dans le jeu de résultats. Fournir ce paramètre génère une
+      alerte PHP si le jeu de résultats utilise un curseur d'avancement seul.
      </simpara>
     </listitem>
    </varlistentry>
@@ -70,12 +69,13 @@
   &reftitle.examples;
   <para>
    <example>
-    <title>Itère avec un curseur d'avancement seul</title>
+    <title>Itération avec un curseur d'avancement seul</title>
     <simpara>
      Si l'on appelle <function>db2_fetch_both</function> sans le numéro d'une
-     ligne spécifique, la ligne suivante sera automatiquement récupérée par le
-     jeu de résultats. L'exemple suivant accède aux colonnes retournées dans
-     le tableau avec la méthode des noms de colonne et par indice numérique.
+     ligne spécifique, la ligne suivante du jeu de résultats sera
+     automatiquement récupérée. L'exemple suivant accède aux colonnes
+     retournées dans le tableau à la fois par nom de colonne et par indice
+     numérique.
     </simpara>
     <programlisting role="php">
 <![CDATA[

--- a/reference/ibm_db2/functions/db2-fetch-object.xml
+++ b/reference/ibm_db2/functions/db2-fetch-object.xml
@@ -40,9 +40,8 @@
     <listitem>
      <simpara>
       Demande une ligne spécifique commençant à l'index 1 du jeu de
-      résultats. Si l'on passe ce paramètre, le résultat sera une
-      alerte PHP si le résultat utilise un curseur à avancement
-      seul.
+      résultats. Le passage de ce paramètre entraîne une alerte PHP
+      si le jeu de résultats utilise un curseur unidirectionnel.
      </simpara>
     </listitem>
    </varlistentry>
@@ -56,17 +55,17 @@
    résultats.
   </simpara>
   <simpara>
-   Les serveurs IBM DB2, Cloudscape et Apache Derby remplissent normalement les
-   nom des colonnes avec des majuscules, par conséquent, les propriétés de
-   l'objet refléteront ce cas.
+   Les serveurs IBM DB2, Cloudscape et Apache Derby mettent normalement les
+   noms des colonnes en majuscules, par conséquent, les propriétés de
+   l'objet refléteront cette casse.
   </simpara>
   <simpara>
    Si la requête SELECT appelle une fonction scalaire pour modifier la
    valeur d'une colonne, les serveurs de base de données retournent le numéro
    de colonne en tant que nom de colonne dans le jeu de résultats. Si l'on
-   préfère une description plus détaillée du nom des colonnes et des
-   propriétés de l'objet, il est possible d'utiliser la clause AS pour assigner un
-   nom à la colonne dans le jeu de résultats.
+   préfère un nom de colonne et une propriété d'objet plus descriptifs,
+   il est possible d'utiliser la clause AS pour assigner un nom à la colonne
+   dans le jeu de résultats.
   </simpara>
   <simpara>
    Retourne &false; si aucune ligne n'a été récupérée.
@@ -80,10 +79,10 @@
    <simpara>
     L'exemple suivant envoie une requête SELECT avec une fonction scalaire,
     RTRIM, qui supprime les espaces à partir de la fin de la colonne. Au lieu
-    de créer un objet avec les propriétés "RACE" et "2", nous utilisons la
-    clause AS dans la requête SELECT pour assigner le nom "nom" à la colonne
-    modifiée. Le serveur de base de données remplit le nom des colonnes avec
-    des majuscules, alors l'objet aura les propriétés "RACE" et "NOM".
+    de créer un objet avec les propriétés "RACE" et "2", la clause AS est
+    utilisée dans la requête SELECT pour assigner le nom "nom" à la colonne
+    modifiée. Le serveur de base de données met les noms des colonnes en
+    majuscules, l'objet aura donc les propriétés "RACE" et "NOM".
    </simpara>
    <programlisting role="php">
 <![CDATA[

--- a/reference/ibm_db2/functions/db2-fetch-row.xml
+++ b/reference/ibm_db2/functions/db2-fetch-row.xml
@@ -6,7 +6,7 @@
  <refnamediv>
   <refname>db2_fetch_row</refname>
   <refpurpose>
-   Modifie le pointeur du jeu de résultat à la prochaine ligne ou à la ligne
+   Modifie le pointeur du jeu de résultats à la prochaine ligne ou à la ligne
    demandée
   </refpurpose>
  </refnamediv>
@@ -21,10 +21,10 @@
   <simpara>
    La fonction <function>db2_fetch_row</function> peut être utilisée pour itérer à travers un jeu de
    résultats ou pour pointer à une ligne spécifique d'un jeu de résultats
-   si l'on a demandé un curseur flottant.
+   si l'on a demandé un curseur défilant.
   </simpara>
   <simpara>
-   Pour obtenir des champs individuels du jeu de résultats, appelez la fonction
+   Pour obtenir des champs individuels du jeu de résultats, il faut appeler la fonction
    <function>db2_result</function>.
   </simpara>
   <simpara>
@@ -44,8 +44,7 @@
     <term><parameter>stmt</parameter></term>
     <listitem>
      <simpara>
-      Une ressource <literal>stmt</literal> valide contenant le jeu de
-      résultats.
+      Une ressource <literal>stmt</literal> valide.
      </simpara>
     </listitem>
    </varlistentry>
@@ -53,9 +52,9 @@
     <term><parameter>row_number</parameter></term>
     <listitem>
      <simpara>
-      Avec des curseurs flottants, il est possible de demander un numéro de ligne
-      spécifique du jeu de résultats. Les numéros des lignes commencent par
-      l'indice 1
+      Avec des curseurs défilants, il est possible de demander un numéro de ligne
+      spécifique du jeu de résultats. Les numéros des lignes commencent à
+      l'indice 1.
      </simpara>
     </listitem>
    </varlistentry>
@@ -75,7 +74,7 @@
   &reftitle.examples;
   <para>
    <example>
-    <title>Itère à travers un jeu de résultats</title>
+    <title>Itération à travers un jeu de résultats</title>
     <simpara>
      L'exemple suivant démontre comment itérer à travers un jeu de résultats
      avec la fonction <function>db2_fetch_row</function> et récupérer les
@@ -106,20 +105,20 @@ chèvre Rickety Ride
     </screen>
    </example>
    <example>
-    <title>Alternatives recommandées i5/OS pour db2_fetch_row/db2_result</title>
+    <title>Alternatives recommandées sur i5/OS à db2_fetch_row/db2_result</title>
     <simpara>
      Sur i5/OS, il est recommandé d'utiliser
      <function>db2_fetch_both</function>, <function>db2_fetch_array</function>
      ou <function>db2_fetch_object</function> au lieu de
      <function>db2_fetch_row</function>/<function>db2_result</function>.
-     En général
-     <function>db2_fetch_row</function>/<function>db2_result</function> a plus
-     de problèmes avec des types de colonne variés dans la traduction de
-     <literal>EBCIDIC</literal> à <literal>ASCII</literal>, en incluant de
+     En général,
+     <function>db2_fetch_row</function>/<function>db2_result</function> ont plus
+     de problèmes avec divers types de colonnes lors de la traduction
+     <literal>EBCIDIC</literal> vers <literal>ASCII</literal>, y compris une
      possible troncature dans les applications <literal>DBCS</literal>.
-     Il serait possible d'aussi trouver une performance d'utiliser
+     Il est également possible de trouver les performances de
      <function>db2_fetch_both</function>, <function>db2_fetch_array</function>
-     et <function>db2_fetch_object</function> à utiliser
+     et <function>db2_fetch_object</function> supérieures à celles de
      <function>db2_fetch_row</function>/<function>db2_result</function>.
     </simpara>
     <programlisting role="php">

--- a/reference/ibm_db2/functions/db2-field-name.xml
+++ b/reference/ibm_db2/functions/db2-field-name.xml
@@ -49,7 +49,7 @@
   &reftitle.returnvalues;
   <simpara>
    Retourne une chaîne contenant le nom de la colonne spécifiée. Si la colonne
-   spécifiée n'existe pas dans le jeu de résultat,
+   spécifiée n'existe pas dans le jeu de résultats,
    <function>db2_field_name</function> retourne &false;.
   </simpara>
  </refsect1>

--- a/reference/ibm_db2/functions/db2-field-num.xml
+++ b/reference/ibm_db2/functions/db2-field-num.xml
@@ -6,7 +6,7 @@
  <refnamediv>
   <refname>db2_field_num</refname>
   <refpurpose>
-   Retourne la position du nom de la colonne du jeu de résultats
+   Retourne la position de la colonne nommée dans un jeu de résultats
   </refpurpose>
  </refnamediv>
  <refsect1 role="description">
@@ -18,7 +18,7 @@
   </methodsynopsis>
 
   <simpara>
-   Retourne la position du nom de la colonne du jeu de résultats
+   Retourne la position de la colonne nommée dans un jeu de résultats.
   </simpara>
 
  </refsect1>
@@ -29,7 +29,7 @@
    <term><parameter>stmt</parameter></term>
     <listitem>
      <simpara>
-      Spécifie une ressource contenant un jeu de résultats.
+      Spécifie une ressource d'instruction contenant un jeu de résultats.
      </simpara>
     </listitem>
    </varlistentry>
@@ -48,8 +48,8 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   Retourne un entier contenant la position commençant à 0 du nom de la
-   colonne dans le jeu de résultats. Si la colonne spécifiée n'existe pas dans
+   Retourne un entier contenant la position commençant à 0 de la colonne
+   nommée dans le jeu de résultats. Si la colonne spécifiée n'existe pas dans
    le jeu de résultats, <function>db2_field_num</function> retourne &false;.
   </simpara>
  </refsect1>

--- a/reference/ibm_db2/functions/db2-field-type.xml
+++ b/reference/ibm_db2/functions/db2-field-type.xml
@@ -6,7 +6,7 @@
  <refnamediv>
   <refname>db2_field_type</refname>
   <refpurpose>
-   Retourne le type de donnée de la colonne indiquée du jeu de résultats
+   Retourne le type de données de la colonne indiquée du jeu de résultats
   </refpurpose>
  </refnamediv>
  <refsect1 role="description">
@@ -18,7 +18,7 @@
   </methodsynopsis>
 
   <simpara>
-   Retourne le type de donnée de la colonne indiquée du jeu de résultats.
+   Retourne le type de données de la colonne indiquée du jeu de résultats.
   </simpara>
 
  </refsect1>

--- a/reference/ibm_db2/functions/db2-field-width.xml
+++ b/reference/ibm_db2/functions/db2-field-width.xml
@@ -20,9 +20,9 @@
 
   <simpara>
    Retourne la largeur de la valeur courante de la colonne indiquée du jeu de
-   résultats. Cela est la largeur maximale de la colonne pour un type de
-   données de longueur fixe ou la largeur actuelle de la colonne pour un type
-   de données de longueur fixe.
+   résultats. Il s'agit de la largeur maximale de la colonne pour un type de
+   données de longueur fixe, ou de la largeur réelle de la colonne pour un
+   type de données de longueur variable.
   </simpara>
 
  </refsect1>

--- a/reference/ibm_db2/functions/db2-foreign-keys.xml
+++ b/reference/ibm_db2/functions/db2-foreign-keys.xml
@@ -69,9 +69,9 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Retourne une ressource avec le jeu de résultats contenant des lignes
-   décrivant les clés étrangères à la table spécifiée. Le jeu de résultats est
-   composé des colonnes suivantes :
+   Retourne une ressource d'instruction avec un jeu de résultats contenant des
+   lignes décrivant les clés étrangères de la table spécifiée. Le jeu de
+   résultats est composé des colonnes suivantes :
    <informaltable>
     <tgroup cols="2">
      <thead>
@@ -121,13 +121,13 @@
       </row>
       <row>
        <entry>UPDATE_RULE</entry>
-       <entry>Entier représentant l'action appliquée à la clé étrangère lorsque
-       une opération est de type UPDATE.</entry>
+       <entry>Entier représentant l'action appliquée à la clé étrangère
+       lorsqu'une opération SQL est de type UPDATE.</entry>
       </row>
       <row>
        <entry>DELETE_RULE</entry>
-       <entry>Entier représentant l'action appliquée à la clé étrangère lorsque
-       une opération est de type DELETE.</entry>
+       <entry>Entier représentant l'action appliquée à la clé étrangère
+       lorsqu'une opération SQL est de type DELETE.</entry>
       </row>
       <row>
        <entry>FK_NAME</entry>

--- a/reference/ibm_db2/functions/db2-free-result.xml
+++ b/reference/ibm_db2/functions/db2-free-result.xml
@@ -17,11 +17,11 @@
   </methodsynopsis>
 
   <simpara>
-   Libère la mémoire des ressources du système et de base de données associée
-   du jeu de résultats. Ces ressources sont libérées implicitement lorsqu'un
+   Libère les ressources système et de base de données qui sont associées
+   à un jeu de résultats. Ces ressources sont libérées implicitement lorsqu'un
    script se termine, mais il est possible d'appeler
    <function>db2_free_result</function> pour libérer explicitement les
-   ressources avant la fin du script.
+   ressources du jeu de résultats avant la fin du script.
   </simpara>
 
  </refsect1>
@@ -32,7 +32,7 @@
     <term><parameter>stmt</parameter></term>
     <listitem>
      <simpara>
-      Une ressource valide.
+      Une ressource d'instruction valide.
      </simpara>
     </listitem>
    </varlistentry>

--- a/reference/ibm_db2/functions/db2-free-stmt.xml
+++ b/reference/ibm_db2/functions/db2-free-stmt.xml
@@ -6,7 +6,7 @@
  <refnamediv>
   <refname>db2_free_stmt</refname>
   <refpurpose>
-   Libère la mémoire associée à la ressource indiquée
+   Libère les ressources associées à la ressource d'instruction indiquée
   </refpurpose>
  </refnamediv>
  <refsect1 role="description">
@@ -17,11 +17,11 @@
   </methodsynopsis>
 
   <simpara>
-   Libère la mémoire des ressources du système et de base de données associée
-   au jeu de résultats. Ces ressources sont libérées implicitement lorsqu'un
+   Libère les ressources du système et de base de données associées
+   à une ressource d'instruction. Ces ressources sont libérées implicitement lorsqu'un
    script se termine, mais il est possible d'appeler
-   <function>db_free_stmt</function> pour libérer explicitement les
-   ressources avant la fin du script.
+   <function>db2_free_stmt</function> pour libérer explicitement les
+   ressources d'instruction avant la fin du script.
   </simpara>
 
  </refsect1>
@@ -32,7 +32,7 @@
     <term><parameter>stmt</parameter></term>
     <listitem>
      <simpara>
-      Une ressource valide.
+      Une ressource d'instruction valide.
      </simpara>
     </listitem>
    </varlistentry>

--- a/reference/ibm_db2/functions/db2-get-option.xml
+++ b/reference/ibm_db2/functions/db2-get-option.xml
@@ -5,7 +5,7 @@
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.db2-get-option">
  <refnamediv>
   <refname>db2_get_option</refname>
-  <refpurpose>Récupère la valeur d'une option pour une requête ou une connexion</refpurpose>
+  <refpurpose>Récupère la valeur d'une option pour une ressource d'instruction ou une ressource de connexion</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -16,7 +16,7 @@
    <methodparam><type>string</type><parameter>option</parameter></methodparam>
   </methodsynopsis>
   <simpara>
-   Récupère la valeur d'une option spécifiée pour une ressource de requête ou une ressource
+   Récupère la valeur d'une option spécifiée pour une ressource d'instruction ou une ressource
    de connexion.
   </simpara>
  </refsect1>
@@ -28,7 +28,7 @@
     <term><parameter>resource</parameter></term>
     <listitem>
     <simpara>
-     Une ressource de requête valide retournée par
+     Une ressource d'instruction valide retournée par
      <function>db2_prepare</function> ou une ressource de connexion valide retournée par
      <function>db2_connect</function> ou <function>db2_pconnect</function>.
     </simpara>
@@ -38,13 +38,13 @@
    <term><parameter>option</parameter></term>
    <listitem>
     <para>
-     Des options de requête ou de connexion valides. Les nouvelles options suivantes sont
-     disponibles depuis la version 1.6.0 d'ibm_db2. Elles fournissent d'utiles informations
+     Des options d'instruction ou de connexion valides. Les nouvelles options suivantes sont
+     disponibles à partir de la version 1.6.0 d'ibm_db2. Elles fournissent d'utiles informations
      de traçage qui peuvent être fixées pendant l'exécution avec
      <function>db2_get_option</function>.
      <note>
       <simpara>
-       Les anciennes versions d'ibm_db ne supportent pas ces nouvelles options.
+       Les anciennes versions d'ibm_db2 ne supportent pas ces nouvelles options.
       </simpara>
       <simpara>
        Lorsqu'une valeur dans chaque option est fixée, certains serveurs peuvent ne pas
@@ -62,12 +62,12 @@
         <listitem>
          <para>
           <literal>SQL_ATTR_INFO_USERID</literal> : un pointeur vers une &string; utilisée pour identifier
-          l'identifiant de l'usager (ID) envoyé vers le serveur de base de données lors de la connexion à DB2.
+          l'identifiant de l'usager (ID) envoyé vers le serveur de base de données lors de l'utilisation de DB2 Connect.
           <note>
            <simpara>
-            DB2 pour les serveurs z/OS et OS/390 supportent jusqu'à 16 caractères.
-            Le user-id ne doit pas être confondu avec l'identification user-id ; il s'agit
-            seulement d'un but d'identification et ne doit pas être autorisé pour des autorisations.
+            DB2 pour les serveurs z/OS et OS/390 supporte jusqu'à 16 caractères.
+            Le user-id ne doit pas être confondu avec le user-id d'authentification ; il sert
+            uniquement à des fins d'identification et n'est pas utilisé pour des autorisations.
            </simpara>
           </note>
          </para>
@@ -78,10 +78,10 @@
         <listitem>
          <para>
           <literal>SQL_ATTR_INFO_ACCTSTR</literal> : un pointeur vers une &string; utilisée pour identifier
-          le compte du client envoyé vers le serveur de base de données lors de la connexion à DB2.
+          le compte du client envoyé vers le serveur de base de données lors de l'utilisation de DB2 Connect.
           <note>
            <simpara>
-            DB2 pour les serveurs z/OS et OS/390 supportent jusqu'à 200 caractères.
+            DB2 pour les serveurs z/OS et OS/390 supporte jusqu'à 200 caractères.
            </simpara>
           </note>
          </para>
@@ -92,10 +92,10 @@
         <listitem>
          <para>
           <literal>SQL_ATTR_INFO_APPLNAME</literal> : un pointeur vers une &string; utilisée pour identifier
-          le nom de l'application du client envoyée vers le serveur de base de données lors de la connexion à DB2.
+          le nom de l'application du client envoyé vers le serveur de base de données lors de l'utilisation de DB2 Connect.
           <note>
            <simpara>
-            DB2 pour les serveurs z/OS et OS/390 supportent jusqu'à 32 caractères.
+            DB2 pour les serveurs z/OS et OS/390 supporte jusqu'à 32 caractères.
            </simpara>
           </note>
          </para>
@@ -106,10 +106,10 @@
         <listitem>
          <para>
           <literal>SQL_ATTR_INFO_WRKSTNNAME</literal> : un pointeur vers une &string; utilisée pour identifier
-          le nom de la machine du client envoyée vers le serveur de base de données lors de la connexion à DB2.
+          le nom de la machine du client envoyé vers le serveur de base de données lors de l'utilisation de DB2 Connect.
           <note>
            <simpara>
-            DB2 pour les serveurs z/OS et OS/390 supportent jusqu'à 18 caractères.
+            DB2 pour les serveurs z/OS et OS/390 supporte jusqu'à 18 caractères.
            </simpara>
           </note>
          </para>
@@ -121,10 +121,10 @@
    </varlistentry>
   </variablelist>
   <para>
-   La table suivante spécifie quelles options qui sont compatibles avec le type
-   de ressource disponible :
+   La table suivante spécifie quelles options sont compatibles avec les types
+   de ressources disponibles :
    <table>
-    <title>Matrice ressource paramètre</title>
+    <title>Matrice ressource-paramètre</title>
     <tgroup cols="5">
      <colspec colnum="1" colname="col1" align="center"/>
      <colspec colnum="2" colname="col2" align="center"/>
@@ -141,7 +141,7 @@
      <tbody>
       <row>
        <entry colname="col3">Connexion</entry>
-       <entry colname="col4">Requête</entry>
+       <entry colname="col4">Instruction</entry>
        <entry colname="col5">Jeu de résultats</entry>
       </row>
       <row>
@@ -188,7 +188,7 @@
  <refsect1 role="examples">
   &reftitle.examples;
   <example>
-   <title>Fixe et récupère les paramètres d'une ressource de connexion</title>
+   <title>Définit et récupère les paramètres au travers d'une ressource de connexion</title>
    <programlisting role="php">
 <![CDATA[
 <?php
@@ -204,7 +204,7 @@ echo "Attributs de connexion passés avec la chaîne de caractères de connexion
 
 /* Crée un tableau associatif d'options avec les paires clé/valeur valides */
 /* Assigne les attributs à partir de la chaîne de caractères de connexion */
-/* Accède les options spécifiées */
+/* Accède aux options spécifiées */
 $options1 = array('userid' => 'db2inst1');
 $conn1 = db2_connect($database, $user, $password, $options1);
 $val = db2_get_option($conn1, 'userid');
@@ -229,7 +229,7 @@ echo "Attributs après la connexion :\n";
 
 /* Crée un tableau associatif d'options avec les paires clé/valeur valides */
 /* Assigne les attributs après que la connexion soit faite */
-/* Accède les options spécifiées */
+/* Accède aux options spécifiées */
 $options5 = array('userid' => 'db2inst1');
 $conn5 = db2_connect($database, $user, $password);
 $rc = db2_set_option($conn5, $options5, 1);

--- a/reference/ibm_db2/functions/db2-last-insert-id.xml
+++ b/reference/ibm_db2/functions/db2-last-insert-id.xml
@@ -55,7 +55,7 @@
      <simpara>
       Une ressource de connexion valide, créée par <function>db2_connect</function>
       ou <function>db2_pconnect</function>. La valeur de ce paramètre ne peut pas
-      être une ressource de commande ou de résultat.
+      être une ressource d'instruction ou un jeu de résultats.
      </simpara>
     </listitem>
    </varlistentry>
@@ -113,7 +113,7 @@ else {
    &example.outputs;
    <screen>
 <![CDATA[
-Dernier ID généré : 1
+Dernier ID inséré : 1
 ]]>
    </screen>
   </example>

--- a/reference/ibm_db2/functions/db2-lob-read.xml
+++ b/reference/ibm_db2/functions/db2-lob-read.xml
@@ -6,7 +6,7 @@
  <refnamediv>
   <refname>db2_lob_read</refname>
   <refpurpose>
-   Récupère de grands objets binaires de tailles prédéfinies à chaque invocation
+   Récupère une taille définie par l'utilisateur de fichiers LOB à chaque invocation
   </refpurpose>
  </refnamediv>
 
@@ -19,9 +19,9 @@
    <methodparam><type>int</type><parameter>length</parameter></methodparam>
   </methodsynopsis>
   <simpara>
-   La fonction <function>db2_lob_read</function> permet de passer à travers une colonne
-   spécifique d'un jeu de résultats et récupérer les grands objets binaires de
-   taille prédéfinie.
+   La fonction <function>db2_lob_read</function> permet d'itérer à travers une colonne
+   spécifique d'un jeu de résultats et de récupérer une taille définie par l'utilisateur
+   de données LOB.
   </simpara>
  </refsect1>
 
@@ -32,7 +32,7 @@
     <term><parameter>stmt</parameter></term>
     <listitem>
      <simpara>
-      Une ressource <literal>stmt</literal> valide contenant des grands objets binaires.
+      Une ressource <literal>stmt</literal> valide contenant des données LOB.
      </simpara>
     </listitem>
    </varlistentry>
@@ -49,7 +49,7 @@
     <term><parameter>length</parameter></term>
     <listitem>
      <simpara>
-      La taille des grands objets binaires à récupérer de la ressource
+      La taille des données LOB à récupérer depuis la ressource
       <literal>stmt</literal>.
      </simpara>
     </listitem>
@@ -60,8 +60,8 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   Retourne le nombre de données spécifiés. Retourne &false; si les données
-   ne peuvent être récupérées.
+   Retourne la quantité de données spécifiée par l'utilisateur. Retourne &false;
+   si les données ne peuvent être récupérées.
   </simpara>
  </refsect1>
 

--- a/reference/ibm_db2/functions/db2-next-result.xml
+++ b/reference/ibm_db2/functions/db2-next-result.xml
@@ -6,7 +6,7 @@
  <refnamediv>
   <refname>db2_next_result</refname>
   <refpurpose>
-   Demande le prochain jeu de résultats de la ressource indiquée
+   Demande le prochain jeu de résultats d'une procédure stockée
   </refpurpose>
  </refnamediv>
  <refsect1 role="description">
@@ -17,12 +17,13 @@
   </methodsynopsis>
 
   <simpara>
-   Une procédure d'enregistrement peut retourner aucun ou plusieurs jeux de
+   Une procédure stockée peut retourner aucun ou plusieurs jeux de
    résultats. Il faut gérer le premier jeu de résultats de la même manière
-   que l'on gère les résultats retournés par une simple requête SELECT,
-   pour obtenir le second ou les résultats suivants, il faut appeler la
-   fonction <function>db2_next_result</function> et retourner le résultat dans
-   une variable PHP.
+   que l'on gère les résultats retournés par une simple requête SELECT ;
+   pour obtenir le deuxième jeu de résultats et les suivants à partir
+   d'une procédure stockée, il faut appeler la fonction
+   <function>db2_next_result</function> et retourner le résultat dans
+   une variable PHP au nom unique.
   </simpara>
 
  </refsect1>
@@ -43,22 +44,24 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   Retourne une nouvelle ressource contenant le jeu de résultats suivants si
-   la procédure contenait un jeu de résultats suivant. Retourne &false; si la
-   procédure n'avait plus de jeu de résultats à retourner.
+   Retourne une nouvelle ressource d'instruction contenant le jeu de résultats
+   suivant si la procédure stockée a retourné un autre jeu de résultats.
+   Retourne &false; si la procédure stockée n'a pas retourné d'autre jeu de
+   résultats.
   </simpara>
  </refsect1>
 
  <refsect1 role="examples">
   &reftitle.examples;
   <example>
-   <title>Exemple avec <function>db2_next_result</function></title>
+   <title>Appel d'une procédure stockée qui retourne plusieurs jeux de résultats</title>
    <simpara>
-    Dans l'exemple suivant, nous appelons une procédure qui retourne trois
-    jeux de résultats. Le premier jeu de résultats est récupéré directement
-    de la même ressource sur laquelle on a invoqué une requête CALL, alors
-    que le deuxième et troisième jeux de résultats sont récupérés des
-    ressources retournées par l'appel de la fonction
+    Dans l'exemple suivant, une procédure stockée qui retourne trois
+    jeux de résultats est appelée. Le premier jeu de résultats est récupéré
+    directement à partir de la même ressource d'instruction sur laquelle la
+    requête CALL a été invoquée, alors que le deuxième et le troisième jeux
+    de résultats sont récupérés à partir des ressources d'instruction
+    retournées par les appels à la fonction
     <function>db2_next_result</function>.
    </simpara>
    <programlisting role="php">

--- a/reference/ibm_db2/functions/db2-num-fields.xml
+++ b/reference/ibm_db2/functions/db2-num-fields.xml
@@ -6,7 +6,7 @@
  <refnamediv>
   <refname>db2_num_fields</refname>
   <refpurpose>
-   Retourne le nombre de champs contenu du jeu de résultats
+   Retourne le nombre de champs contenus dans un jeu de résultats
   </refpurpose>
  </refnamediv>
  <refsect1 role="description">
@@ -32,7 +32,7 @@
     <term><parameter>stmt</parameter></term>
     <listitem>
      <simpara>
-      Une ressource valide contenant un jeu de résultats.
+      Une ressource d'instruction valide contenant un jeu de résultats.
      </simpara>
     </listitem>
    </varlistentry>
@@ -42,15 +42,15 @@
   &reftitle.returnvalues;
   <simpara>
    Retourne un entier représentant le nombre de champs dans le jeu de
-   résultats associé avec la ressource spécifiée. Retourne &false; si la
-   ressource n'est pas valide.
+   résultats associé avec la ressource d'instruction spécifiée. Retourne &false;
+   si la ressource d'instruction n'est pas une valeur d'entrée valide.
   </simpara>
  </refsect1>
 
  <refsect1 role="examples">
   &reftitle.examples;
   <example>
-   <title>Exemple avec <function>db2_num_fields</function></title>
+   <title>Récupération du nombre de champs dans un jeu de résultats</title>
    <simpara>
     L'exemple suivant démontre comment obtenir le nombre de champs retournés
     dans le jeu de résultats.
@@ -64,7 +64,7 @@ $stmt = db2_prepare($conn, $sql);
 db2_execute($stmt, $sql);
 $columns = db2_num_fields($stmt);
 
-echo "Il y a {$columns} colonne dans le jeu de résultats.";
+echo "Il y a {$columns} colonnes dans le jeu de résultats.";
 ?>
 ]]>
    </programlisting>

--- a/reference/ibm_db2/functions/db2-num-rows.xml
+++ b/reference/ibm_db2/functions/db2-num-rows.xml
@@ -22,29 +22,29 @@
   </simpara>
   <simpara>
    Afin de déterminer le nombre de lignes que retournera une requête SELECT,
-   utiliser la requête SELECT COUNT(*) avec les mêmes attributs lorsqu'on
-   a effectué la requête SELECT et la récupération des valeurs.
+   il faut exécuter la requête SELECT COUNT(*) avec les mêmes prédicats que
+   la requête SELECT prévue et récupérer la valeur.
   </simpara>
   <simpara>
-   Si la logique de l'application vérifie le nombre de ligne retournée par
-   une requête SELECT et effectue le saut si le nombre de ligne est 0,
-   modifiez l'application pour tenter de retourner la première ligne avec
+   Si la logique de l'application vérifie le nombre de lignes retournées par
+   une requête SELECT et effectue un branchement si le nombre de lignes est 0,
+   il est recommandé de modifier l'application pour tenter de retourner la première ligne avec
    <function>db2_fetch_assoc</function>, <function>db2_fetch_both</function>,
    <function>db2_fetch_array</function> ou <function>db2_fetch_row</function>,
-   et effectuez le saut si la fonction retourne &false;.
+   et d'effectuer le branchement si la fonction retourne &false;.
   </simpara>
 
   <note>
    <simpara>
     Lors de l'envoi d'une requête SELECT avec un curseur flottant,
-    <function>db2_num_rows</function> retournera le nombre de lignes retournées
-    par la requête SELECT. Cependant, le temps système associé avec des
+    <function>db2_num_rows</function> retourne le nombre de lignes retournées
+    par la requête SELECT. Cependant, le temps système associé aux
     curseurs flottants dégrade considérablement les performances de
-    l'application, alors si cela est la seule raison pour laquelle l'on utilise
-    des curseurs flottants, il est recommandé d'utiliser des curseurs à avancement
-    seul et de plus appeler SELECT COUNT(*) ou compter sur les valeurs de
-    retour des fonctions de type <type>bool</type> pour obtenir
-    l'équivalent de fonctionnalité avec une performance bien meilleure.
+    l'application, ainsi, si cela est la seule raison pour laquelle l'on envisage d'utiliser
+    des curseurs flottants, il est recommandé d'utiliser un curseur à avancement
+    seul et soit d'appeler SELECT COUNT(*), soit de s'appuyer sur la valeur
+    de retour de type <type>bool</type> des fonctions de récupération pour obtenir
+    une fonctionnalité équivalente avec des performances bien meilleures.
    </simpara>
   </note>
 

--- a/reference/ibm_db2/functions/db2-pclose.xml
+++ b/reference/ibm_db2/functions/db2-pclose.xml
@@ -15,9 +15,9 @@
    <methodparam><type>resource</type><parameter>connection</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Cette fonction ferme une connexion DB2, créée avec
-   <function>db2_pconnect</function> et libère les ressources correspondantes
-   du serveur.
+   Cette fonction ferme une connexion client DB2, créée avec
+   <function>db2_pconnect</function>, et rend les ressources correspondantes
+   au serveur de base de données.
    <note>
     <simpara>
      Cette fonction n'est disponible que sur i5/OS en réponse à des requêtes
@@ -28,9 +28,9 @@
   <simpara>
    Si l'on a une connexion client DB2 persistante créée avec la fonction
    <function>db2_pconnect</function>, il est possible d'utiliser cette fonction pour
-   fermer la connexion. Pour éviter des coûts de connexion significatifs, cette
-   fonction ne doit être utilisée que dans de rares cas, où la connexion est devenue
-   amorphe, ou que la connexion persistante ne sera plus utilisée pour un long moment.
+   fermer la connexion. Pour éviter des coûts de performance significatifs liés à la connexion,
+   cette fonction ne devrait être utilisée que dans de rares cas, lorsque la connexion persistante
+   ne répond plus ou qu'elle ne sera plus nécessaire pendant une longue période.
   </simpara>
  </refsect1>
 
@@ -41,7 +41,7 @@
     <term><parameter>connection</parameter></term>
     <listitem>
      <simpara>
-      Une ressource de connexion active DB2.
+      Spécifie une connexion client DB2 active.
      </simpara>
     </listitem>
    </varlistentry>

--- a/reference/ibm_db2/functions/db2-pconnect.xml
+++ b/reference/ibm_db2/functions/db2-pconnect.xml
@@ -29,10 +29,10 @@
   </simpara>
 
   <simpara>
-   En appelant <function>db2_close</function> sur une connexion persistante,
-   une erreur sera affichée toujours &true;, mais les connexions des clients DB2
-   demeureront ouvertes et attendront de servir la prochaine demande de la
-   fonction <function>db2_pconnect</function>.
+   Appeler <function>db2_close</function> sur une connexion persistante
+   retourne toujours &true;, mais la connexion sous-jacente du client DB2
+   demeure ouverte et attend de servir la prochaine requête correspondante
+   de la fonction <function>db2_pconnect</function>.
   </simpara>
 
   <simpara>
@@ -190,7 +190,7 @@
       </variablelist>
      </para>
      <para>
-      Les options suivantes sont disponibles depuis ibm_db2 version 1.7.0.
+      Les options suivantes sont disponibles à partir d'ibm_db2 version 1.7.0.
       <variablelist>
        <varlistentry>
         <term><parameter>trustedcontext</parameter></term>
@@ -218,14 +218,14 @@ db2set DB2COMM=TCPIP</literallayout>
      </variablelist>
      </para>
      <para>
-      Les options i5/OS suivantes sont disponibles depuis ibm_db2 version 1.5.1.
+      Les options i5/OS suivantes sont disponibles à partir d'ibm_db2 version 1.5.1.
       <tip>
        <simpara>
-        Des attributs de connexion contradictoires, en conjonction avec une
-        connexion persistante peut produire des résultats indéterminés sur i5/OS.
-        La politique du site doit être établie pour toutes les applications qui
-        utilisent une connexion persistante. La valeur par défaut de
-        DB2_AUTOCOMMIT_ON est recommandée avec les connexions persistantes.
+        Des attributs de connexion contradictoires, en conjonction avec des
+        connexions persistantes, peuvent produire des résultats indéterminés sur i5/OS.
+        La politique du site doit être établie pour toutes les applications
+        utilisant chaque profil utilisateur de connexion persistante. La valeur
+        par défaut DB2_AUTOCOMMIT_ON est recommandée avec les connexions persistantes.
        </simpara>
       </tip>
       <variablelist>
@@ -233,7 +233,7 @@ db2set DB2COMM=TCPIP</literallayout>
         <term><parameter>i5_lib</parameter></term>
         <listitem>
          <simpara>
-          Une caractère qui indique la bibliothèque par défaut qui sera
+          Une valeur de type caractère qui indique la bibliothèque par défaut qui sera
           utilisée pour résoudre les références de fichiers non qualifiées.
           Cette option n'est pas valide si la connexion utilise le mode
           de nommage système.
@@ -270,7 +270,7 @@ db2set DB2COMM=TCPIP</literallayout>
            <simpara>
             La directive du &php.ini; <parameter>ibm_db2.i5_allow_commit</parameter>==0
             ou <literal>DB2_I5_TXN_NO_COMMIT</literal> est la valeur par défaut, mais peut
-            être remplacé par l'option <parameter>i5_commit</parameter>.
+            être remplacée par l'option <parameter>i5_commit</parameter>.
            </simpara>
           </note>
          </para>
@@ -282,16 +282,19 @@ db2set DB2COMM=TCPIP</literallayout>
           ou non répétables et les fantômes sont possibles.
          </simpara>
          <simpara>
-          <literal>DB2_I5_TXN_READ_COMMITTED</literal> : les lectures sont cohérentes.
-          Les lecteurs non répétables et les fantômes sont possibles.
+          <literal>DB2_I5_TXN_READ_COMMITTED</literal> : les lectures incohérentes
+          ne sont pas possibles. Les lectures non répétables et les fantômes
+          sont possibles.
          </simpara>
          <simpara>
-          <literal>DB2_I5_TXN_REPEATABLE_READ</literal> : les lectures cohérentes et
-          répétables, mais les fantômes sont possibles.
+          <literal>DB2_I5_TXN_REPEATABLE_READ</literal> : les lectures incohérentes
+          et les lectures non répétables ne sont pas possibles. Les fantômes
+          sont possibles.
          </simpara>
          <simpara>
-          <literal>DB2_I5_TXN_SERIALIZABLE</literal> : les transactions sont activées.
-          les lectures incohérentes, ou non répétables et les fantômes sont impossibles.
+          <literal>DB2_I5_TXN_SERIALIZABLE</literal> : les transactions sont sérialisables.
+          Les lectures incohérentes, les lectures non répétables et les fantômes
+          ne sont pas possibles.
          </simpara>
         </listitem>
        </varlistentry>
@@ -310,8 +313,8 @@ db2set DB2COMM=TCPIP</literallayout>
           <literal>DB2_ALL_IO</literal> : toutes les requêtes sont optimisées
           dans le but de traiter la requête complète le plus rapidement possible.
           C'est une bonne option lorsque le résultat de la requête doit être
-          écrit dans un fichier ou un rapport, ou que l'interface accumule toutes
-          les données avant des exporter. Les requêtes codées avec la clause
+          écrit dans un fichier ou un rapport, ou que l'interface accumule
+          toutes les données de sortie. Les requêtes codées avec la clause
           <literal>OPTIMIZE FOR nnn ROWS</literal> respectent aussi cet objectif.
           C'est le comportement par défaut.
          </simpara>
@@ -331,7 +334,7 @@ db2set DB2COMM=TCPIP</literallayout>
            <simpara>
             La directive du &php.ini; <parameter>ibm_db2.i5_dbcs_alloc</parameter>==0
             ou <literal>DB2_I5_DBCS_ALLOC_OFF</literal> est la valeur par défaut, mais peut
-            être remplacé par l'option <parameter>i5_dbcs_alloc</parameter>.
+            être remplacée par l'option <parameter>i5_dbcs_alloc</parameter>.
            </simpara>
           </note>
           </para>
@@ -346,7 +349,7 @@ db2set DB2COMM=TCPIP</literallayout>
           utilisé : <literal>yyyy-mm-dd</literal>. C'est le format par défaut.
          </simpara>
          <simpara>
-          <literal>DB2_I5_FMT_USA</literal> : le format des États Unis d'Amérique
+          <literal>DB2_I5_FMT_USA</literal> : le format des États-Unis d'Amérique
           est utilisé : <literal>mm/dd/yyyy</literal>.
          </simpara>
          <simpara>
@@ -370,7 +373,7 @@ db2set DB2COMM=TCPIP</literallayout>
           <literal>yy/mm/dd</literal> est utilisé.
          </simpara>
          <simpara>
-          <literal>DB2_I5_FMT_JUL</literal> : Le format de date julien
+          <literal>DB2_I5_FMT_JUL</literal> : le format de date julien
           <literal>yy/ddd</literal> est utilisé.
          </simpara>
          <simpara>
@@ -398,7 +401,7 @@ db2set DB2COMM=TCPIP</literallayout>
           <literal>DB2_I5_SEP_BLANK</literal> : un espace est utilisé comme séparateur de date.
          </simpara>
          <simpara>
-          <literal>DB2_I5_SEP_JOB</literal> : la configuration par défaut est utilisée
+          <literal>DB2_I5_SEP_JOB</literal> : la configuration par défaut est utilisée.
          </simpara>
         </listitem>
        </varlistentry>
@@ -433,8 +436,8 @@ db2set DB2COMM=TCPIP</literallayout>
         <term><parameter>i5_time_sep</parameter></term>
         <listitem>
          <simpara>
-          <literal>DB2_I5_SEP_COLON</literal> : un deux-point ( : ) est utilisé comme
-          séparateur d'heure. C'est le défaut.
+          <literal>DB2_I5_SEP_COLON</literal> : un deux-points ( : ) est utilisé comme
+          séparateur d'heure. C'est la valeur par défaut.
          </simpara>
          <simpara>
           <literal>DB2_I5_SEP_PERIOD</literal> : un point ( . ) est utilisé comme
@@ -472,20 +475,21 @@ db2set DB2COMM=TCPIP</literallayout>
       </variablelist>
      </para>
      <para>
-      Les options suivantes i5/OS sont disponibles depuis ibm_db2 version 1.8.0.
+      L'option i5/OS suivante est disponible à partir d'ibm_db2 version 1.8.0.
       <variablelist>
        <varlistentry>
         <term><parameter>i5_libl</parameter></term>
         <listitem>
          <para>
-          Un caractère qui indique la bibliothèque qui sera utilisée pour résoudre
-          les références de fichiers non qualifiées. Spécifier la liste de bibliothèque
-          sous la forme d'éléments séparés par des espaces :
+          Une valeur de type caractère qui indique la liste de bibliothèques
+          qui sera utilisée pour résoudre les références de fichiers non
+          qualifiées. Spécifier la liste de bibliothèques sous la forme
+          d'éléments séparés par des espaces :
           <literal>'i5_libl'=&gt;"MYLIB YOURLIB ANYLIB"</literal>.
           <note>
            <simpara>
             i5_libl appelle <literal>qsys2/qcmdexc('cmd',cmdlen)</literal>, qui
-            est disponible depuis i5/OS V5R4.
+            n'est disponible qu'à partir d'i5/OS V5R4.
            </simpara>
           </note>
          </para>
@@ -608,8 +612,8 @@ Deuxième connexion persistante réussie.
    <example>
     <title>Utilisation de contextes de confiance DB2</title>
     <simpara>
-     L'exemple suivant montre comment activer un utilisateur de confiance,
-     basculer dessus, et obtenir un identifiant d'utilisateur.
+     L'exemple suivant montre comment activer le contexte de confiance,
+     changer d'utilisateur et obtenir l'identifiant de l'utilisateur courant.
     </simpara>
     <programlisting role="php">
 <![CDATA[
@@ -643,7 +647,7 @@ if($tc_conn) {
         $res = db2_set_option ($tc_conn, $parameters, 1);
 
         $userAfter = db2_get_option($tc_conn, "trusted_user");
-        //Do more work as trusted user.
+        //Travail supplémentaire en tant qu'utilisateur de confiance.
 
         if($userBefore != $userAfter) {
             echo "Utilisateur changé." . "\n";
@@ -663,7 +667,7 @@ else {
     <screen>
 <![CDATA[
 Connexion de confiance réussie.
-Utilisateur changé
+Utilisateur changé.
 ]]>
     </screen>
    </example>

--- a/reference/ibm_db2/functions/db2-prepare.xml
+++ b/reference/ibm_db2/functions/db2-prepare.xml
@@ -56,7 +56,7 @@
       <emphasis>Fonctionnalité avancée</emphasis> : Les marqueurs permettent
       non seulement de passer des valeurs d'entrées dans les requêtes SQL
       préparées, mais permettent aussi de récupérer des paramètres de SORTIE et
-      d'ENTRÉE/SORTIE des procédures d'enregistrement en utilisant la fonction
+      d'ENTRÉE/SORTIE des procédures stockées en utilisant la fonction
       <function>db2_bind_param</function>.
      </simpara>
     </listitem>
@@ -88,8 +88,8 @@
     <term><parameter>options</parameter></term>
     <listitem>
      <simpara>
-      Un tableau associatif contenant les options de la requête. Il est possible de
-      utiliser ce paramètre pour demander un curseur flottant sur les
+      Un tableau associatif contenant les options de la requête. Il est possible
+      d'utiliser ce paramètre pour demander un curseur flottant sur les
       serveurs de base de données qui supportent cette fonctionnalité.
      </simpara>
      <simpara>
@@ -103,10 +103,10 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   Retourne une variable ressource si la requête SQL était envoyée
-   correctement ou &false; si le serveur de base de données a
-   retourné une erreur. Il est possible de déterminer quelle erreur a été retournée
-   en appelant la fonction
+   Retourne une ressource d'instruction si la requête SQL a été analysée et
+   préparée avec succès par le serveur de base de données. Retourne &false;
+   si le serveur de base de données a retourné une erreur. Il est possible de
+   déterminer quelle erreur a été retournée en appelant la fonction
    <function>db2_stmt_error</function> ou <function>db2_stmt_errormsg</function>.
   </simpara>
  </refsect1>

--- a/reference/ibm_db2/functions/db2-primary-keys.xml
+++ b/reference/ibm_db2/functions/db2-primary-keys.xml
@@ -6,7 +6,7 @@
  <refnamediv>
   <refname>db2_primary_keys</refname>
   <refpurpose>
-   Retourne un jeu de résultats listant les clés d'une table
+   Retourne un jeu de résultats listant les clés primaires d'une table
   </refpurpose>
  </refnamediv>
  <refsect1 role="description">
@@ -20,7 +20,7 @@
   </methodsynopsis>
 
   <simpara>
-   Retourne un jeu de résultats listant les clés d'une table.
+   Retourne un jeu de résultats listant les clés primaires d'une table.
   </simpara>
 
  </refsect1>
@@ -69,9 +69,9 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Retourne une ressource avec le jeu de résultats contenant des lignes
-   décrivant les clés primaires à la table spécifiée. Le jeu de résultats est
-   composé des colonnes suivantes :
+   Retourne une ressource d'instruction avec un jeu de résultats contenant des
+   lignes décrivant les clés primaires pour la table spécifiée. Le jeu de
+   résultats est composé des colonnes suivantes :
    <informaltable>
     <tgroup cols="2">
      <thead>

--- a/reference/ibm_db2/functions/db2-procedure-columns.xml
+++ b/reference/ibm_db2/functions/db2-procedure-columns.xml
@@ -6,7 +6,7 @@
  <refnamediv>
   <refname>db2_procedure_columns</refname>
   <refpurpose>
-   Retourne un jeu de résultats listant les paramètres de procédure d'enregistrement
+   Retourne un jeu de résultats listant les paramètres de procédure stockée
   </refpurpose>
  </refnamediv>
  <refsect1 role="description">
@@ -22,7 +22,7 @@
 
   <simpara>
    Retourne un jeu de résultats listant les paramètres pour une ou plusieurs
-   procédures d'enregistrement.
+   procédures stockées.
   </simpara>
 
  </refsect1>
@@ -52,9 +52,9 @@
     <term><parameter>schema</parameter></term>
     <listitem>
      <simpara>
-      Le schéma qui contient les tables. Le paramètre accepte les formes
-      contenant <literal>_</literal> et <literal>%</literal> en tant que mot
-      clé.
+      Le schéma qui contient les procédures. Ce paramètre accepte un motif
+      de recherche contenant <literal>_</literal> et <literal>%</literal>
+      en tant que caractères génériques.
      </simpara>
     </listitem>
    </varlistentry>
@@ -62,9 +62,9 @@
     <term><parameter>procedure</parameter></term>
     <listitem>
      <simpara>
-      Le nom de la procédure. Le paramètre accepte les formes
-      contenant <literal>_</literal> et <literal>%</literal> en tant que mot
-      clé.
+      Le nom de la procédure. Ce paramètre accepte un motif de recherche
+      contenant <literal>_</literal> et <literal>%</literal> en tant que
+      caractères génériques.
      </simpara>
     </listitem>
    </varlistentry>
@@ -72,10 +72,10 @@
     <term><parameter>parameter</parameter></term>
     <listitem>
      <simpara>
-      Le nom du paramètre. Ce paramètre accepte un paramètre de recherche de
-      forme contenant <literal>_</literal> et <literal>%</literal> en tant
-      que mot clé. Si ce paramètre est &null;, tous les paramètres pour la
-      procédure d'enregistrement spécifiée sont retournés.
+      Le nom du paramètre. Ce paramètre accepte un motif de recherche
+      contenant <literal>_</literal> et <literal>%</literal> en tant que
+      caractères génériques. Si ce paramètre est &null;, tous les paramètres
+      pour les procédures stockées spécifiées sont retournés.
      </simpara>
     </listitem>
    </varlistentry>
@@ -84,10 +84,10 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Retourne une ressource avec le jeu de résultats contenant les lignes qui
-   décrivent les paramètres pour les procédures d'enregistrement qui concordent
-   avec les paramètres spécifiés. Les lignes sont composées des colonnes
-   suivantes :
+   Retourne une ressource d'instruction avec un jeu de résultats contenant
+   les lignes qui décrivent les paramètres pour les procédures stockées qui
+   correspondent aux paramètres spécifiés. Les lignes sont composées des
+   colonnes suivantes :
    <informaltable>
     <tgroup cols="2">
      <thead>
@@ -99,12 +99,12 @@
      <tbody>
       <row>
        <entry>PROCEDURE_CAT</entry>
-       <entry>Nom du catalogue que contient la table.
-       La valeur est &null; si la table n'a pas de catalogue.</entry>
+       <entry>Le catalogue qui contient la procédure.
+       La valeur est &null; si cette table n'a pas de catalogue.</entry>
       </row>
       <row>
        <entry>PROCEDURE_SCHEM</entry>
-       <entry>Nom du schéma que contient la procédure d'enregistrement.</entry>
+       <entry>Nom du schéma qui contient la procédure stockée.</entry>
       </row>
       <row>
        <entry>PROCEDURE_NAME</entry>
@@ -138,7 +138,7 @@
             </row>
             <row>
              <entry>3 (SQL_PARAM_OUTPUT)</entry>
-             <entry>Paramètre d'entrée (OUT).</entry>
+             <entry>Paramètre de sortie (OUT).</entry>
             </row>
            </tbody>
           </tgroup>
@@ -157,28 +157,28 @@
       </row>
       <row>
        <entry>COLUMN_SIZE</entry>
-       <entry>Un entier représentant la grandeur du paramètre.</entry>
+       <entry>Un entier représentant la taille du paramètre.</entry>
       </row>
       <row>
        <entry>BUFFER_LENGTH</entry>
-       <entry>Nombre d'octets maximaux nécessaires pour enregistrer des
+       <entry>Nombre maximal d'octets nécessaires pour stocker les
        données de ce paramètre.</entry>
       </row>
       <row>
        <entry>DECIMAL_DIGITS</entry>
-       <entry>L'échelle du paramètre ou &null; où l'échelle n'est pas
+       <entry>L'échelle du paramètre, ou &null; lorsque l'échelle n'est pas
        applicable.</entry>
       </row>
       <row>
        <entry>NUM_PREC_RADIX</entry>
        <entry>Un entier pouvant être <literal>10</literal> (représentant un
-       type de données numérique exact), <literal>2</literal> (représentant une
-       approximation de type de données numériques) ou &null; (représentant un type
+       type de données numérique exact), <literal>2</literal> (représentant un
+       type de données numérique approché) ou &null; (représentant un type
        de données pour lequel la base n'est pas applicable).</entry>
       </row>
       <row>
        <entry>NULLABLE</entry>
-       <entry>Un entier représentant si le paramètre peut être nul ou pas.</entry>
+       <entry>Un entier indiquant si le paramètre peut être nul ou non.</entry>
       </row>
       <row>
        <entry>REMARKS</entry>
@@ -190,31 +190,31 @@
       </row>
       <row>
        <entry>SQL_DATA_TYPE</entry>
-       <entry>Un entier représentant la grandeur du paramètre.</entry>
+       <entry>Un entier représentant la taille du paramètre.</entry>
       </row>
       <row>
        <entry>SQL_DATETIME_SUB</entry>
        <entry>Retourne un entier représentant un code de sous-type
-       <literal>datetime</literal> ou
-       &null; si les types de données SQL n'appliquent pas.</entry>
+       <literal>datetime</literal>, ou &null; pour les types de données SQL
+       auxquels cela ne s'applique pas.</entry>
       </row>
       <row>
        <entry>CHAR_OCTET_LENGTH</entry>
-       <entry>Grandeur maximale en octets pour les types de données d'un
-       caractère du paramètre, qui concorde avec COLUMN_SIZE pour un seul
-       octet de données ou &null; pour un type de données qui n'est pas des
-       caractères.</entry>
+       <entry>Longueur maximale en octets pour un paramètre de type de
+       données caractère, qui correspond à COLUMN_SIZE pour les données
+       d'un jeu de caractères mono-octet, ou &null; pour les types de
+       données non caractères.</entry>
       </row>
       <row>
        <entry>ORDINAL_POSITION</entry>
-       <entry>La position du paramètre commençant à 1 dans la requête
-       <literal>CALL</literal>.</entry>
+       <entry>La position du paramètre, indexée à partir de 1, dans
+       l'instruction <literal>CALL</literal>.</entry>
       </row>
       <row>
        <entry>IS_NULLABLE</entry>
-       <entry>Une chaîne dont la valeur est <literal>YES</literal> signifie que le paramètre
-       accepte ou retourne des valeurs &null; et <literal>NO</literal> signifie que le
-       paramètre n'accepte pas ou ne retourne pas de valeurs &null;.</entry>
+       <entry>Une valeur de chaîne où 'YES' signifie que le paramètre
+       accepte ou retourne des valeurs &null;, et 'NO' signifie que le
+       paramètre n'accepte ou ne retourne pas de valeurs &null;.</entry>
       </row>
      </tbody>
     </tgroup>

--- a/reference/ibm_db2/functions/db2-procedures.xml
+++ b/reference/ibm_db2/functions/db2-procedures.xml
@@ -6,8 +6,8 @@
  <refnamediv>
   <refname>db2_procedures</refname>
   <refpurpose>
-   Retourne un jeu de résultats listant les procédures d'enregistrement
-   enregistrées dans la base de données
+   Retourne un jeu de résultats listant les procédures stockées
+   enregistrées dans une base de données
   </refpurpose>
  </refnamediv>
  <refsect1 role="description">
@@ -21,8 +21,8 @@
   </methodsynopsis>
 
   <simpara>
-   Retourne un jeu de résultats listant les procédures d'enregistrement
-   enregistrées dans la base de données.
+   Retourne un jeu de résultats listant les procédures stockées
+   enregistrées dans une base de données.
   </simpara>
 
  </refsect1>
@@ -44,7 +44,7 @@
      <simpara>
       Un qualificatif pour les bases de données DB2 qui fonctionnent sur
       les serveurs OS/390 ou z/OS. Pour les autres bases de données,
-      passez &null; ou une chaîne vide.
+      il faut passer &null; ou une chaîne vide.
      </simpara>
     </listitem>
    </varlistentry>
@@ -52,9 +52,9 @@
     <term><parameter>schema</parameter></term>
     <listitem>
      <simpara>
-      Le schéma qui contient les tables. Le paramètre accepte les formes
-      contenant <literal>_</literal> et <literal>%</literal> en tant que mot
-      clé.
+      Le schéma qui contient les procédures. Ce paramètre accepte un motif
+      de recherche contenant <literal>_</literal> et <literal>%</literal>
+      comme caractères génériques.
      </simpara>
     </listitem>
    </varlistentry>
@@ -62,9 +62,9 @@
     <term><parameter>procedure</parameter></term>
     <listitem>
      <simpara>
-      Le nom de la procédure. Le paramètre accepte les formes
-      contenant <literal>_</literal> et <literal>%</literal> en tant que mot
-      clé.
+      Le nom de la procédure. Ce paramètre accepte un motif de recherche
+      contenant <literal>_</literal> et <literal>%</literal> comme
+      caractères génériques.
      </simpara>
     </listitem>
    </varlistentry>
@@ -73,9 +73,9 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Retourne une ressource avec le jeu de résultats contenant les lignes qui
-   décrivent les procédures enregistrées qui concordent avec les paramètres
-   spécifiés. Les lignes sont composées des colonnes suivantes :
+   Retourne une ressource d'instruction avec un jeu de résultats contenant
+   les lignes qui décrivent les procédures stockées qui correspondent aux
+   paramètres spécifiés. Les lignes sont composées des colonnes suivantes :
    <informaltable>
     <tgroup cols="2">
      <thead>
@@ -87,12 +87,12 @@
       <tbody>
        <row>
         <entry>PROCEDURE_CAT</entry>
-        <entry>Nom du catalogue que contient la table.
+        <entry>Le catalogue qui contient la procédure.
         La valeur est &null; si la table n'a pas de catalogue.</entry>
        </row>
        <row>
         <entry>PROCEDURE_SCHEM</entry>
-        <entry>Nom du schéma que contient la procédure d'enregistrement.</entry>
+        <entry>Nom du schéma qui contient la procédure stockée.</entry>
        </row>
        <row>
         <entry>PROCEDURE_NAME</entry>
@@ -100,24 +100,24 @@
        </row>
        <row>
         <entry>NUM_INPUT_PARAMS</entry>
-        <entry>Nombre de paramètres d'entrée (IN) pour la procédure d'enregistrement.</entry>
+        <entry>Nombre de paramètres d'entrée (IN) pour la procédure stockée.</entry>
        </row>
        <row>
         <entry>NUM_OUTPUT_PARAMS</entry>
-        <entry>Nombre de paramètres de sortie (OUT) pour la procédure d'enregistrement.</entry>
+        <entry>Nombre de paramètres de sortie (OUT) pour la procédure stockée.</entry>
        </row>
        <row>
         <entry>NUM_RESULT_SETS</entry>
-        <entry>Nombre de jeux de résultats retournés par la procédure d'enregistrement.</entry>
+        <entry>Nombre de jeux de résultats retournés par la procédure stockée.</entry>
        </row>
        <row>
         <entry>REMARKS</entry>
-        <entry>Commentaires concernant la procédure d'enregistrement.</entry>
+        <entry>Commentaires concernant la procédure stockée.</entry>
        </row>
        <row>
         <entry>PROCEDURE_TYPE</entry>
-        <entry>Retourne toujours &one;, indiquant que la
-        procédure d'enregistrement ne retourne aucune valeur de retour.</entry>
+        <entry>Retourne toujours <literal>1</literal>, indiquant que la
+        procédure stockée ne retourne aucune valeur de retour.</entry>
        </row>
       </tbody>
      </tgroup>

--- a/reference/ibm_db2/functions/db2-result.xml
+++ b/reference/ibm_db2/functions/db2-result.xml
@@ -41,9 +41,8 @@
     <term><parameter>column</parameter></term>
      <listitem>
       <simpara>
-       Un tableau d'entier commençant avec l'indice 0 qui pointe vers les
-       champs du jeu de résultats ou une chaîne représentant le nom de la
-       colonne.
+       Soit un entier correspondant au champ commençant à l'indice 0 dans le
+       jeu de résultats, soit une chaîne représentant le nom de la colonne.
       </simpara>
      </listitem>
     </varlistentry>
@@ -54,8 +53,8 @@
   &reftitle.returnvalues;
   <simpara>
    Retourne la valeur du champ demandé si le champ existe dans le jeu de
-   résultats. Retourne &null; si le champ n'existe pas et retourne une
-   alerte PHP.
+   résultats. Retourne &null; si le champ n'existe pas, et émet une
+   alerte.
   </simpara>
  </refsect1>
 

--- a/reference/ibm_db2/functions/db2-rollback.xml
+++ b/reference/ibm_db2/functions/db2-rollback.xml
@@ -17,11 +17,11 @@
   </methodsynopsis>
 
   <simpara>
-   Annule une transaction en cours sur la connexion spécifiée et commence une
-   nouvelle transaction. Les applications PHP ont normalement
-   pour valeur par défaut AUTOCOMMIT d'activé, alors
-   <function>db2_commit</function> n'est pas nécessaire tant que AUTOCOMMIT
-   n'est pas désactivée pour la ressource de connexion.
+   Annule une transaction en cours sur la ressource de connexion spécifiée et
+   commence une nouvelle transaction. Les applications PHP utilisent normalement
+   le mode AUTOCOMMIT par défaut, donc <function>db2_rollback</function>
+   n'a normalement aucun effet tant que AUTOCOMMIT n'a pas été désactivé pour
+   la ressource de connexion.
   </simpara>
 
  </refsect1>
@@ -29,17 +29,16 @@
   &reftitle.parameters;
   <variablelist>
    <varlistentry>
-   <term><parameter>connection</parameter></term>
+    <term><parameter>connection</parameter></term>
     <listitem>
      <simpara>
-      Une variable ressource de connexion valide retournée par
+      Une variable ressource de connexion à la base de données valide retournée par
       <function>db2_connect</function> ou <function>db2_pconnect</function>.
      </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
  </refsect1>
-
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
@@ -50,17 +49,17 @@
  <refsect1 role="examples">
   &reftitle.examples;
   <example>
-   <title>Annulation d'une requête DELETE</title>
+   <title>Annulation d'une instruction DELETE</title>
    <simpara>
-    Dans l'exemple suivant, nous comptons le nombre de ligne dans la table,
-    désactivons le mode AUTOCOMMIT sur la connexion de la base de données,
-    supprimons toutes les lignes dans la table et retournons le nombre
-    &zero; pour prouver que les lignes ont bien été supprimées.
-    Ensuite nous utilisons la fonction <function>db2_rollback</function> et
-    retournons la nouvelle valeur du nombre de ligne dans la table pour
-    montrer que le nombre est le même que celui que nous avions avant d'effectuer la
-    requête DELETE. Le retour à l'état original de la table démontre que
-    l'annulation de la transaction a réussi.
+    Dans l'exemple suivant, le nombre de lignes dans une table est compté,
+    le mode AUTOCOMMIT est désactivé sur une connexion de base de données,
+    toutes les lignes de la table sont supprimées et le compteur retourne
+    <literal>0</literal> pour prouver que les lignes ont bien été supprimées.
+    Ensuite, <function>db2_rollback</function> est invoquée, et le nombre
+    de lignes mis à jour dans la table est retourné pour montrer que le nombre
+    est le même qu'avant l'exécution de l'instruction DELETE. Le retour à
+    l'état original de la table démontre que l'annulation de la transaction
+    a réussi.
    </simpara>
    <programlisting role="php">
 <![CDATA[
@@ -68,24 +67,24 @@
 $conn = db2_connect($database, $user, $password);
 
 if ($conn) {
-    $stmt = db2_exec($conn, "SELECT count(*) FROM animaux");
+    $stmt = db2_exec($conn, "SELECT count(*) FROM animals");
     $res = db2_fetch_array( $stmt );
     echo $res[0] . "\n";
 
     // Désactive AUTOCOMMIT
     db2_autocommit($conn, DB2_AUTOCOMMIT_OFF);
 
-    // Suppression de toutes les lignes de ANIMAUX
+    // Supprime toutes les lignes de ANIMALS
     db2_exec($conn, "DELETE FROM animals");
 
-    $stmt = db2_exec($conn, "SELECT count(*) FROM animaux");
+    $stmt = db2_exec($conn, "SELECT count(*) FROM animals");
     $res = db2_fetch_array( $stmt );
     echo $res[0] . "\n";
 
-    // Annule la requête DELETE
+    // Annule l'instruction DELETE
     db2_rollback( $conn );
 
-    $stmt = db2_exec( $conn, "SELECT count(*) FROM animaux" );
+    $stmt = db2_exec( $conn, "SELECT count(*) FROM animals" );
     $res = db2_fetch_array( $stmt );
     echo $res[0] . "\n";
     db2_close($conn);

--- a/reference/ibm_db2/functions/db2-server-info.xml
+++ b/reference/ibm_db2/functions/db2-server-info.xml
@@ -24,7 +24,7 @@
     <tgroup cols="3">
      <thead>
       <row>
-       <entry>Nom Propriété</entry>
+       <entry>Nom de la propriété</entry>
        <entry>Type de retour</entry>
        <entry>Description</entry>
       </row>
@@ -70,7 +70,7 @@
           <term>UR</term>
           <listitem>
            <simpara>
-            Lecture non-envoyée (<literal>Uncommitted read</literal>) : les changements sont
+            Lecture non validée (<literal>Uncommitted read</literal>) : les changements sont
             immédiatement visibles par toutes les transactions concurrentes.
            </simpara>
           </listitem>
@@ -80,7 +80,7 @@
           <listitem>
            <simpara>
             Stabilité du curseur (<literal>Cursor stability</literal>) : une ligne lue par une
-            transaction peut être modifiée et envoyée par une seconde
+            transaction peut être modifiée et validée par une seconde
             transaction concurrente.
            </simpara>
           </listitem>
@@ -100,7 +100,7 @@
           <listitem>
            <simpara>
             Lecture répétée (<literal>Repeatable read</literal>) : les données affectées par les
-            transaction en attente ne sont pas disponibles aux autres
+            transactions en attente ne sont pas disponibles aux autres
             transactions.
            </simpara>
           </listitem>
@@ -109,9 +109,9 @@
           <term>NC</term>
           <listitem>
            <simpara>
-            Aucun envoi (<literal>No commit</literal>) : tout changement est visible à la fin
-            d'une opération réussie. Les envois explicites et retours
-            arrières ne sont pas alloués.
+            Aucune validation (<literal>No commit</literal>) : tout changement est visible à la fin
+            d'une opération réussie. Les validations explicites et retours
+            arrières ne sont pas autorisés.
            </simpara>
           </listitem>
          </varlistentry>
@@ -133,7 +133,7 @@
       <row>
        <entry>ISOLATION_OPTION</entry>
        <entry>&array;</entry>
-       <entry>Un tableau d'options d'isolation supporté par le serveur de
+       <entry>Un tableau des options d'isolation supportées par le serveur de
        base de données. Les options d'isolation sont décrites dans la
        propriété DFT_ISOLATION.</entry>
       </row>
@@ -166,13 +166,13 @@
       <row>
        <entry>MAX_INDEX_SIZE</entry>
        <entry>&integer;</entry>
-       <entry>Taille maximale des colonnes combinées dans un index supporté
+       <entry>Taille maximale des colonnes combinées dans un index supportée
        par le serveur de base de données, exprimée en octets.</entry>
       </row>
       <row>
        <entry>MAX_PROC_NAME_LEN</entry>
        <entry>&integer;</entry>
-       <entry>Taille maximale d'un nom de procédure supporté par le serveur de
+       <entry>Taille maximale d'un nom de procédure supportée par le serveur de
        base de données, exprimée en octets.</entry>
       </row>
       <row>
@@ -184,19 +184,19 @@
       <row>
        <entry>MAX_SCHEMA_NAME_LEN</entry>
        <entry>&integer;</entry>
-       <entry>Taille maximale d'un nom de schéma supporté par le serveur de
-       base de données, exprimé en octets.</entry>
+       <entry>Taille maximale d'un nom de schéma supportée par le serveur de
+       base de données, exprimée en octets.</entry>
       </row>
       <row>
        <entry>MAX_STATEMENT_LEN</entry>
        <entry>&integer;</entry>
-       <entry>Taille maximale d'une requête SQL supporté par le serveur de
+       <entry>Taille maximale d'une requête SQL supportée par le serveur de
        base de données, exprimée en octets.</entry>
       </row>
       <row>
        <entry>MAX_TABLE_NAME_LEN</entry>
        <entry>&integer;</entry>
-       <entry>Taille maximale d'un nom de table supporté par le serveur de
+       <entry>Taille maximale d'un nom de table supportée par le serveur de
        base de données, exprimée en octets.</entry>
       </row>
       <row>
@@ -211,7 +211,7 @@
        <entry>PROCEDURES</entry>
        <entry>&boolean;</entry>
        <entry>&true; si le serveur de base de données supporte l'utilisation
-        de la requête CALL pour appeler les procédures enregistrées, &false; si
+        de la requête CALL pour appeler les procédures stockées, &false; si
         le serveur de base de données ne supporte pas la requête CALL.</entry>
       </row>
       <row>
@@ -232,7 +232,7 @@
           <term>ENTRY</term>
           <listitem>
            <simpara>
-            Niveau de conformité SQL-92.
+            Niveau d'entrée de conformité SQL-92.
            </simpara>
           </listitem>
          </varlistentry>
@@ -240,7 +240,7 @@
           <term>FIPS127</term>
           <listitem>
            <simpara>
-            Conformité traditionnelle FIPS-127-2.
+            Conformité transitoire FIPS-127-2.
            </simpara>
           </listitem>
          </varlistentry>

--- a/reference/ibm_db2/functions/db2-set-option.xml
+++ b/reference/ibm_db2/functions/db2-set-option.xml
@@ -5,7 +5,7 @@
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.db2-set-option">
  <refnamediv>
   <refname>db2_set_option</refname>
-  <refpurpose>Fixe des options pour une connexion ou des ressources</refpurpose>
+  <refpurpose>Fixe des options pour une ressource de connexion ou une ressource d'instruction</refpurpose>
  </refnamediv>
  <refsect1 role="description">
   &reftitle.description;
@@ -16,8 +16,8 @@
    <methodparam><type>int</type><parameter>type</parameter></methodparam>
   </methodsynopsis>
   <simpara>
-   Fixe des options pour une ressource ou une connexion. Il n'est pas possible de
-   fixer des options pour un jeu de résultats.
+   Fixe des options pour une ressource d'instruction ou une ressource de connexion.
+   Il n'est pas possible de fixer des options pour des ressources de jeu de résultats.
   </simpara>
  </refsect1>
  <refsect1 role="parameters">
@@ -27,8 +27,8 @@
     <term><parameter>resource</parameter></term>
     <listitem>
      <simpara>
-      Une ressource valide comme retournée par
-      <function>db2_prepare</function> ou une connexion valide comme
+      Une ressource d'instruction valide retournée par
+      <function>db2_prepare</function> ou une ressource de connexion valide
       retournée par <function>db2_connect</function> ou
       <function>db2_pconnect</function>.
      </simpara>
@@ -38,10 +38,10 @@
     <term><parameter>options</parameter></term>
     <listitem>
      <para>
-      Un tableau associatif contenant des options de ressources ou de
+      Un tableau associatif contenant des options d'instruction ou de
       connexion valides. Ce paramètre peut être utilisé pour changer
-      les valeurs d'autocommit, types de curseur (flottant ou à avance
-      seule) et spécifier la casse des noms de colonne (minuscule,
+      les valeurs d'autocommit, les types de curseur (flottant ou à avance
+      seule) et pour spécifier la casse des noms de colonne (minuscule,
       majuscule ou naturelle) qui apparaîtra dans le jeu de résultats.
       <variablelist>
        <varlistentry>
@@ -49,11 +49,11 @@
         <listitem>
          <simpara>
           Passer <constant>DB2_AUTOCOMMIT_ON</constant> active
-          l'autocommit pour la connexion spécifiée.
+          l'autocommit pour la ressource de connexion spécifiée.
          </simpara>
          <simpara>
           Passer <constant>DB2_AUTOCOMMIT_OFF</constant> désactive
-          l'autocommit pour la connexion spécifiée.
+          l'autocommit pour la ressource de connexion spécifiée.
          </simpara>
         </listitem>
        </varlistentry>
@@ -62,17 +62,16 @@
         <listitem>
          <simpara>
           Passer <constant>DB2_FORWARD_ONLY</constant> spécifie un
-          curseur à avance seule pour une ressource. Ceci est le
-          type de défaut pour un curseur et est supporté par tous
+          curseur à avance seule pour une ressource d'instruction. Ceci est
+          le type de curseur par défaut, et il est supporté par tous
           les serveurs de base de données.
          </simpara>
          <simpara>
           Passer <constant>DB2_SCROLLABLE</constant> spécifie un
-          curseur flottant pour une ressource. Les curseurs
-          flottants permettent aux lignes de résultats d'être
-          accessibles dans un ordre non séquentiel. Ce type de
-          curseur est supporté seulement par les bases de données
-          IBM DB2 Universal Database.
+          curseur flottant pour une ressource d'instruction. Les curseurs
+          flottants permettent aux lignes du jeu de résultats d'être
+          accessibles dans un ordre non séquentiel, mais ils ne sont supportés
+          que par les bases de données IBM DB2 Universal Database.
          </simpara>
         </listitem>
        </varlistentry>
@@ -127,18 +126,18 @@
         <listitem>
          <simpara>
           Passer <constant>DB2_DEFERRED_PREPARE_ON</constant> active
-          la préparation différée sur la ressource de requête spécifiée.
+          la préparation différée sur la ressource d'instruction spécifiée.
          </simpara>
          <simpara>
           Passer <constant>DB2_DEFERRED_PREPARE_OFF</constant> désactive
-          la préparation différée sur la ressource de requête spécifiée.
+          la préparation différée sur la ressource d'instruction spécifiée.
          </simpara>
         </listitem>
        </varlistentry>
       </variablelist>
      </para>
      <para>
-      Les nouvelles options suivantes i5/OS sont disponibles depuis la
+      Les nouvelles options suivantes i5/OS sont disponibles à partir de la
       version 1.5.1 d'ibm_db2. Ces options s'appliquent uniquement lorsque
       PHP et ibm_db2 fonctionnent nativement sur un système i5.
       <variablelist>
@@ -149,13 +148,13 @@
           <literal>DB2_I5_FETCH_ON</literal> : les curseurs sont en
           lecture seule et ne peuvent être utilisés pour positionner
           des mises à jour et des suppressions. Ceci est la valeur
-          par défaut a moins que la variable d'environnement
-          <literal>SQL_ATTR_FOR_FETCH_ONLY</literal> ait été mis à
+          par défaut à moins que la variable d'environnement
+          <literal>SQL_ATTR_FOR_FETCH_ONLY</literal> ait été mise à
           <literal>SQL_FALSE</literal>.
          </simpara>
          <simpara>
           <literal>DB2_I5_FETCH_OFF</literal> : les curseurs
-          peuvent être positionnés pour mises à jour et
+          peuvent être positionnés pour des mises à jour et des
           suppressions.
          </simpara>
         </listitem>
@@ -163,29 +162,29 @@
       </variablelist>
      </para>
      <para>
-      Les nouvelles options suivantes sont disponibles depuis
-      ibm_db2 version 1.8.0 et suivants.
+      La nouvelle option suivante est disponible à partir de
+      ibm_db2 version 1.8.0.
       <variablelist>
        <varlistentry>
         <term><parameter>rowcount</parameter></term>
         <listitem>
          <simpara>
           <literal>DB2_ROWCOUNT_PREFETCH_ON</literal> - Le client peut demander
-          un comptage complet des lignes avant des récupérer, ce qui
+          un comptage complet des lignes avant de les récupérer, ce qui
           signifie que la fonction <function>db2_num_rows</function> retourne
           le nombre de lignes sélectionnées même si un curseur
           <literal>ROLLFORWARD_ONLY</literal> est utilisé.
          </simpara>
          <simpara>
           <literal>DB2_ROWCOUNT_PREFETCH_OFF</literal> - Le client
-          ne peut pas demander un comptage complet des lignes avant des récupérer.
+          ne peut pas demander un comptage complet des lignes avant de les récupérer.
          </simpara>
         </listitem>
        </varlistentry>
       </variablelist>
      </para>
      <para>
-      Les options suivantes sont nouvelles, et disponibles depuis
+      Les options suivantes sont nouvelles, et disponibles à partir de
       ibm_db2 version 1.7.0.
       <variablelist>
        <varlistentry>
@@ -193,10 +192,10 @@
         <listitem>
          <simpara>
           Pour basculer l'utilisateur vers un utilisateur de confiance,
-          indiquez l'identifiant utilisateur sous forme de chaîne, de l'utilisateur
-          de confiance que l'on veut utiliser. Cette option peut être
-          configurée au niveau de la connexion uniquement. Pour utiliser cette
-          option, un contexte de confiance doit être activé sur la ressource
+          il faut passer l'identifiant utilisateur (chaîne de caractères) de
+          l'utilisateur de confiance comme valeur de cette clé. Cette option ne
+          peut être configurée que sur une ressource de connexion. Pour utiliser
+          cette option, un contexte de confiance doit être activé sur la ressource
           de connexion.
          </simpara>
         </listitem>
@@ -205,17 +204,17 @@
         <term><parameter>trusted_password</parameter></term>
         <listitem>
          <simpara>
-          Le mot de passe, sous forme de chaîne, qui correspond à l'utilisateur
-          de confiance.
+          Le mot de passe (chaîne de caractères) qui correspond à l'utilisateur
+          spécifié par la clé trusted_user.
          </simpara>
         </listitem>
        </varlistentry>
       </variablelist>
      </para>
      <para>
-      Les options suivantes sont nouvelles, et disponibles depuis
-      ibm_db2 version 1.6.0. Ces options sont pratiques pour obtenir des informations de
-      suivis, accessibles via <function>db2_get_option</function>.
+      Les options suivantes sont nouvelles, et disponibles à partir de
+      ibm_db2 version 1.6.0. Ces options fournissent des informations de
+      suivi utiles, accessibles pendant l'exécution via <function>db2_get_option</function>.
       <note>
        <simpara>
         Lorsque la valeur de chaque option est sur le point d'être définie, quelques
@@ -236,10 +235,10 @@
          <para>
           <literal>SQL_ATTR_INFO_USERID</literal> : un pointeur vers une &string;
           terminée par &null; utilisée pour identifier l'ID utilisateur du client envoyé
-          au serveur de base de données, lors de la connexion DB2.
+          au serveur de base de données hôte lors de l'utilisation de DB2 Connect.
           <note>
            <simpara>
-            DB2 pour les serveurs z/OS et OS/390 supporte une longueur supérieure à
+            DB2 pour les serveurs z/OS et OS/390 supporte une longueur jusqu'à
             16 caractères. L'ID utilisateur ne doit pas être confondu avec l'ID utilisateur
             d'identification, il est utilisé pour les processus d'identification uniquement
             et non pour ceux d'autorisation.
@@ -253,11 +252,11 @@
         <listitem>
          <para>
           <literal>SQL_ATTR_INFO_ACCTSTR</literal> : un pointeur vers une &string;
-          terminée par &null; utilisée pour identifier le compte du client à envoyer
-          au serveur de base de données lors de la connexion DB2..
+          terminée par &null; utilisée pour identifier la chaîne de comptabilité du client
+          à envoyer au serveur de base de données hôte lors de l'utilisation de DB2 Connect.
           <note>
            <simpara>
-            DB2 pour les serveurs z/OS et OS/390 supporte une longueur supérieure à
+            DB2 pour les serveurs z/OS et OS/390 supporte une longueur jusqu'à
             200 caractères.
            </simpara>
           </note>
@@ -270,10 +269,10 @@
          <para>
           <literal>SQL_ATTR_INFO_APPLNAME</literal> : un pointeur vers une &string;
           terminée par &null; utilisée pour identifier le nom de l'application client
-          à envoyer au serveur de base de données lors de la connexion DB2.
+          à envoyer au serveur de base de données hôte lors de l'utilisation de DB2 Connect.
           <note>
            <simpara>
-            DB2 pour les serveurs z/OS and OS/390 supportent une longueur supérieure à
+            DB2 pour les serveurs z/OS et OS/390 supporte une longueur jusqu'à
             32 caractères.
            </simpara>
           </note>
@@ -285,11 +284,11 @@
         <listitem>
          <para>
           <literal>SQL_ATTR_INFO_WRKSTNNAME</literal> : un pointeur vers une &string;
-          terminée par &null; utilisée pour identifier le nom de la station à
-          envoyer au serveur de base de données lors de la connexion DB2.
+          terminée par &null; utilisée pour identifier le nom de la station de travail du client
+          à envoyer au serveur de base de données hôte lors de l'utilisation de DB2 Connect.
           <note>
            <simpara>
-            DB2 pour les serveurs z/OS et OS/390 supportent une longueur supérieure à
+            DB2 pour les serveurs z/OS et OS/390 supporte une longueur jusqu'à
             18 caractères.
            </simpara>
           </note>
@@ -305,7 +304,7 @@
     <listitem>
      <simpara>
       Un &integer; qui spécifie le type de ressource qui a été passé à
-      la fonction. Le type de ressource et valeur doit correspondre.
+      la fonction. Le type de ressource et cette valeur doivent correspondre.
      </simpara>
      <simpara>
       Passer <literal>1</literal> en tant que valeur spécifie
@@ -314,7 +313,7 @@
      <simpara>
       Passer n'importe quel &integer; différent de
       <literal>1</literal> en tant que valeur spécifie qu'une
-      ressource a été passée à la fonction.
+      ressource d'instruction a été passée à la fonction.
      </simpara>
     </listitem>
    </varlistentry>
@@ -325,7 +324,7 @@
    Le tableau suivant spécifie quelles options sont compatibles avec quels
    types de ressources :
    <table>
-    <title>Matrice ressource paramètre</title>
+    <title>Matrice ressource-paramètre</title>
     <tgroup cols="5">
      <colspec colnum="1" colname="col1" align="center"/>
      <colspec colnum="2" colname="col2" align="center"/>
@@ -344,7 +343,7 @@
      <tbody>
       <row>
        <entry colname="col3">Connexion</entry>
-       <entry colname="col4">Requête</entry>
+       <entry colname="col4">Instruction</entry>
        <entry colname="col5">Jeu de résultats</entry>
       </row>
       <row>

--- a/reference/ibm_db2/functions/db2-special-columns.xml
+++ b/reference/ibm_db2/functions/db2-special-columns.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 020edc73be983e8e2aca04782ff7c901da4afad7 Maintainer: jsgoupil Status: ready -->
+<!-- EN-Revision: 020edc73be983e8e2aca04782ff7c901da4afad7 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.db2-special-columns">
  <refnamediv>
@@ -84,7 +84,7 @@
           <entry>0</entry>
           <entry>SQL_SCOPE_CURROW</entry>
           <entry>L'identifiant de la ligne est valide seulement lorsque
-          curseur est positionné sur la ligne.</entry>
+          le curseur est positionné sur la ligne.</entry>
          </row>
          <row>
           <entry>1</entry>
@@ -95,7 +95,7 @@
          <row>
           <entry>2</entry>
           <entry>SQL_SCOPE_SESSION</entry>
-          <entry>L'identifiant de la ligne est valide durant la durée de la
+          <entry>L'identifiant de la ligne est valide pour la durée de la
           connexion.</entry>
          </row>
         </tbody>
@@ -110,9 +110,9 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Retourne une ressource avec un jeu de résultats contenant des lignes avec
-   des informations uniques pour une table. Les lignes sont composées des
-   colonnes suivantes :
+   Retourne une ressource d'instruction avec un jeu de résultats contenant
+   des lignes avec des informations uniques pour une table. Les lignes sont
+   composées des colonnes suivantes :
    <informaltable>
     <tgroup cols="2">
      <thead>
@@ -139,7 +139,7 @@
             <entry>0</entry>
             <entry>SQL_SCOPE_CURROW</entry>
             <entry>L'identifiant de la ligne est valide seulement lorsque
-            curseur est positionné sur la ligne.</entry>
+            le curseur est positionné sur la ligne.</entry>
            </row>
            <row>
             <entry>1</entry>
@@ -150,7 +150,7 @@
            <row>
             <entry>2</entry>
             <entry>SQL_SCOPE_SESSION</entry>
-            <entry>L'identifiant de la ligne est valide durant la durée de la
+            <entry>L'identifiant de la ligne est valide pour la durée de la
             connexion.</entry>
            </row>
           </tbody>
@@ -168,28 +168,28 @@
       </row>
       <row>
        <entry>TYPE_NAME</entry>
-       <entry>Une chaîne représentant le type de données pour la
+       <entry>Une chaîne représentant le type de données SQL pour la
        colonne.</entry>
       </row>
       <row>
        <entry>COLUMN_SIZE</entry>
-       <entry>Un entier représentant la grandeur de la colonne.</entry>
+       <entry>Un entier représentant la taille de la colonne.</entry>
       </row>
       <row>
        <entry>BUFFER_LENGTH</entry>
-       <entry>Nombre d'octets maximaux nécessaires pour enregistrer des
+       <entry>Nombre maximal d'octets nécessaires pour stocker les
        données de cette colonne.</entry>
       </row>
       <row>
        <entry>DECIMAL_DIGITS</entry>
-       <entry>L'échelle de la colonne ou &null; où l'échelle n'est pas
+       <entry>L'échelle de la colonne, ou &null; lorsque l'échelle n'est pas
        applicable.</entry>
       </row>
       <row>
        <entry>NUM_PREC_RADIX</entry>
        <entry>Un entier pouvant être <literal>10</literal> (représentant un
        type de données numérique exact), <literal>2</literal> (représentant un
-       type de données numériques approximé) ou &null; (représentant un type
+       type de données numérique approximatif) ou &null; (représentant un type
        de données pour lequel la base n'est pas applicable).</entry>
       </row>
       <row>

--- a/reference/ibm_db2/functions/db2-statistics.xml
+++ b/reference/ibm_db2/functions/db2-statistics.xml
@@ -43,7 +43,7 @@
      <simpara>
       Un qualificatif pour les bases de données DB2 qui fonctionnent sur
       les serveurs OS/390 ou z/OS. Pour les autres bases de données,
-      passez &null; ou une chaîne vide.
+      il faut passer &null; ou une chaîne vide.
      </simpara>
     </listitem>
    </varlistentry>
@@ -81,8 +81,10 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Ce que la fonction retourne, premièrement lors de succès, ensuite lors
-   d'échec. Voir aussi l'entité &return.success;
+   Retourne une ressource d'instruction avec un jeu de résultats contenant des
+   lignes décrivant les statistiques et les index pour les tables de base
+   correspondant aux paramètres spécifiés. Les lignes sont composées des
+   colonnes suivantes :
    <informaltable>
     <tgroup cols="2">
      <thead>
@@ -94,12 +96,12 @@
      <tbody>
       <row>
        <entry>TABLE_CAT</entry>
-       <entry>Nom du catalogue que contient la table.
-       La valeur est &null; si la table n'a pas de catalogue.</entry>
+       <entry>Le catalogue qui contient la table.
+       La valeur est &null; si cette table n'a pas de catalogue.</entry>
       </row>
       <row>
        <entry>TABLE_SCHEM</entry>
-       <entry>Nom du schéma que contient la table.</entry>
+       <entry>Nom du schéma qui contient la table.</entry>
       </row>
       <row>
        <entry>TABLE_NAME</entry>
@@ -109,7 +111,7 @@
        <entry>NON_UNIQUE</entry>
        <entry>
         <para>
-         Un entier représentant si l'index interdit les valeurs uniques ou si
+         Un entier indiquant si l'index interdit les valeurs uniques ou si
          la ligne représente des statistiques sur la table elle-même :
          <informaltable>
           <tgroup cols="2">
@@ -126,7 +128,7 @@
             </row>
             <row>
              <entry>1 (SQL_TRUE)</entry>
-             <entry>Les valeurs index doivent être uniques.</entry>
+             <entry>Les valeurs de l'index doivent être uniques.</entry>
             </row>
             <row>
              <entry>&null;</entry>
@@ -140,8 +142,8 @@
       </row>
       <row>
        <entry>INDEX_QUALIFIER</entry>
-       <entry>Une chaîne de caractères représentant un qualificatif qui devrait
-       avoir été préalablement fixé à INDEX_NAME pour qualifier complètement
+       <entry>Une chaîne de caractères représentant le qualificatif qui devrait
+       être préfixé à INDEX_NAME pour qualifier complètement
        l'index.</entry>
       </row>
       <row>
@@ -169,16 +171,16 @@
             </row>
             <row>
              <entry>1 (SQL_INDEX_CLUSTERED)</entry>
-             <entry>La ligne contient des informations à propos d'index groupé.</entry>
+             <entry>La ligne contient des informations à propos d'un index groupé.</entry>
             </row>
             <row>
              <entry>2 (SQL_INDEX_HASH)</entry>
-             <entry>La ligne contient des informations à propos d'index haché.</entry>
+             <entry>La ligne contient des informations à propos d'un index haché.</entry>
             </row>
             <row>
              <entry>3 (SQL_INDEX_OTHER)</entry>
-             <entry>La ligne contient des informations à propos du type
-             d'index qui n'est pas groupé ni haché.</entry>
+             <entry>La ligne contient des informations à propos d'un type
+             d'index qui n'est ni groupé ni haché.</entry>
             </row>
            </tbody>
           </tgroup>
@@ -188,9 +190,9 @@
       </row>
       <row>
        <entry>ORDINAL_POSITION</entry>
-       <entry>Un tableau commençant à l'index 1 indiquant la colonne dans
-       l'index. &null; si la ligne contient des informations statistiques à
-       propos de la table.</entry>
+       <entry>La position (commençant à 1) de la colonne dans l'index. &null;
+       si la ligne contient des informations statistiques à propos de la
+       table.</entry>
       </row>
       <row>
        <entry>COLUMN_NAME</entry>
@@ -200,9 +202,9 @@
       <row>
        <entry>ASC_OR_DESC</entry>
        <entry>
-        <literal>A</literal> si la colonne est triée en ordre alphabétique,
-        <literal>D</literal> si la colonne est triée en ordre alphabétique
-        inverse, &null; si la ligne contient des informations statistiques à
+        <literal>A</literal> si la colonne est triée en ordre croissant,
+        <literal>D</literal> si la colonne est triée en ordre décroissant,
+        &null; si la ligne contient des informations statistiques à
         propos de la table.
        </entry>
       </row>

--- a/reference/ibm_db2/functions/db2-stmt-error.xml
+++ b/reference/ibm_db2/functions/db2-stmt-error.xml
@@ -21,17 +21,17 @@
    SQL.
   </simpara>
   <simpara>
-   Sans passer de ressource en tant qu'argument à la fonction
-   <function>db2_stmt_error</function>, elle retournera le message
-   d'erreur associé avec le dernier essai de retour d'une requête SQL, par
-   exemple, provenant de <function>db2_prepare</function> ou
-   <function>db2_exec</function>.
+   Si aucune ressource d'instruction n'est passée en argument à la fonction
+   <function>db2_stmt_error</function>, le pilote retourne la valeur de
+   SQLSTATE associée avec la dernière tentative de retour d'une ressource
+   d'instruction, par exemple, provenant de <function>db2_prepare</function>
+   ou <function>db2_exec</function>.
   </simpara>
   <para>
    Pour comprendre les valeurs de SQLSTATE, il est possible de taper la commande
    suivante dans le processeur de ligne de commandes de DB2 :
    <userinput>db2 '? <parameter>sqlstate-value</parameter>'</userinput>. Il
-   est aussi possible d'appeler la fonction <function>db2_conn_errormsg</function>
+   est aussi possible d'appeler la fonction <function>db2_stmt_errormsg</function>
    pour obtenir un message d'erreur explicite ainsi que la valeur de SQLCODE
    associée.
   </para>
@@ -41,10 +41,10 @@
   &reftitle.parameters;
   <variablelist>
    <varlistentry>
-   <term><parameter>stmt</parameter></term>
+    <term><parameter>stmt</parameter></term>
     <listitem>
      <simpara>
-      Une ressource valide.
+      Une ressource d'instruction valide.
      </simpara>
     </listitem>
    </varlistentry>

--- a/reference/ibm_db2/functions/db2-stmt-errormsg.xml
+++ b/reference/ibm_db2/functions/db2-stmt-errormsg.xml
@@ -20,11 +20,11 @@
    Retourne le dernier message d'erreur d'une requête SQL.
   </simpara>
   <simpara>
-   Sans passer de ressource en tant qu'argument à la fonction
-   <function>db2_stmt_errormsg</function>, elle retournera le message
-   d'erreur associé avec le dernier essai de retour d'une requête SQL, par
-   exemple, provenant de <function>db2_prepare</function> ou
-   <function>db2_exec</function>.
+   Si aucune ressource d'instruction n'est passée en argument à
+   <function>db2_stmt_errormsg</function>, le pilote retourne le message
+   d'erreur associé avec la dernière tentative de retour d'une ressource
+   d'instruction, par exemple, provenant de <function>db2_prepare</function>
+   ou <function>db2_exec</function>.
   </simpara>
 
  </refsect1>
@@ -35,7 +35,7 @@
     <term><parameter>stmt</parameter></term>
     <listitem>
      <simpara>
-      Une ressource valide.
+      Une ressource d'instruction valide.
      </simpara>
     </listitem>
    </varlistentry>
@@ -44,8 +44,8 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   Retourne une chaîne contenant le message d'erreur et le SQLCODE pour la
-   dernière erreur qui s'est déroulée après l'exécution d'une requête SQL.
+   Retourne une chaîne contenant le message d'erreur et la valeur SQLCODE
+   pour la dernière erreur survenue lors de l'exécution d'une requête SQL.
   </simpara>
  </refsect1>
 

--- a/reference/ibm_db2/functions/db2-table-privileges.xml
+++ b/reference/ibm_db2/functions/db2-table-privileges.xml
@@ -6,8 +6,8 @@
  <refnamediv>
   <refname>db2_table_privileges</refname>
   <refpurpose>
-   Retourne un jeu de résultats listant les tables et leurs privilèges
-   qui leur sont associées d'une base de données
+   Retourne un jeu de résultats listant les tables et les privilèges
+   qui leur sont associés dans une base de données
   </refpurpose>
  </refnamediv>
  <refsect1 role="description">
@@ -21,8 +21,8 @@
   </methodsynopsis>
 
   <simpara>
-   Retourne un jeu de résultats listant les tables et leurs privilèges
-   qui leur sont associées d'une base de données.
+   Retourne un jeu de résultats listant les tables et les privilèges
+   qui leur sont associés dans une base de données.
   </simpara>
 
  </refsect1>
@@ -44,7 +44,7 @@
      <simpara>
       Un qualificatif pour les bases de données DB2 qui fonctionnent sur
       les serveurs OS/390 ou z/OS. Pour les autres bases de données,
-      passez &null; ou une chaîne vide.
+      passer &null; ou une chaîne vide.
      </simpara>
     </listitem>
    </varlistentry>
@@ -52,19 +52,19 @@
     <term><parameter>schema</parameter></term>
     <listitem>
      <simpara>
-      Le schéma qui contient les tables. Le paramètre accepte les formes
-      contenant <literal>_</literal> et <literal>%</literal> en tant que mot
-      clé.
+      Le schéma qui contient les tables. Ce paramètre accepte un motif
+      de recherche contenant <literal>_</literal> et <literal>%</literal>
+      en tant que caractères génériques.
      </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term><parameter>table-name</parameter></term>
+    <term><parameter>table_name</parameter></term>
     <listitem>
      <simpara>
-      Le nom de la table. Le paramètre accepte les formes
-      contenant <literal>_</literal> et <literal>%</literal> en tant que mot
-      clé.
+      Le nom de la table. Ce paramètre accepte un motif de recherche
+      contenant <literal>_</literal> et <literal>%</literal> en tant que
+      caractères génériques.
      </simpara>
     </listitem>
    </varlistentry>
@@ -73,9 +73,9 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Retourne une ressource avec le jeu de résultats contenant les lignes qui
-   décrivent les privilèges pour la table qui concordent avec les paramètres spécifiés. Les
-   lignes sont composées des colonnes suivantes :
+   Retourne une ressource d'instruction avec un jeu de résultats contenant les
+   lignes décrivant les privilèges des tables qui correspondent aux paramètres
+   spécifiés. Les lignes sont composées des colonnes suivantes :
    <informaltable>
     <tgroup cols="2">
      <thead>
@@ -87,12 +87,12 @@
      <tbody>
       <row>
        <entry>TABLE_CAT</entry>
-       <entry>Nom du catalogue que contient la table.
-       La valeur est &null; si la table n'a pas de catalogue.</entry>
+       <entry>Le catalogue qui contient la table. La valeur est &null; si
+       cette table n'a pas de catalogues.</entry>
       </row>
       <row>
        <entry>TABLE_SCHEM</entry>
-       <entry>Nom du schéma que contient la table.</entry>
+       <entry>Nom du schéma qui contient la table.</entry>
       </row>
       <row>
        <entry>TABLE_NAME</entry>
@@ -100,24 +100,26 @@
       </row>
       <row>
        <entry>GRANTOR</entry>
-       <entry>ID d'autorisation de l'utilisateur qui a donné le privilège.</entry>
+       <entry>ID d'autorisation de l'utilisateur qui a accordé le privilège.</entry>
       </row>
       <row>
        <entry>GRANTEE</entry>
        <entry>ID d'autorisation de l'utilisateur à qui le privilège a été
-       donné.</entry>
+        accordé.</entry>
       </row>
       <row>
        <entry>PRIVILEGE</entry>
-       <entry>Le privilège qui a été donné. Cela peut être un de ces mots
-       suivants : ALTER, CONTROL, DELETE, INDEX, INSERT, REFERENCES, SELECT ou
-       UPDATE.</entry>
+       <entry>
+        Le privilège qui a été accordé. Cela peut être l'un des suivants :
+        ALTER, CONTROL, DELETE, INDEX, INSERT, REFERENCES, SELECT ou UPDATE.
+       </entry>
       </row>
       <row>
        <entry>IS_GRANTABLE</entry>
-       <entry>Une chaîne contenant "YES" ou "NO" indiquant si l'utilisateur à
-       qui le privilège a été donné peut donner le privilège aux autres
-       utilisateurs.</entry>
+       <entry>
+        Une chaîne valant "YES" ou "NO" indiquant si le bénéficiaire peut
+        accorder le privilège à d'autres utilisateurs.
+       </entry>
       </row>
      </tbody>
     </tgroup>

--- a/reference/ibm_db2/functions/db2-tables.xml
+++ b/reference/ibm_db2/functions/db2-tables.xml
@@ -21,8 +21,8 @@
   </methodsynopsis>
 
   <simpara>
-   Retourne un jeu de résultats listant les tables et leurs métadonnées
-   qui leur sont associées d'une base de données
+   Retourne un jeu de résultats listant les tables et les métadonnées
+   associées dans une base de données.
   </simpara>
 
  </refsect1>
@@ -52,9 +52,9 @@
     <term><parameter>schema</parameter></term>
     <listitem>
      <simpara>
-      Le schéma qui contient les tables. Le paramètre accepte les formes
-      contenant <literal>_</literal> et <literal>%</literal> en tant que mot
-      clé.
+      Le schéma qui contient les tables. Ce paramètre accepte un motif de recherche
+      contenant <literal>_</literal> et <literal>%</literal> en tant que
+      caractères génériques.
      </simpara>
     </listitem>
    </varlistentry>
@@ -62,9 +62,9 @@
     <term><parameter>table_name</parameter></term>
     <listitem>
      <simpara>
-      Le nom de la table. Le paramètre accepte les formes
-      contenant <literal>_</literal> et <literal>%</literal> en tant que mot
-      clé.
+      Le nom de la table. Ce paramètre accepte un motif de recherche
+      contenant <literal>_</literal> et <literal>%</literal> en tant que
+      caractères génériques.
      </simpara>
     </listitem>
    </varlistentry>
@@ -72,9 +72,9 @@
     <term><parameter>table_type</parameter></term>
     <listitem>
      <simpara>
-      Une liste des identifiants du type de table délimitée par des virgules.
-      Pour concorder avec tous les schémas, passez &null; ou une chaîne
-      vide. Les identifiants valides sont :
+      Une liste d'identifiants de type de table délimitée par des virgules.
+      Pour correspondre à tous les types de tables, passez &null; ou une chaîne
+      vide. Les identifiants de type de table valides incluent :
       ALIAS, HIERARCHY TABLE, INOPERATIVE VIEW, NICKNAME,
       MATERIALIZED QUERY TABLE, SYSTEM TABLE, TABLE, TYPED TABLE, TYPED VIEW
       et VIEW.
@@ -86,8 +86,8 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Retourne une ressource avec le jeu de résultats contenant les lignes qui
-   décrivent les tables qui concordent avec les paramètres spécifiés. Les
+   Retourne une ressource d'instruction avec un jeu de résultats contenant les lignes
+   décrivant les tables qui correspondent aux paramètres spécifiés. Les
    lignes sont composées des colonnes suivantes :
    <informaltable>
     <tgroup cols="2">
@@ -100,12 +100,12 @@
      <tbody>
       <row>
        <entry>TABLE_CAT</entry>
-       <entry>Nom du catalogue que contient la table.
-       La valeur est &null; si la table n'a pas de catalogue.</entry>
+       <entry>Le catalogue qui contient la table.
+       La valeur est &null; si cette table n'a pas de catalogues.</entry>
       </row>
       <row>
        <entry>TABLE_SCHEM</entry>
-       <entry>Nom du schéma que contient la table.</entry>
+       <entry>Nom du schéma qui contient la table.</entry>
       </row>
       <row>
        <entry>TABLE_NAME</entry>
@@ -113,7 +113,7 @@
       </row>
       <row>
        <entry>TABLE_TYPE</entry>
-       <entry>Identifiant de la table.</entry>
+       <entry>Identifiant de type de table pour la table.</entry>
       </row>
       <row>
        <entry>REMARKS</entry>

--- a/reference/ibm_db2/ini.xml
+++ b/reference/ibm_db2/ini.xml
@@ -191,12 +191,12 @@
       </listitem>
       <listitem>
        <simpara>
-        1 - lire non envoyé, lecture sale possible.
+        1 - lecture non validée, lecture sale possible.
        </simpara>
       </listitem>
       <listitem>
        <simpara>
-        2 - lire envoyé, lecture sale impossible.
+        2 - lecture validée, lecture sale impossible.
        </simpara>
       </listitem>
       <listitem>

--- a/reference/ibm_db2/setup.xml
+++ b/reference/ibm_db2/setup.xml
@@ -26,7 +26,7 @@
     L'utilisateur appelant l'exécutable PHP ou module SAPI doit spécifier
     l'instance DB2 avant d'accéder à ces fonctions. Il est possible de spécifier le
     nom de l'instance DB2 dans &php.ini; en utilisant l'option de
-    configuration <literal>ibm_db2.instance_name</literal> ou il est possible d'approvisionner le profile de l'instance DB2 avant d'appeler l'exécutable PHP.
+    configuration <literal>ibm_db2.instance_name</literal> ou il est possible d'approvisionner le profil de l'instance DB2 avant d'appeler l'exécutable PHP.
    </simpara>
    <para>
     Si l'on a créé une instance DB2 nommée <literal>db2inst1</literal>


### PR DESCRIPTION
Corrections de langue et de traduction dans reference/, de filter to ibm_db2 (orthographe, grammaire, fidélité à l'anglais).