### PR TITLE
Nits translation: reference/ (iconv to image)

### DIFF
--- a/reference/iconv/book.xml
+++ b/reference/iconv/book.xml
@@ -11,19 +11,24 @@
  <preface xml:id="intro.iconv">
   &reftitle.intro;
   <para>
-   Ce module est une interface vers la bibliothèque iconv.
-   L'extension iconv convertit des fichiers entre divers jeux de caractères.
-   Les jeux supportés dépendent de l'implémentation de la fonction 
-   <literal>iconv()</literal>
-   sur le système. Il est à noter que cette fonction ne fonctionne pas toujours bien
-   sur tous les systèmes. Dans ce cas, ce serait une bonne idée d'installer la
-   bibliothèque <link xlink:href="&url.libiconv;">GNU libiconv</link>.
+   Ce module contient une interface vers la fonctionnalité de conversion de
+   jeux de caractères iconv. Avec ce module, il est possible de transformer
+   une chaîne représentée dans un jeu de caractères local en une chaîne
+   représentée dans un autre jeu de caractères, qui peut être le jeu de
+   caractères Unicode. Les jeux de caractères supportés dépendent de
+   l'implémentation iconv du système.
+   Il est à noter que la fonction iconv sur certains systèmes peut ne pas
+   fonctionner comme prévu. Dans ce cas, ce serait une bonne idée d'installer
+   la bibliothèque <link xlink:href="&url.libiconv;">GNU libiconv</link>.
+   Elle aboutira très probablement à des résultats plus cohérents.
   </para>
+
   <para>
-   Cette extension dispose de beaucoup de fonctions 
-   utiles pour aider à écrire des scripts multilingues.
-   Les sections suivantes présentent les nouvelles fonctionnalités.
-  </para> 
+   Cette extension est fournie avec
+   diverses fonctions utilitaires qui aident à écrire des scripts
+   multilingues. Les sections suivantes présentent les nouvelles
+   fonctionnalités.
+  </para>
  </preface>
  <!-- }}} -->
 

--- a/reference/iconv/constants.xml
+++ b/reference/iconv/constants.xml
@@ -64,7 +64,7 @@
        (<type>int</type>)
       </entry>
       <entry><type>int</type></entry>
-      <entry>Un masque utilisé par <function>iconv_mime_decode</function></entry>
+      <entry>Un masque utilisé pour <function>iconv_mime_decode</function></entry>
      </row>
      <row xml:id="constant.iconv-mime-decode-continue-on-error">
       <entry>

--- a/reference/iconv/functions/iconv-get-encoding.xml
+++ b/reference/iconv/functions/iconv-get-encoding.xml
@@ -47,9 +47,9 @@
    Retourne la valeur courante de la variable de configuration en cas de succès&return.falseforfailure;.
   </para>
   <para>
-   Si <parameter>type</parameter> est omis ou différent de <literal>all</literal>
-   (c'est-à-dire "tous"), <function>iconv_get_encoding</function> retourne un
-   tableau contenant toutes les valeurs de ces constantes.
+   Si <parameter>type</parameter> est omis ou défini à <literal>all</literal>,
+   <function>iconv_get_encoding</function> retourne un
+   tableau contenant toutes les valeurs de ces variables.
   </para>
  </refsect1>
 

--- a/reference/iconv/functions/iconv-mime-decode-headers.xml
+++ b/reference/iconv/functions/iconv-mime-decode-headers.xml
@@ -41,7 +41,8 @@
       <para>
        <parameter>mode</parameter> détermine le comportement de la fonction,
        si <function>iconv_mime_decode_headers</function> rencontre un
-       en-tête <literal>MIME</literal> malformé.
+       en-tête <literal>MIME</literal> malformé. Il est possible de spécifier
+       toute combinaison des masques suivants.
        <table>
         <title>Masques acceptés par la fonction <function>iconv_mime_decode_headers</function></title>
         <tgroup cols="3">
@@ -57,11 +58,11 @@
            <entry>1</entry>
            <entry>ICONV_MIME_DECODE_STRICT</entry>
            <entry>
-            Si utilisés, les en-têtes sont décodés en respectant scrupuleusement
-            le standard de la <link xlink:href="&url.rfc;2047">RFC2047</link>.
-            Cette option est désactivée par défaut, car il y a de nombreux clients
-            mails qui ne suivent pas ces spécifications et qui ne produisent pas
-            d'en-têtes <literal>MIME</literal> corrects.
+            Si activée, l'en-tête fourni est décodé en respectant scrupuleusement
+            le standard défini dans la <link xlink:href="&url.rfc;2047">RFC2047</link>.
+            Cette option est désactivée par défaut, car il existe de nombreux
+            clients mail défectueux qui ne suivent pas la spécification et qui ne
+            produisent pas d'en-têtes <literal>MIME</literal> corrects.
            </entry>
           </row>
           <row>
@@ -85,9 +86,9 @@
       <para>
        Le paramètre optionnel <parameter>encoding</parameter> spécifie le
        jeu de caractères utilisé pour représenter le résultat.
-       S'il est omis, le jeu défini dans le fichier &php.ini;
+       S'il est omis ou &null;,
        <link linkend="iconv.configuration">iconv.internal_encoding</link>
-       est utilisé.
+       sera utilisé.
       </para>
      </listitem>
     </varlistentry>
@@ -98,9 +99,9 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Retourne un tableau associatif qui contient les en-têtes 
-   <literal>MIME</literal> spécifiés par le paramètre 
-   <parameter>headers</parameter>, ou bien &false;
+   Retourne un tableau associatif qui contient l'ensemble des en-têtes
+   <literal>MIME</literal> spécifiés par le paramètre
+   <parameter>headers</parameter> en cas de succès, ou bien &false;
    si une erreur survient durant le décodage.
   </para>
   <para>

--- a/reference/iconv/functions/iconv-mime-decode.xml
+++ b/reference/iconv/functions/iconv-mime-decode.xml
@@ -5,7 +5,7 @@
 <refentry xml:id="function.iconv-mime-decode" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>iconv_mime_decode</refname>
-  <refpurpose>Décode un champ d’en‐tête MIME</refpurpose>
+  <refpurpose>Décode un champ d'en-tête <literal>MIME</literal></refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -17,7 +17,7 @@
    <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>encoding</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
   <para>
-   <function>iconv_mime_decode</function> décode un champ d’en‐tête MIME.
+   Décode un champ d'en-tête <literal>MIME</literal>.
   </para>
  </refsect1>
 
@@ -29,7 +29,7 @@
      <term><parameter>string</parameter></term>
      <listitem>
       <para>
-       L’en‐tête encodé, sous la forme d’une &string;.
+       L'en-tête encodé, sous la forme d'une chaîne de caractères.
       </para>
      </listitem>
     </varlistentry>
@@ -37,11 +37,12 @@
      <term><parameter>mode</parameter></term>
      <listitem>
       <para>
-       <parameter>mode</parameter> détermine le comportement lorsque
-       <function>iconv_mime_decode</function> rencontre un champ d’en-tête
-       <literal>MIME</literal> mal formé.
+       <parameter>mode</parameter> détermine le comportement dans le cas où
+       <function>iconv_mime_decode</function> rencontre un champ d'en-tête
+       <literal>MIME</literal> mal formé. Il est possible de spécifier toute combinaison
+       des masques de bits suivants.
        <table>
-        <title>Masques acceptables pour la fonction <function>iconv_mime_decode</function></title>
+        <title>Masques de bits acceptables par <function>iconv_mime_decode</function></title>
         <tgroup cols="3">
          <thead>
           <row>
@@ -55,21 +56,20 @@
            <entry>1</entry>
            <entry>ICONV_MIME_DECODE_STRICT</entry>
            <entry>
-            Si défini, l’en‐tête correspondant sera décodé en suivant 
-            strictement le standard <link xlink:href="&url.rfc;2047">RFC2047</link>.
-            Cette option est désactivée par défaut, car il existe beaucoup 
-            de mauvais <literal>clients de courriel</literal> qui ne suivent pas
-            ce standard et donc, produisent de mauvais en‐têtes 
-            <literal>MIME</literal>.
+            Si défini, l'en-tête fourni est décodé en pleine conformité avec les
+            standards définis dans la <link xlink:href="&url.rfc;2047">RFC2047</link>.
+            Cette option est désactivée par défaut, car il existe beaucoup de
+            clients de courriel défectueux qui ne suivent pas la spécification et
+            ne produisent pas d'en-têtes <literal>MIME</literal> corrects.
            </entry>
           </row>
           <row>
            <entry>2</entry>
            <entry>ICONV_MIME_DECODE_CONTINUE_ON_ERROR</entry>
            <entry>
-            Si défini, <function>iconv_mime_decode</function> 
-            essaie de continuer à décoder l’en‐tête passé, 
-            même si des erreurs apparaissent.
+            Si défini, <function>iconv_mime_decode_headers</function>
+            tente d'ignorer toute erreur grammaticale et de continuer à traiter
+            un en-tête fourni.
            </entry>
           </row>
          </tbody>
@@ -83,9 +83,9 @@
      <listitem>
       <para>
        Le paramètre optionnel <parameter>encoding</parameter> spécifie
-       le jeu de caractères à utiliser pour représenter le résultat. 
-       S’il est omis,
-       <link linkend="iconv.configuration">iconv.internal_encoding</link> 
+       le jeu de caractères à utiliser pour représenter le résultat.
+       S'il est omis ou vaut &null;,
+       <link linkend="iconv.configuration">iconv.internal_encoding</link>
        sera utilisé.
       </para>
      </listitem>
@@ -97,7 +97,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Retourne un champ <literal>MIME</literal> en cas de succès,
+   Retourne un champ <literal>MIME</literal> décodé en cas de succès,
    ou &false; si une erreur survient durant le décodage.
   </para>
  </refsect1>
@@ -132,7 +132,7 @@
     <programlisting role="php">
 <![CDATA[
 <?php
-// Ceci affichera : "Subject: Prüfung Prüfung"
+// Ceci produit : "Subject: Prüfung Prüfung"
 echo iconv_mime_decode("Subject: =?UTF-8?B?UHLDvGZ1bmcgUHLDvGZ1bmc=?=",
                        0, "ISO-8859-1");
 ?>

--- a/reference/iconv/functions/iconv-set-encoding.xml
+++ b/reference/iconv/functions/iconv-set-encoding.xml
@@ -5,7 +5,7 @@
 <refentry xml:id="function.iconv-set-encoding" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>iconv_set_encoding</refname>
-  <refpurpose>Modifie le jeu courant de caractères d'encodage</refpurpose>
+  <refpurpose>Modifie le réglage courant pour la conversion d'encodage de caractères</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -16,8 +16,8 @@
    <methodparam><type>string</type><parameter>encoding</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Modifie le jeu de caractères courant, et remplace la valeur courante
-   du paramètre <parameter>type</parameter> par <parameter>encoding</parameter>.
+   Modifie la valeur de la variable de configuration interne spécifiée par
+   <parameter>type</parameter> vers <parameter>encoding</parameter>.
   </para>
  </refsect1>
 
@@ -29,7 +29,7 @@
      <term><parameter>type</parameter></term>
      <listitem>
       <para>
-       Les valeurs possibles de <parameter>type</parameter> sont :
+       La valeur de <parameter>type</parameter> peut être l'une des suivantes :
        <simplelist>
         <member>input_encoding</member>
         <member>output_encoding</member>

--- a/reference/iconv/functions/iconv-strlen.xml
+++ b/reference/iconv/functions/iconv-strlen.xml
@@ -16,11 +16,11 @@
    <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>encoding</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
   <para>
-   À l'opposé de <function>strlen</function>, la valeur de retour de
-   <function>iconv_strlen</function> est le nombre de caractères faisant
-   partie de la séquence d'octets <parameter>string</parameter>, ce qui n'est
-   pas toujours la même chose que la taille en octets de la chaîne de
-   caractères.
+   À l'opposé de <function>strlen</function>,
+   <function>iconv_strlen</function> compte les occurrences des caractères
+   présents dans la séquence d'octets <parameter>string</parameter> en se
+   basant sur le jeu de caractères spécifié, ce qui n'est pas nécessairement
+   identique à la longueur de la chaîne en octets.
   </para>
  </refsect1>
 

--- a/reference/iconv/functions/iconv-strpos.xml
+++ b/reference/iconv/functions/iconv-strpos.xml
@@ -56,7 +56,7 @@
       <para>
        Le paramètre optionnel <parameter>offset</parameter> spécifie la position
        à partir de laquelle la recherche doit commencer.
-       Si la position est négative, elle est comptée depuis la fin de la &string;
+       Si la position est négative, elle est comptée depuis la fin de la &string;.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/iconv/functions/iconv-strrpos.xml
+++ b/reference/iconv/functions/iconv-strrpos.xml
@@ -25,7 +25,7 @@
    <function>iconv_strrpos</function> est le nombre de caractères qui
    apparaissent avant l'aiguille, plutôt que la position en octets
    où l'aiguille a été trouvée. Les caractères sont comptés
-   sur la base du jeu de caractères spécifié <parameter>encoding</parameter>.
+   sur la base du jeu de caractères spécifié par <parameter>encoding</parameter>.
   </para>
  </refsect1>
 
@@ -63,8 +63,8 @@
   </para>
   <para>
    Si <parameter>haystack</parameter> ou <parameter>needle</parameter>
-   ne sont pas des chaînes de caractères, ils seront convertis en chaîne de caractères et reconnus
-   comme code ASCII de chaque caractère.
+   n'est pas une chaîne de caractères, il sera converti en chaîne de caractères et appliqué
+   comme valeur ordinale d'un caractère.
   </para>
  </refsect1>
 

--- a/reference/iconv/functions/iconv-substr.xml
+++ b/reference/iconv/functions/iconv-substr.xml
@@ -48,8 +48,8 @@
       <para>
        Si <parameter>offset</parameter> est négatif,
        <function>iconv_substr</function> retourne le segment en commençant à la
-       position <parameter>offset</parameter> caractères et en allant vers la
-       fin de la &string; <parameter>string</parameter>.
+       position située à <parameter>offset</parameter> caractères de la fin
+       de <parameter>string</parameter>.
       </para>
      </listitem>
     </varlistentry>
@@ -64,7 +64,7 @@
       </para>
       <para>
        Si <parameter>length</parameter> est passé et négatif,
-       <function>iconv_substr</function> coupe la portion externe de
+       <function>iconv_substr</function> extrait la portion de
        <parameter>string</parameter> depuis le caractère numéro <parameter>offset</parameter>
        jusqu'au caractère numéro <parameter>length</parameter>, compté depuis la fin de
        la &string;. Dans le cas où <parameter>offset</parameter> est également négatif,
@@ -100,10 +100,10 @@
    <parameter>offset</parameter> et <parameter>length</parameter>.
   </para>
   <para>
-   Si <parameter>string</parameter> est plus petit que <parameter>offset</parameter>,
-   &false; est retourné.
-   Si <parameter>string</parameter> est égal à <parameter>offset</parameter>
-   caractères long, une &string; vide est retournée.
+   Si <parameter>string</parameter> est plus court que <parameter>offset</parameter>
+   caractères, &false; est retourné.
+   Si <parameter>string</parameter> fait exactement <parameter>offset</parameter>
+   caractères de long, une &string; vide est retournée.
   </para>
  </refsect1>
  

--- a/reference/iconv/functions/iconv.xml
+++ b/reference/iconv/functions/iconv.xml
@@ -30,7 +30,7 @@
      <term><parameter>from_encoding</parameter></term>
      <listitem>
       <para>
-       L'encodage utilisé pour interpréter <parameter>string</parameter>.
+       L'encodage actuellement utilisé pour interpréter <parameter>string</parameter>.
       </para>
      </listitem>
     </varlistentry>
@@ -44,13 +44,12 @@
        Si la chaîne <literal>//TRANSLIT</literal> est ajoutée au paramètre
        <parameter>to_encoding</parameter>, alors la translittération est activée.
        Cela signifie que lorsqu'un caractère ne peut être représenté dans le jeu
-       de caractères cible, il pourrait être représenté approximativement à partir
-       d'un ou plusieurs caractères représentant le même caractère.
+       de caractères cible, il peut être approché par un ou plusieurs caractères
+       d'apparence similaire.
        Si la chaîne <literal>//IGNORE</literal> est ajoutée, les caractères
        ne pouvant être représentés dans le jeu de caractères cible seront
-       tout simplement ignorés. Sinon, une alerte de niveau
-       <constant>E_NOTICE</constant> sera générée et la fonction retournera
-       &false;.
+       silencieusement ignorés. Sinon, une <constant>E_NOTICE</constant> sera
+       générée et la fonction retournera &false;.
       </para>
       <caution>
        <para>
@@ -105,9 +104,8 @@ echo 'Brut     : ', iconv("UTF-8", "ISO-8859-1", $text), PHP_EOL;
 Original : Ceci est le symbole de l'Euro '€'.
 TRANSLIT : Ceci est le symbole de l'Euro 'EUR'.
 IGNORE   : Ceci est le symbole de l'Euro ''.
-Brut     : Ceci est le symbole de l'Euro '
-Notice: iconv(): Detected an illegal character in input string in /Users/macbook/Desktop/- on line 8
-Ceci est le symbole de l'Euro '
+Brut     :
+Notice: iconv(): Detected an illegal character in input string in .\iconv-example.php on line 7
 ]]>
     </screen>
    </example>

--- a/reference/iconv/reference.xml
+++ b/reference/iconv/reference.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 96c9d88bad9a7d7d44bfb7f26c226df7ee9ddf26 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 96c9d88bad9a7d7d44bfb7f26c226df7ee9ddf26 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 
 <reference xml:id="ref.iconv" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -9,7 +9,7 @@
  <partintro>
   &reftitle.seealso;
   <para>
-   Voir aussi les <link linkend="ref.recode">GNU Recode</link>.
+   Voir aussi les <link linkend="ref.recode">fonctions GNU Recode</link>.
   </para>
  </partintro>
 

--- a/reference/igbinary/functions/igbinary-serialize.xml
+++ b/reference/igbinary/functions/igbinary-serialize.xml
@@ -33,8 +33,8 @@
      <listitem>
       <simpara>
        La valeur à sérialiser. <function>igbinary_serialize</function>
-       gère tous les types sauf les <type>resource</type>s et certains <type>object</type>s (confère la note ci-dessous).
-       Même des &array;x qui contiennent des références à eux-même peuvent être sérialisés avec <function>igbinary_serialize</function>.
+       gère tous les types sauf les <type>resource</type>s et certains <type>object</type>s (voir la note ci-dessous).
+       Même des &array;s qui contiennent des références à eux-mêmes peuvent être sérialisés avec <function>igbinary_serialize</function>.
        Les références circulaires à l'intérieur d'un &array; ou d'un &object; à sérialiser seront également stockées.
        Toute autre référence sera perdue.
       </simpara>
@@ -66,7 +66,7 @@
    sous forme de flux d'octets qui peut être stocké à n'importe quel endroit.
   </simpara>
   <simpara>
-   Il est à noter que c'est une chaîne binaire qui peut inclure des caractères nuls, et doit donc être stockée et gérée comme telle.
+   Il est à noter que c'est une chaîne binaire qui peut inclure n'importe quelle valeur d'octet, et doit donc être stockée et gérée comme telle.
    Par exemple, dans une base de données, la sortie de la fonction <function>igbinary_serialize</function>
    doit, en général, être stockée dans un champ de type <literal>BLOB</literal>
    plutôt que dans un champ de type <literal>CHAR</literal> ou <literal>TEXT</literal>.

--- a/reference/igbinary/functions/igbinary-unserialize.xml
+++ b/reference/igbinary/functions/igbinary-unserialize.xml
@@ -27,7 +27,7 @@
     et l'autochargement d'objet, et ainsi, un utilisateur mal intentionné peut être capable d'exploiter
     ce comportement.
     À la place, un standard d'échange sûr tel que JSON (via <function>json_decode</function> et
-    <function>json_encode</function>) doit être utilisé pour passer des données sérialisées à l'utilisateur.
+    <function>json_encode</function>) doit être utilisé pour passer des données sérialisées au client.
    </simpara>
    <simpara>
     S'il est indispensable de désérialiser des données sérialisées provenant de l'extérieur, la fonction
