### PR TITLE
Nits translation: reference/ (imagick to imap)

### DIFF
--- a/reference/imagick/book.xml
+++ b/reference/imagick/book.xml
@@ -12,23 +12,23 @@
  <preface xml:id="intro.imagick">
   &reftitle.intro;
   <para>
-   Imagick est une extension PHP native pour créer et modifier les images,
+   &warn.experimental;
+   Imagick est une extension PHP native permettant de créer et de modifier des images
    en utilisant l'API ImageMagick.
   </para>
 <!-- {{{ About Imagick -->
   <section xml:id="imagick.aboutimagemagick">
    <title>À propos d'ImageMagick</title>
    <para>
-    &warn.experimental;
     ImageMagick est une suite de logiciels permettant la création,
     l'édition et la composition d'images bitmap. Elle peut lire, convertir
-    et écrire les images dans divers formats (une centaine) dont
+    et écrire des images dans divers formats (plus d'une centaine) dont
     DPX, EXR, GIF, JPEG, JPEG-2000, PDF, PhotoCD, PNG, Postscript, SVG et TIFF.
    </para>
    <para>
-    ImageMagick Studio LLC, une organisation à but
-    non lucratif dont la vocation est de rendre les logiciels de
-    manipulation d'images librement disponibles.
+    ImageMagick Studio LLC est une organisation à but non lucratif dont la
+    vocation est de rendre librement disponibles des solutions logicielles
+    de traitement d'images.
    </para>
   </section>
 <!-- }}} -->

--- a/reference/imagick/imagick/adaptivesharpenimage.xml
+++ b/reference/imagick/imagick/adaptivesharpenimage.xml
@@ -70,7 +70,7 @@
    <example>
     <title>Exemple avec <function>Imagick::adaptiveSharpenImage</function></title>
     <para>
-     Augmente le contraste de l'image d'un rayon de 2 et un sigma de 1
+     Augmente le contraste de l'image avec un rayon de 2 et un sigma de 1.
     </para>
     <programlisting role="php">
 <![CDATA[

--- a/reference/imagick/imagick/adaptivethresholdimage.xml
+++ b/reference/imagick/imagick/adaptivethresholdimage.xml
@@ -18,9 +18,9 @@
    <methodparam><type>int</type><parameter>offset</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Sélectionne le niveau individuel de chaque pixel, en se basant sur un intervalle
-   d'intensité, dans le voisinage. Cela permet d'appliquer une fonction de seuil 
-   à une image dont l'histogramme ne contient pas de pic distinct.
+   Sélectionne un seuil individuel pour chaque pixel, en se basant sur l'intervalle
+   des valeurs d'intensité dans son voisinage local. Cela permet d'appliquer un seuillage
+   à une image dont l'histogramme global d'intensité ne contient pas de pic distinct.
   </para>
  </refsect1>
  
@@ -32,7 +32,7 @@
      <term><parameter>width</parameter></term>
      <listitem>
       <para>
-       La largeur du voisinage.
+       La largeur du voisinage local.
       </para>
      </listitem>
     </varlistentry>
@@ -40,7 +40,7 @@
      <term><parameter>height</parameter></term>
      <listitem>
       <para>
-       La hauteur du voisinage.
+       La hauteur du voisinage local.
       </para>
      </listitem>
     </varlistentry>
@@ -48,7 +48,7 @@
      <term><parameter>offset</parameter></term>
      <listitem>
       <para>
-       La moyenne de la position.
+       Le décalage de la moyenne.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/imagick/imagick/addnoiseimage.xml
+++ b/reference/imagick/imagick/addnoiseimage.xml
@@ -6,7 +6,7 @@
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="imagick.addnoiseimage">
  <refnamediv>
   <refname>Imagick::addNoiseImage</refname>
-  <refpurpose>Ajoute un bruit blanc à une image</refpurpose>
+  <refpurpose>Ajoute un bruit aléatoire à une image</refpurpose>
  </refnamediv>
  
  <refsect1 role="description">
@@ -17,7 +17,7 @@
    <methodparam choice="opt"><type>int</type><parameter>channel</parameter><initializer>Imagick::CHANNEL_DEFAULT</initializer></methodparam>
   </methodsynopsis>
   <para>
-   Ajoute un bruit blanc à une image.
+   Ajoute un bruit aléatoire à une image.
   </para>
  </refsect1>
  

--- a/reference/imagick/imagick/annotateimage.xml
+++ b/reference/imagick/imagick/annotateimage.xml
@@ -100,7 +100,7 @@ $pixel = new ImagickPixel( 'gray' );
 $image->newImage(800, 75, $pixel);
 
 /* Texte noir */
-$pixel->setFillColor('black');
+$draw->setFillColor('black');
 
 /* Propriétés du texte */
 $draw->setFont('Bookman-DemiItalic');

--- a/reference/imagick/imagick/blackthresholdimage.xml
+++ b/reference/imagick/imagick/blackthresholdimage.xml
@@ -6,7 +6,7 @@
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="imagick.blackthresholdimage">
  <refnamediv>
   <refname>Imagick::blackThresholdImage</refname>
-  <refpurpose>Force tous les pixels au-delà d'un seuil à noir</refpurpose>
+  <refpurpose>Force tous les pixels en dessous d'un seuil à noir</refpurpose>
  </refnamediv>
  
  <refsect1 role="description">
@@ -17,7 +17,7 @@
   </methodsynopsis>
   <para>
    Équivalent de la fonction <function>Imagick::thresholdImage</function>, mais
-   force tous les pixels au-delà du seuil <parameter>threshold</parameter>
+   force tous les pixels en dessous du seuil <parameter>threshold</parameter>
    en noir, et laisse les autres pixels inchangés.
   </para>
  </refsect1>

--- a/reference/imagick/imagick/clipimage.xml
+++ b/reference/imagick/imagick/clipimage.xml
@@ -6,7 +6,7 @@
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="imagick.clipimage">
  <refnamediv>
   <refname>Imagick::clipImage</refname>
-  <refpurpose>S'aligne sur le premier chemin d'un profil 8BIM</refpurpose>
+  <refpurpose>Découpe le long du premier chemin du profil 8BIM</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -16,7 +16,7 @@
    <void/>
   </methodsynopsis>
   <para>
-   S'aligne sur le premier chemin d'un profil 8BIM, si présent.
+   Découpe le long du premier chemin du profil 8BIM, si présent.
   </para>
  </refsect1>
 

--- a/reference/imagick/imagick/clippathimage.xml
+++ b/reference/imagick/imagick/clippathimage.xml
@@ -6,7 +6,7 @@
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="imagick.clippathimage">
  <refnamediv>
   <refname>Imagick::clipPathImage</refname>
-  <refpurpose>Suit le chemin d'un profil 8BIM</refpurpose>
+  <refpurpose>Découpe le long du chemin d'un profil 8BIM</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -17,7 +17,7 @@
    <methodparam><type>bool</type><parameter>inside</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Suit le chemin d'un profil 8BIM, s'il est présent.
+   Découpe le long du chemin d'un profil 8BIM, s'il est présent.
    Les opérations suivantes auront lieu dans ce chemin.
    Cela peut être un nombre, s'il est précédé par #, pour
    utiliser un chemin numéroté, p. ex. "#1" pour utiliser le

--- a/reference/imagick/imagick/colormatriximage.xml
+++ b/reference/imagick/imagick/colormatriximage.xml
@@ -14,7 +14,7 @@
    <methodparam><type>array</type><parameter>color_matrix</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Applique une transformation de couleur à une image. La méthode permet des changements de saturation, une rotation de teinte, une luminance en alpha, et divers autres effets. Bien que des matrices de transformation de taille variable puissent être utilisées, on utilise généralement une matrice 5x5 pour une image RGBA et une 6x6 pour CMYKA (ou RGBA avec des décalages). La matrice est similaire à celles utilisées par Adobe Flash, sauf que les décalages sont dans la colonne 6 plutôt que 5 (en support des images CMYKA) et les décalages sont normalisés (divisez le décalage Flash par 255).
+   Applique une transformation de couleur à une image. La méthode permet des changements de saturation, une rotation de teinte, une luminance en alpha, et divers autres effets. Bien que des matrices de transformation de taille variable puissent être utilisées, on utilise généralement une matrice 5x5 pour une image RGBA et une 6x6 pour CMYKA (ou RGBA avec des décalages). La matrice est similaire à celles utilisées par Adobe Flash, sauf que les décalages sont dans la colonne 6 plutôt que 5 (en support des images CMYKA) et les décalages sont normalisés (diviser le décalage Flash par 255).
   </para>
 
 

--- a/reference/imagick/imagick/combineimages.xml
+++ b/reference/imagick/imagick/combineimages.xml
@@ -33,8 +33,8 @@
      <listitem>
       <para>
        Fournit une constante de canal valide pour le mode de canal.
-       Pour utiliser plus d'un canal, combinez les constantes de type
-       de canal en utilisant les opérateurs de bits. Se reporter à la liste des
+       Pour utiliser plus d'un canal, il faut combiner les constantes de type
+       de canal en utilisant les opérateurs bit à bit. Se reporter à la liste des
        <link linkend="imagick.constants.channel">constantes de canal</link>.
       </para>
      </listitem>

--- a/reference/imagick/imagick/commentimage.xml
+++ b/reference/imagick/imagick/commentimage.xml
@@ -72,7 +72,7 @@ $im->newImage(100, 100, new ImagickPixel("red"));
 $im->commentImage("Bonjour le monde!");
 
 /* Affichage du commentaire */
-echo $im->getImageProperty("commentaire");
+echo $im->getImageProperty("comment");
 
 ?>
 ]]>

--- a/reference/imagick/imagick/compareimagechannels.xml
+++ b/reference/imagick/imagick/compareimagechannels.xml
@@ -39,8 +39,8 @@
      <listitem>
       <para>
        Fournit une constante de canal valide pour le mode de canal.
-       Pour utiliser plus d'un canal, combinez les constantes de type
-       de canal en utilisant les opérateurs de bits. Se reporter à la liste des
+       Pour utiliser plus d'un canal, il faut combiner les constantes de type
+       de canal en utilisant les opérateurs bit à bit. Se reporter à la liste des
        <link linkend="imagick.constants.channel">constantes de canal</link>.
       </para>
      </listitem>

--- a/reference/imagick/imagick/compositeimage.xml
+++ b/reference/imagick/imagick/compositeimage.xml
@@ -69,8 +69,8 @@
      <listitem>
       <para>
        Fournit une constante de canal valide pour le mode de canal.
-       Pour utiliser plus d'un canal, combinez les constantes de type
-       de canal en utilisant les opérateurs de bits. Se reporter à la liste des
+       Pour utiliser plus d'un canal, il faut combiner les constantes de type
+       de canal en utilisant les opérateurs bit à bit. Se reporter à la liste des
        <link linkend="imagick.constants.channel">constantes de canal</link>.
       </para>
      </listitem>

--- a/reference/imagick/imagick/contrastimage.xml
+++ b/reference/imagick/imagick/contrastimage.xml
@@ -17,7 +17,7 @@
   </methodsynopsis>
   <para>
    Améliore l'intensité des différences entre les éléments
-   clairs et sombres de l'image. Donnez une valeur différente
+   clairs et sombres de l'image. Donner une valeur différente
    de zéro pour améliorer le contraste, et sinon,
    il sera réduit.
   </para>

--- a/reference/imagick/imagick/contraststretchimage.xml
+++ b/reference/imagick/imagick/contraststretchimage.xml
@@ -49,8 +49,8 @@
      <listitem>
       <para>
        Fournit une constante de canal valide pour le mode de canal.
-       Pour utiliser plus d'un canal, combinez les constantes de type
-       de canal en utilisant les opérateurs de bits. Par défaut, c'est
+       Pour utiliser plus d'un canal, il faut combiner les constantes de type
+       de canal en utilisant les opérateurs bit à bit. Par défaut, c'est
        <constant>Imagick::CHANNEL_ALL</constant>. Se reporter à la liste des
        <link linkend="imagick.constants.channel">constantes de canal</link>.
       </para>

--- a/reference/imagick/imagick/convolveimage.xml
+++ b/reference/imagick/imagick/convolveimage.xml
@@ -38,8 +38,8 @@
      <listitem>
       <para>
        Fournit une constante de canal valide pour le mode de canal.
-       Pour utiliser plus d'un canal, combinez les constantes de type
-       de canal en utilisant les opérateurs de bits. Se reporter à la liste des
+       Pour utiliser plus d'un canal, il faut combiner les constantes de type
+       de canal en utilisant les opérateurs bit à bit. Se reporter à la liste des
        <link linkend="imagick.constants.channel">constantes de canal</link>.
       </para>
      </listitem>

--- a/reference/imagick/imagick/cropthumbnailimage.xml
+++ b/reference/imagick/imagick/cropthumbnailimage.xml
@@ -18,7 +18,7 @@
    <methodparam choice="opt"><type>bool</type><parameter>legacy</parameter><initializer>&false;</initializer></methodparam>
   </methodsynopsis>
   <para>
-  Crée une miniature de taille fixe, en réduisant sa taille de haut en bas, en 
+  Crée une miniature de taille fixe, en agrandissant ou en réduisant sa taille, en
   recadrant l'image autour du centre.
   </para>
  </refsect1>

--- a/reference/imagick/imagick/evaluateimage.xml
+++ b/reference/imagick/imagick/evaluateimage.xml
@@ -49,8 +49,8 @@
      <listitem>
       <para>
        Fournit une constante de canal valide pour le mode de canal.
-       Pour utiliser plus d'un canal, combinez les constantes de type
-       de canal en utilisant les opérateurs de bits. Se reporter à la liste des
+       Pour utiliser plus d'un canal, il faut combiner les constantes de type
+       de canal en utilisant les opérateurs bit à bit. Se reporter à la liste des
        <link linkend="imagick.constants.channel">constantes de canal</link>.
       </para>
      </listitem>

--- a/reference/imagick/imagick/forwardfouriertransformimage.xml
+++ b/reference/imagick/imagick/forwardfouriertransformimage.xml
@@ -59,7 +59,7 @@ function createMask() {
     $draw->setStrokeColor('rgb(255, 255, 255)');
     $draw->setFillColor('rgb(255, 255, 255)');
 
-    // Désine un cercle sur l'axe des y, avec son centre
+    // Dessine un cercle sur l'axe des y, avec son centre
     // à x, y qui touche l'origine
     $draw->circle(250, 250, 220, 250);
 

--- a/reference/imagick/imagick/functionimage.xml
+++ b/reference/imagick/imagick/functionimage.xml
@@ -71,7 +71,7 @@
   &reftitle.examples;
   <para>
    <example>
-    <title>Crée un gradient sinusoidal</title>
+    <title>Crée un gradient sinusoïdal</title>
     <programlisting role="php">
 <![CDATA[
 <?php
@@ -88,15 +88,15 @@ echo $imagick->getImageBlob();
     </programlisting>
     &example.outputs.similar;
     <mediaobject>
-     <alt>Résultat de la création d'un gradient sinusoidal</alt>
+     <alt>Résultat de la création d'un gradient sinusoïdal</alt>
      <imageobject>
-      <imagedata fileref="en/reference/imagick/figures/functionImage_sinusoidal.png"/>
+      <imagedata fileref="en/reference/imagick/figures/functionImage_sinusoïdal.png"/>
      </imageobject>
     </mediaobject>
    </example>
    
    <example>
-    <title>Crée un gradient depuis le polynome (4x^2 - 4x + 1) </title>
+    <title>Crée un gradient depuis le polynôme (4x^2 - 4x + 1) </title>
     <programlisting role="php">
 <![CDATA[
 <?php
@@ -113,7 +113,7 @@ echo $imagick->getImageBlob();
     </programlisting>
     &example.outputs.similar;
     <mediaobject>
-     <alt>Résultat de la création d'un gradient à partir d'un polynome</alt>
+     <alt>Résultat de la création d'un gradient à partir d'un polynôme</alt>
      <imageobject>
       <imagedata fileref="en/reference/imagick/figures/functionImage_polynomial.png"/>
      </imageobject>
@@ -123,7 +123,7 @@ echo $imagick->getImageBlob();
    <example>
     <title>
      Crée un gradient complexe depuis le
-     polynome (4x^2 - 4x^2 + 1) modulé par un gradient sinusoidal
+     polynôme (4x^2 - 4x^2 + 1) modulé par un gradient sinusoïdal
     </title>
     <programlisting role="php">
 <![CDATA[

--- a/reference/imagick/imagick/fximage.xml
+++ b/reference/imagick/imagick/fximage.xml
@@ -40,8 +40,8 @@
      <listitem>
       <para>
        Fournit une constante de canal valide pour le mode de canal.
-       Pour utiliser plus d'un canal, combinez les constantes de type
-       de canal en utilisant les opérateurs de bits. Se reporter à la liste des
+       Pour utiliser plus d'un canal, il faut combiner les constantes de type
+       de canal en utilisant les opérateurs bit à bit. Se reporter à la liste des
        <link linkend="imagick.constants.channel">constantes de canal</link>.
       </para>
      </listitem>

--- a/reference/imagick/imagick/gammaimage.xml
+++ b/reference/imagick/imagick/gammaimage.xml
@@ -17,10 +17,10 @@
    <methodparam choice="opt"><type>int</type><parameter>channel</parameter><initializer>Imagick::CHANNEL_DEFAULT</initializer></methodparam>
   </methodsynopsis>
   <para>
-   Applique une correction gamma à l'image. La même image est vue sur différents
-   écrans vont avoir des différences de perceptions dans la représentation
+   Applique une correction gamma à l'image. La même image vue sur différents
+   écrans aura des différences de perception dans la représentation
    des intensités. Spécifier des corrections gamma individuelles pour
-   les différentes couleurs, ou bien ajustez les trois corrections gamma 
+   les différentes couleurs, ou bien ajuster les trois corrections gamma
    d'un seul coup. Les valeurs typiques vont de 0.8 à 2.3.
   </para>
  </refsect1>
@@ -42,8 +42,8 @@
      <listitem>
       <para>
        Fournit une constante de canal valide pour le mode de canal.
-       Pour utiliser plus d'un canal, combinez les constantes de type
-       de canal en utilisant les opérateurs de bits. Se reporter à la liste des
+       Pour utiliser plus d'un canal, il faut combiner les constantes de type
+       de canal en utilisant les opérateurs bit à bit. Se reporter à la liste des
        <link linkend="imagick.constants.channel">constantes de canal</link>.
       </para>
      </listitem>

--- a/reference/imagick/imagick/gaussianblurimage.xml
+++ b/reference/imagick/imagick/gaussianblurimage.xml
@@ -51,8 +51,8 @@
      <listitem>
       <para>
        Fournit une constante de canal valide pour le mode de canal.
-       Pour utiliser plus d'un canal, combinez les constantes de type
-       de canal en utilisant les opérateurs de bits. Se reporter à la liste des
+       Pour utiliser plus d'un canal, il faut combiner les constantes de type
+       de canal en utilisant les opérateurs bit à bit. Se reporter à la liste des
        <link linkend="imagick.constants.channel">constantes de canal</link>.
       </para>
      </listitem>

--- a/reference/imagick/imagick/getcopyright.xml
+++ b/reference/imagick/imagick/getcopyright.xml
@@ -16,7 +16,7 @@
    <void/>
   </methodsynopsis>
   <para>
-   Retourne le copyright de l'API ImageMagick API.
+   Retourne le copyright de l'API ImageMagick.
   </para>
  </refsect1>
 

--- a/reference/imagick/imagick/getimageblueprimary.xml
+++ b/reference/imagick/imagick/getimageblueprimary.xml
@@ -6,7 +6,7 @@
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="imagick.getimageblueprimary">
  <refnamediv>
   <refname>Imagick::getImageBluePrimary</refname>
-  <refpurpose>Retourne la chromacité de la couleur bleue</refpurpose>
+  <refpurpose>Retourne la chromaticité de la couleur bleue</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -16,7 +16,7 @@
    <void/>
   </methodsynopsis>
   <para>
-   Retourne la chromacité de la couleur bleue. 
+   Retourne la chromaticité de la couleur bleue. 
    Retourne un tableau avec les clés "x" et "y".
   </para>
  </refsect1>

--- a/reference/imagick/imagick/getimageblueprimary.xml
+++ b/reference/imagick/imagick/getimageblueprimary.xml
@@ -16,7 +16,7 @@
    <void/>
   </methodsynopsis>
   <para>
-   Retourne la chromaticité de la couleur bleue. 
+   Retourne la chromaticité de la couleur bleue.
    Retourne un tableau avec les clés "x" et "y".
   </para>
  </refsect1>

--- a/reference/imagick/imagick/getimagechanneldistortion.xml
+++ b/reference/imagick/imagick/getimagechanneldistortion.xml
@@ -40,8 +40,8 @@
      <listitem>
       <para>
        Fournit une constante de canal valide pour le mode de canal.
-       Pour utiliser plus d'un canal, combinez les constantes de type
-       de canal en utilisant les opérateurs de bits. Se reporter à la liste des
+       Pour utiliser plus d'un canal, il faut combiner les constantes de type
+       de canal en utilisant les opérateurs bit à bit. Se reporter à la liste des
        <link linkend="imagick.constants.channel">constantes de canal</link>.
       </para>
      </listitem>

--- a/reference/imagick/imagick/getimagechannelextrema.xml
+++ b/reference/imagick/imagick/getimagechannelextrema.xml
@@ -34,8 +34,8 @@
      <listitem>
       <para>
        Fournit une constante de canal valide pour le mode de canal.
-       Pour utiliser plus d'un canal, combinez les constantes de type
-       de canal en utilisant les opérateurs de bits. Se reporter à la liste des
+       Pour utiliser plus d'un canal, il faut combiner les constantes de type
+       de canal en utilisant les opérateurs bit à bit. Se reporter à la liste des
        <link linkend="imagick.constants.channel">constantes de canal</link>.
       </para>
      </listitem>

--- a/reference/imagick/imagick/getimagechannelmean.xml
+++ b/reference/imagick/imagick/getimagechannelmean.xml
@@ -28,8 +28,8 @@
      <listitem>
       <para>
        Fournit une constante de canal valide pour le mode de canal.
-       Pour utiliser plus d'un canal, combinez les constantes de type
-       de canal en utilisant les opérateurs de bits. Se reporter à la liste des
+       Pour utiliser plus d'un canal, il faut combiner les constantes de type
+       de canal en utilisant les opérateurs bit à bit. Se reporter à la liste des
        <link linkend="imagick.constants.channel">constantes de canal</link>.
       </para>
      </listitem>

--- a/reference/imagick/imagick/getimagecolors.xml
+++ b/reference/imagick/imagick/getimagecolors.xml
@@ -28,7 +28,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Retourne un <type>int</type>, le nombre de couleur unique dans l'image.
+   Retourne un <type>int</type>, le nombre de couleurs uniques dans l'image.
   </para>
  </refsect1>
 

--- a/reference/imagick/imagick/getimagegreenprimary.xml
+++ b/reference/imagick/imagick/getimagegreenprimary.xml
@@ -6,7 +6,7 @@
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="imagick.getimagegreenprimary">
  <refnamediv>
   <refname>Imagick::getImageGreenPrimary</refname>
-  <refpurpose>Retourne la chromacité de la couleur verte</refpurpose>
+  <refpurpose>Retourne la chromaticité de la couleur verte</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -16,7 +16,7 @@
    <void/>
   </methodsynopsis>
   <para>
-   Retourne la chromacité de la couleur verte. 
+   Retourne la chromaticité de la couleur verte. 
    Retourne un tableau avec les clés "x" et "y".
   </para>
  </refsect1>

--- a/reference/imagick/imagick/getimagegreenprimary.xml
+++ b/reference/imagick/imagick/getimagegreenprimary.xml
@@ -16,7 +16,7 @@
    <void/>
   </methodsynopsis>
   <para>
-   Retourne la chromaticité de la couleur verte. 
+   Retourne la chromaticité de la couleur verte.
    Retourne un tableau avec les clés "x" et "y".
   </para>
  </refsect1>

--- a/reference/imagick/imagick/getimagehistogram.xml
+++ b/reference/imagick/imagick/getimagehistogram.xml
@@ -77,7 +77,7 @@ function getImageHistogram($imagePath) {
     $backgroundColor = 'black';
 
     $draw = new \ImagickDraw();
-    $draw->setStrokeWidth(0); // en rend les lignes le plus fin possible
+    $draw->setStrokeWidth(0); // rend les lignes les plus fines possible
 
     $imagick = new \Imagick();
     $imagick->newImage(500, 500, $backgroundColor);

--- a/reference/imagick/imagick/getimageprofiles.xml
+++ b/reference/imagick/imagick/getimageprofiles.xml
@@ -40,7 +40,7 @@
      <listitem>
       <para>
        S'il faut retourner seulement les noms des profils.
-       Si &false; est fourni, seuls les noms des propriétés seront retournés.
+       Si &false; est fourni, seuls les noms des profils seront retournés.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/imagick/imagick/getimageredprimary.xml
+++ b/reference/imagick/imagick/getimageredprimary.xml
@@ -6,7 +6,7 @@
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="imagick.getimageredprimary">
  <refnamediv>
   <refname>Imagick::getImageRedPrimary</refname>
-  <refpurpose>Retourne la chromacité du point rouge</refpurpose>
+  <refpurpose>Retourne la chromaticité du point rouge</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -16,7 +16,7 @@
    <void/>
   </methodsynopsis>
   <para>
-   Retourne la chromacité du point rouge sous la forme d'un tableau
+   Retourne la chromaticité du point rouge sous la forme d'un tableau
    avec les clés "x" et "y".
   </para>
  </refsect1>
@@ -29,7 +29,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Retourne la chromacité du point rouge sous la forme d'un tableau
+   Retourne la chromaticité du point rouge sous la forme d'un tableau
    avec les clés "x" et "y".
    &imagick.imagickexception.throw;
   </para>

--- a/reference/imagick/imagick/getimagewhitepoint.xml
+++ b/reference/imagick/imagick/getimagewhitepoint.xml
@@ -6,7 +6,7 @@
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="imagick.getimagewhitepoint">
  <refnamediv>
   <refname>Imagick::getImageWhitePoint</refname>
-  <refpurpose>Retourne la chromacité du point blanc</refpurpose>
+  <refpurpose>Retourne la chromaticité du point blanc</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -16,7 +16,7 @@
    <void/>
   </methodsynopsis>
   <para>
-   Retourne la chromacité du point blanc, sous la forme d'un tableau
+   Retourne la chromaticité du point blanc, sous la forme d'un tableau
    associatif avec les clés "x" et "y".
   </para>
  </refsect1>
@@ -29,7 +29,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Retourne la chromacité du point blanc, sous la forme d'un tableau
+   Retourne la chromaticité du point blanc, sous la forme d'un tableau
    associatif avec les clés "x" et "y".
   </para>
  </refsect1>

--- a/reference/imagick/imagick/getpixeliterator.xml
+++ b/reference/imagick/imagick/getpixeliterator.xml
@@ -51,8 +51,8 @@ function getPixelIterator($imagePath) {
     $imagick = new \Imagick(realpath($imagePath));
     $imageIterator = $imagick->getPixelIterator();
 
-    foreach ($imageIterator as $row => $pixels) { /* On parcourt les lignes de piexel */
-        foreach ($pixels as $column => $pixel) { /* On parcourt les pixel dans la ligne (colonne) */
+    foreach ($imageIterator as $row => $pixels) { /* On parcourt les lignes de pixels */
+        foreach ($pixels as $column => $pixel) { /* On parcourt les pixels dans la ligne (colonne) */
             /** @var $pixel \ImagickPixel */
             if ($column % 2) {
                 $pixel->setColor("rgba(0, 0, 0, 0)"); /* On peint tous les seconds pixels en noir */

--- a/reference/imagick/imagick/getquantum.xml
+++ b/reference/imagick/imagick/getquantum.xml
@@ -14,7 +14,7 @@
    <void />
   </methodsynopsis>
   <para>
-   Renvoie la place quantique d'ImageMagick. Si HDRI est activé, le type est un flottant, sinon c'est un entier.
+   Renvoie la plage quantique d'ImageMagick. Si HDRI est activé, le type est un flottant, sinon c'est un entier.
   </para>
 
 

--- a/reference/imagick/imagick/getversion.xml
+++ b/reference/imagick/imagick/getversion.xml
@@ -16,7 +16,7 @@
    <void/>
   </methodsynopsis>
   <para>
-   Retourne la version de l'APIImageMagick API, sous forme de chaîne
+   Retourne la version de l'API ImageMagick, sous forme de chaîne
    et de nombre.
   </para>
  </refsect1>
@@ -29,7 +29,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Retourne la version de l'APIImageMagick API, sous forme de chaîne
+   Retourne la version de l'API ImageMagick, sous forme de chaîne
    et de nombre.
   </para>
  </refsect1>

--- a/reference/imagick/imagick/levelimage.xml
+++ b/reference/imagick/imagick/levelimage.xml
@@ -64,8 +64,8 @@
      <listitem>
       <para>
        Fournit une constante de canal valide pour le mode de canal.
-       Pour utiliser plus d'un canal, combinez les constantes de type
-       de canal en utilisant les opérateurs de bits. Se reporter à la liste des
+       Pour utiliser plus d'un canal, il faut combiner les constantes de type
+       de canal en utilisant les opérateurs bit à bit. Se reporter à la liste des
        <link linkend="imagick.constants.channel">constantes de canal</link>.
       </para>
      </listitem>

--- a/reference/imagick/imagick/modulateimage.xml
+++ b/reference/imagick/imagick/modulateimage.xml
@@ -19,7 +19,7 @@
   </methodsynopsis>
   <para>
    Contrôle l'intensité, la saturation et la teinte d'une image.
-   La couleur est le pourcentage de rotation absolue depuis la 
+   La teinte est le pourcentage de rotation absolue depuis la
    position courante. Par exemple, la valeur 50 engendre une 
    rotation anti-horaire de 90 degrés, 150 produit une rotation 
    horaire de 90 degrés, tandis que 0 et 200 produisent des 

--- a/reference/imagick/imagick/motionblurimage.xml
+++ b/reference/imagick/imagick/motionblurimage.xml
@@ -61,7 +61,7 @@
      <listitem>
       <para>
        Une constante de canal, valide pour le mode de canal. Pour spécifier un
-       ou plusieurs canaux, combinez les constantes de canaux avec les opérateurs logiques.
+       ou plusieurs canaux, il faut combiner les constantes de canaux avec les opérateurs bit à bit.
        Voir la liste de constantes de <link linkend="imagick.constants.channel">canaux</link>.
        L'argument de canal est disponible uniquement si Imagick est compilé avec
        ImageMagick, version 6.4.4 ou plus récente.

--- a/reference/imagick/imagick/negateimage.xml
+++ b/reference/imagick/imagick/negateimage.xml
@@ -40,8 +40,8 @@
      <listitem>
       <para>
        Fournit une constante de canal valide pour le mode de canal.
-       Pour utiliser plus d'un canal, combinez les constantes de type
-       de canal en utilisant les opérateurs de bits. Se reporter à la liste des
+       Pour utiliser plus d'un canal, il faut combiner les constantes de type
+       de canal en utilisant les opérateurs bit à bit. Se reporter à la liste des
        <link linkend="imagick.constants.channel">constantes de canal</link>.
       </para>
      </listitem>

--- a/reference/imagick/imagick/normalizeimage.xml
+++ b/reference/imagick/imagick/normalizeimage.xml
@@ -30,8 +30,8 @@
      <listitem>
       <para>
        Fournit une constante de canal valide pour le mode de canal.
-       Pour utiliser plus d'un canal, combinez les constantes de type
-       de canal en utilisant les opérateurs de bits. Se reporter à la liste des
+       Pour utiliser plus d'un canal, il faut combiner les constantes de type
+       de canal en utilisant les opérateurs bit à bit. Se reporter à la liste des
        <link linkend="imagick.constants.channel">constantes de canal</link>.
       </para>
      </listitem>

--- a/reference/imagick/imagick/orderedposterizeimage.xml
+++ b/reference/imagick/imagick/orderedposterizeimage.xml
@@ -45,8 +45,8 @@
      <listitem>
       <para>
        Fournit une constante de canal valide pour le mode de canal.
-       Pour utiliser plus d'un canal, combinez les constantes de type
-       de canal en utilisant les opérateurs de bits. Se reporter à la liste des
+       Pour utiliser plus d'un canal, il faut combiner les constantes de type
+       de canal en utilisant les opérateurs bit à bit. Se reporter à la liste des
        <link linkend="imagick.constants.channel">constantes de canal</link>.
       </para>
      </listitem>

--- a/reference/imagick/imagick/paintfloodfillimage.xml
+++ b/reference/imagick/imagick/paintfloodfillimage.xml
@@ -5,7 +5,7 @@
 
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="imagick.paintfloodfillimage">
  <refnamediv>
-  <refname>Imagick::colorFloodfillImage</refname>
+  <refname>Imagick::paintFloodfillImage</refname>
   <refpurpose>Change les pixels qui sont d'une couleur</refpurpose>
  </refnamediv>
 

--- a/reference/imagick/imagick/paintopaqueimage.xml
+++ b/reference/imagick/imagick/paintopaqueimage.xml
@@ -62,8 +62,8 @@
      <listitem>
       <para>
        Fournit une constante de canal valide pour le mode de canal.
-       Pour utiliser plus d'un canal, combinez les constantes de type
-       de canal en utilisant les opérateurs de bits. Se reporter à la liste des
+       Pour utiliser plus d'un canal, il faut combiner les constantes de type
+       de canal en utilisant les opérateurs bit à bit. Se reporter à la liste des
        <link linkend="imagick.constants.channel">constantes de canal</link>.
       </para>
      </listitem>

--- a/reference/imagick/imagick/randomthresholdimage.xml
+++ b/reference/imagick/imagick/randomthresholdimage.xml
@@ -50,8 +50,8 @@
      <listitem>
       <para>
        Fournit une constante de canal valide pour le mode de canal.
-       Pour utiliser plus d'un canal, combinez les constantes de type
-       de canal en utilisant les opérateurs de bits. Se reporter à la liste des
+       Pour utiliser plus d'un canal, il faut combiner les constantes de type
+       de canal en utilisant les opérateurs bit à bit. Se reporter à la liste des
        <link linkend="imagick.constants.channel">constantes de canal</link>.
       </para>
      </listitem>

--- a/reference/imagick/imagick/setimagebias.xml
+++ b/reference/imagick/imagick/setimagebias.xml
@@ -62,7 +62,7 @@
     <programlisting role="php">
 <![CDATA[
 <?php
-// Requiert ImageMagick version 6.9.0-1 pour avoir un effet sur les convulsions
+// Requiert ImageMagick version 6.9.0-1 pour avoir un effet sur convolveImage
 function setImageBias($bias) {
     $imagick = new \Imagick(realpath("images/stack.jpg"));
 

--- a/reference/imagick/imagick/setimageblueprimary.xml
+++ b/reference/imagick/imagick/setimageblueprimary.xml
@@ -6,7 +6,7 @@
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="imagick.setimageblueprimary">
  <refnamediv>
   <refname>Imagick::setImageBluePrimary</refname>
-  <refpurpose>Configure la chromacité du point bleu</refpurpose>
+  <refpurpose>Configure la chromaticité du point bleu</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -17,7 +17,7 @@
    <methodparam><type>float</type><parameter>y</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Configure la chromacité du point bleu.
+   Configure la chromaticité du point bleu.
   </para>
  </refsect1>
 

--- a/reference/imagick/imagick/setimagegreenprimary.xml
+++ b/reference/imagick/imagick/setimagegreenprimary.xml
@@ -6,7 +6,7 @@
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="imagick.setimagegreenprimary">
  <refnamediv>
   <refname>Imagick::setImageGreenPrimary</refname>
-  <refpurpose>Configure la chromacité du point vert</refpurpose>
+  <refpurpose>Configure la chromaticité du point vert</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -17,7 +17,7 @@
    <methodparam><type>float</type><parameter>y</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Configure la chromacité du point vert.
+   Configure la chromaticité du point vert.
   </para>
  </refsect1>
 

--- a/reference/imagick/imagick/setimageredprimary.xml
+++ b/reference/imagick/imagick/setimageredprimary.xml
@@ -6,7 +6,7 @@
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="imagick.setimageredprimary">
  <refnamediv>
   <refname>Imagick::setImageRedPrimary</refname>
-  <refpurpose>Configure la chromacité du point rouge</refpurpose>
+  <refpurpose>Configure la chromaticité du point rouge</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -17,7 +17,7 @@
    <methodparam><type>float</type><parameter>y</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Configure la chromacité du point rouge.
+   Configure la chromaticité du point rouge.
   </para>
  </refsect1>
 

--- a/reference/imagick/imagick/setimagetickspersecond.xml
+++ b/reference/imagick/imagick/setimagetickspersecond.xml
@@ -83,11 +83,11 @@ foreach ($imagick as $frame) {
     $imagick->setImageTicksPerSecond(50);
     
     if ($frameCount < ($totalFrames / 2)) {
-        // Modification de la frame pour quelle s'affiche pendant deux fois plus de temps qu'actuellement
+        // Modification de la frame pour qu'elle s'affiche pendant deux fois plus de temps qu'actuellement
         $imagick->setImageTicksPerSecond(50);
     } else {
 
-        // Modification de la frame pour quelle s'affiche pendant deux fois moins de temps qu'actuellement
+        // Modification de la frame pour qu'elle s'affiche pendant deux fois moins de temps qu'actuellement
         $imagick->setImageTicksPerSecond(200);
     }
 

--- a/reference/imagick/imagick/setimagewhitepoint.xml
+++ b/reference/imagick/imagick/setimagewhitepoint.xml
@@ -6,7 +6,7 @@
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="imagick.setimagewhitepoint">
  <refnamediv>
   <refname>Imagick::setImageWhitePoint</refname>
-  <refpurpose>Configure la chromacité du point blanc</refpurpose>
+  <refpurpose>Configure la chromaticité du point blanc</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -17,7 +17,7 @@
    <methodparam><type>float</type><parameter>y</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Configure la chromacité du point blanc.
+   Configure la chromaticité du point blanc.
   </para>
  </refsect1>
 

--- a/reference/imagick/imagick/setsize.xml
+++ b/reference/imagick/imagick/setsize.xml
@@ -17,8 +17,8 @@
    <methodparam><type>int</type><parameter>rows</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Configure la taille de l'objet Imagick. 
-   Configurez cet attribut avant d'ouvrir une image brute, aux
+   Configure la taille de l'objet Imagick.
+   Configurer cet attribut avant d'ouvrir une image brute, aux
    formats RGB, GRAY ou CMYK.
   </para>
  </refsect1>

--- a/reference/imagick/imagick/setsizeoffset.xml
+++ b/reference/imagick/imagick/setsizeoffset.xml
@@ -18,8 +18,8 @@
    <methodparam><type>int</type><parameter>offset</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Configure la taille et la position de l'objet Imagick. 
-   Configurez ces attributs avant de lire une image brute, aux
+   Configure la taille et la position de l'objet Imagick.
+   Configurer ces attributs avant de lire une image brute, aux
    formats RGB, GRAY ou CMYK.
    &imagick.method.available.0x629;
   </para>

--- a/reference/imagick/imagick/shadeimage.xml
+++ b/reference/imagick/imagick/shadeimage.xml
@@ -18,7 +18,7 @@
    <methodparam><type>float</type><parameter>elevation</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Récupère une lumière distante de l'image pour créer un effet 3D.
+   Projette une lumière distante sur l'image pour créer un effet 3D.
    Il est possible de contrôler le positionnement de la lumière avec l'azimut
    et l'élévation ; l'azimut est mesuré en degré de l'axe X et l'élévation
    est mesurée sur l'axe Z.

--- a/reference/imagick/imagick/shearimage.xml
+++ b/reference/imagick/imagick/shearimage.xml
@@ -83,7 +83,7 @@
        <entry>PECL imagick 2.1.0</entry>
        <entry>
         Autorise maintenant une chaîne représentant la couleur comme
-        troisième paramètre. Les anciennes versions n'autorisent que
+        premier paramètre. Les anciennes versions n'autorisent que
         des objets ImagickPixel.
        </entry>
       </row>

--- a/reference/imagick/imagick/sketchimage.xml
+++ b/reference/imagick/imagick/sketchimage.xml
@@ -23,7 +23,7 @@
    et la déviation standard <parameter>sigma</parameter>. Pour de bons
    résultats, le paramètre <parameter>radius</parameter> doit être plus
    élevé que le paramètre <parameter>sigma</parameter>. Utiliser un
-   <parameter>sigma</parameter> de 0 et Imagick::sketchImage() sélectionnera
+   <parameter>radius</parameter> de 0 et Imagick::sketchImage() sélectionnera
    automatiquement un bon radius à sa place. Le paramètre
    <parameter>angle</parameter> fournit l'angle du flou du mouvement.
    &imagick.method.available.0x629;

--- a/reference/imagick/imagick/steganoimage.xml
+++ b/reference/imagick/imagick/steganoimage.xml
@@ -17,7 +17,7 @@
    <methodparam><type>int</type><parameter>offset</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Cache un filigrane numérique dans l'image. Récupérez le filigrane
+   Cache un filigrane numérique dans l'image. Récupérer le filigrane
    plus tard pour prouver l'authenticité de l'image. Le paramètre
    <parameter>offset</parameter> définit la position de départ à
    partir de laquelle on cache le filigrane.

--- a/reference/imagick/imagick/transparentpaintimage.xml
+++ b/reference/imagick/imagick/transparentpaintimage.xml
@@ -6,7 +6,7 @@
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="imagick.transparentpaintimage">
  <refnamediv>
   <refname>Imagick::transparentPaintImage</refname>
-  <refpurpose>Colorise les pixels transparents</refpurpose>
+  <refpurpose>Rend des pixels transparents</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -20,7 +20,7 @@
   </methodsynopsis>
 
   <para>
-   Colorise les pixels correspondant à la couleur transparente.
+   Rend transparents les pixels correspondant à la couleur cible.
    &imagick.method.available.0x638;
   </para>
  </refsect1>
@@ -33,7 +33,7 @@
      <term><parameter>target</parameter></term>
      <listitem>
       <para>
-       La couleur cible à coloriser.
+       La couleur cible à rendre transparente.
       </para>
      </listitem>
     </varlistentry>
@@ -57,7 +57,7 @@
      <term><parameter>invert</parameter></term>
      <listitem>
       <para>
-       Si &true;, colorise tous les pixels qui ne correspondent
+       Si &true;, rend transparents tous les pixels qui ne correspondent
        pas à la couleur cible.
       </para>
      </listitem>

--- a/reference/imagick/imagick/unsharpmaskimage.xml
+++ b/reference/imagick/imagick/unsharpmaskimage.xml
@@ -22,8 +22,8 @@
   <para>
    Rend une image plus nette. L'image est traitée avec un opérateur Gaussien
    d'un rayon donné et d'une déviation standard (sigma). Pour de bons résultats,
-   le rayon doit être supérieur au sigma. L'utilisation d'un rayon de 0 et
-   Imagick::UnsharpMaskImage() sélectionne un bon rayon pour.
+   le rayon doit être supérieur au sigma. Avec un rayon de 0,
+   Imagick::UnsharpMaskImage() sélectionne un bon rayon automatiquement.
   </para>
  </refsect1>
 

--- a/reference/imagick/imagick/vignetteimage.xml
+++ b/reference/imagick/imagick/vignetteimage.xml
@@ -32,7 +32,7 @@
      <term><parameter>blackPoint</parameter></term>
      <listitem>
       <para>
-       Le rayon du flou
+       Le point noir.
       </para>
      </listitem>
     </varlistentry>
@@ -40,7 +40,7 @@
      <term><parameter>whitePoint</parameter></term>
      <listitem>
       <para>
-       La déviation standard
+       Le point blanc.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/imagick/imagick/whitethresholdimage.xml
+++ b/reference/imagick/imagick/whitethresholdimage.xml
@@ -6,7 +6,7 @@
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="imagick.whitethresholdimage">
  <refnamediv>
   <refname>Imagick::whiteThresholdImage</refname>
-  <refpurpose>Force tous les pixels en dessous du seuil en blanc</refpurpose>
+  <refpurpose>Force tous les pixels au-dessus du seuil en blanc</refpurpose>
  </refnamediv>
  
  <refsect1 role="description">
@@ -17,7 +17,8 @@
   </methodsynopsis>
   <para>
    Identique à Imagick::ThresholdImage() mais force tous les pixels
-   en dessous du seuil en blanc, laissant tous les autres pixels inchangés.
+   au-dessus du seuil en blanc, laissant inchangés tous les pixels
+   en dessous du seuil.
   </para>
  </refsect1>
  

--- a/reference/imagick/imagickdraw/getstrokedashoffset.xml
+++ b/reference/imagick/imagickdraw/getstrokedashoffset.xml
@@ -24,7 +24,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Retourne un nombre décimal représentant, le début du pointillé dans le motif.
+   Retourne un nombre décimal représentant le début du pointillé dans le motif.
   </para>
  </refsect1>
 

--- a/reference/imagick/imagickdraw/pathcurvetoquadraticbezierabsolute.xml
+++ b/reference/imagick/imagickdraw/pathcurvetoquadraticbezierabsolute.xml
@@ -19,10 +19,10 @@
   </methodsynopsis>
   &warn.undocumented.func;
   <para>
-   Dessine une courbe de Bézier quadratique, en coordonnées relatives, par 
-   rapport au point courant (<parameter>x</parameter>,<parameter>y</parameter>),
+   Dessine une courbe de Bézier quadratique, depuis le point courant
+   jusqu'à (<parameter>x</parameter>,<parameter>y</parameter>),
    en utilisant le point (<parameter>x1</parameter>,<parameter>y1</parameter>) comme
-   point de contrôle. À la fin du dessin, le nouveau point courant
+   point de contrôle, en coordonnées absolues. À la fin du dessin, le nouveau point courant
    devient le point final (<parameter>x</parameter>,<parameter>y</parameter>)
    utilisé par le polybezier.
   </para>

--- a/reference/imagick/imagickdraw/pathcurvetoquadraticbeziersmoothabsolute.xml
+++ b/reference/imagick/imagickdraw/pathcurvetoquadraticbeziersmoothabsolute.xml
@@ -6,7 +6,7 @@
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="imagickdraw.pathcurvetoquadraticbeziersmoothabsolute">
  <refnamediv>
   <refname>ImagickDraw::pathCurveToQuadraticBezierSmoothAbsolute</refname>
-  <refpurpose>Dessine une courbe de Bézier de puissance 4, en coordonnées absolues</refpurpose>
+  <refpurpose>Dessine une courbe de Bézier quadratique, en coordonnées absolues</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -18,7 +18,7 @@
   </methodsynopsis>
 
   <para>
-   Dessine une courbe de Bézier de puissance 4, en coordonnées relatives, à 
+   Dessine une courbe de Bézier quadratique, en coordonnées absolues, à
    partir du point courant (<parameter>x</parameter>, <parameter>y</parameter>). Le point de contrôle est la réflexion du
    point de contrôle sur la commande de dessin en coordonnées absolues.
    S'il n'y a pas eu de commande précédente ou si la commande précédente

--- a/reference/imagick/imagickdraw/pathcurvetoquadraticbeziersmoothrelative.xml
+++ b/reference/imagick/imagickdraw/pathcurvetoquadraticbeziersmoothrelative.xml
@@ -6,7 +6,7 @@
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="imagickdraw.pathcurvetoquadraticbeziersmoothrelative">
  <refnamediv>
   <refname>ImagickDraw::pathCurveToQuadraticBezierSmoothRelative</refname>
-  <refpurpose>Dessine une courbe de Bézier de puissance 4, en coordonnées relatives</refpurpose>
+  <refpurpose>Dessine une courbe de Bézier quadratique, en coordonnées relatives</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -18,7 +18,7 @@
   </methodsynopsis>
   &warn.undocumented.func;
   <para>
-   Dessine une courbe de Bézier de puissance 4, en coordonnées relatives, à 
+   Dessine une courbe de Bézier quadratique, en coordonnées relatives, à
    partir du point courant (<parameter>x</parameter>, <parameter>y</parameter>). Le point de contrôle est la réflexion du
    point de contrôle sur la commande de dessin en coordonnées relatives.
    S'il n'y a pas eu de commande précédente ou si la commande précédente

--- a/reference/imagick/imagickdraw/pathcurvetosmoothabsolute.xml
+++ b/reference/imagick/imagickdraw/pathcurvetosmoothabsolute.xml
@@ -30,7 +30,7 @@
    alors que le premier point de contrôle coïncide avec le point courant. 
    (<parameter>x2</parameter>,<parameter>y2</parameter>) 
    est le second point de contrôle (c.-à-d., le point de contrôle à la fin
-   de la ligne. À la fin de la commande, le nouveau point courant est le point
+   de la ligne). À la fin de la commande, le nouveau point courant est le point
    final, de coordonnées (<parameter>x</parameter>,<parameter>y</parameter>),
    dans le polybezier.
   </para>

--- a/reference/imagick/imagickdraw/pathcurvetosmoothrelative.xml
+++ b/reference/imagick/imagickdraw/pathcurvetosmoothrelative.xml
@@ -30,7 +30,7 @@
    alors que le premier point de contrôle coïncide avec le point courant. 
    (<parameter>x2</parameter>,<parameter>y2</parameter>) 
    est le second point de contrôle (c.-à-d., le point de contrôle à la fin
-   de la ligne. À la fin de la commande, le nouveau point courant est le point
+   de la ligne). À la fin de la commande, le nouveau point courant est le point
    final, de coordonnées (<parameter>x</parameter>,<parameter>y</parameter>),
    dans le polybezier.
   </para>

--- a/reference/imagick/imagickdraw/pathellipticarcabsolute.xml
+++ b/reference/imagick/imagickdraw/pathellipticarcabsolute.xml
@@ -23,7 +23,7 @@
   &warn.undocumented.func;
   <para>
    Dessine un arc d'ellipse à partir du point courant (<parameter>x</parameter>, <parameter>y</parameter>), en utilisant
-   des coordonnées relatives. La taille et l'orientation de l'ellipse
+   des coordonnées absolues. La taille et l'orientation de l'ellipse
    sont définies par deux rayons, (<parameter>rx</parameter>, <parameter>ry</parameter>) et une rotation xAxisRotation, 
    qui indique comment l'ellipse, dans son ensemble, est située dans 
    le système de coordonnées. Le centre (<parameter>cx</parameter>, <parameter>cy</parameter>) de l'ellipse est calculé
@@ -67,7 +67,7 @@
      <term><parameter>large_arc</parameter></term>
      <listitem>
       <para>
-       option d'<parameter>large_arc_flag</parameter>
+       option <parameter>large_arc_flag</parameter>
       </para>
      </listitem>
     </varlistentry>

--- a/reference/imagick/imagickdraw/pathellipticarcrelative.xml
+++ b/reference/imagick/imagickdraw/pathellipticarcrelative.xml
@@ -66,7 +66,7 @@
      <term><parameter>large_arc</parameter></term>
      <listitem>
       <para>
-       L'option d'<parameter>large_arc_flag</parameter>
+       L'option <parameter>large_arc_flag</parameter>
       </para>
      </listitem>
     </varlistentry>
@@ -74,7 +74,7 @@
      <term><parameter>sweep</parameter></term>
      <listitem>
       <para>
-       L'option d'<parameter>sweep_flag</parameter>
+       L'option <parameter>sweep_flag</parameter>
       </para>
      </listitem>
     </varlistentry>

--- a/reference/imagick/imagickdraw/pathlinetohorizontalabsolute.xml
+++ b/reference/imagick/imagickdraw/pathlinetohorizontalabsolute.xml
@@ -17,8 +17,8 @@
   </methodsynopsis>
   &warn.undocumented.func;
   <para>
-   Dessine une ligne verticale à partir du point courant, jusqu'au point cible,
-   en utilisant des coordonnées relatives. Le point cible devient alors le point
+   Dessine une ligne horizontale à partir du point courant, jusqu'au point cible,
+   en utilisant des coordonnées absolues. Le point cible devient alors le point
    courant.
   </para>
  </refsect1>

--- a/reference/imagick/imagickdraw/polyline.xml
+++ b/reference/imagick/imagickdraw/polyline.xml
@@ -18,7 +18,7 @@
   &warn.undocumented.func;
   <para>
    Dessine une ligne brisée, en utilisant le trait courant, sa largeur et 
-   son motif, ainsi que sa ligne de remplissage ou sa texture, en 
+   son motif, ainsi que sa couleur de remplissage ou sa texture, en
    utilisant les coordonnées spécifiées.
   </para>
  </refsect1>

--- a/reference/imagick/imagickdraw/rectangle.xml
+++ b/reference/imagick/imagickdraw/rectangle.xml
@@ -32,6 +32,7 @@
      <term><parameter>top_left_x</parameter></term>
      <listitem>
       <para>
+       abscisse du coin supérieur gauche
       </para>
      </listitem>
     </varlistentry>

--- a/reference/imagick/imagickdraw/setfillpatternurl.xml
+++ b/reference/imagick/imagickdraw/setfillpatternurl.xml
@@ -18,7 +18,7 @@
   &warn.undocumented.func;
   <para>
    Configure l'URL du motif de remplissage des surfaces. Seules les URL
-   locales (<literal>"#identifier"</literal>) sont prises en charge actuellement.
+   locales (<literal>"#identifier"</literal>) sont supportées actuellement.
    Ces URL sont normalement créées en définissant un nom de motif de remplissage
    avec DrawPushPattern/DrawPopPattern.
   </para>

--- a/reference/imagick/imagickdraw/setstrokelinejoin.xml
+++ b/reference/imagick/imagickdraw/setstrokelinejoin.xml
@@ -6,7 +6,7 @@
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="imagickdraw.setstrokelinejoin">
  <refnamediv>
   <refname>ImagickDraw::setStrokeLineJoin</refname>
-  <refpurpose>Spécifie la forme à utiliser pour dessiner les fins de lignes</refpurpose>
+  <refpurpose>Spécifie la forme à utiliser aux coins des chemins</refpurpose>
  </refnamediv>
  
  <refsect1 role="description">
@@ -17,8 +17,8 @@
   </methodsynopsis>
   &warn.undocumented.func;
   <para>
-   Spécifie la forme à utiliser pour dessiner les fins de lignes 
-   et les autres formes vectorielles, quand elles utilisent un trait.
+   Spécifie la forme à utiliser aux coins des chemins
+   (ou d'autres formes vectorielles), quand ils utilisent un trait.
   </para>
  </refsect1>
  

--- a/reference/imagick/imagickdraw/setviewbox.xml
+++ b/reference/imagick/imagickdraw/setviewbox.xml
@@ -23,7 +23,7 @@
    vectorielles. Généralement, on configure cette valeur avec la même taille
    que l'image. Lorsque les données vectorielles sont sauvées en SVG ou MVG,
    la boîte de vue est utilisée pour spécifier la taille de l'image dans laquelle
-   le lecteur vidéo va dessiner les données.
+   le visualiseur va dessiner les données.
   </para>
  </refsect1>
  

--- a/reference/imagick/imagickkernel/frombuiltin.xml
+++ b/reference/imagick/imagickkernel/frombuiltin.xml
@@ -15,7 +15,7 @@
    <methodparam><type>string</type><parameter>kernelString</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Crée un noyau à partir d'un noyau intégré. Voir http://www.imagemagick.org/Usage/morphology/#kernel pour des exemples. Actuellement, les symboles de 'rotation' ne sont pas pris en charge. Exemple :
+   Crée un noyau à partir d'un noyau intégré. Voir http://www.imagemagick.org/Usage/morphology/#kernel pour des exemples. Actuellement, les symboles de 'rotation' ne sont pas supportés. Exemple :
    $diamondKernel = ImagickKernel::fromBuiltIn(\Imagick::KERNEL_DIAMOND, "2");
   </para>
 

--- a/reference/imagick/imagickkernelexception.xml
+++ b/reference/imagick/imagickkernelexception.xml
@@ -3,7 +3,7 @@
 <!-- EN-Revision: 4947a993e6d5050f4271f3c5eb7b1cd4b7c1c2e4 Maintainer: yannick Status: ready -->
 <!-- Reviewed: no -->
 
-<reference xml:id="class.imagickkernelexception" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+<reference xml:id="class.imagickkernelexception" role="exception" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>La classe ImagickKernelException</title>
  <titleabbrev>ImagickKernelException</titleabbrev>

--- a/reference/imagick/imagickpixel/construct.xml
+++ b/reference/imagick/imagickpixel/construct.xml
@@ -72,7 +72,7 @@ function construct() {
         "#ffff00000000", //  #rrrrggggbbbb
         "#ffff00000000ffff", //  #rrrrggggbbbbaaaa
         "rgb(255, 0, 0)", //  un entier dans l'intervalle 0—255 pour chaque composant
-        "rgb(100.0%, 0.0%, 0.0%)", //  un ombre à virgule flottante, dans l'intervalle 0—100% pour chaque composant
+        "rgb(100.0%, 0.0%, 0.0%)", //  un nombre à virgule flottante, dans l'intervalle 0-100% pour chaque composant
         "rgb(255, 0, 0)", //  intervalle 0 - 255
         "rgba(255, 0, 0, 1.0)", //  pareil, mais avec une valeur alpha explicite
         "rgb(100%, 0%, 0%)", //  intervalle 0.0% - 100.0%

--- a/reference/imagick/imagickpixel/getcolorcount.xml
+++ b/reference/imagick/imagickpixel/getcolorcount.xml
@@ -56,7 +56,7 @@
 ]]>
     </programlisting>
     <para>
-     La sortie pour ce sera similaire à :
+     La sortie sera similaire à :
     </para>
     <screen role="php">
 <![CDATA[

--- a/reference/imagick/imagickpixel/sethsl.xml
+++ b/reference/imagick/imagickpixel/sethsl.xml
@@ -19,7 +19,7 @@
   </methodsynopsis>
   <para>
    Définit la couleur décrite par l'objet ImagickPixel en utilisant
-   les valeurs normalisées pour la densité, la saturation et la luminosité.
+   les valeurs normalisées pour la teinte, la saturation et la luminosité.
   </para>
  </refsect1>
 
@@ -31,8 +31,8 @@
      <term><parameter>hue</parameter></term>
      <listitem>
       <para>
-       La valeur normalisée pour la densité, décrite par un arc fractionnel
-       (entre 0 et 1) du cercle de densité, dont la valeur zéro correspond à
+       La valeur normalisée pour la teinte, décrite par un arc fractionnel
+       (entre 0 et 1) du cercle des teintes, dont la valeur zéro correspond à
        rouge.
       </para>
      </listitem>

--- a/reference/imagick/imagickpixeliterator/newpixeliterator.xml
+++ b/reference/imagick/imagickpixeliterator/newpixeliterator.xml
@@ -6,7 +6,7 @@
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="imagickpixeliterator.newpixeliterator">
  <refnamediv>
   <refname>ImagickPixelIterator::newPixelIterator</refname>
-  <refpurpose>Retourne un nouveau pixel de l'itérateur</refpurpose>
+  <refpurpose>Retourne un nouvel itérateur de pixels</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -17,7 +17,7 @@
   </methodsynopsis>
   &warn.undocumented.func;
   <para>
-   Retourne un nouveau pixel de l'itérateur.
+   Retourne un nouvel itérateur de pixels.
   </para>
  </refsect1>
 

--- a/reference/imagick/imagickpixeliterator/newpixelregioniterator.xml
+++ b/reference/imagick/imagickpixeliterator/newpixelregioniterator.xml
@@ -6,7 +6,7 @@
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="imagickpixeliterator.newpixelregioniterator">
  <refnamediv>
   <refname>ImagickPixelIterator::newPixelRegionIterator</refname>
-  <refpurpose>Retourne un nouveau pixel de l'itérateur</refpurpose>
+  <refpurpose>Retourne un nouvel itérateur de pixels</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -21,7 +21,7 @@
   </methodsynopsis>
   &warn.undocumented.func;
   <para>
-   Retourne un nouveau pixel de l'itérateur.
+   Retourne un nouvel itérateur de pixels.
   </para>
  </refsect1>
 

--- a/reference/imap/functions/imap-fetchbody.xml
+++ b/reference/imap/functions/imap-fetchbody.xml
@@ -38,7 +38,7 @@
      <listitem>
       <para>
        Le numéro de la section. C'est une chaîne d'entiers, délimités
-       par une virgule qui correspondent aux index dans la liste
+       par un point qui correspondent aux index dans la liste
        des sections du message, tel que prévu par la spécification IMAP4.
       </para>
      </listitem>

--- a/reference/imap/functions/imap-fetchmime.xml
+++ b/reference/imap/functions/imap-fetchmime.xml
@@ -36,7 +36,7 @@
      <term><parameter>section</parameter></term>
      <listitem>
       <para>
-       Le numéro de la section. C'est une chaîne d'entiers délimités par une virgule
+       Le numéro de la section. C'est une chaîne d'entiers délimités par un point
        qui représente l'index de la liste des sections du corps du message, tel
        que spécifié par l'IMAP4.
       </para>

--- a/reference/imap/functions/imap-headerinfo.xml
+++ b/reference/imap/functions/imap-headerinfo.xml
@@ -242,7 +242,7 @@
     </listitem>
     <listitem>
      <simpara>
-      <literal>"udate"</literal> : Date de l<literal>"envoi du message, sous la forme d"</literal>une date Unix
+      <literal>"udate"</literal> : Date de l'envoi du message, sous la forme d'une date Unix
      </simpara>
     </listitem>
     <listitem>

--- a/reference/imap/functions/imap-mime-header-decode.xml
+++ b/reference/imap/functions/imap-mime-header-decode.xml
@@ -70,11 +70,11 @@ for ($i=0; $i<count($elements); $i++) {
     &example.outputs;
     <screen>
 <![CDATA[
-Charset: ISO-8859-1
-Text: Keld Jørn Simonsen
+Charset : ISO-8859-1
+Texte : Keld Jørn Simonsen
 
-Charset: default
-Text:  <keld@example.com>
+Charset : default
+Texte :  <keld@example.com>
 ]]>
     </screen>
    </example>

--- a/reference/imap/functions/imap-rfc822-parse-adrlist.xml
+++ b/reference/imap/functions/imap-rfc822-parse-adrlist.xml
@@ -15,7 +15,7 @@
    <methodparam><type>string</type><parameter>default_hostname</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Analyse la chaîne <parameter>address</parameter>,
+   Analyse la chaîne d'adresses,
    telle que définie dans la <link xlink:href="&url.rfc;2822">RFC2822</link>.
   </para>
  </refsect1>
@@ -66,7 +66,7 @@
     </listitem>
     <listitem>
      <simpara>
-      <literal>"adl"</literal> : at domain source route (NDT : ???)
+      <literal>"adl"</literal> : at domain source route
      </simpara>
     </listitem>
    </itemizedlist>
@@ -107,7 +107,7 @@ foreach ($address_array as $id => $val) {
   adl      :
 # 1
   Boîte   : postmaster
-  hôte    : example.com
+  Hôte    : example.com
   Nom    :
   adl      :
 # 2

--- a/reference/imap/functions/imap-savebody.xml
+++ b/reference/imap/functions/imap-savebody.xml
@@ -48,7 +48,7 @@
      <listitem>
       <para>
        Le numéro de la section. C'est une &string; d'entiers, délimités par
-       une virgule qui correspondent à l'index dans la liste des sections
+       un point qui correspondent à l'index dans la liste des sections
        du corps, tel que prévu par la spécification IMAP4.
       </para>
      </listitem>

--- a/reference/imap/functions/imap-search.xml
+++ b/reference/imap/functions/imap-search.xml
@@ -118,7 +118,7 @@
         </listitem>
         <listitem>
          <simpara>
-          SEEN - tous les messages lus (avec le flag\\SEEN flag)
+          SEEN - tous les messages lus (avec le flag \\SEEN)
          </simpara>
         </listitem>
         <listitem>

--- a/reference/imap/functions/imap-set-quota.xml
+++ b/reference/imap/functions/imap-set-quota.xml
@@ -93,7 +93,7 @@ imap_close($mbox);
  <refsect1 role="notes">
   &reftitle.notes;
   <para>
-   <function>imap_get_quota</function> ne fonctionne actuellement qu'avec
+   Cette fonction ne fonctionne actuellement qu'avec
    les bibliothèques c-client2000.
   </para>
   <para>

--- a/reference/imap/functions/imap-sort.xml
+++ b/reference/imap/functions/imap-sort.xml
@@ -62,8 +62,8 @@
         </listitem>
         <listitem>
          <simpara>
-          <constant>SORTCC</constant> : nom de la boîte aux lettres de 
-          copie cachée (cc address)
+          <constant>SORTCC</constant> : nom de la boîte aux lettres de
+          copie carbone (cc address)
          </simpara>
         </listitem>
         <listitem>

--- a/reference/imap/functions/imap-utf7-decode.xml
+++ b/reference/imap/functions/imap-utf7-decode.xml
@@ -18,7 +18,7 @@
    <parameter>string</parameter> en ISO-8859-1.
   </para>
   <para>
-   Cette fonction sert à encoder les noms de boîtes aux lettres qui
+   Cette fonction sert à décoder les noms de boîtes aux lettres qui
    contiennent des caractères internationaux hors de l'espace ASCII.
   </para>
  </refsect1>


### PR DESCRIPTION
Corrections de langue et de traduction dans reference/, de imagick to imap (orthographe, grammaire, fidélité à l'anglais).