@@ -55,8 +55,8 @@
       La chaîne de caractères sérialisée, générée par <function>igbinary_serialize</function>.
      </simpara>
      <simpara>
-      Si la variable désérialisée est un &object;, après avoir réussi à le reconstruire,
-      PHP tentera automatiquement d'appeler les méthodes magiques
+      Si la valeur désérialisée est un &object;, après avoir réussi à le reconstruire,
+      igbinary tentera automatiquement d'appeler les méthodes
       <link linkend="object.unserialize">__unserialize()</link> ou
       <link linkend="object.wakeup">__wakeup()</link> (si l'une d'elles existe).
      </simpara>

--- a/reference/image/book.xml
+++ b/reference/image/book.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 213fbd9440a224f9c1da4942c85124ce0c120c52 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 213fbd9440a224f9c1da4942c85124ce0c120c52 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 
 <book xml:id="book.image" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -17,7 +17,7 @@
    <acronym>WBMP</acronym> et <acronym>XPM</acronym>. Et PHP peut même générer
    directement des images pour le navigateur, avec la bibliothèque <acronym>GD</acronym>.
    <acronym>GD</acronym> et PHP auront aussi besoin d'autres bibliothèques, en fonction
-   des formats souhaités utiliser.
+   des formats à utiliser.
   </para>
   <para>
    Il est possible d'utiliser les fonctions PHP pour obtenir les

--- a/reference/image/configure.xml
+++ b/reference/image/configure.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 9ba738103b63ee4f129dadf3f8585568609e63b7 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 9ba738103b63ee4f129dadf3f8585568609e63b7 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <section xml:id="image.installation" xmlns="http://docbook.org/ns/docbook">
  &reftitle.install;
@@ -13,21 +13,21 @@
   La bibliothèque GD requiert <productname>libpng</productname> et
   <productname>libjpeg</productname> pour compiler.
   À partir de PHP 7.4.0, <option role="configure">--with-gd</option> devient
-  <option role="configure">--enable-gd</option> (s'il faut activer l'extension
-  tout) et <option role="configure">--with-external-gd</option>
+  <option role="configure">--enable-gd</option> (pour activer ou non
+  l'extension) et <option role="configure">--with-external-gd</option>
   (pour choisir d'utiliser une <productname>libgd</productname> externe, plutôt
   que celle fournie).
  </para>
  <para>
-  Sous Windows, il faut inclure la bibliothèque 
+  Sous Windows, il faut inclure la bibliothèque
   <filename>php_gd.dll</filename> comme extension dans le fichier &php.ini;.
-  Antérieur à PHP 8.0.0, la DLL était nommée <filename>php_gd2.dll</filename>.
+  Avant PHP 8.0.0, la DLL était nommée <filename>php_gd2.dll</filename>.
  </para>
 
  <para>
-  Augmentez les possibilités des GD de gérer d'autres formats d'images
-  en spécifiant les options <literal>--with-XXXX</literal> de compilation
-  suivantes : 
+  Pour étendre les possibilités de GD à gérer d'autres formats d'images,
+  il est possible de spécifier les options <literal>--with-XXXX</literal>
+  de compilation suivantes :
   <table>
    <title>Formats d'image supportés</title>
    <tgroup cols="2">
@@ -51,7 +51,7 @@
       <entry>
        Pour activer le support de la bibliothèque JPEG, ajouter l'option
        <option role="configure">--with-jpeg-dir=DIR</option>. Jpeg 6b, 7 ou 8
-       est supporté.
+       sont supportés.
        À partir de PHP 7.4.0, utiliser à la place
        <option role="configure">--with-jpeg</option>
       </entry>
@@ -74,9 +74,9 @@
      <row>
       <entry><literal>xpm</literal></entry>
       <entry>
-       Pour activer le support de la bibliothèque XPM, ajoutez l'option
+       Pour activer le support de la bibliothèque XPM, ajouter l'option
        <option role="configure">--with-xpm-dir=DIR</option>. Si le script
-       de compilation n'est pas capable de trouver les bibliothèques 
+       de compilation n'est pas capable de trouver les bibliothèques
        nécessaires, il faudra ajouter le chemin vers les bibliothèques X11.
        À partir de PHP 7.4.0, utiliser à la place
        <option role="configure">--with-xpm</option>
@@ -85,7 +85,7 @@
      <row>
       <entry><literal>webp</literal></entry>
       <entry>
-       Pour activer la prise en charge de WebP, ajoutez 
+       Pour activer le support de WebP, ajouter
        <option role="configure">--with-webp-dir=DIR</option>.
        À partir de PHP 7.4.0, utiliser à la place
        <option role="configure">--with-webp</option>
@@ -102,9 +102,9 @@
   </note>
  </para>
  <para>
-  Augmentez les possibilités de GD pour qu'elle manipule différents types 
-  de polices de caractères en ajoutant les options 
-  <literal>--with-XXXX</literal> de compilation suivantes : 
+  Pour étendre les possibilités de GD à manipuler différents types
+  de polices de caractères, il est possible d'ajouter les options
+  <literal>--with-XXXX</literal> de compilation suivantes :
   <table>
    <title>Bibliothèques des polices de caractères supportées</title>
    <tgroup cols="2">
@@ -118,7 +118,7 @@
      <row>
       <entry><literal>FreeType 2</literal></entry>
       <entry>
-       Pour activer le support de FreeType 2, ajoutez l'option
+       Pour activer le support de FreeType 2, ajouter l'option
        <option role="configure">--with-freetype-dir=DIR</option>.
        À partir de PHP 7.4.0 utiliser <option role="configure">--with-freetype</option>
        à la place, qui dépend de <productname>pkg-config</productname>.
@@ -127,8 +127,8 @@
      <row>
       <entry><literal>Chaînes TrueType</literal></entry>
       <entry>
-       Pour activer le support des chaînes de caractères TrueType, 
-       ajoutez l'option 
+       Pour activer le support des chaînes de caractères TrueType,
+       ajouter l'option
        <option role="configure">--enable-gd-native-ttf</option>.
        (Cette option n'a aucun effet et a été supprimée à partir de PHP 7.2.0.)
       </entry>

--- a/reference/image/constants.xml
+++ b/reference/image/constants.xml
@@ -731,7 +731,7 @@
    <listitem>
     <simpara>
      Le nombre de constantes de type d'image (y compris le type "inconnu")
-     pris en charge par les fonctions <function>image_type_to_mime_type</function> et <function>image_type_to_extension</function>
+     supportées par les fonctions <function>image_type_to_mime_type</function> et <function>image_type_to_extension</function>
     </simpara>
    </listitem>
   </varlistentry>

--- a/reference/image/examples.xml
+++ b/reference/image/examples.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9960a09a5705102bf4dd0ce63e03d9ec716d0015 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 9960a09a5705102bf4dd0ce63e03d9ec716d0015 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 
 <chapter xml:id="image.examples" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -26,13 +26,13 @@ imagepng($im);
     </programlisting>
    </example>
    Cet exemple doit être appelé depuis une page HTML avec une balise
-   image telle que : <literal>&lt;img src=&quot;button.php?text&quot;&gt;</literal>.
+   image telle que : <literal>&lt;img src=&quot;button.php?text=text&quot;&gt;</literal>.
    Le script ci-dessus, <filename>button.php</filename>, prend la chaîne
-   <literal>&quot;texte&quot;</literal> et l'inscrit
+   <literal>&quot;text&quot;</literal> et l'inscrit
    sur le fond d'image appelé <literal>&quot;images/button1.png&quot;</literal>,
-   puis l'affiche. C'est une méthode très pratique pour éviter de redessiner un
-   nouveau bouton, dès que l'on change son texte. De cette façon, ils sont
-   générés dynamiquement.
+   puis l'affiche. C'est une méthode très pratique pour éviter de redessiner une
+   nouvelle image de bouton à chaque changement de texte. Avec cette méthode, ils
+   sont générés dynamiquement.
   </para>
  </section>
  <section xml:id="image.examples-watermark">
@@ -70,8 +70,8 @@ imagepng($im);
      </imageobject>
     </mediaobject>
    </example>
-   Cet exemple montre un moyen simple d'appliquer un tatouage numérique
-   et un cachet aux photos et les images sous licence.
+   Cet exemple montre un moyen courant d'appliquer un tatouage numérique
+   et un cachet aux photos et aux images sous licence.
    Il est à noter la présence d'un canal Alpha dans le cachet ainsi que du texte
    anti-aliasé. Ces 2 éléments seront préservés lors de la copie.
   </para>
@@ -118,13 +118,12 @@ imagepng($im, 'photo_stamp.png');
      </imageobject>
     </mediaobject>
    </example>
-   Cet exemple utilise la fonction <function>imagecopymerge</function>
-   pour fusionner le cachet avec notre image originale. En utilisant cette
-   fonction, nous pouvons définir l'opacité de notre cachet - dans notre
-   exemple, nous l'avons défini à 50%. En pratique, il est plus judicieux
-   de rendre notre protection semi-transparente, la rendant plus difficile à
-   enlever mais permettant également aux visionneuses d'images de la lire sans
-   problème.
+   Cet exemple utilise <function>imagecopymerge</function> pour fusionner
+   le cachet avec l'image originale. Avec cette fonction, il est possible
+   de définir l'opacité du cachet : dans cet exemple, elle est fixée à
+   50%. En pratique, cela est utile pour la protection des droits d'auteur,
+   car les tatouages semi-transparents sont difficiles à retirer tout en
+   permettant aux personnes qui regardent l'image de la voir.
   </para>
  </section>
 </chapter>

--- a/reference/image/functions/gd-info.xml
+++ b/reference/image/functions/gd-info.xml
@@ -30,7 +30,7 @@
   </para>
   <para>
    <table>
-    <title>Éléments du tableau retournés par <function>gd_info</function></title>
+    <title>Éléments du tableau retourné par <function>gd_info</function></title>
     <tgroup cols="2">
      <thead>
       <row>
@@ -51,8 +51,8 @@
       </row>
       <row>
        <entry>FreeType Linkage</entry>
-       <entry>&string; décrivant la façon avec
-        laquelle FreeType a été lié. Les valeurs attendues sont :
+       <entry>&string; décrivant la façon dont
+        FreeType a été lié. Les valeurs attendues sont :
         '<literal>with freetype</literal>', '<literal>with TTF library</literal>' et
         '<literal>with unknown library</literal>'. Cet élément ne sera
         défini que si <literal>FreeType Support</literal> est évalué

--- a/reference/image/functions/getimagesize.xml
+++ b/reference/image/functions/getimagesize.xml
@@ -16,7 +16,7 @@
   </methodsynopsis>
   <para>
    <function>getimagesize</function> détermine la taille de toute image supportée
-   fournie et en retourne les dimensions, le type d'image et une chaîne type
+   fournie et en retourne les dimensions, le type d'image et une chaîne de texte de type
    <literal>height/width</literal> à placer dans une balise
    <acronym>HTML</acronym> <tag>IMG</tag> normale
    et le type de contenu <acronym>HTTP</acronym> correspondant.
@@ -35,8 +35,8 @@
    </para>
    <para>
     Il ne faut pas utiliser <function>getimagesize</function> pour vérifier qu'un
-    fichier donné est une image valide. Il est préférable d'utiliser à la place une solution prévue
-    pour cela telle que l'extension <link linkend="book.fileinfo">FileInfo</link>.
+    fichier donné est une image valide. Il faut utiliser à la place une solution prévue
+    pour cela telle que l'extension <link linkend="book.fileinfo">Fileinfo</link>.
    </para>
   </caution>
   
@@ -58,7 +58,7 @@
   </note>
   <note>
    <simpara>
-    Les images GIF consistant d'un ou plusieurs cadres, où chaque cadre peut occuper
+    Les images GIF sont constituées d'un ou plusieurs cadres, où chaque cadre peut occuper
     uniquement une partie de l'image. La taille de l'image qui est rapportée par
     <function>getimagesize</function> est la taille globale (lue depuis le descripteur logique de l'écran).
    </simpara>
@@ -88,10 +88,11 @@
        supplémentaires du fichier image. Actuellement, cette option
        va retourner différents marqueurs <acronym>JPG</acronym>
        APP dans un tableau associatif. Certains programmes utilisent
-       ces marqueurs APP pour préciser les informations dans les balises
-       HTML. Un marqueur commun est le marqueur APP13, décrit
-       à <link xlink:href="&url.iptc;">IPTC</link>. Il est possible d'utiliser
-       la fonction <function>iptcparse</function> pour analyser ce marqueur,
+       ces marqueurs APP pour intégrer des informations textuelles dans les
+       images. Un cas très répandu consiste à intégrer des informations
+       <link xlink:href="&url.iptc;">IPTC</link> dans le marqueur APP13.
+       Il est possible d'utiliser
+       la fonction <function>iptcparse</function> pour analyser ce marqueur APP13 binaire,
        et obtenir des informations intelligibles.
       </para>
       <note>
@@ -114,7 +115,7 @@
    <literal>bits</literal>.
   </para>
   <para>
-   L'index 0 contient la largeur. L'index 1 contient la hauteur.
+   Les indices 0 et 1 contiennent respectivement la largeur et la hauteur de l'image.
   </para>
   <note>
    <para>
@@ -131,15 +132,16 @@
     Par exemple, si le drapeau Exif <literal>Orientation</literal> est défini sur une valeur qui
     fait pivoter l'image de 90 ou 270 degrés, les indices 0 et 1 sont échangés,
     c'est-à-dire qu'ils contiennent respectivement la hauteur et la largeur.
-</simpara>
+   </simpara>
   </note>
   <para>
    L'index 2 est une constante parmi <constant>IMAGETYPE_<replaceable>*</replaceable></constant>,
    indiquant le type de l'image.
   </para>
   <para>
-   L'index 3 contient la chaîne à placer dans les balises
-   <acronym>IMG</acronym> : <literal>height="xxx" width="yyy"</literal>.
+   L'index 3 est une chaîne de texte avec la chaîne
+   <literal>height="yyy" width="xxx"</literal> correcte qui peut être utilisée
+   directement dans une balise <acronym>IMG</acronym>.
   </para>
   <para>
    <literal>mime</literal> correspond au type MIME d'une image.
@@ -172,8 +174,8 @@ if ($size && $fp) {
    <literal>bits</literal> est le nombre de bits pour chaque couleur.
   </para>
   <para>
-   Cependant, la présence des valeurs de <literal>channels</literal> et
-   de <literal>bits</literal> peut mener à la confusion. Par
+   Pour certains types d'images, la présence des valeurs de <literal>channels</literal> et
+   de <literal>bits</literal> peut prêter à confusion. Par
    exemple, une image <acronym>GIF</acronym> utilise toujours trois canaux par
    pixel, mais le nombre de bits par pixel ne peut être calculé dans le cas
    d'une image animée <acronym>GIF</acronym> ayant une table de couleur
@@ -212,9 +214,9 @@ if ($size && $fp) {
       <row>
        <entry>8.2.0</entry>
        <entry>
-        Retourne les dimensions actuelles de l'image, bits et chaînes des images AVIF;
-        précédemment, les dimensions étaient reportées en tant que <literal>0x0</literal>,
-        et bits et chaînes n'étaient pas reportées du tout.
+        Retourne désormais les dimensions réelles de l'image, les bits et les canaux des images AVIF ;
+        précédemment, les dimensions étaient rapportées en tant que <literal>0x0</literal>,
+        et les bits et les canaux n'étaient pas rapportés du tout.
        </entry>
       </row>
       <row>

--- a/reference/image/functions/getimagesizefromstring.xml
+++ b/reference/image/functions/getimagesizefromstring.xml
@@ -22,7 +22,7 @@
   </para>
   <para>
    Voir la documentation sur la fonction <function>getimagesize</function>
-   pour plus de détails sur la façon dont cette fonction marche.
+   pour plus de détails sur le fonctionnement de cette fonction.
   </para>
  </refsect1>
 
@@ -68,7 +68,7 @@ $img = '/path/to/test.png';
 // Ouverture via un fichier
 $size_info1 = getimagesize($img);
 
-// Ouverture via une chaîne
+// Ou ouverture via une chaîne
 $data       = file_get_contents($img);
 $size_info2 = getimagesizefromstring($data);
 ?>

--- a/reference/image/functions/image-type-to-extension.xml
+++ b/reference/image/functions/image-type-to-extension.xml
@@ -34,7 +34,7 @@
      <term><parameter>include_dot</parameter></term>
      <listitem>
       <para>
-       Si l'on doit ajouter un point à l'extension ou non. 
+       Indique s'il faut ajouter un point à l'extension ou non.
        Par défaut, vaut &true;.
       </para>
      </listitem>

--- a/reference/image/functions/image2wbmp.xml
+++ b/reference/image/functions/image2wbmp.xml
@@ -33,7 +33,7 @@
      <listitem>
       <para>
        Une ressource d'image, retournée par une des fonctions de création
-       d'image, tel que <function>imagecreatetruecolor</function>.
+       d'image, telles que <function>imagecreatetruecolor</function>.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/image/functions/imageaffine.xml
+++ b/reference/image/functions/imageaffine.xml
@@ -50,7 +50,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Retourne l'objet d'image liée en cas de succès&return.falseforfailure;.
+   Retourne l'objet image transformée en cas de succès&return.falseforfailure;.
   </para>
  </refsect1>
 

--- a/reference/image/functions/imageaffinematrixconcat.xml
+++ b/reference/image/functions/imageaffinematrixconcat.xml
@@ -16,8 +16,8 @@
    <methodparam><type>array</type><parameter>matrix2</parameter></methodparam>
   </methodsynopsis>
   <para>
-    Retourne la concaténation de deux matrices de transformation affine, ce qui 
-   est utile si plusieurs transformations doivent être appliquées à la même 
+    Retourne la concaténation de deux matrices de transformation affine, ce qui
+   est utile si plusieurs transformations devraient être appliquées à la même
    image en une seule fois.
   </para>
  </refsect1>

--- a/reference/image/functions/imageaffinematrixget.xml
+++ b/reference/image/functions/imageaffinematrixget.xml
@@ -56,7 +56,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Une matrice de transformation affine (un tableau avec des clés de <literal>0</literal> à <literal>5</literal> et nombres décimaux en valeur).
+   Une matrice de transformation affine (un tableau avec des clés de <literal>0</literal> à <literal>5</literal> et des valeurs de type <type>float</type>).
    &return.falseforfailure;.
   </para>
  </refsect1>

--- a/reference/image/functions/imagealphablending.xml
+++ b/reference/image/functions/imagealphablending.xml
@@ -14,15 +14,16 @@
    <methodparam><type>bool</type><parameter>enable</parameter></methodparam>
   </methodsynopsis>
   <para>
-   <function>imagealphablending</function> fournit deux modes de dessin
-   des images en vraies couleurs (truecolors). En mode "blending", le canal
-   alpha de chaque couleur est fourni à chaque fonction de dessin, tel que
-   <function>imagesetpixel</function> peut déterminer sa transparence. GD va alors
-   automatiquement mixer la couleur à ce point, et stocker le résultat dans
-   l'image. Le pixel résultant est alors opaque. En mode non-mixant, la
-   couleur est copiée littéralement avec ses informations de canal alpha,
-   et remplace le pixel de destination. Le mixage n'est pas disponible
-   avec les images à palette.
+   <function>imagealphablending</function> permet deux modes différents de
+   dessin sur les images en vraies couleurs (truecolor). En mode "blending",
+   la composante du canal alpha de la couleur fournie à toutes les fonctions
+   de dessin, telles que <function>imagesetpixel</function>, détermine dans
+   quelle mesure la couleur sous-jacente doit transparaître. En conséquence,
+   GD mélange automatiquement la couleur existante en ce point avec la couleur
+   de dessin, et stocke le résultat dans l'image. Le pixel résultant est opaque.
+   En mode non-blending, la couleur de dessin est copiée littéralement avec ses
+   informations de canal alpha, en remplaçant le pixel de destination. Le mode
+   blending n'est pas disponible lors du dessin sur les images à palette.
   </para>
  </refsect1>
 
@@ -35,8 +36,8 @@
      <term><parameter>enable</parameter></term>
      <listitem>
       <para>
-       Si l'on doit activer le mode blending ou non.
-       Sur les images à couleurs vraies, la valeur par défaut
+       S'il faut activer le mode blending ou non.
+       Sur les images en vraies couleurs, la valeur par défaut
        est &true;, sinon, la valeur par défaut est &false;.
       </para>
      </listitem>

--- a/reference/image/functions/imageantialias.xml
+++ b/reference/image/functions/imageantialias.xml
@@ -14,7 +14,7 @@
    <methodparam><type>bool</type><parameter>enable</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Active les méthodes de dessin rapide antialias concernant les lignes et les polygones.
+   Active les méthodes de dessin rapide antialias concernant les lignes et les polygones filaires.
    Les composantes alpha ne sont pas supportées. Fonctionne en utilisant une opération
    directe de mélange, uniquement avec les images truecolor.
   </para>
@@ -24,7 +24,7 @@
   <para>
    L'utilisation des primitives antialias avec des arrière-plans transparents peut
    mener à des résultats imprévus. La méthode de mélange utilise
-   la couleur d'arrière-plan comme toute autre couleur. Le manque de support
+   la couleur d'arrière-plan comme toute autre couleur. L'absence de support
    du composant alpha empêche l'utilisation d'antialias basé sur l'alpha.
   </para>
  </refsect1>
@@ -68,8 +68,8 @@
      <row>
       <entry>7.2.0</entry>
       <entry>
-       <function>imageantialias</function> est maintenant généralement 
-       disponible. Auparavant, elle était seulement disponible si PHP a été 
+       <function>imageantialias</function> est maintenant généralement
+       disponible. Antérieurement, elle était seulement disponible si PHP était
        compilé avec la version groupée de la bibliothèque GD.
       </entry>
      </row>
@@ -102,7 +102,7 @@ imageline($normal, 0, 0, 200, 100, $red);
 imageline($aa, 0, 0, 200, 100, $red_aa);
 
 // Fusionne les 2 images, côté par côté pour l'affichage
-// (AA: gauche, Normal: Droit)
+// (AA: gauche, Normal: droite)
 imagecopymerge($aa, $normal, 200, 0, 0, 0, 200, 100, 100);
 
 // Affichage de l'image

--- a/reference/image/functions/imagearc.xml
+++ b/reference/image/functions/imagearc.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="function.imagearc" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>imagearc</refname>
-  <refpurpose>Dessine une ellipse partielle</refpurpose>
+  <refpurpose>Dessine un arc</refpurpose>
  </refnamediv>
  <refsect1 role="description">
   &reftitle.description;
@@ -20,7 +20,7 @@
    <methodparam><type>int</type><parameter>color</parameter></methodparam>
   </methodsynopsis>
   <para>
-   <function>imagearc</function> dessine une ellipse partielle, centrée sur les
+   <function>imagearc</function> dessine un arc de cercle, centré sur les
    coordonnées fournies.
   </para>
  </refsect1>
@@ -33,7 +33,7 @@
      <term><parameter>center_x</parameter></term>
      <listitem>
       <para>
-       X : coordonnée du centre.
+       Coordonnée x du centre.
       </para>
      </listitem>
     </varlistentry>
@@ -41,7 +41,7 @@
      <term><parameter>center_y</parameter></term>
      <listitem>
       <para>
-       Y : coordonnée du centre.
+       Coordonnée y du centre.
       </para>
      </listitem>
     </varlistentry>
@@ -49,7 +49,7 @@
      <term><parameter>width</parameter></term>
      <listitem>
       <para>
-       La largeur de l'ellipse.
+       La largeur de l'arc.
       </para>
      </listitem>
     </varlistentry>
@@ -57,7 +57,7 @@
      <term><parameter>height</parameter></term>
      <listitem>
       <para>
-       La hauteur de l'ellipse.
+       La hauteur de l'arc.
       </para>
      </listitem>
     </varlistentry>
@@ -65,7 +65,7 @@
      <term><parameter>start_angle</parameter></term>
      <listitem>
       <para>
-       L'angle de début de l'ellipse, en degrés.
+       L'angle de début de l'arc, en degrés.
       </para>
      </listitem>
     </varlistentry>
@@ -73,9 +73,9 @@
      <term><parameter>end_angle</parameter></term>
      <listitem>
       <para>
-       L'angle de fin de l'ellipse, en degrés.
-       0° correspond à la position "trois heures" et l'ellipse est
-       dessinée dans le sens des aiguilles d'une montre.
+       L'angle de fin de l'arc, en degrés.
+       0° correspond à la position "trois heures" et l'arc est
+       dessiné dans le sens des aiguilles d'une montre.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/image/functions/imagebmp.xml
+++ b/reference/image/functions/imagebmp.xml
@@ -32,8 +32,8 @@
       <para>&gd.image.path;</para>
       <note>
        <para>
-        &null; est invalide si l'argument <parameter>compressed</parameter> est
-        inutilisé.
+        &null; est invalide si l'argument <parameter>compressed</parameter>
+        n'est pas utilisé.
        </para>
       </note>
      </listitem>
@@ -42,7 +42,7 @@
      <term><parameter>compressed</parameter></term>
      <listitem>
       <para>
-       Si le BMP doit être compressé avec <literal>run-length encoding</literal> (RLE), ou pas.
+       Si le BMP doit être compressé avec run-length encoding (RLE), ou pas.
       </para>
      </listitem>
     </varlistentry>
@@ -74,7 +74,7 @@
       <entry>8.0.0</entry>
       <entry>
        Le type de <parameter>compressed</parameter> est désormais &boolean; ;
-       auparavant c'était &integer;.
+       antérieurement c'était &integer;.
       </entry>
      </row>
     </tbody>

--- a/reference/image/functions/imagechar.xml
+++ b/reference/image/functions/imagechar.xml
@@ -35,7 +35,7 @@
      <term><parameter>x</parameter></term>
      <listitem>
       <para>
-       X : coordonnée de départ.
+       Coordonnée X de départ.
       </para>
      </listitem>
     </varlistentry>
@@ -43,7 +43,7 @@
      <term><parameter>y</parameter></term>
      <listitem>
       <para>
-       Y : coordonnée de départ.
+       Coordonnée Y de départ.
       </para>
      </listitem>
     </varlistentry>
@@ -107,7 +107,7 @@ $string = 'PHP';
 $bg = imagecolorallocate($im, 255, 255, 255);
 $black = imagecolorallocate($im, 0, 0, 0);
 
-// affiche un "P" noir dans le coin gauche en haut
+// affiche un "P" noir dans le coin supérieur gauche
 imagechar($im, 1, 0, 0, $string, $black);
 
 header('Content-type: image/png');

--- a/reference/image/functions/imagecharup.xml
+++ b/reference/image/functions/imagecharup.xml
@@ -32,7 +32,7 @@
      <term><parameter>x</parameter></term>
      <listitem>
       <para>
-       X : coordonnée de départ.
+       Coordonnée x du point de départ.
       </para>
      </listitem>
     </varlistentry>
@@ -40,7 +40,7 @@
      <term><parameter>y</parameter></term>
      <listitem>
       <para>
-       Y : coordonnée de départ.
+       Coordonnée y du point de départ.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/image/functions/imagecolorallocate.xml
+++ b/reference/image/functions/imagecolorallocate.xml
@@ -58,7 +58,7 @@
     </varlistentry>
    </variablelist>
    Ces paramètres sont des entiers compris entre 0 et 255 ou des hexadécimaux
-   compris entre 0x00 and 0xFF.
+   compris entre 0x00 et 0xFF.
   </para>
  </refsect1>
 

--- a/reference/image/functions/imagecolorallocatealpha.xml
+++ b/reference/image/functions/imagecolorallocatealpha.xml
@@ -115,12 +115,12 @@ $yellow = imagecolorallocatealpha($image, 255, 255, 0, 75);
 $red    = imagecolorallocatealpha($image, 255, 0, 0, 75);
 $blue   = imagecolorallocatealpha($image, 0, 0, 255, 75);
 
-// Dessine 3 ellipses
+// Dessine 3 cercles superposés
 imagefilledellipse($image, $yellow_x, $yellow_y, $radius, $radius, $yellow);
 imagefilledellipse($image, $red_x, $red_y, $radius, $radius, $red);
 imagefilledellipse($image, $blue_x, $blue_y, $radius, $radius, $blue);
 
-// Ne pas oublier d'envoyer un header correct
+// Ne pas oublier d'envoyer un en-tête correct
 header('Content-Type: image/png');
 
 // et finalement, afficher le résultat
@@ -130,7 +130,7 @@ imagepng($image);
    </programlisting>
    &example.outputs.similar;
    <mediaobject>
-    <alt>Sortie de l'exemple : imagecolorallocatealpha()</alt>
+    <alt>Sortie de l'exemple : Exemple d'utilisation de imagecolorallocatealpha()</alt>
     <imageobject>
      <imagedata fileref="en/reference/image/figures/imagecolorallocatealpha.png"/>
     </imageobject>
@@ -144,7 +144,7 @@ imagepng($image);
    </title>
    <para>
     Généralement les valeurs alpha <literal>0</literal> désignent les pixels
-    complètement transparent, et le canal alpha a 8 bits. Pour convertir de
+    complètement transparents, et le canal alpha a 8 bits. Pour convertir de
     telles valeurs alpha pour être compatible avec
     <function>imagecolorallocatealpha</function>, un peu d'arithmétique simple
     est suffisante :
@@ -152,9 +152,9 @@ imagepng($image);
    <programlisting role="php">
 <![CDATA[
 <?php
-$alpha8 = 0; // fully transparent
+$alpha8 = 0; // totalement transparent
 var_dump(127 - ($alpha8 >> 1));
-$alpha8 = 255; // fully opaque
+$alpha8 = 255; // totalement opaque
 var_dump(127 - ($alpha8 >> 1));
 ?>
 ]]>

--- a/reference/image/functions/imagecolorat.xml
+++ b/reference/image/functions/imagecolorat.xml
@@ -21,9 +21,9 @@
   </para>
   <para>
    Si l'image
-   est une image en TrueColor, cette fonction retourne la valeur RGB
-   du pixel, sous forme d'un entier. Utiliser les opérateurs de bits et les
-   masques pour distinguer le rouge, du vert et du bleu : 
+   est une image en truecolor, cette fonction retourne la valeur RGB
+   du pixel, sous forme d'un entier. Il faut utiliser les opérateurs de bits et les
+   masques pour distinguer les composantes rouge, verte et bleue :
   </para>
  </refsect1>
  <refsect1 role="parameters">

--- a/reference/image/functions/imagecolorclosestalpha.xml
+++ b/reference/image/functions/imagecolorclosestalpha.xml
@@ -59,7 +59,7 @@
      </listitem>
     </varlistentry>
    </variablelist>
-   Les paramètres sur les couleurs sont des entiers compris entre 0 et 255 ou
+   Les paramètres de couleur sont des entiers compris entre 0 et 255 ou
    des hexadécimaux compris entre 0x00 et 0xFF.
   </para>
  </refsect1>

--- a/reference/image/functions/imagecolorclosesthwb.xml
+++ b/reference/image/functions/imagecolorclosesthwb.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="function.imagecolorclosesthwb" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>imagecolorclosesthwb</refname>
-  <refpurpose>Lit l'index de la couleur spécifiée avec sa teinte, blanc et noir</refpurpose>
+  <refpurpose>Récupère l'index de la couleur ayant la teinte, le blanc et le noir</refpurpose>
  </refnamediv>
  <refsect1 role="description">
   &reftitle.description;
@@ -16,7 +16,8 @@
    <methodparam><type>int</type><parameter>blue</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Lit l'index de la couleur spécifiée avec sa teinte, blanc et noir.
+   Récupère l'index de la couleur ayant la teinte, le blanc
+   et le noir les plus proches de la couleur donnée.
   </para>
  </refsect1>
  <refsect1 role="parameters">
@@ -49,7 +50,8 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Retourne un entier représentant l'index de la couleur.
+   Retourne un entier correspondant à l'index de la couleur ayant
+   la teinte, le blanc et le noir les plus proches de la couleur donnée.
   </para>
  </refsect1>
 
@@ -80,7 +82,7 @@
 <?php
 $im = imagecreatefromgif('php.gif');
 
-echo 'HWB : ' . imagecolorclosesthwb($im, 116, 115, 152);
+echo 'HWB: ' . imagecolorclosesthwb($im, 116, 115, 152);
 ?>
 ]]>
     </programlisting>

--- a/reference/image/functions/imagecolordeallocate.xml
+++ b/reference/image/functions/imagecolordeallocate.xml
@@ -16,10 +16,9 @@
    <methodparam><type>int</type><parameter>color</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Supprime la couleur <parameter>color</parameter>
-   précédemment allouée avec la fonction
-   <function>imagecolorallocate</function>, pour l'image
-   <parameter>image</parameter>.
+   Supprime une couleur précédemment allouée avec
+   <function>imagecolorallocate</function> ou
+   <function>imagecolorallocatealpha</function>.
   </para>
  </refsect1>
  <refsect1 role="parameters">

--- a/reference/image/functions/imagecolorexact.xml
+++ b/reference/image/functions/imagecolorexact.xml
@@ -51,7 +51,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Retourne l'index de la couleur spécifié dans la palette, ou -1 si
+   Retourne l'index de la couleur spécifiée dans la palette, ou -1 si
    la couleur n'existe pas.
   </para>
  </refsect1>

--- a/reference/image/functions/imagecolorexactalpha.xml
+++ b/reference/image/functions/imagecolorexactalpha.xml
@@ -18,7 +18,8 @@
    <methodparam><type>int</type><parameter>alpha</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Retourne l'index d'une couleur avec son canal alpha.
+   Retourne l'index de la couleur spécifiée et son canal alpha dans la palette
+   de l'image.
   </para>
  </refsect1>
  <refsect1 role="parameters">
@@ -56,7 +57,7 @@
     </varlistentry>
    </variablelist>
    Les paramètres sur les couleurs sont des entiers compris entre 0 et 255
-   ou des hexadécimaux compris entre 0x00 and 0xFF.
+   ou des hexadécimaux compris entre 0x00 et 0xFF.
   </para>
  </refsect1>
  <refsect1 role="returnvalues">

--- a/reference/image/functions/imagecolormatch.xml
+++ b/reference/image/functions/imagecolormatch.xml
@@ -36,8 +36,8 @@
      <term><parameter>image2</parameter></term>
      <listitem>
       <para>
-       Un objet de palette d'image pointant sur une image
-       qui a la même taille que <parameter>image1</parameter>.
+       Un objet image en palette pointant sur une image
+       de même taille que <parameter>image1</parameter>.
       </para>
      </listitem>
     </varlistentry>
@@ -66,8 +66,8 @@
       <entry>8.0.0</entry>
       <entry>
        <parameter>image1</parameter> et <parameter>image2</parameter> attendent
-       désormais des instances de <classname>GdImage</classname> ; auparavant,
-       <type>resource</type>s étaient attendues
+       désormais des instances de <classname>GdImage</classname> ; antérieurement,
+       des <type>resource</type>s étaient attendues.
       </entry>
      </row>
     </tbody>

--- a/reference/image/functions/imagecolorresolve.xml
+++ b/reference/image/functions/imagecolorresolve.xml
@@ -88,7 +88,7 @@ $im = imagecreatefromgif('phplogo.gif');
 // Récupération des couleurs les plus proches de l'image
 $colors = array();
 $colors[] = imagecolorresolve($im, 255, 255, 255);
-$colors[] = imagecolorresolve($im, 0, 0, 200)
+$colors[] = imagecolorresolve($im, 0, 0, 200);
 
 // Affichage
 print_r($colors);

--- a/reference/image/functions/imagecolorresolvealpha.xml
+++ b/reference/image/functions/imagecolorresolvealpha.xml
@@ -92,7 +92,7 @@
  <refsect1 role="examples">
   &reftitle.examples;
   <example>
-   <title>Exemple avec <function>imagecoloresolve</function>
+   <title>Exemple avec <function>imagecoloresolvealpha</function>
     pour récupérer les couleurs d'une image</title>
    <programlisting role="php">
 <![CDATA[

--- a/reference/image/functions/imagecolorset.xml
+++ b/reference/image/functions/imagecolorset.xml
@@ -19,10 +19,10 @@
    <methodparam choice="opt"><type>int</type><parameter>alpha</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
   <para>
-   Permet d'attribuer à un index
-   d'une palette une couleur spécifique. C'est une fonction très
-   pratique pour effectuer du remplissage de couleur sans le faire
-   réellement.
+   Affecte la couleur spécifiée à l'index spécifié dans la palette.
+   Cela est utile pour créer des effets similaires à un remplissage
+   par diffusion dans les images à palette, sans le surcoût d'effectuer
+   le remplissage réel.
   </para>
  </refsect1>
  <refsect1 role="parameters">

--- a/reference/image/functions/imagecolorsforindex.xml
+++ b/reference/image/functions/imagecolorsforindex.xml
@@ -61,7 +61,7 @@
       <entry>8.0.0</entry>
       <entry>
        La fonction <function>imagecolorsforindex</function> lance désormais une exception <classname>ValueError</classname>
-       si <parameter>color</parameter> est hors de portée; auparavant, &false; était retourné à la place.
+       si <parameter>color</parameter> est hors plage ; antérieur à cela, &false; était retourné à la place.
       </entry>
      </row>
     </tbody>

--- a/reference/image/functions/imagecolortransparent.xml
+++ b/reference/image/functions/imagecolortransparent.xml
@@ -107,8 +107,8 @@ imagepng($im, './imagecolortransparent.png');
   &reftitle.notes;
   <note>
    <para>
-    La transparence est copiée uniquement avec la fonction 
-    <function>imagecopymerge</function> et les images en couleur vraies,
+    La transparence est copiée uniquement avec la fonction
+    <function>imagecopymerge</function> et les images en couleurs vraies,
     non pas avec la fonction <function>imagecopy</function> ou les images
     de palette.
    </para>
@@ -118,7 +118,7 @@ imagepng($im, './imagecolortransparent.png');
     La couleur de transparence est une propriété de l'image, elle n'est pas
     une propriété de la couleur. Une fois que l'on a défini la couleur de
     transparence, chaque région de l'image de cette couleur que l'on a
-    dessiné précédemment sera transparente.
+    dessinée précédemment sera transparente.
    </para>
   </note>
  </refsect1>

--- a/reference/image/functions/imageconvolution.xml
+++ b/reference/image/functions/imageconvolution.xml
@@ -5,7 +5,7 @@
 <refentry xml:id="function.imageconvolution" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>imageconvolution</refname>
-  <refpurpose>Applique une matrice de la convolution 3x3, en utilisant le coefficient et l'excentrage</refpurpose>
+  <refpurpose>Applique une matrice de convolution 3x3, en utilisant un coefficient et un décalage</refpurpose>
  </refnamediv>
  <refsect1 role="description">
   &reftitle.description;
@@ -17,9 +17,8 @@
    <methodparam><type>float</type><parameter>offset</parameter></methodparam>
   </methodsynopsis>
   <para>
-   <function>imageconvolution</function> applique une matrice de la convolution
-   3x3, en utilisant le coefficient <parameter>div</parameter> et l'excentrage
-   <parameter>offset</parameter>.
+   Applique une matrice de convolution sur l'image, en utilisant le
+   coefficient et le décalage donnés.
   </para>
  </refsect1>
  <refsect1 role="parameters">
@@ -32,7 +31,7 @@
      <listitem>
       <para>
        Une matrice 3x3 : un tableau contenant trois tableaux de trois
-       nombres à virgules flottantes.
+       nombres à virgule flottante.
       </para>
      </listitem>
     </varlistentry>
@@ -48,7 +47,7 @@
      <term><parameter>offset</parameter></term>
      <listitem>
       <para>
-       La position de la couleur.
+       Le décalage de couleur.
       </para>
      </listitem>
     </varlistentry>
@@ -84,7 +83,7 @@
   &reftitle.examples;
   <para>
    <example>
-    <title>Impression du logo PHP.net avec <function>imageconvolution</function></title>
+    <title>Embossage du logo PHP.net</title>
     <programlisting role="php">
 <![CDATA[
 <?php
@@ -100,14 +99,14 @@ imagepng($image, null, 9);
     </programlisting>
     &example.outputs;
     <mediaobject>
-     <alt>Affichage de l'exemple : Impression du logo PHP.net</alt>
+     <alt>Affichage de l'exemple : Embossage du logo PHP.net</alt>
      <imageobject>
       <imagedata fileref="en/reference/image/figures/imageconvolution_emboss.png"/>
      </imageobject>
     </mediaobject>
    </example>
    <example>
-    <title>Flou gaussien avec <function>imageconvolution</function></title>
+    <title>Flou gaussien</title>
     <programlisting role="php">
 <![CDATA[
 <?php
@@ -118,7 +117,7 @@ imagestring($image, 5, 10, 8, 'Texte flou gaussien', 0x00ff00);
 $gaussian = array(array(1.0, 2.0, 1.0), array(2.0, 4.0, 2.0), array(1.0, 2.0, 1.0));
 imageconvolution($image, $gaussian, 16, 0);
 
-// Récrit le texte pour la comparaison
+// Réécrit le texte pour la comparaison
 imagestring($image, 5, 10, 18, 'Texte flou gaussien', 0x00ff00);
 
 header('Content-Type: image/png');

--- a/reference/image/functions/imagecopy.xml
+++ b/reference/image/functions/imagecopy.xml
@@ -49,7 +49,7 @@
      <term><parameter>dst_x</parameter></term>
      <listitem>
       <para>
-       X : coordonnées du point de destination.
+       Coordonnée x du point de destination.
       </para>
      </listitem>
     </varlistentry>
@@ -57,7 +57,7 @@
      <term><parameter>dst_y</parameter></term>
      <listitem>
       <para>
-       Y : coordonnées du point de destination.
+       Coordonnée y du point de destination.
       </para>
      </listitem>
     </varlistentry>
@@ -65,7 +65,7 @@
      <term><parameter>src_x</parameter></term>
      <listitem>
       <para>
-       X : coordonnées du point source.
+       Coordonnée x du point source.
       </para>
      </listitem>
     </varlistentry>
@@ -73,7 +73,7 @@
      <term><parameter>src_y</parameter></term>
      <listitem>
       <para>
-       Y : coordonnées du point source.
+       Coordonnée y du point source.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/image/functions/imagecopymerge.xml
+++ b/reference/image/functions/imagecopymerge.xml
@@ -100,10 +100,10 @@
        suivant le paramètre <parameter>pct</parameter>, qui peut valoir de
        0 à 100. Si <parameter>pct</parameter> = 0, aucune action n'est
        faite, alors que si <parameter>pct</parameter> = 100,
-       <function>imagecopymerge</function> se comporte exactement comme
-       <function>imagecopy</function> pour les images de palette, sauf
-       pour l'ignorance des composants alpha, tandis qu'il implémente la
-       transparence alpha pour les images en couleur vraies.
+       <function>imagecopymerge</function> se comporte de manière identique à
+       <function>imagecopy</function> pour les images de palette, à l'exception
+       du fait qu'elle ignore les composants alpha, tandis qu'elle implémente
+       la transparence alpha pour les images en couleurs vraies.
       </para>
      </listitem>
     </varlistentry>
@@ -157,7 +157,7 @@ $src = imagecreatefromgif('php.gif');
 // Copie et fusionne
 imagecopymerge($dest, $src, 10, 10, 0, 0, 100, 47, 75);
 
-// Affichage et libération de la mémoire
+// Affichage
 header('Content-Type: image/gif');
 imagegif($dest);
 ?>

--- a/reference/image/functions/imagecopymergegray.xml
+++ b/reference/image/functions/imagecopymergegray.xml
@@ -32,10 +32,10 @@
    dans l'image de destination.
   </para>
   <para>
-   <function>imagecopymergegray</function> est identique à la fonction
+   Cette fonction est identique à la fonction
    <function>imagecopymerge</function>, hormis le fait que lors de la
-   fusion, le "hue" de l'image sera conservé grâce à la conversion
-   de la zone dans l'image de destination en gris, avant l'opération
+   fusion, la teinte de la source est conservée en convertissant
+   les pixels de destination en niveaux de gris avant l'opération
    de copie.
   </para>
  </refsect1>
@@ -103,14 +103,15 @@
      <term><parameter>pct</parameter></term>
      <listitem>
       <para>
-       Le paramètre <parameter>src_image</parameter> sera changé
-       en niveaux de gris en accord avec le paramètre
+       Le paramètre <parameter>src_image</parameter> sera converti
+       en niveaux de gris selon le paramètre
        <parameter>pct</parameter> où 0 correspond à une conversion totale en
        niveaux de gris et 100 ne modifie rien.
-       Lorsque <parameter>pct</parameter> = 100, cette fonction se comporte de la
-       même façon que la fonction <function>imagecopy</function> pour les palettes,
-       sauf pour l'ignorance des composants alpha, alors qu'elle implémente la
-       transparence alpha pour les images true colour.
+       Lorsque <parameter>pct</parameter> = 100, cette fonction se comporte de
+       manière identique à la fonction <function>imagecopy</function> pour les
+       images en palette, à l'exception du fait qu'elle ignore les composants
+       alpha, alors qu'elle implémente la transparence alpha pour les images
+       en couleurs vraies.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/image/functions/imagecopyresampled.xml
+++ b/reference/image/functions/imagecopyresampled.xml
@@ -70,7 +70,7 @@
      <term><parameter>dst_x</parameter></term>
      <listitem>
       <para>
-       X : coordonnées du point de destination.
+       Coordonnée x du point de destination.
       </para>
      </listitem>
     </varlistentry>
@@ -78,7 +78,7 @@
      <term><parameter>dst_y</parameter></term>
      <listitem>
       <para>
-       Y : coordonnées du point de destination.
+       Coordonnée y du point de destination.
       </para>
      </listitem>
     </varlistentry>
@@ -86,7 +86,7 @@
      <term><parameter>src_x</parameter></term>
      <listitem>
       <para>
-       X : coordonnées du point source.
+       Coordonnée x du point source.
       </para>
      </listitem>
     </varlistentry>
@@ -94,7 +94,7 @@
      <term><parameter>src_y</parameter></term>
      <listitem>
       <para>
-       Y : coordonnées du point source.
+       Coordonnée y du point source.
       </para>
      </listitem>
     </varlistentry>
@@ -252,7 +252,7 @@ imagejpeg($image_p, null, 100);
     </programlisting>
     &example.outputs.similar;
     <mediaobject>
-     <alt>Affichage de l'exemple : Rééchantillonne une image proportionnellement</alt>
+     <alt>Affichage de l'exemple : Redimensionnement proportionnel d'une image</alt>
      <imageobject>
       <imagedata fileref="en/reference/image/figures/imagecopyresampled_2.jpg"/>
      </imageobject>
@@ -271,8 +271,7 @@ imagejpeg($image_p, null, 100);
     couleur ne peut être allouée, la couleur la plus proche (en théorie)
     est utilisée. Ce n'est pas toujours la couleur la plus proche visuellement.
     Cela peut générer des problèmes étranges, comme des images blanches.
-    Pour éviter ce problème, passez en image TrueColor, comme celle 
-    générée par la fonction <function>imagecreatetruecolor</function>.
+    Pour éviter ce problème, il faut utiliser une image TrueColor, telle que celle générée par la fonction <function>imagecreatetruecolor</function>.
    </para>
   </note>
  </refsect1>

--- a/reference/image/functions/imagecopyresized.xml
+++ b/reference/image/functions/imagecopyresized.xml
@@ -30,24 +30,23 @@
   </para>
   <para>
    En d'autres termes, <function>imagecopyresized</function> prendra une
-   forme rectangulaire <parameter>src_image</parameter> d'une largeur de
+   zone rectangulaire de <parameter>src_image</parameter> d'une largeur de
    <parameter>src_width</parameter> et d'une hauteur <parameter>src_height</parameter>
    à la position (<parameter>src_x</parameter>,<parameter>src_y</parameter>)
-   et le placera dans une zone rectangulaire <parameter>dst_image</parameter>
+   et la placera dans une zone rectangulaire de <parameter>dst_image</parameter>
    d'une largeur de <parameter>dst_width</parameter> et d'une hauteur de
    <parameter>dst_height</parameter> à la position
    (<parameter>dst_x</parameter>,<parameter>dst_y</parameter>).
   </para>
   <para>
-   Si les dimensions de la source et de la destination ne sont pas égales, un
-   étirement adéquat est effectué pour faire correspondre
-   les deux. Les coordonnées fournies sont définies par rapport
+   Si les coordonnées et les dimensions de la source et de la destination
+   diffèrent, un étirement ou un rétrécissement approprié du fragment
+   d'image sera effectué. Les coordonnées sont définies par rapport
    au coin supérieur gauche. Cette fonction peut être
-   utilisée pour recopier des régions à l'intérieur
+   utilisée pour copier des régions à l'intérieur
    d'une même image (si <parameter>dst_image</parameter> et
    <parameter>src_image</parameter> sont identiques), mais si les
-   régions se chevauchent, le résultat risque d'être
-   incohérent.
+   régions se chevauchent, les résultats seront imprévisibles.
   </para>
  </refsect1>
  <refsect1 role="parameters">
@@ -70,7 +69,7 @@
      <term><parameter>dst_x</parameter></term>
      <listitem>
       <para>
-       X : coordonnée du point de destination.
+       Coordonnée x du point de destination.
       </para>
      </listitem>
     </varlistentry>
@@ -78,7 +77,7 @@
      <term><parameter>dst_y</parameter></term>
      <listitem>
       <para>
-       Y : coordonnée du point de destination.
+       Coordonnée y du point de destination.
       </para>
      </listitem>
     </varlistentry>
@@ -86,7 +85,7 @@
      <term><parameter>src_x</parameter></term>
      <listitem>
       <para>
-       X : coordonnée du point source.
+       Coordonnée x du point source.
       </para>
      </listitem>
     </varlistentry>
@@ -94,7 +93,7 @@
      <term><parameter>src_y</parameter></term>
      <listitem>
       <para>
-       Y : coordonnée du point source.
+       Coordonnée y du point source.
       </para>
      </listitem>
     </varlistentry>
@@ -203,8 +202,8 @@ imagejpeg($thumb);
      </imageobject>
     </mediaobject>
     <para>
-     L'image affichée aura une taille de moitié moins que l'image d'origine, mais une
-     meilleure qualité peut être obtenue en utilisant la fonction
+     L'image sera affichée à la moitié de sa taille, bien qu'une
+     meilleure qualité puisse être obtenue en utilisant
      <function>imagecopyresampled</function>.
     </para>
    </example>
@@ -214,15 +213,18 @@ imagejpeg($thumb);
   &reftitle.notes;
   <note>
    <para>
-    Il y a un problème dû aux limitations de la taille de la palette
-    (255 + 1 couleurs différentes). Filtrer ou rééchantillonner une image
-    demande plus de 255 couleurs, une approximation est alors utilisée pour 
-    calculer le nouveau nombre de couleurs. Avec une palette, si une nouvelle
-    couleur ne peut être allouée, la couleur la plus proche (en théorie)
-    est utilisée ; ce n'est pas toujours celle qui est la plus proche visuellement.
-    Cela peut générer des problèmes étranges, comme des images blanches.
-    Pour éviter ce problème, passez en image TrueColor, comme celles
-    générées par la fonction <function>imagecreatetruecolor</function>.
+    Il y a un problème dû aux limitations des images à palette
+    (255 + 1 couleurs). Le rééchantillonnage ou le filtrage d'une image
+    nécessite généralement plus de 255 couleurs, une sorte d'approximation
+    est alors utilisée pour calculer le nouveau pixel rééchantillonné et sa
+    couleur. Avec une image à palette, une tentative d'allocation d'une
+    nouvelle couleur est effectuée et, en cas d'échec, la couleur la plus
+    proche (en théorie) est choisie. Ce n'est pas toujours la couleur
+    visuellement la plus proche. Cela peut produire un résultat étrange,
+    comme des images blanches (ou visuellement blanches). Pour éviter ce
+    problème, il faut utiliser une image TrueColor comme image de
+    destination, telle qu'une image créée par
+    <function>imagecreatetruecolor</function>.
    </para>
   </note>
  </refsect1>

--- a/reference/image/functions/imagecreate.xml
+++ b/reference/image/functions/imagecreate.xml
@@ -16,14 +16,14 @@
   </methodsynopsis>
   <para>
    <function>imagecreate</function> retourne un identifiant d'image
-   représentant une image vide.
+   représentant une image vide de la taille spécifiée.
   </para>
   <para>
-   En général, nous recommandons l'utilisation de la fonction
+   En général, il est recommandé d'utiliser la fonction
    <function>imagecreatetruecolor</function> au lieu de la fonction
    <function>imagecreate</function> afin que l'opération sur l'image
-   s'effectue avec une qualité la plus haute possible. Pour
-   sortir une palette, alors la fonction <function>imagetruecolortopalette</function>
+   s'effectue avec la plus haute qualité possible. Pour produire
+   une image à palette, la fonction <function>imagetruecolortopalette</function>
    doit être appelée immédiatement avant l'enregistrement de l'image avec la fonction
    <function>imagepng</function> ou la fonction <function>imagegif</function>.
   </para>
@@ -85,24 +85,24 @@
   <para>
    <example>
     <title>
-     Création d'une image GD et affichage de cette image
+     Création d'un nouveau flux d'image GD et affichage d'une image.
     </title>
     <programlisting role="php">
 <![CDATA[
 <?php
 header("Content-Type: image/png");
 $im = @imagecreate(110, 20)
-    or die("Impossible d'initialiser la bibliothèque GD");
+    or die("Impossible d'initialiser le nouveau flux d'image GD");
 $background_color = imagecolorallocate($im, 0, 0, 0);
 $text_color = imagecolorallocate($im, 233, 14, 91);
-imagestring($im, 1, 5, 5,  "A Simple Text String", $text_color);
+imagestring($im, 1, 5, 5,  "Une simple chaîne de texte", $text_color);
 imagepng($im);
 ?>
 ]]>
     </programlisting>
     &example.outputs.similar;
     <mediaobject>
-     <alt>Affichage de l'exemple : imagecreate()</alt>
+     <alt>Affichage de l'exemple : Création d'un nouveau flux d'image GD et affichage d'une image.</alt>
      <imageobject>
       <imagedata fileref="en/reference/image/figures/imagecreate.png"/>
      </imageobject>

--- a/reference/image/functions/imagecreatefromavif.xml
+++ b/reference/image/functions/imagecreatefromavif.xml
@@ -14,7 +14,7 @@
   </methodsynopsis>
   <para>
    <function>imagecreatefromavif</function> retourne un objet image
-   obtenu à partir du fichier <parameter>filename</parameter>.
+   représentant l'image obtenue à partir du fichier <parameter>filename</parameter> donné.
   </para>
  </refsect1>
  
@@ -26,7 +26,7 @@
      <term><parameter>filename</parameter></term>
      <listitem>
       <para>
-        Chemin vers l'image <acronym>AVIF</acronym>.
+        Chemin vers l'image matricielle <acronym>AVIF</acronym>.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/image/functions/imagecreatefrombmp.xml
+++ b/reference/image/functions/imagecreatefrombmp.xml
@@ -57,7 +57,7 @@
       <entry>8.0.0</entry>
       <entry>
        En cas de succès, cette fonction retourne désormais une instance de
-       <classname>GDImage</classname> ; auparavant,
+       <classname>GDImage</classname> ; antérieurement,
        une <type>resource</type> était retournée.
       </entry>
      </row>

--- a/reference/image/functions/imagecreatefromgd.xml
+++ b/reference/image/functions/imagecreatefromgd.xml
@@ -54,7 +54,7 @@
       <entry>8.0.0</entry>
       <entry>
        En cas de succès, cette fonction retourne désormais une instance de
-       <classname>GDImage</classname> ; auparavant,
+       <classname>GDImage</classname> ; antérieurement,
        une <type>resource</type> était retournée.
       </entry>
      </row>

--- a/reference/image/functions/imagecreatefromgd2.xml
+++ b/reference/image/functions/imagecreatefromgd2.xml
@@ -54,7 +54,7 @@
       <entry>8.0.0</entry>
       <entry>
        En cas de succès, cette fonction retourne désormais une instance de
-       <classname>GDImage</classname> ; auparavant,
+       <classname>GDImage</classname> ; antérieur à cela,
        une <type>resource</type> était retournée.
       </entry>
      </row>
@@ -74,7 +74,8 @@
 // Charge l'image gd2
 $im = imagecreatefromgd2('./test.gd2');
 
-// Applique un effet sur l'image : on applique ici un filtre négatif si nous
+// Applique un effet sur l'image, dans ce cas
+// on inverse les couleurs de l'image
 if(function_exists('imagefilter'))
 {
     imagefilter($im, IMG_FILTER_NEGATE);

--- a/reference/image/functions/imagecreatefromgd2part.xml
+++ b/reference/image/functions/imagecreatefromgd2part.xml
@@ -17,7 +17,7 @@
    <methodparam><type>int</type><parameter>height</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Crée une nouvelle image depuis une partie d'un fichier GD2 ou d'une URL.
+   Crée une nouvelle image à partir d'une partie de fichier GD2 ou d'une URL.
   </para>
   &tip.fopen-wrapper;
  </refsect1>
@@ -85,7 +85,7 @@
       <entry>8.0.0</entry>
       <entry>
        En cas de succès, cette fonction retourne désormais une instance de
-       <classname>GDImage</classname> ; auparavant,
+       <classname>GDImage</classname> ; antérieur à PHP 8.0.0,
        une <type>resource</type> était retournée.
       </entry>
      </row>
@@ -108,7 +108,7 @@ $image = getimagesize('./test.gd2');
 // Création de l'instance d'image maintenant que nous avons les dimensions
 $im = imagecreatefromgd2part('./test.gd2', 4, 4, ($image[0] / 2) - 6, ($image[1] / 2) - 6);
 
-// Opération sur l'image : ici, nous imprimons l'image
+// Opération sur l'image : ici, nous appliquons un effet de relief
 if(function_exists('imagefilter'))
 {
     imagefilter($im, IMG_FILTER_EMBOSS);

--- a/reference/image/functions/imagecreatefromgif.xml
+++ b/reference/image/functions/imagecreatefromgif.xml
@@ -19,9 +19,9 @@
   </para>
   <caution>
    <para>
-    Lors de la lecture en mémoire de fichiers GIF animés, seule la première frame
-    est retournée par l'objet de l'image. La taille de l'image n'est
-    pas forcément ce qui est rapporté par <function>getimagesize</function>.
+    Lors de la lecture en mémoire de fichiers GIF animés, seule la première image
+    est retournée dans l'objet image. La taille de l'image n'est
+    pas forcément celle rapportée par <function>getimagesize</function>.
    </para>
   </caution>
   &tip.fopen-wrapper;
@@ -61,7 +61,7 @@
       <entry>8.0.0</entry>
       <entry>
        En cas de succès, cette fonction retourne désormais une instance de
-       <classname>GDImage</classname> ; auparavant,
+       <classname>GDImage</classname> ; antérieur à PHP 8.0.0,
        une <type>resource</type> était retournée.
       </entry>
      </row>
@@ -94,7 +94,7 @@ function LoadGif($imgname)
         imagefilledrectangle ($im, 0, 0, 150, 30, $bgc);
 
         /* Affiche un message d'erreur dans l'image */
-        imagestring ($im, 1, 5, 5, 'Error loading ' . $imgname, $tc);
+        imagestring ($im, 1, 5, 5, 'Erreur de chargement ' . $imgname, $tc);
     }
 
     return $im;

--- a/reference/image/functions/imagecreatefromjpeg.xml
+++ b/reference/image/functions/imagecreatefromjpeg.xml
@@ -15,8 +15,8 @@
   </methodsynopsis>
   <para>
    <function>imagecreatefromjpeg</function> retourne un identifiant d'image
-   représentant une image obtenue à partir du fichier
-   <parameter>filename</parameter>.
+   représentant l'image obtenue à partir du fichier
+   <parameter>filename</parameter> donné.
   </para>
   &tip.fopen-wrapper;
  </refsect1>
@@ -55,7 +55,7 @@
       <entry>8.0.0</entry>
       <entry>
        En cas de succès, cette fonction retourne désormais une instance de
-       <classname>GDImage</classname> ; auparavant,
+       <classname>GDImage</classname> ; antérieurement,
        une <type>resource</type> était retournée.
       </entry>
      </row>

--- a/reference/image/functions/imagecreatefrompng.xml
+++ b/reference/image/functions/imagecreatefrompng.xml
@@ -15,7 +15,7 @@
   </methodsynopsis>
   <para>
    <function>imagecreatefrompng</function> retourne un identifiant d'image
-   représentant une image obtenue à partir du fichier
+   représentant l'image obtenue à partir du fichier
    <parameter>filename</parameter>.
   </para>
   &tip.fopen-wrapper;
@@ -55,7 +55,7 @@
       <entry>8.0.0</entry>
       <entry>
        En cas de succès, cette fonction retourne désormais une instance de
-       <classname>GDImage</classname> ; auparavant,
+       <classname>GDImage</classname> ; antérieurement,
        une <type>resource</type> était retournée.
       </entry>
      </row>

--- a/reference/image/functions/imagecreatefromstring.xml
+++ b/reference/image/functions/imagecreatefromstring.xml
@@ -15,8 +15,8 @@
   <para>
    <function>imagecreatefromstring</function> retourne un identifiant d'image
    représentant l'image obtenue depuis la chaîne <parameter>data</parameter>.
-   Le type de l'image sera automatiquement détecté si l'on a compilé PHP avec
-   les supports : JPEG, PNG, GIF, BMP, WBMP, GD2, WEBP, et AVIF.
+   Ces types seront automatiquement détectés si la compilation de PHP les
+   supporte : JPEG, PNG, GIF, BMP, WBMP, GD2, WEBP et AVIF.
   </para>
  </refsect1>
  <refsect1 role="parameters">
@@ -66,7 +66,7 @@
       <entry>8.0.0</entry>
       <entry>
        En cas de succès, cette fonction retourne désormais une instance de
-       <classname>GDImage</classname> ; auparavant,
+       <classname>GDImage</classname> ; antérieurement,
        une <type>resource</type> était retournée.
       </entry>
      </row>
@@ -101,7 +101,7 @@ if ($im !== false) {
     imagepng($im);
 }
 else {
-    echo 'An error occurred.';
+    echo 'Une erreur est survenue.';
 }
 ?>
 ]]>

--- a/reference/image/functions/imagecreatefromtga.xml
+++ b/reference/image/functions/imagecreatefromtga.xml
@@ -53,8 +53,8 @@
      <row>
       <entry>8.0.0</entry>
       <entry>
-       En cas de succès, cette fonction retourne désormais une instance <classname>GDImage</classname>;
-       précédemment, une &resource; était retournée.
+       En cas de succès, cette fonction retourne désormais une instance de <classname>GDImage</classname> ;
+       antérieurement, une &resource; était retournée.
       </entry>
      </row>
     </tbody>

--- a/reference/image/functions/imagecreatefromtga.xml
+++ b/reference/image/functions/imagecreatefromtga.xml
@@ -54,7 +54,7 @@
       <entry>8.0.0</entry>
       <entry>
        En cas de succès, cette fonction retourne désormais une instance de <classname>GDImage</classname> ;
-       antérieurement, une &resource; était retournée.
+       précédemment, une &resource; était retournée.
       </entry>
      </row>
     </tbody>

--- a/reference/image/functions/imagecreatefromwbmp.xml
+++ b/reference/image/functions/imagecreatefromwbmp.xml
@@ -14,13 +14,13 @@
    <methodparam><type>string</type><parameter>filename</parameter></methodparam>
   </methodsynopsis>
   <para>
-   <function>imagecreatefromwbmp</function> retourne une ressource d'image
-   PHP, représentant l'image <parameter>filename</parameter>.
+   <function>imagecreatefromwbmp</function> retourne un identifiant d'image
+   représentant l'image obtenue à partir du nom de fichier donné.
   </para>
   <note>
    <simpara>
-    Les images WBMP sont Wireless Bitmaps, et non Windows Bitmaps. Le dernier
-    peut être chargé grâce à <function>imagecreatefrombmp</function>.
+    Les images WBMP sont des Wireless Bitmaps, et non des Windows Bitmaps. Ces dernières
+    peuvent être chargées grâce à <function>imagecreatefrombmp</function>.
    </simpara>
   </note>
   &tip.fopen-wrapper;

--- a/reference/image/functions/imagecreatefromwebp.xml
+++ b/reference/image/functions/imagecreatefromwebp.xml
@@ -58,7 +58,7 @@
       <entry>8.0.0</entry>
       <entry>
        En cas de succès, cette fonction retourne désormais une instance de
-       <classname>GDImage</classname> ; auparavant,
+       <classname>GDImage</classname> ; antérieurement,
        une <type>resource</type> était retournée.
       </entry>
      </row>

--- a/reference/image/functions/imagecreatefromxbm.xml
+++ b/reference/image/functions/imagecreatefromxbm.xml
@@ -55,7 +55,7 @@
       <entry>8.0.0</entry>
       <entry>
        En cas de succès, cette fonction retourne désormais une instance de
-       <classname>GDImage</classname> ; auparavant,
+       <classname>GDImage</classname> ; antérieurement,
        une <type>resource</type> était retournée.
       </entry>
      </row>

--- a/reference/image/functions/imagecreatefromxpm.xml
+++ b/reference/image/functions/imagecreatefromxpm.xml
@@ -76,17 +76,17 @@
 // Vérifie le support XPM
 if(!(imagetypes() & IMG_XPM))
 {
-    die('Le support XPM n\'a pu être vérifié !');
+    die('Le support pour xpm n\'a pas été trouvé !');
 }
 
-// Création de l'instance d'une image
+// Création de l'instance d'image
 $xpm = imagecreatefromxpm('./example.xpm');
 
-// Quelques opérations sur l'image ici
+// Effectuer ici les opérations sur l'image
 
-// PHP n'a pas le support pour l'écriture des images XPM
-// aussi, dans ce cas, nous sauvegardons l'image dans un fichier JPEG
-// avec une qualité de 100%
+// PHP ne supporte pas l'écriture des images xpm
+// aussi, dans ce cas, l'image est sauvegardée
+// dans un fichier jpeg avec une qualité de 100%
 imagejpeg($xpm, './example.jpg', 100);
 ?>
 ]]>

--- a/reference/image/functions/imagecreatetruecolor.xml
+++ b/reference/image/functions/imagecreatetruecolor.xml
@@ -15,8 +15,8 @@
    <methodparam><type>int</type><parameter>height</parameter></methodparam>
   </methodsynopsis>
   <para>
-   <function>imagecreatetruecolor</function> retourne un objet
-    représentant une image noire.
+   <function>imagecreatetruecolor</function> retourne un objet image
+   représentant une image noire de la taille spécifiée.
   </para>
  </refsect1>
  <refsect1 role="parameters">
@@ -76,7 +76,7 @@
   <para>
    <example>
     <title>
-     Création d'un flux d'image GD, et affichage
+     Création d'un nouveau flux d'image GD et affichage d'une image.
     </title>
     <programlisting role="php">
 <![CDATA[
@@ -104,7 +104,6 @@ imagepng($im);
  <refsect1 role="seealso">
   &reftitle.seealso;
   <simplelist>
-   <member><function>imagedestroy</function></member>
    <member><function>imagecreate</function></member>
   </simplelist>
  </refsect1>

--- a/reference/image/functions/imagecrop.xml
+++ b/reference/image/functions/imagecrop.xml
@@ -29,8 +29,8 @@
     <term><parameter>rectangle</parameter></term>
     <listitem>
      <para>
-      <type>array</type> contenant les clés <literal>x</literal>, 
-      <literal>y</literal>, <literal>width</literal> et
+      Le rectangle de recadrage sous forme de <type>array</type> contenant les clés
+      <literal>x</literal>, <literal>y</literal>, <literal>width</literal> et
       <literal>height</literal>.
      </para>
     </listitem>
@@ -57,6 +57,7 @@
      </row>
     </thead>
     <tbody>
+     &gd.changelog.image-param;
      <row>
       <entry>8.0.0</entry>
       <entry>

--- a/reference/image/functions/imagecropauto.xml
+++ b/reference/image/functions/imagecropauto.xml
@@ -37,7 +37,7 @@
        <listitem>
         <simpara>
          Identique à <constant>IMG_CROP_TRANSPARENT</constant>.
-         Antérieur à PHP 7.4.0, la bibliothèque libgd intégrée utilisait
+         Antérieurement à PHP 7.4.0, la bibliothèque libgd intégrée utilisait
          <constant>IMG_CROP_SIDES</constant> en tant que solution de repli,
          si l'image n'avait pas de couleur de transparence.
         </simpara>
@@ -103,7 +103,7 @@
      </para>
      <note>
       <simpara>
-       Antérieur à PHP 7.4.0, la bibliothèque libgd intégrée utilisait un algorithme
+       Antérieurement à PHP 7.4.0, la bibliothèque libgd intégrée utilisait un algorithme
        quelque peu différent, donc le même <parameter>threshold</parameter> produisait
        des résultats différents pour libgd système et intégré.
       </simpara>
@@ -158,14 +158,14 @@
        Le comportement de imagecropauto de la bibliothèque libgd intégrée a été
        synchronisé avec celle de libgd système : <constant>IMG_CROP_DEFAULT</constant>
        n'utilise plus <constant>IMG_CROP_SIDES</constant> comme solution de repli et
-       la tolérance de rognage utilise désormais le même algorithme que libgd système.     
+       la tolérance de rognage utilise désormais le même algorithme que libgd système.
       </entry>
      </row>
      <row>
       <entry>7.4.0</entry>
       <entry>
        La valeur par défaut de <parameter>mode</parameter> a été modifiée en
-       <constant>IMG_CROP_AUTO</constant>. Auparavant, la valeur par défaut était
+       <constant>IMG_CROP_AUTO</constant>. Antérieurement, la valeur par défaut était
        <literal>-1</literal> qui correspond à <constant>IMG_CROP_DEFAULT</constant>,
        mais passer <literal>-1</literal> est désormais obsolète.
       </entry>
@@ -184,7 +184,7 @@
      Comme indiqué dans la section valeur de retour, <function>imagecropauto</function>
      retourne &false; si l'image entière a été rognée. Dans cet exemple, nous 
      avons un objet d'image <literal>$im</literal> qui ne devrait être
-     automatiquement rognée que s'il y a quelque chose à rogner ; sinon, nous
+     automatiquement rogné que s'il y a quelque chose à rogner ; sinon, nous
      voulons conserver l'image originale.
     </para>
     <programlisting role="php">

--- a/reference/image/functions/imagefill.xml
+++ b/reference/image/functions/imagefill.xml
@@ -5,7 +5,7 @@
 <refentry xml:id="function.imagefill" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>imagefill</refname>
-  <refpurpose>Remplissage</refpurpose>
+  <refpurpose>Remplissage par diffusion</refpurpose>
  </refnamediv>
  <refsect1 role="description">
   &reftitle.description;
@@ -32,7 +32,7 @@
      <term><parameter>x</parameter></term>
      <listitem>
       <para>
-       X : coordonnée du point de départ.
+       Coordonnée X du point de départ.
       </para>
      </listitem>
     </varlistentry>
@@ -40,7 +40,7 @@
      <term><parameter>y</parameter></term>
      <listitem>
       <para>
-       Y : coordonnée du point de départ.
+       Coordonnée Y du point de départ.
       </para>
      </listitem>
     </varlistentry>
@@ -90,7 +90,7 @@
 
 $im = imagecreatetruecolor(100, 100);
 
-// Fixe le fond rouge
+// Définit le fond en rouge
 $red = imagecolorallocate($im, 255, 0, 0);
 imagefill($im, 0, 0, $red);
 

--- a/reference/image/functions/imagefilledarc.xml
+++ b/reference/image/functions/imagefilledarc.xml
@@ -76,7 +76,7 @@
      <listitem>
       <para>
        L'angle de fin de l'arc, en degrés.
-       0° est situé à une position de 3 heures sur un cadran horaire, et
+       0° est situé à la position de trois heures, et
        l'arc est dessiné dans le sens des aiguilles d'une montre.
       </para>
      </listitem>
@@ -93,7 +93,7 @@
      <term><parameter>style</parameter></term>
      <listitem>
       <para>
-       Un champ d'octets, combiné avec l'opérateur OR :
+       Un OU bit à bit des possibilités suivantes :
        <orderedlist>
         <listitem><simpara><constant>IMG_ARC_PIE</constant></simpara></listitem>
         <listitem><simpara><constant>IMG_ARC_CHORD</constant></simpara></listitem>
@@ -101,14 +101,14 @@
         <listitem><simpara><constant>IMG_ARC_EDGED</constant></simpara></listitem>
        </orderedlist>
        <constant>IMG_ARC_PIE</constant> et <constant>IMG_ARC_CHORD</constant> sont
-       mutuellement exclusives; <constant>IMG_ARC_CHORD</constant> ne fait que
+       mutuellement exclusives ; <constant>IMG_ARC_CHORD</constant> ne fait que
        connecter les angles de début et de fin avec une ligne droite, tandis
-       que <constant>IMG_ARC_PIE</constant> produit une ligne courbe.
-       <constant>IMG_ARC_NOFILL</constant> indique que l'arc (ou corde) doit être
-       dessiné mais pas rempli. <constant>IMG_ARC_EDGED</constant>, utilisé conjointement
-       avec <constant>IMG_ARC_NOFILL</constant>, indique que les angles de
-       début et de fin doivent être connectés au centre. Cette fonction est
-       recommandée pour faire les graphiques de type camembert.
+       que <constant>IMG_ARC_PIE</constant> produit un bord arrondi.
+       <constant>IMG_ARC_NOFILL</constant> indique que l'arc ou la corde
+       devrait être tracé sans remplissage. <constant>IMG_ARC_EDGED</constant>,
+       utilisé conjointement avec <constant>IMG_ARC_NOFILL</constant>, indique que les angles de
+       début et de fin devraient être connectés au centre : c'est une bonne
+       manière de tracer le contour (au lieu de remplir) d'une « part de camembert ».
       </para>
      </listitem>
     </varlistentry>

--- a/reference/image/functions/imagefilledpolygon.xml
+++ b/reference/image/functions/imagefilledpolygon.xml
@@ -37,9 +37,9 @@
      <term><parameter>points</parameter></term>
      <listitem>
       <para>
-       Un tableau qui contient les coordonnées
+       Un tableau contenant successivement les coordonnées
        <literal>x</literal> et <literal>y</literal>
-       du sommet des polygones.
+       des sommets du polygone.
       </para>
      </listitem>
     </varlistentry>
@@ -47,12 +47,12 @@
      <term><parameter>num_points</parameter></term>
      <listitem>
       <para>
-       Nombre total de points (sommets), qui doivent être d'au moins 3.
+       Nombre total de points (sommets), qui doit être d'au moins 3.
       </para>
       <simpara>
        Si ce paramètre est omis conformément à la deuxième signature,
        <parameter>points</parameter> doit avoir un nombre pair d'éléments, et
-       <parameter>num_points</parameter> est assumé d'être <code>count($points)/2</code>.
+       <parameter>num_points</parameter> est supposé valoir <code>count($points)/2</code>.
       </simpara>
      </listitem>
     </varlistentry>

--- a/reference/image/functions/imagefilledrectangle.xml
+++ b/reference/image/functions/imagefilledrectangle.xml
@@ -34,7 +34,7 @@
      <term><parameter>x1</parameter></term>
      <listitem>
       <para>
-       X : coordonnée du point 1.
+       Coordonnée x du point 1.
       </para>
      </listitem>
     </varlistentry>
@@ -42,7 +42,7 @@
      <term><parameter>y1</parameter></term>
      <listitem>
       <para>
-       Y : coordonnée du point 1.
+       Coordonnée y du point 1.
       </para>
      </listitem>
     </varlistentry>
@@ -50,7 +50,7 @@
      <term><parameter>x2</parameter></term>
      <listitem>
       <para>
-       X : coordonnée du point 2.
+       Coordonnée x du point 2.
       </para>
      </listitem>
     </varlistentry>
@@ -58,7 +58,7 @@
      <term><parameter>y2</parameter></term>
      <listitem>
       <para>
-       Y : coordonnée du point 2.
+       Coordonnée y du point 2.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/image/functions/imagefilltoborder.xml
+++ b/reference/image/functions/imagefilltoborder.xml
@@ -34,7 +34,7 @@
      <term><parameter>x</parameter></term>
      <listitem>
       <para>
-       X : coordonnée de départ.
+       Coordonnée x du point de départ.
       </para>
      </listitem>
     </varlistentry>
@@ -42,7 +42,7 @@
      <term><parameter>y</parameter></term>
      <listitem>
       <para>
-       Y : coordonnée de départ.
+       Coordonnée y du point de départ.
       </para>
      </listitem>
     </varlistentry>
@@ -120,7 +120,7 @@ imagepng($im);
     </programlisting>
     &example.outputs.similar;
     <mediaobject>
-     <alt>Affichage de l'exemple : imagefilltoborder()</alt>
+     <alt>Affichage de l'exemple : Remplissage d'une ellipse avec une couleur</alt>
      <imageobject>
       <imagedata fileref="en/reference/image/figures/imagefilltoborder.png"/>
      </imageobject>

--- a/reference/image/functions/imagefilter.xml
+++ b/reference/image/functions/imagefilter.xml
@@ -156,8 +156,8 @@
         </listitem>
         <listitem>
          <simpara>
-          <constant>IMG_FILTER_SCATTER</constant> : Niveau de soustraction de l'effet. 
-          Il ne doit pas être supérieur ou égal au niveau d'addition défini avec 
+          <constant>IMG_FILTER_SCATTER</constant> : Niveau de soustraction de l'effet.
+          Il ne doit pas être supérieur ou égal au niveau d'addition défini par
           <parameter>arg2</parameter>.
          </simpara>
         </listitem>
@@ -355,7 +355,7 @@ else
     <programlisting role="php">
 <![CDATA[
 <?php
-// Defini la fonction negate afin qu'elle soit portable pour 
+// Définit la fonction negate afin qu'elle soit portable pour
 // les versions de php sans imagefilter()
 function negate($im)
 {
@@ -444,7 +444,7 @@ imagepng($output);
 // Charge l'image
 $logo = imagecreatefrompng('./php.png');
 
-// Applique un effet de diffusion très doux à l'image
+// Applique un effet de dispersion très doux à l'image
 imagefilter($logo, IMG_FILTER_SCATTER, 3, 5);
 
 // Affiche l'image avec l'effet de dispersion

--- a/reference/image/functions/imageftbbox.xml
+++ b/reference/image/functions/imageftbbox.xml
@@ -17,15 +17,14 @@
    <methodparam choice="opt"><type>array</type><parameter>options</parameter><initializer>[]</initializer></methodparam>
   </methodsynopsis>
   <para>
-   <function>imageftbbox</function> calcule le rectangle d'encadrement
-   pour le texte <parameter>text</parameter>, en utilisant la police
-   courante et freetype2.
+   Cette fonction calcule et retourne le rectangle d'encadrement
+   en pixels pour un texte FreeType.
   </para>
   <note>
    <para>
-    Antérieur à PHP 8.0.0, <function>imageftbbox</function> était une variante
+    Antérieurement à PHP 8.0.0, <function>imageftbbox</function> était une variante
     étendue de <function>imagettfbbox</function> qui en plus supportait
-    <parameter>extrainfo</parameter>.
+    <parameter>options</parameter>.
     À partir de PHP 8.0.0, <function>imagettfbbox</function> est un alias de
     <function>imageftbbox</function>.
    </para>
@@ -143,8 +142,8 @@
    </informaltable>
   </para>
   <para>
-   Les points sont relatifs au <emphasis>texte</emphasis> suivant le paramètre
-   <parameter>angle</parameter>, aussi, "en haut à gauche" signifie le coin en
+   Les points sont relatifs au <emphasis>texte</emphasis> indépendamment du paramètre
+   <parameter>angle</parameter>, ainsi, "en haut à gauche" signifie le coin en
    haut à gauche lorsque l'on regarde le texte horizontalement.
   </para>
   <para>

--- a/reference/image/functions/imagefttext.xml
+++ b/reference/image/functions/imagefttext.xml
@@ -74,7 +74,7 @@
      <term><parameter>y</parameter></term>
      <listitem>
       <para>
-       L'ordonnée <literal>y-ordinate</literal>. Ce paramètre configure la
+       L'ordonnée. Ce paramètre configure la
        position de base de la police, et non pas le bas de cette dernière.
       </para>
      </listitem>
@@ -131,7 +131,7 @@ $font = 'SomeFont';
      <listitem>
       <para>
        <table>
-       <title>Indexes possibles pour le tableau <parameter>options</parameter></title>
+       <title>Index possibles pour le tableau <parameter>options</parameter></title>
         <tgroup cols="2">
          <thead>
           <row>

--- a/reference/image/functions/imagegammacorrect.xml
+++ b/reference/image/functions/imagegammacorrect.xml
@@ -16,7 +16,8 @@
    <methodparam><type>float</type><parameter>output_gamma</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Applique une correction gamma à l'image GD <parameter>image</parameter>.
+   Applique une correction gamma à l'image GD <parameter>image</parameter>
+   en fonction d'un gamma d'entrée et d'un gamma de sortie.
   </para>
  </refsect1>
  <refsect1 role="parameters">

--- a/reference/image/functions/imagegd.xml
+++ b/reference/image/functions/imagegd.xml
@@ -62,8 +62,8 @@
       <row>
        <entry>7.2.0</entry>
        <entry>
-        <function>imagegd</function> permet maintenant de produire des images 
-        TrueColor. Auparavant, elles ont été implicitement converties en palette.
+        <function>imagegd</function> permet maintenant de produire des images
+        TrueColor. Antérieurement, elles étaient implicitement converties en palette.
        </entry>
       </row>
      </tbody>
@@ -87,7 +87,6 @@ imagestring($im, 1, 5, 5,  "Un texte simple", $text_color);
 
 // Affichage de l'image
 imagegd($im);
-
 ?>
 ]]>
     </programlisting>
@@ -107,7 +106,6 @@ imagestring($im, 1, 5, 5,  "Un texte simple", $text_color);
 // Sauvegarde de l'image GD
 // Le format de fichier pour les images GD est .gd, voir http://www.libgd.org/GdFileFormats
 imagegd($im, 'simple.gd');
-
 ?>
 ]]>
     </programlisting>

--- a/reference/image/functions/imagegd2.xml
+++ b/reference/image/functions/imagegd2.xml
@@ -35,7 +35,7 @@
      <term><parameter>chunk_size</parameter></term>
      <listitem>
       <para>
-       Taille de la pièce.
+       Taille du fragment.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/image/functions/imagegif.xml
+++ b/reference/image/functions/imagegif.xml
@@ -22,7 +22,7 @@
   <para>
    Le format de l'image sera <acronym>GIF87a</acronym>, à moins que l'image n'ait
    une couleur transparente (mise en place grâce à la fonction
-   <function>imagecolortransparent</function>)), ce qui fera qu'elle sera au format
+   <function>imagecolortransparent</function>), ce qui fera qu'elle sera au format
    <acronym>GIF89a</acronym>.
   </para>
  </refsect1>
@@ -118,8 +118,8 @@ echo 'Conversion avec succès de l\'image PNG en GIF !';
    <para>
     Le code suivant permet d'écrire des scripts PHP plus portables :
     le type de GD est automatiquement détecté. Il remplace la
-    séquence <literal>header ("Content-Type: image/gif"); ImageGif($im);</literal>
-    par un code plus souple :
+    séquence <literal>header ("Content-Type: image/gif");
+    imagegif ($im);</literal> par un code plus souple :
     <informalexample>
      <programlisting role="php">
 <![CDATA[

--- a/reference/image/functions/imagegrabwindow.xml
+++ b/reference/image/functions/imagegrabwindow.xml
@@ -60,7 +60,7 @@
  <refsect1 role="errors">
   &reftitle.errors;
   <para>
-   Une alerte de type E_NOTICE est émise si <parameter>window_handle</parameter> est
+   Une alerte de type E_NOTICE est émise si <parameter>handle</parameter> est
    un gestionnaire de fenêtre invalide.
    Une alerte de type E_WARNING est émise si l'API Windows est trop ancienne.
   </para>

--- a/reference/image/functions/imageinterlace.xml
+++ b/reference/image/functions/imageinterlace.xml
@@ -63,7 +63,7 @@
       <entry>8.0.5</entry>
       <entry>
        <function>imageinterlace</function> retourne désormais un <type>bool</type> ;
-       auparavant un <type>int</type> était retourné
+       antérieurement un <type>int</type> était retourné
        (non-zéro pour les images entrelacées, zéro sinon).
       </entry>
      </row>
@@ -72,7 +72,7 @@
       <entry>8.0.0</entry>
       <entry>
        <parameter>enable</parameter> attend désormais un <type>bool</type> ;
-       auparavant il s'attendait à un <type>int</type>.
+       antérieurement il attendait un <type>int</type>.
       </entry>
      </row>
     </tbody>

--- a/reference/image/functions/imageistruecolor.xml
+++ b/reference/image/functions/imageistruecolor.xml
@@ -62,7 +62,7 @@
 <?php
 // $im est une instance d'image
 
-// Vérife si l'image est en truecolor ou non
+// Vérifie si l'image est en truecolor ou non
 if(!imageistruecolor($im))
 {
     // Création d'une nouvelle image en truecolor

--- a/reference/image/functions/imageline.xml
+++ b/reference/image/functions/imageline.xml
@@ -64,7 +64,7 @@
      <term><parameter>color</parameter></term>
      <listitem>
       <para>
-       La couleur de remplissage. &gd.identifier.color;
+       La couleur de la ligne. &gd.identifier.color;
       </para>
      </listitem>
     </varlistentry>
@@ -99,14 +99,14 @@
   &reftitle.examples;
   <para>
    <example>
-    <title>Trace une ligne fine</title>
+    <title>Trace une ligne épaisse</title>
     <programlisting role="php">
 <![CDATA[
 <?php
 
 function imagelinethick($image, $x1, $y1, $x2, $y2, $color, $thick = 1)
 {
-    /* de cette manière, ca ne marche bien que pour les lignes orthogonales
+    /* de cette manière, ça ne marche bien que pour les lignes orthogonales
     imagesetthickness($image, $thick);
     return imageline($image, $x1, $y1, $x2, $y2, $color);
     */

--- a/reference/image/functions/imageloadfont.xml
+++ b/reference/image/functions/imageloadfont.xml
@@ -25,9 +25,10 @@
      <term><parameter>filename</parameter></term>
      <listitem>
       <para>
-       Le format des polices dépend actuellement du système
-       d'exploitation. Ce qui signifie qu'il faut générer
-       des fichiers de polices pour la machine qui fait tourner PHP.
+       Le format des fichiers de polices est actuellement binaire et
+       dépendant de l'architecture. Cela signifie qu'il faut générer les
+       fichiers de polices sur le même type de processeur que la machine
+       qui fait tourner PHP.
       </para>
       <para>
        <table>

--- a/reference/image/functions/imageopenpolygon.xml
+++ b/reference/image/functions/imageopenpolygon.xml
@@ -70,12 +70,12 @@
      <term><parameter>num_points</parameter></term>
      <listitem>
       <para>
-       Nombre total de points (sommets), qui doivent être d'au moins 3.
+       Nombre total de points (sommets), qui doit être d'au moins 3.
       </para>
       <simpara>
        Si ce paramètre est omis conformément à la deuxième signature,
        <parameter>points</parameter> doit avoir un nombre pair d'éléments, et
-       <parameter>num_points</parameter> est assumé d'être <code>count($points)/2</code>.
+       <parameter>num_points</parameter> est supposé valoir <code>count($points)/2</code>.
       </simpara>
      </listitem>
     </varlistentry>

--- a/reference/image/functions/imagepalettecopy.xml
+++ b/reference/image/functions/imagepalettecopy.xml
@@ -66,7 +66,7 @@
       <entry>8.0.0</entry>
       <entry>
        <parameter>dst</parameter> et <parameter>src</parameter> attendent
-       désormais des instances de <classname>GdImage</classname> ; auparavant,
+       désormais des instances de <classname>GdImage</classname> ; antérieurement,
        des <type>resource</type>s étaient attendues.
       </entry>
      </row>

--- a/reference/image/functions/imagepng.xml
+++ b/reference/image/functions/imagepng.xml
@@ -45,7 +45,7 @@
       <para>
        Degré de compression : de 0 (aucune compression) à 9.
        La valeur par défaut (<literal>-1</literal>) utilise la compression par défaut de zlib.
-       Pour plus d'informations voir le <link xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="&url.zlib.manual;">manuel zlib</link>.
+       Pour plus d'informations, voir le <link xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="&url.zlib.manual;">manuel zlib</link>.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/image/functions/imagepolygon.xml
+++ b/reference/image/functions/imagepolygon.xml
@@ -67,12 +67,12 @@
      <term><parameter>num_points</parameter></term>
      <listitem>
       <para>
-       Nombre total de points (sommets), qui doivent être d'au moins 3.
+       Nombre total de points (sommets), qui doit être d'au moins 3.
       </para>
       <simpara>
        Si ce paramètre est omis conformément à la deuxième signature,
        <parameter>points</parameter> doit avoir un nombre pair d'éléments, et
-       <parameter>num_points</parameter> est assumé d'être <code>count($points)/2</code>.
+       <parameter>num_points</parameter> est supposé valoir <code>count($points)/2</code>.
       </simpara>
      </listitem>
     </varlistentry>

--- a/reference/image/functions/imageresolution.xml
+++ b/reference/image/functions/imageresolution.xml
@@ -20,13 +20,13 @@
    <function>imageresolution</function> permet de définir et récupérer la résolution d'une image
    en DPI (dots per inch/point par pouce). Si les paramètres optionnels sont &null;,
    la résolution actuelle est retournée dans un tableau indexé. Si uniquement
-   <parameter>resolution_x</parameter> n'est pas &null;, la résolution horizontale et verticale sont
-   définies à cette valeur. Si aucun des paramètres optionnels ne sont &null;, la résolution
-   horizontale et verticale sont définies à ces valeurs respectivement.
+   <parameter>resolution_x</parameter> n'est pas &null;, les résolutions horizontale et verticale sont
+   définies à cette valeur. Si aucun des paramètres optionnels n'est &null;, les résolutions
+   horizontale et verticale sont définies à ces valeurs, respectivement.
   </para>
   <para>
    La résolution est uniquement utilisée en tant que métadonnées quand les images
-   sont lues et écrites à des formats supportant ce genre d'information (actuellement
+   sont lues depuis ou écrites vers des formats supportant ce genre d'information (actuellement
    PNG et JPEG). Ceci n'affecte pas les opérations de dessin. La résolution par
    défaut des nouvelles images est 96 DPI.
   </para>

--- a/reference/image/functions/imagesavealpha.xml
+++ b/reference/image/functions/imagesavealpha.xml
@@ -19,15 +19,15 @@
    les informations du canal alpha (en opposition à la transparence à couleur unique)
    doivent être conservées lors de la sauvegarde d'images.
    Cela est supporté seulement pour les formats d'images qui supportent la totalité
-   des informations de chaînes alpha, par exemple <literal>PNG</literal>, <literal>WebP</literal>
+   des informations du canal alpha, c'est-à-dire <literal>PNG</literal>, <literal>WebP</literal>
    et <literal>AVIF</literal>.
    <note>
     <simpara>
      <function>imagesavealpha</function> est seulement significatif pour les
-     images <literal>PNG</literal>, comme les chaînes alpha pleines sont toujours sauvegardées
+     images <literal>PNG</literal>, puisque le canal alpha complet est toujours sauvegardé
      pour <literal>WebP</literal> et <literal>AVIF</literal>. Il n'est pas recommandé de se
      reposer sur ce comportement, cela pourrait changer dans le futur.
-     Donc, <function>imagesavealpha</function> devrait être appelé intentionnellement aussi
+     Ainsi, <function>imagesavealpha</function> devrait être appelé intentionnellement aussi
      pour les images <literal>WebP</literal> et <literal>AVIF</literal>.
     </simpara>
    </note>
@@ -47,7 +47,7 @@
      <term><parameter>enable</parameter></term>
      <listitem>
       <para>
-       Si l'on doit ou non sauvegarder le canal alpha. Par défaut &false;. 
+       Si l'on doit ou non sauvegarder le canal alpha. Par défaut &false;.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/image/functions/imagescale.xml
+++ b/reference/image/functions/imagescale.xml
@@ -46,7 +46,7 @@
     <term><parameter>height</parameter></term>
     <listitem>
      <para>
-      La hauteur à utiliser pour la mise à l'échelle de l'image. Si omis ou 
+      La hauteur à utiliser pour la mise à l'échelle de l'image. Si omise ou
       négative, le ratio de l'image sera préservé.
      </para>
     </listitem>
@@ -61,7 +61,7 @@
       <constant>IMG_BICUBIC_FIXED</constant> ou toute autre (utilisera deux passages).
       <note>
        <simpara>
-        <constant>IMG_WEIGHTED4</constant> n'est pas encore pris en charge.
+        <constant>IMG_WEIGHTED4</constant> n'est pas encore supporté.
        </simpara>
       </note>
      </para>

--- a/reference/image/functions/imagesetbrush.xml
+++ b/reference/image/functions/imagesetbrush.xml
@@ -102,10 +102,10 @@ imagefilledrectangle($im, 0, 0, 299, 99, $white);
 // Définit la brosse
 imagesetbrush($im, $php);
 
-// Dessine quelques brosses
+// Dessine quelques brosses, chacune chevauchant la précédente
 imageline($im, 50, 50, 50, 60, IMG_COLOR_BRUSHED);
 
-// Affichage de l'image au navigateur
+// Affiche l'image dans le navigateur
 header('Content-type: image/png');
 
 imagepng($im);

--- a/reference/image/functions/imagesetinterpolation.xml
+++ b/reference/image/functions/imagesetinterpolation.xml
@@ -182,8 +182,8 @@
 // Chargement de l'image
 $im = imagecreate(500, 500);
 
-// Par défaut, l'interpolation est IMG_BILINEAR_FIXED ; on utilse plutôt
-// le filtre 'Mitchell' :
+// Par défaut, l'interpolation est IMG_BILINEAR_FIXED ; utilisation
+// du filtre 'Mitchell' :
 imagesetinterpolation($im, IMG_MITCHELL);
 
 // On continue de travailler avec $im ...

--- a/reference/image/functions/imagesetpixel.xml
+++ b/reference/image/functions/imagesetpixel.xml
@@ -30,7 +30,7 @@
      <term><parameter>x</parameter></term>
      <listitem>
       <para>
-       X : coordonnée.
+       Coordonnée X.
       </para>
      </listitem>
     </varlistentry>
@@ -38,7 +38,7 @@
      <term><parameter>y</parameter></term>
      <listitem>
       <para>
-       Y : coordonnée.
+       Coordonnée Y.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/image/functions/imagesettile.xml
+++ b/reference/image/functions/imagesettile.xml
@@ -30,11 +30,11 @@
   </para>
   <caution>
    <para>
-    Il n'y a rien à faire lorsqu'on en a terminé avec une brosse,
-    mais en cas de destruction de l'image de brosse (ou si PHP la détruit), il ne FAUT plus utiliser
+    Il n'y a rien à faire lorsqu'on en a terminé avec un carrelage,
+    mais en cas de destruction de l'image de carrelage (ou si PHP la détruit), il ne FAUT plus utiliser
     l'option <constant>IMG_COLOR_TILED</constant> des fonctions
     <function>imagefill</function> et <function>imagefilledpolygon</function>,
-    avant d'avoir créé une nouvelle brosse.
+    avant d'avoir créé un nouveau carrelage.
    </para>
   </caution>
  </refsect1>
@@ -47,7 +47,7 @@
      <term><parameter>tile</parameter></term>
      <listitem>
       <para>
-       L'objet de l'image à utiliser en tant que carrelage.
+       L'objet image à utiliser en tant que carrelage.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/image/functions/imagestringup.xml
+++ b/reference/image/functions/imagestringup.xml
@@ -32,7 +32,7 @@
      <term><parameter>x</parameter></term>
      <listitem>
       <para>
-       Coordonnée X du coin en haut, à gauche.
+       Coordonnée X du coin en bas, à gauche.
       </para>
      </listitem>
     </varlistentry>
@@ -40,7 +40,7 @@
      <term><parameter>y</parameter></term>
      <listitem>
       <para>
-       Coordonnée Y du coin en haut, à gauche.
+       Coordonnée Y du coin en bas, à gauche.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/image/functions/imagesx.xml
+++ b/reference/image/functions/imagesx.xml
@@ -59,7 +59,7 @@
 <![CDATA[
 <?php
 
-// Création d'une image 300*200 image
+// Création d'une image 300*200
 $img = imagecreatetruecolor(300, 200);
 
 echo imagesx($img); // 300

--- a/reference/image/functions/imagetruecolortopalette.xml
+++ b/reference/image/functions/imagetruecolortopalette.xml
@@ -90,7 +90,7 @@
 // Création d'une image truecolor
 $im = imagecreatetruecolor(100, 100);
 
-// Conversion en palette de 255 couleurs
+// Conversion en palette sans tramage et avec 255 couleurs
 imagetruecolortopalette($im, false, 255);
 
 // Sauvegarde de l'image

--- a/reference/image/functions/imagettfbbox.xml
+++ b/reference/image/functions/imagettfbbox.xml
@@ -18,8 +18,8 @@
    <methodparam choice="opt"><type>array</type><parameter>options</parameter><initializer>[]</initializer></methodparam>
   </methodsynopsis>
   <para>
-   Calcule et retourne le rectangle entourant le texte
-   <parameter>text</parameter>, écrit avec une police truetype.
+   Cette fonction calcule et retourne le rectangle entourant, en pixels,
+   pour un texte TrueType.
   </para>
   <note>
    <para>
@@ -184,7 +184,7 @@ imagettftext($im, 10, 45, $x, $y, $black, $font, 'Powered by PHP ' . phpversion(
 // Nous créons notre rectangle entourant notre second texte
 $bbox = imagettfbbox(10, 45, $font, 'and Zend Engine ' . zend_version());
 
-// Définit les coordonnées afin que le second text suive le premier
+// Définit les coordonnées afin que le second texte suive le premier
 $x = $bbox[0] + (imagesx($im) / 2) - ($bbox[4] / 2) + 10;
 $y = $bbox[1] + (imagesy($im) / 2) - ($bbox[5] / 2) - 5;
 

--- a/reference/image/functions/imagettftext.xml
+++ b/reference/image/functions/imagettftext.xml
@@ -51,7 +51,7 @@
      <listitem>
       <para>
        L'angle, en degrés ; 0 degré correspond à la lecture du texte
-       de gauche à droite. Les valeurs positives représentent une rotation
+       de gauche à droite. Des valeurs plus élevées représentent une rotation
        dans le sens contraire des aiguilles d'une montre. Par exemple,
        une valeur de 90 correspondra à une lecture du texte de bas en haut.
       </para>
@@ -62,8 +62,8 @@
      <listitem>
       <para>
        Les coordonnées données par <parameter>x</parameter> et
-       <parameter>y</parameter> définiront la position du premier caractère
-       (le coin bas-gauche du caractère). Cela est différent de la fonction
+       <parameter>y</parameter> définiront le point de base du premier caractère
+       (approximativement le coin bas-gauche du caractère). Cela est différent de la fonction
        <function>imagestring</function>, où
        <parameter>x</parameter> et <parameter>y</parameter> définissent
        le coin haut-gauche du premier caractère. Par exemple, "haut gauche"
@@ -97,16 +97,16 @@
        La chaîne de texte, en UTF-8.
       </para>
       <para>
-       Peut inclure des références à des caractères numériques,
-       décimales (sous la forme : <literal>&amp;#8364;</literal>) pour accéder aux caractères
-       d'une police au-delà du premier 127.
+       Peut inclure des références à des caractères numériques décimales
+       (sous la forme : <literal>&amp;#8364;</literal>) pour accéder aux caractères
+       d'une police au-delà de la position 127.
        Le format hexadécimal (comme <literal>&amp;#xA9;</literal>) est pris en charge.
        Les chaînes de caractères encodées en UTF-8 peuvent être passées directement.
       </para>
       <para>
        Les entités nommées, comme <literal>&amp;copy;</literal>, ne sont pas supportées. Utiliser la
-       fonction <function>html_entity_decode</function> pour encoder ces entités
-       nommées en chaîne UTF-8.
+       fonction <function>html_entity_decode</function> pour décoder ces entités
+       nommées en chaînes UTF-8.
       </para>
       <para>
        Si un caractère est utilisé dans une chaîne qui n'est pas supportée
@@ -129,7 +129,7 @@
   &reftitle.returnvalues;
   <para>
    Retourne un tableau de 8 éléments représentant quatre points
-   marquants les limites du texte. L'ordre des points est : inférieur
+   marquant les limites du texte. L'ordre des points est : inférieur
    gauche, inférieur droit, supérieur droit, supérieur gauche. Les
    points sont relatifs au texte par rapport à l'angle, donc, "supérieur
    gauche" signifie dans le coin en haut à gauche lorsqu'on

--- a/reference/image/functions/imagetypes.xml
+++ b/reference/image/functions/imagetypes.xml
@@ -14,7 +14,7 @@
    <void/>
   </methodsynopsis>
   <para>
-   Retourne un champ d'octets correspondant aux formats d'images supportés
+   Retourne un champ de bits correspondant aux formats d'images supportés
    par la version PHP utilisée.
   </para>
  </refsect1>
@@ -27,7 +27,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Retourne un champ d'octets correspondant aux formats d'images supportés
+   Retourne un champ de bits correspondant aux formats d'images supportés
    par la version de GD utilisée. Les valeurs suivantes sont possibles :
    <constant>IMG_AVIF</constant> | <constant>IMG_BMP</constant> |
    <constant>IMG_GIF</constant> | <constant>IMG_JPG</constant> |

--- a/reference/image/functions/imagewbmp.xml
+++ b/reference/image/functions/imagewbmp.xml
@@ -36,9 +36,9 @@
      <term><parameter>foreground_color</parameter></term>
      <listitem>
       <para>
-       Il est possible de choisir la couleur de fond avec ce paramètre.
+       Il est possible de choisir la couleur de premier plan avec ce paramètre.
        Il convient d'utiliser l'identifiant retourné par <function>imagecolorallocate</function>
-       comme valeur de ce paramètre. La couleur de fond par défaut est noire.
+       comme valeur de ce paramètre. La couleur de premier plan par défaut est noire.
       </para>
      </listitem>
     </varlistentry>
@@ -91,7 +91,7 @@ $text_color = imagecolorallocate($im, 233, 14, 91);
 imagestring($im, 1, 5, 5,  'Un texte simple', $text_color);
 
 // Définit le contenu de l'en-tête - dans ce cas, image/vnd.wap.wbmp
-// Hint: see image_type_to_mime_type() for content-types
+// Astuce : voir la fonction image_type_to_mime_type() pour les types de contenu
 header('Content-Type: image/vnd.wap.wbmp');
 
 // Affichage de l'image

--- a/reference/image/functions/imagexbm.xml
+++ b/reference/image/functions/imagexbm.xml
@@ -21,9 +21,9 @@
   </para>
   <note>
    <simpara>
-    <function>imagexbm</function> n'applique pas de rembourrage, de sorte que 
-    la largeur de l'image doit être un multiple de 8. Cette restriction ne 
-    s'applique plus à partir de PHP 7.0.9, respectivement.
+    <function>imagexbm</function> n'applique pas de rembourrage, de sorte que
+    la largeur de l'image doit être un multiple de 8. Cette restriction ne
+    s'applique plus à partir de PHP 7.0.9.
    </simpara>
   </note>
  </refsect1>
@@ -42,12 +42,12 @@
        directement affiché sur la sortie standard.
       </para>
       <para>
-       Le nom de fichier <parameter>filename</parameter> (sans l'extension .xbm) 
+       Le nom de fichier <parameter>filename</parameter> (sans l'extension .xbm)
        est également utilisé pour les identificateurs C du <acronym>XBM</acronym>,
-       auquel cas les caractères non alphanumériques des paramètres régionaux 
-       actuels sont remplacés par des soulignements. Si 
-       <parameter>filename</parameter> a la valeur null, 
-       <literal>image</literal> est utilisée pour générer les identificateurs C.
+       auquel cas les caractères non alphanumériques des paramètres régionaux
+       actuels sont remplacés par des tirets bas. Si
+       <parameter>filename</parameter> a la valeur &null;,
+       <literal>image</literal> est utilisé pour générer les identificateurs C.
       </para>
      </listitem>
     </varlistentry>
@@ -55,9 +55,9 @@
      <term><parameter>foreground_color</parameter></term>
      <listitem>
       <para>
-       Il est possible de définir le premier plan avec ce paramètre en définissant
-       un identifiant obtenu depuis la fonction <function>imagecolorallocate</function>.
-       Par défaut, la couleur du premier plan est noir. Toutes les autres 
+       Il est possible de définir la couleur du premier plan avec ce paramètre,
+       en utilisant un identifiant obtenu depuis la fonction <function>imagecolorallocate</function>.
+       Par défaut, la couleur du premier plan est noire. Toutes les autres
        couleurs sont traitées comme arrière-plan.
       </para>
      </listitem>
@@ -126,7 +126,7 @@ imagexbm($im, 'simpletext.xbm');
   </para>
   <para>
    <example>
-    <title>Sauvegarde d'un fichier XBM avec une couleur de premier-plan différente</title>
+    <title>Sauvegarde d'un fichier XBM avec une couleur de premier plan différente</title>
     <programlisting role="php">
 <![CDATA[
 <?php
@@ -135,7 +135,7 @@ $im = imagecreatetruecolor(120, 20);
 $text_color = imagecolorallocate($im, 233, 14, 91);
 imagestring($im, 1, 5, 5,  'Un texte simple', $text_color);
 
-// Définit la couleur de premier-plan
+// Définit la couleur de premier plan
 $foreground_color = imagecolorallocate($im, 255, 0, 0);
 
 // Sauvegarde de l'image

--- a/reference/image/functions/png2wbmp.xml
+++ b/reference/image/functions/png2wbmp.xml
@@ -67,7 +67,7 @@
      <term><parameter>threshold</parameter></term>
      <listitem>
       <para>
-       Valeur du seuil, entre 0 et 8 inclus.
+       Valeur du seuil, entre 0 et 8 (inclus).
       </para>
      </listitem>
     </varlistentry>


### PR DESCRIPTION
Corrections de langue et de traduction dans reference/, de iconv to image (orthographe, grammaire, fidélité à l'anglais).