### PR TITLE
Nits translation: reference/ (info to mongodb)

### DIFF
--- a/reference/info/functions/cli-get-process-title.xml
+++ b/reference/info/functions/cli-get-process-title.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: b08b472de7041be8dbae153556b714efa93f20c0 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: a331ac8a86bb5929b79be9a369fac1e3af516241 Maintainer: yannick Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.cli-get-process-title" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>

--- a/reference/info/functions/cli-set-process-title.xml
+++ b/reference/info/functions/cli-set-process-title.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: b08b472de7041be8dbae153556b714efa93f20c0 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 2df224f44552cfc88fad705cca33c4cdb01d62ed Maintainer: yannick Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="function.cli-set-process-title" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -16,12 +16,12 @@
    <methodparam><type>string</type><parameter>title</parameter></methodparam>
   </methodsynopsis>
 
-  <simpara>
+  <para>
    Définit le titre du processus visible avec des outils comme
    <command>top</command> et <command>ps</command>. Cette fonction
    n'est disponible qu'en mode
    <link linkend="features.commandline">CLI</link>.
-  </simpara>
+  </para>
 
  </refsect1>
 
@@ -31,9 +31,9 @@
    <varlistentry>
     <term><parameter>title</parameter></term>
     <listitem>
-     <simpara>
+     <para>
       Le nouveau titre
-     </simpara>
+     </para>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -41,18 +41,18 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <simpara>
+  <para>
    &return.success;
-  </simpara>
+  </para>
  </refsect1>
 
  <refsect1 role="errors">
   &reftitle.errors;
 
-  <simpara>
+  <para>
    Une alerte de niveau <constant>E_WARNING</constant> sera générée si le système
    sous-jacent n'est pas supporté.
-  </simpara>
+  </para>
  </refsect1>
 
  <refsect1 role="changelog">
@@ -81,8 +81,10 @@
 
  <refsect1 role="examples">
   &reftitle.examples;
-  <informalexample>
-   <programlisting role="php">
+  <para>
+   <example>
+    <title>Exemple avec <function>cli_set_process_title</function></title>
+    <programlisting role="php">
 <![CDATA[
 <?php
 $title = "Mon super script PHP";
@@ -97,15 +99,18 @@ if (!cli_set_process_title($title)) {
 }
 ?>
 ]]>
-   </programlisting>
-  </informalexample>
+    </programlisting>
+   </example>
+  </para>
  </refsect1>
 
  <refsect1 role="seealso">
   &reftitle.seealso;
-  <simplelist>
-   <member><function>cli_get_process_title</function></member>
-  </simplelist>
+  <para>
+   <simplelist>
+    <member><function>cli_get_process_title</function></member>
+   </simplelist>
+  </para>
  </refsect1>
 
 </refentry>

--- a/reference/intl/dateformatter.xml
+++ b/reference/intl/dateformatter.xml
@@ -11,7 +11,7 @@
   <section xml:id="intldateformatter.intro">
    &reftitle.intro;
    <simpara>
-    La classe <classname>DateFormatter</classname> est une classe concrète,
+    La classe <classname>IntlDateFormatter</classname> est une classe concrète,
     qui active l'analyse et le formatage de dates, basé sur des chaînes modèles,
     ou des règles.
    </simpara>

--- a/reference/intl/dateformatter/formatobject.xml
+++ b/reference/intl/dateformatter/formatobject.xml
@@ -141,7 +141,7 @@ echo "avec DateTime :\n\t",
     &example.outputs;
     <screen>
 <![CDATA[
-défault :
+défaut :
     6 juin 2013 17:05:06
 long $format (complet):
     jeudi 6 juin 2013 17:05:06 heure d’été irlandaise

--- a/reference/intl/dateformatter/get-datetype.xml
+++ b/reference/intl/dateformatter/get-datetype.xml
@@ -118,7 +118,7 @@ echo 'L\'affichage avec le second type de date est ' . $fmt->format(0);
 Le type de date du formateur est : 0
 L'affichage avec le premier type de date est Wednesday, December 31, 1969 4:00:00 PM PT
 Maintenant, le type de date du formateur est : 2
-L'affichage avec le premier type de date est 12/31/69 4:00:00 PM PT
+L'affichage avec le second type de date est 12/31/69 4:00:00 PM PT
 ]]>
   </screen>
  </refsect1>

--- a/reference/intl/dateformatter/get-locale.xml
+++ b/reference/intl/dateformatter/get-locale.xml
@@ -131,7 +131,7 @@ echo 'Le second format utilisé est ' . $fmt->format(0);
 La locale du formateur est : en
 Le premier format utilisé est Wednesday, December 31, 1969 4:00:00 PM PT
 La locale du formateur est : de
-Le deuxième format utilisé est Mittwoch, 31. Dezember 1969 16:00 Uhr GMT-08:00
+Le second format utilisé est Mittwoch, 31. Dezember 1969 16:00 Uhr GMT-08:00
 ]]>
   </screen>
  </refsect1>

--- a/reference/intl/dateformatter/is-lenient.xml
+++ b/reference/intl/dateformatter/is-lenient.xml
@@ -82,7 +82,7 @@ if (intl_get_error_code() != 0) {
     echo "\nError_code est : " . intl_get_error_code();
 }
 datefmt_set_lenient($fmt,false);
-echo Maintenant, le formateur est strict : ';
+echo 'Maintenant, le formateur est strict : ';
 if ($fmt->isLenient()) {
     echo 'Oui';
 } else {

--- a/reference/intl/dateformatter/localtime.xml
+++ b/reference/intl/dateformatter/localtime.xml
@@ -95,7 +95,7 @@ $fmt = datefmt_create(
     IntlDateFormatter::GREGORIAN
 );
 $arr = datefmt_localtime($fmt, 'Wednesday, December 31, 1969 at 4:00:00 PM Pacific Standard Time', $offset);
-echo 'Résultat de l'analyse ';
+echo 'Résultat de l\'analyse ';
 if ($arr) {
     foreach ($arr as $key => $value) {
         echo "$key : $value , ";
@@ -119,7 +119,7 @@ $fmt = new IntlDateFormatter(
     IntlDateFormatter::GREGORIAN
 );
 $arr = $fmt->localtime('Wednesday, December 31, 1969 at 4:00:00 PM Pacific Standard Time', $offset);
-echo 'Résultat de l'analyse ';
+echo 'Résultat de l\'analyse ';
 if ($arr) {
     foreach ($arr as $key => $value) {
         echo "$key : $value , ";

--- a/reference/intl/grapheme/grapheme-strpos.xml
+++ b/reference/intl/grapheme/grapheme-strpos.xml
@@ -72,7 +72,7 @@
   &reftitle.returnvalues;
   <para>
    Retourne la position sous forme d'entier. Si <parameter>needle</parameter> n'est pas trouvé,
-   <function>grapheme_strripos()</function> retourne &false;.   
+   <function>grapheme_strpos</function> retourne &false;.
   </para>
  </refsect1>
  

--- a/reference/intl/grapheme/grapheme-strstr.xml
+++ b/reference/intl/grapheme/grapheme-strstr.xml
@@ -7,7 +7,7 @@
 <refentry xml:id="function.grapheme-strstr" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>grapheme_strstr</refname>
-  <refpurpose>Retourne la partie d'une chaîne à partir d'une occurrence, insensible à la casse</refpurpose>
+  <refpurpose>Retourne la partie d'une chaîne à partir d'une occurrence, sensible à la casse</refpurpose>
  </refnamediv>
  <refsect1 role="description">
   &reftitle.description;

--- a/reference/intl/intlbreakiterator/settext.xml
+++ b/reference/intl/intlbreakiterator/settext.xml
@@ -28,11 +28,18 @@
     <term><parameter>text</parameter></term>
     <listitem>
      <para>
-      &return.success;
+
      </para>
     </listitem>
    </varlistentry>
   </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &return.success;
+  </para>
  </refsect1>
 
  <refsect1 role="changelog">
@@ -56,13 +63,6 @@
      </tbody>
     </tgroup>
    </informaltable>
-  </para>
- </refsect1>
-
- <refsect1 role="returnvalues">
-  &reftitle.returnvalues;
-  <para>
-   
   </para>
  </refsect1>
 

--- a/reference/intl/intlcalendar.xml
+++ b/reference/intl/intlcalendar.xml
@@ -609,7 +609,7 @@
        <constant>IntlCalendar::FIELD_MINUTE</constant>,
        <constant>IntlCalendar::FIELD_SECOND</constant> et
        <constant>IntlCalendar::FIELD_MILLISECOND</constant>. La plage est de
-       <literal>0</literal> to <literal>24 * 3600 * 1000 - 1</literal>. Ce n'est
+       <literal>0</literal> à <literal>24 * 3600 * 1000 - 1</literal>. Ce n'est
        pas le nombre de millisecondes écoulées dans la journée, car lors des transitions DST
        il aura des discontinuités analogues à celles de l'heure locale. 
       </para>
@@ -624,7 +624,7 @@
      <listitem>
       <para>
        Le champ de calendrier dont la valeur est <literal>1</literal> pour indiquer un mois
-       bisextile et <literal>0</literal> sinon.
+       bissextile et <literal>0</literal> sinon.
       </para>
      </listitem>
     </varlistentry>
@@ -816,8 +816,8 @@
      </term>
      <listitem>
       <para>
-       La sortie de <function>IntlCalendar::getRepeatedWallTimeOption</function>
-       indiquant que les heures murales dans la plage répétée devraient se référer à
+       La sortie de <function>IntlCalendar::getSkippedWallTimeOption</function>
+       indiquant que les heures murales dans la plage sautée devraient se référer à
        l'instant lorsque la transition de l'heure d'été arrive (débute).
       </para>
      </listitem>

--- a/reference/intl/intlcalendar/createinstance.xml
+++ b/reference/intl/intlcalendar/createinstance.xml
@@ -28,7 +28,7 @@
   <para>
    En fournissant un fuseau horaire, et une locale, cette méthode
    crée un objet <classname>IntlCalendar</classname>. Cette méthode
-   factorielle peut retourner une sous-classe de la classe
+   d'usine peut retourner une sous-classe de la classe
    <classname>IntlCalendar</classname>.
   </para>
   <para>

--- a/reference/intl/intlcalendar/settime.xml
+++ b/reference/intl/intlcalendar/settime.xml
@@ -27,8 +27,8 @@
   <para>
    Définit l'instant représenté par cet objet. L'instant est représenté par un
    <type>float</type> dont la valeur est un nombre entier de millisecondes
-   depuis l'époque Unix (1 Jan 1970 00:00:00.000 UTC), en ignorant la
-   dernière seconde. Toutes les valeurs des champs seront recalculées en
+   depuis l'époque Unix (1 Jan 1970 00:00:00.000 UTC), en ignorant les
+   secondes intercalaires. Toutes les valeurs des champs seront recalculées en
    conséquence.
   </para>
  </refsect1>
@@ -47,7 +47,7 @@
     <listitem>
      <para>
       Un instant, représenté par le nombre de millisecondes entre l'instant
-      et l'époque Unix, en ignorant la dernière seconde.
+      et l'époque Unix, en ignorant les secondes intercalaires.
      </para>
     </listitem>
    </varlistentry>

--- a/reference/intl/intlchar/digit.xml
+++ b/reference/intl/intlchar/digit.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: fe67f9ad47e7f04f50c4ec1366bdbcbd8ab940f2 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: e166139c786f6fd72a5f856c14027a3c22a8ce7a Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="intlchar.digit" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>

--- a/reference/intl/intlchar/getbidipairedbracket.xml
+++ b/reference/intl/intlchar/getbidipairedbracket.xml
@@ -19,6 +19,7 @@
   <para>
    Pour <code>IntlChar::PROPERTY_BIDI_PAIRED_BRACKET_TYPE !== IntlChar::BPT_NONE</code>, cela équivaut à
    <function>IntlChar::charMirror</function>.
+   Sinon, <parameter>codepoint</parameter> lui-même est renvoyé.
   </para>
  </refsect1>
 

--- a/reference/intl/intlchar/istitle.xml
+++ b/reference/intl/intlchar/istitle.xml
@@ -57,7 +57,7 @@ var_dump(IntlChar::istitle("ǆ"));
 
 // Lettre grecque en majuscule Alpha avec prosgegrammeni U+1FBC
 var_dump(IntlChar::istitle("ᾼ"));
-// Lettre grecque en minuscule Alpha avec prosgegrammeni U+1FBE
+// Lettre grecque en minuscule Alpha avec ypogegrammeni U+1FB3
 var_dump(IntlChar::istitle("ᾳ"));
 // Lettre grecque en majuscule Alpha U+0391
 var_dump(IntlChar::istitle("Α"));

--- a/reference/intl/locale/get-display-variant.xml
+++ b/reference/intl/locale/get-display-variant.xml
@@ -40,7 +40,7 @@
      <term><parameter>locale</parameter></term>
      <listitem>
       <para>
-       La locale dont il faut extraire le nom de la région.
+       La locale dont il faut extraire le nom de la variante.
       </para>
      </listitem>
     </varlistentry>
@@ -48,7 +48,7 @@
      <term><parameter>displayLocale</parameter></term>
      <listitem>
       <para>
-       Un format optionnel pour afficher le nom de la région.
+       Un format optionnel pour afficher le nom de la variante.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/intl/messageformatter/create.xml
+++ b/reference/intl/messageformatter/create.xml
@@ -98,7 +98,7 @@ echo msgfmt_format($fmt, array(4560, 123, 4560/123));
    </programlisting>
   </example>
   <example>
-   <title>Exemple avec <function>msgfmt_create</function>, style procédural</title>
+   <title>Exemple avec <function>msgfmt_create</function>, POO</title>
    <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/intl/messageformatter/format-message.xml
+++ b/reference/intl/messageformatter/format-message.xml
@@ -102,7 +102,7 @@ echo msgfmt_format_message("en",
    </programlisting>
   </example>
   <example>
-   <title>Exemple avec <function>msgfmt_format_message</function>, style procédural</title>
+   <title>Exemple avec <function>msgfmt_format_message</function>, style POO</title>
    <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/intl/messageformatter/get-pattern.xml
+++ b/reference/intl/messageformatter/get-pattern.xml
@@ -63,7 +63,7 @@ $fmt = msgfmt_create( "en_US", "{0, number} singes sur {1, number} arbres" );
 echo "Modèle par défaut : '" . msgfmt_get_pattern( $fmt ) . "'\n";
 echo "Résultat de formatage :  " . msgfmt_format( $fmt, array(123, 456) ) . "\n";
 
-msgfmt_set_pattern( $fmt, "{0, number} arbres hosting {1, number} singes" );
+msgfmt_set_pattern( $fmt, "{0, number} arbres accueillant {1, number} singes" );
 echo "Nouveau modèle :  '" . msgfmt_get_pattern( $fmt ) . "'\n";
 echo "Résultat de formatage : " . msgfmt_format( $fmt, array(123, 456) ) . "\n";
 ?>
@@ -79,7 +79,7 @@ $fmt = new MessageFormatter( "en_US", "{0, number} singes sur {1, number} arbres
 echo "Modèle par défaut : '" . $fmt->getPattern() . "'\n";
 echo "Résultat de formatage :  " . $fmt->format(array(123, 456)) . "\n";
 
-$fmt->setPattern("{0, number} arbres hosting {1, number} singes" );
+$fmt->setPattern("{0, number} arbres accueillant {1, number} singes" );
 echo "Nouveau modèle :  '" . $fmt->getPattern() . "'\n";
 echo "Résultat de formatage : " . $fmt->format(array(123, 456)) . "\n";
 ?>
@@ -91,8 +91,8 @@ echo "Résultat de formatage : " . $fmt->format(array(123, 456)) . "\n";
 <![CDATA[
 Modèle par défaut : '{0,number} singes sur {1,number} arbres'
 Résultat de formatage :  123 singes sur 456 arbres
-Nouveau modèle :  '{0,number} arbres hosting {1,number} singes'
-Résultat de formatage : 123 arbres hosting 456 singes
+Nouveau modèle :  '{0,number} arbres accueillant {1,number} singes'
+Résultat de formatage : 123 arbres accueillant 456 singes
 ]]>
   </screen>
  </refsect1>

--- a/reference/intl/messageformatter/parse.xml
+++ b/reference/intl/messageformatter/parse.xml
@@ -26,7 +26,7 @@
    <methodparam><type>string</type><parameter>string</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Analyse la chaîne <parameter>value</parameter> et retourne les
+   Analyse la chaîne <parameter>string</parameter> et retourne les
    éléments extraits sous forme de &array;.
   </para>
  </refsect1>

--- a/reference/intl/numberformatter/get-attribute.xml
+++ b/reference/intl/numberformatter/get-attribute.xml
@@ -27,7 +27,7 @@
   </methodsynopsis>
   <para>
    Lit un attribut numérique du formateur. Un exemple d'attribut numérique
-   est le nombre de décimales que le formateur va utiliser.
+   est le nombre de chiffres de la partie entière que le formateur va produire.
   </para>
  </refsect1>
 

--- a/reference/intl/numberformatter/parse-currency.xml
+++ b/reference/intl/numberformatter/parse-currency.xml
@@ -91,7 +91,7 @@ echo "We have ".numfmt_parse_currency($fmt, $num, $curr)." in $curr\n";
    </programlisting>
   </example>
   <example>
-   <title>Exemple avec <function>numfmt_parse_currency</function>, &style.procedural;</title>
+   <title>Exemple avec <function>numfmt_parse_currency</function>, style POO</title>
    <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/intl/numberformatter/set-attribute.xml
+++ b/reference/intl/numberformatter/set-attribute.xml
@@ -28,8 +28,8 @@
    <methodparam><type class="union"><type>int</type><type>float</type></type><parameter>value</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Affecte un attribut numérique du formateur. Un exemple d'attribut 
-   numérique est le nombre de décimales à afficher par le formateur.
+   Affecte un attribut numérique du formateur. Un exemple d'attribut
+   numérique est le nombre de chiffres de la partie entière que le formateur va produire.
   </para>
  </refsect1>
 
@@ -131,7 +131,7 @@ $fmt->setAttribute(NumberFormatter::FRACTION_DIGITS, 2);
 
 echo "Mode par défaut d'arrondi:\n";
 echo $fmt->format(3.789), "\n"; // 3.79 (arrondi au dessus)
-echo $fmt->format(3.781), "\n"; // 3.78 (rounded en dessous)
+echo $fmt->format(3.781), "\n"; // 3.78 (arrondi en dessous)
 
 $fmt->setAttribute(NumberFormatter::ROUNDING_MODE, NumberFormatter::ROUND_DOWN);
 

--- a/reference/intl/numberformatter/set-text-attribute.xml
+++ b/reference/intl/numberformatter/set-text-attribute.xml
@@ -95,7 +95,7 @@ echo numfmt_format($fmt, -1234567.891234567890000)."\n";
    </programlisting>
   </example>
   <example>
-   <title>Exemple avec <function>numfmt_set_text_attribute</function>, &style.procedural;</title>
+   <title>Exemple avec <function>numfmt_set_text_attribute</function>, style POO</title>
    <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/intl/transliterator/construct.xml
+++ b/reference/intl/transliterator/construct.xml
@@ -18,7 +18,7 @@
    l'instanciation avec l'opérateur <link linkend="language.oop5.basic.new">new</link>.
   </para>
   <para>
-   Utiliser les méthodes factorisées
+   Utiliser les méthodes d'usine
    <methodname>Transliterator::create</methodname> et
    <methodname>Transliterator::createFromRules</methodname> à la place.
   </para>

--- a/reference/json/constants.xml
+++ b/reference/json/constants.xml
@@ -86,7 +86,7 @@
    <listitem>
     <simpara>
      L'objet ou le tableau passé à la fonction <function>json_encode</function>
-     inclut les références récursives et ne peuvent être encodées.
+     inclut des références récursives et ne peut être encodé.
      Si l'option <constant>JSON_PARTIAL_OUTPUT_ON_ERROR</constant> a été fournie,
      &null; sera encodé à la place de la référence récursive.
     </simpara>
@@ -154,7 +154,7 @@
    <listitem>
     <simpara>
      La valeur passée à <function>json_encode</function>
-     inclut une énumération non prise en charge qui ne peut pas être sérialisée.
+     inclut une énumération non adossée qui ne peut pas être sérialisée.
      Disponible à partir de PHP 8.1.0.
     </simpara>
    </listitem>

--- a/reference/json/functions/json-decode.xml
+++ b/reference/json/functions/json-decode.xml
@@ -191,7 +191,7 @@ array(5) {
      Accéder à des éléments d'un objet qui contiennent des caractères
      non permis par la convention de nommage de PHP (c.-à-d. le trait d'union)
      peut être effectué en encapsulant le nom de l'élément avec
-     des crochets et des apostrophes.
+     des accolades et l'apostrophe.
     </simpara>
     <programlisting role="php">
 <![CDATA[
@@ -324,8 +324,8 @@ object(stdClass)#1 (1) {
   &reftitle.notes;
   <note>
    <para>
-    La spécification JSON ne fait pas partie de Javascript
-    mais d'un sous-ensemble de Javascript.
+    La spécification JSON n'est pas du JavaScript,
+    mais un sous-ensemble de JavaScript.
    </para>
   </note>
   <note>

--- a/reference/json/functions/json-encode.xml
+++ b/reference/json/functions/json-encode.xml
@@ -254,7 +254,7 @@ array(4) {
   string(7) "0.00001"
 }
 string(28) "[123123,-123123,1200,1.0e-5]"
-Chaînes contenant des nombres non formattés proprement
+Chaînes contenant des nombres mal formatés
 array(2) {
   [0]=>
   string(13) "+a33123456789"
@@ -384,8 +384,8 @@ string(2) "12"
     sachant que la spécification est ambiguë sur ce point.
    </para>
    <para>
-    Pour résumer, testez toujours que le décodeur JSON peut gérer
-    la sortie qu'on génère depuis la fonction
+    Pour résumer, il faut toujours tester que le décodeur JSON utilisé peut gérer
+    la sortie produite par la fonction
     <function>json_encode</function>.
    </para>
   </note>

--- a/reference/json/functions/json-last-error.xml
+++ b/reference/json/functions/json-last-error.xml
@@ -100,7 +100,7 @@
      </row>
      <row>
       <entry><constant>JSON_ERROR_UTF16</constant></entry>
-      <entry>Caractères UTF-16 mal formés, probablement mal encodé</entry>
+      <entry>Caractères UTF-16 mal formés, probablement mal encodés</entry>
       <entry></entry>
      </row>
      <row>

--- a/reference/json/setup.xml
+++ b/reference/json/setup.xml
@@ -12,7 +12,7 @@
   </para>
   <para>
    Antérieur à PHP 8.0.0, l'extension JSON était apportée et compilée dans PHP par
-   défaut, mais pouvait être désactivée explicitement en utilisant <option role="configure">--disable-json</option>
+   défaut, mais pouvait être désactivée explicitement en utilisant <option role="configure">--disable-json</option>.
   </para>
  </section>
 

--- a/reference/ldap/controls.xml
+++ b/reference/ldap/controls.xml
@@ -102,7 +102,7 @@ if (!in_array(LDAP_CONTROL_PAGEDRESULTS, ldap_get_entries($ds, $result)[0]['supp
    <listitem>
     <para>
      <constant>LDAP_CONTROL_ASSERT</constant>
-     La clé attendue est [assertion]
+     La clé attendue est filter
     </para>
    </listitem>
    <listitem>

--- a/reference/ldap/functions/ldap-count-entries.xml
+++ b/reference/ldap/functions/ldap-count-entries.xml
@@ -15,9 +15,8 @@
    <methodparam><type>LDAP\Result</type><parameter>result</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Retourne le nombre d'entrées trouvées dans le résultat
-   <parameter>result_identifier</parameter>, sur la connexion
-   <parameter>link_identifier</parameter>.
+   Retourne le nombre d'entrées stockées dans le résultat des
+   opérations de recherche précédentes.
   </para>
  </refsect1>
 

--- a/reference/ldap/functions/ldap-errno.xml
+++ b/reference/ldap/functions/ldap-errno.xml
@@ -15,8 +15,8 @@
   </methodsynopsis>
   <para>
    Retourne le numéro d'erreur standard, généré par la dernière commande
-   LDAP, pour la connexion <parameter>link_identifier</parameter>. Ce numéro
-   peut être converti en message textuel avec <function>ldap_err2str</function>.
+   LDAP. Ce numéro peut être converti en message textuel avec
+   <function>ldap_err2str</function>.
   </para>
  </refsect1>
 
@@ -72,7 +72,7 @@
 <programlisting role="php">
 <![CDATA[
 <?php
-// Cet exemple contient une erreur, que nous interecepterons.
+// Cet exemple contient une erreur, que nous intercepterons.
 $ld = ldap_connect("localhost");
 $bind = ldap_bind($ld);
 // erreur de syntaxe dans l'expression du filtre (errno 87),

--- a/reference/ldap/functions/ldap-free-result.xml
+++ b/reference/ldap/functions/ldap-free-result.xml
@@ -14,10 +14,9 @@
    <methodparam><type>LDAP\Result</type><parameter>result</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Libère toute la mémoire allouée en interne pour stocker le résultat
-   <parameter>result_identifier</parameter>. Si l'appel de cette
-   fonction est omis, toute la mémoire sera libérée automatiquement
-   à la fin du script.
+   Libère toute la mémoire allouée en interne pour stocker le résultat.
+   Si l'appel de cette fonction est omis, toute la mémoire sera libérée
+   automatiquement à la fin du script.
   </para>
   <para>
    Typiquement, toute la mémoire allouée pour le résultat LDAP

--- a/reference/ldap/functions/ldap-list.xml
+++ b/reference/ldap/functions/ldap-list.xml
@@ -23,7 +23,7 @@
   </methodsynopsis>
   <para>
    Effectue une recherche avec le filtre <parameter>filter</parameter>
-   dans le dossier <parameter>base_dn</parameter> avec l'option
+   dans le dossier <parameter>base</parameter> avec l'option
    <constant>LDAP_SCOPE_ONELEVEL</constant>.
   </para>
   <para>

--- a/reference/ldap/functions/ldap-parse-result.xml
+++ b/reference/ldap/functions/ldap-parse-result.xml
@@ -86,7 +86,7 @@
      <term><parameter>controls</parameter></term>
      <listitem>
       <para>
-       Tableau de <link linkend="ldap.controls">Contrôles LDAP</link> à envoyer avec la requête.
+       Un <type>array</type> de Contrôles LDAP qui ont été envoyés avec la réponse.
       </para>
      </listitem>
     </varlistentry>
@@ -138,7 +138,7 @@
 $result = ldap_search($ldap, "cn=userref,dc=my-domain,dc=com", "(cn=user*)");
 $errcode = $dn = $errmsg = $refs =  null;
 if (ldap_parse_result($ldap, $result, $errcode, $dn, $errmsg, $refs)) {
-    // faîtes quelques choses avec $errcode, $dn, $errmsg et $refs
+    // faites quelque chose avec $errcode, $dn, $errmsg et $refs
 }
 ?>
      ]]>

--- a/reference/ldap/functions/ldap-read.xml
+++ b/reference/ldap/functions/ldap-read.xml
@@ -23,7 +23,7 @@
   </methodsynopsis>
   <para>
    Effectue une recherche avec le filtre <parameter>filter</parameter>
-   dans le dossier <parameter>base_dn</parameter> avec la configuration
+   dans le dossier <parameter>base</parameter> avec la configuration
    <constant>LDAP_SCOPE_BASE</constant>. C'est équivalent à lire une
    entrée dans un dossier.
   </para>

--- a/reference/ldap/functions/ldap-search.xml
+++ b/reference/ldap/functions/ldap-search.xml
@@ -23,7 +23,7 @@
   </methodsynopsis>
   <para>
    Effectue une recherche avec le filtre <parameter>filter</parameter> dans le
-   dossier <parameter>base_dn</parameter> avec le paramétrage
+   dossier <parameter>base</parameter> avec le paramétrage
    <constant>LDAP_SCOPE_SUBTREE</constant>. C'est l'équivalent 
    d'une recherche dans le dossier.
   </para>

--- a/reference/ldap/functions/ldap-set-option.xml
+++ b/reference/ldap/functions/ldap-set-option.xml
@@ -170,7 +170,7 @@
            <entry>PHP 7.1.0</entry>
           </row>
           <row>
-           <entry><constant>LDAP_OPT_X_TLS_KEYILE</constant></entry>
+           <entry><constant>LDAP_OPT_X_TLS_KEYFILE</constant></entry>
            <entry><type>string</type></entry>
            <entry>PHP 7.1.0</entry>
           </row>

--- a/reference/ldap/functions/ldap-set-rebind-proc.xml
+++ b/reference/ldap/functions/ldap-set-rebind-proc.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="function.ldap-set-rebind-proc" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>ldap_set_rebind_proc</refname>
-  <refpurpose>Configure une fonction de retour pour refaire des liaisons lors de recherche de référants</refpurpose>
+  <refpurpose>Configure une fonction de rappel pour refaire des liaisons lors de recherche de référents</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/lua/luaclosure.xml
+++ b/reference/lua/luaclosure.xml
@@ -13,7 +13,8 @@
   <section xml:id="luaclosure.intro">
    &reftitle.intro;
    <simpara>
-    LuaClosure est une classe pour LUA_TFUNCTION.
+    LuaClosure est une classe enveloppe pour LUA_TFUNCTION qui peut être
+    retournée lors de l'appel d'une fonction Lua.
    </simpara>
   </section>
 <!-- }}} -->

--- a/reference/luasandbox/differences.xml
+++ b/reference/luasandbox/differences.xml
@@ -68,7 +68,7 @@
  </simplesect>
 
  <simplesect xml:id="reference.luasandbox.differences.modified">
-  <title>Features that have been modified</title>
+  <title>Fonctionnalités qui ont été modifiées</title>
   <itemizedlist>
    <listitem>
     <simpara>

--- a/reference/luasandbox/luasandbox/getprofilerfunctionreport.xml
+++ b/reference/luasandbox/luasandbox/getprofilerfunctionreport.xml
@@ -62,7 +62,7 @@
   </simpara>
   <note>
    <simpara>
-    Sur Windows, cette fonction renvoie toujours zéro. Sur les systèmes
+    Sur Windows, cette fonction renvoie toujours un tableau vide. Sur les systèmes
     d'exploitation qui ne prennent pas en charge <constant>CLOCK_THREAD_CPUTIME_ID</constant>,
     tels que FreeBSD et Mac OS X, cette fonction renverra le temps écoulé
     au mur, pas le temps CPU.

--- a/reference/luasandbox/luasandbox/setcpulimit.xml
+++ b/reference/luasandbox/luasandbox/setcpulimit.xml
@@ -25,8 +25,9 @@
    Le temps utilisé dans les fonctions de rappel PHP est inclus dans la limite.
   </simpara>
   <simpara>
-   Définit le temps limite à une fonction de rappel Lua en cours d'exécution provoque
-   le minuteur à être réinitialisé, ou démarré s'il n'était pas déjà en cours d'exécution.
+   Définir la limite de temps depuis une fonction de rappel pendant que Lua s'exécute
+   entraîne la réinitialisation du minuteur, ou son démarrage s'il n'était pas déjà en
+   cours d'exécution.
   </simpara>
   <note>
    <simpara>

--- a/reference/mail/functions/mail.xml
+++ b/reference/mail/functions/mail.xml
@@ -155,7 +155,7 @@
        afin d'éviter l'ajout de paramètres non désirés à la commande shell.
       </para>
       <para>
-       Depuis que la fonction <function>escapeshellcmd</function> est appliquée automatiquement,
+       Étant donné que la fonction <function>escapeshellcmd</function> est appliquée automatiquement,
        quelques caractères autorisés dans les adresses emails par les RFCs d'internet ne peuvent
        plus être utilisés. La fonction <function>mail</function> ne peut autoriser ces caractères,
        aussi, dans les programmes où leur utilisation est nécessaire, il est recommandé d'utiliser

--- a/reference/mail/ini.xml
+++ b/reference/mail/ini.xml
@@ -40,7 +40,7 @@
      <row>
      <entry><link linkend="ini.mail.force_extra_parameters">mail.force_extra_parameters</link></entry>
      <entry>NULL</entry>
-     <entry><constant>INI_SYSTEM</constant>|<constant>INI_PERDIR</constant></entry>
+     <entry><constant>INI_SYSTEM</constant></entry>
      <entry></entry>
     </row>
      <row>

--- a/reference/mailparse/functions/mailparse-msg-extract-part-file.xml
+++ b/reference/mailparse/functions/mailparse-msg-extract-part-file.xml
@@ -19,7 +19,7 @@
    Extrait et décode une section de message depuis le fichier fourni.
   </simpara>
   <simpara>
-   Le contenu de la section sera encodé suivant son encodage
+   Le contenu de la section sera décodé suivant son encodage de transfert
    - base64, quoted-printable et texte uuencoded sont supportés.
   </simpara>
  </refsect1>

--- a/reference/math/functions/acos.xml
+++ b/reference/math/functions/acos.xml
@@ -14,7 +14,7 @@
    <methodparam><type>float</type><parameter>num</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Retourne l'arc cosinus de <parameter>num</parameter>.
+   Retourne l'arc cosinus de <parameter>num</parameter> en radians.
    <function>acos</function> est la fonction inverse de
    <function>cos</function>, ce qui signifie que
    <code>$num == cos(acos($num))</code> pour chaque valeur de

--- a/reference/math/functions/asin.xml
+++ b/reference/math/functions/asin.xml
@@ -14,8 +14,7 @@
    <methodparam><type>float</type><parameter>num</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Retourne l'arc sinus de <parameter>num</parameter>
-   (<parameter>num</parameter> en radians).
+   Retourne l'arc sinus de <parameter>num</parameter> en radians.
    <function>asin</function> est la fonction inverse de 
    <function>sin</function>, ce qui signifie que
    <code>$num == sin(asin($num))</code> pour chaque valeur de

--- a/reference/math/functions/dechex.xml
+++ b/reference/math/functions/dechex.xml
@@ -82,7 +82,7 @@ a
 <![CDATA[
 <?php
 // L'affichage ci-dessous suppose que nous sommes sur une plateforme 32-bit.
-// Notez que l'affichage est identique pour toutes les valeurs.
+// Il est à noter que l'affichage est identique pour toutes les valeurs.
 echo dechex(-1)."\n";
 echo dechex(PHP_INT_MAX * 2 + 1)."\n";
 echo dechex(pow(2, 32) - 1)."\n";

--- a/reference/math/functions/fpow.xml
+++ b/reference/math/functions/fpow.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="function.fpow" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>fpow</refname>
-  <refpurpose>Elève un nombre à la puissance d'un autre, selon la norme IEEE 754</refpurpose>
+  <refpurpose>Élève un nombre à la puissance d'un autre, selon la norme IEEE 754</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/math/functions/hexdec.xml
+++ b/reference/math/functions/hexdec.xml
@@ -15,7 +15,7 @@
     <methodparam><type>string</type><parameter>hex_string</parameter></methodparam>
    </methodsynopsis>
   <para>
-   Retourne la valeur décimale équivalente à la &string; hexadécimale représenté
+   Retourne la valeur décimale équivalente à la &string; hexadécimale représentée
    par l'argument <parameter>hex_string</parameter>.
    <function>hexdec</function> convertit une &string; hexadécimale en un
    nombre décimal.

--- a/reference/math/functions/max.xml
+++ b/reference/math/functions/max.xml
@@ -31,7 +31,7 @@
     les <link linkend="language.operators.comparison">règles de
     comparaison standard</link>. Actuellement, une chaîne non numérique
     sera comparée à un &integer;, comme s'il s'agissait de la valeur
-    <literal>0</literal>, mais plusieurs &string; non-numérique seront comparées de façon
+    <literal>0</literal>, mais plusieurs &string; non-numériques seront comparées de façon
     alphanumérique. La valeur actuelle retournée sera du même type que
     l'original et aucune conversion de type ne sera appliquée.
    </para>
@@ -145,7 +145,7 @@ $val = max(array(2, 2, 2), array(1, 1, 1, 1)); // array(1, 1, 1, 1)
 var_dump($val);
 
 // Plusieurs tableaux de même longueur sont comparés de la gauche vers la droite
-// aussi, dans notre exemple : 2 == 2, but 5 > 4
+// aussi, dans notre exemple : 2 == 2, mais 5 > 4
 $val = max(array(2, 4, 8), array(2, 5, 1)); // array(2, 5, 1)
 var_dump($val);
 

--- a/reference/math/functions/min.xml
+++ b/reference/math/functions/min.xml
@@ -31,7 +31,7 @@
     les <link linkend="language.operators.comparison">règles de
     comparaison standard</link>. Actuellement, une chaîne non numérique
     sera comparée à un &integer;, comme s'il s'agissait de la valeur
-    <literal>0</literal>, mais plusieurs &string; non-numérique seront comparées de façon
+    <literal>0</literal>, mais plusieurs &string; non-numériques seront comparées de façon
     alphanumérique. La valeur actuelle retournée sera du même type que
     l'original et aucune conversion de type ne sera appliquée.
    </para>
@@ -153,8 +153,8 @@ $val = min('string', array(2, 5, 7), 42);   // string
 var_dump($val);
 
 // Si un argument vaut NULL ou vaut un booléen, il sera comparé avec
-// d'autres valeurs en utilisant la règle FALSE < TRUE suivant les autres
-// types fournis. Dans l'exemple ci-dessous, à la fois -10 et 10 sont traités
+// d'autres valeurs en utilisant les règles FALSE < TRUE et NULL == FALSE suivant
+// les autres types fournis. Dans l'exemple ci-dessous, à la fois -10 et 10 sont traités
 // comme valant TRUE dans la comparaison
 $val = min(-10, FALSE, 10); // FALSE
 var_dump($val);

--- a/reference/math/functions/octdec.xml
+++ b/reference/math/functions/octdec.xml
@@ -31,7 +31,6 @@
        Tous les caractères invalides dans <parameter>octal_string</parameter>
        sont ignorés silencieusement.
        À partir de PHP 7.4.0 fournir des caractères invalides est obsolète.
-       Le nombre à convertir.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/math/functions/pow.xml
+++ b/reference/math/functions/pow.xml
@@ -75,7 +75,7 @@
       <entry>8.4.0</entry>
       <entry>
        Élever <literal>0</literal> à un
-       <parameter>exposant</parameter> négatif est désormais obsolète.
+       <parameter>exponent</parameter> négatif est désormais obsolète.
       </entry>
      </row>
     </tbody>

--- a/reference/math/functions/sqrt.xml
+++ b/reference/math/functions/sqrt.xml
@@ -46,7 +46,7 @@
     <programlisting role="php">
 <![CDATA[
 <?php
-// La précision dépend de votre directive precision
+// La précision dépend de la directive precision
 echo sqrt(9), PHP_EOL; // 3
 echo sqrt(10), PHP_EOL; // 3.16227766 ...
 ?>

--- a/reference/math/roundingmode.xml
+++ b/reference/math/roundingmode.xml
@@ -11,7 +11,7 @@
    <simpara>
     L'énumération <enumname>RoundingMode</enumname> est utilisée pour spécifier comment l'arrondissement
     doit être effectué pour <function>round</function>,
-    <function>bcround</function>, et <methodname>BCMath\Number::round</methodname>.
+    <function>bcround</function>, et <methodname>BcMath\Number::round</methodname>.
    </simpara>
   </section>
 

--- a/reference/mbstring/encodings.xml
+++ b/reference/mbstring/encodings.xml
@@ -45,7 +45,7 @@
      Voir ci-dessus.
     </seg>
     <seg>
-     Contrairement à <literal>UCS-2</literal>, les chaînes sont supposées
+     Contrairement à <literal>UCS-4</literal>, les chaînes sont supposées
      être au format little endian.
     </seg>
    </seglistitem>
@@ -72,8 +72,19 @@
      Voir ci-dessus.
     </seg>
     <seg>
-     Contrairement à <literal>UCS-4</literal>, les chaînes sont supposées
+     Contrairement à <literal>UCS-2</literal>, les chaînes sont supposées
      être au format big endian.
+    </seg>
+   </seglistitem>
+   <seglistitem>
+    <seg>ISO-10646-UCS-2</seg>
+    <seg>UCS-2</seg>
+    <seg>
+     Voir ci-dessus.
+    </seg>
+    <seg>
+     Contrairement à <literal>UCS-2</literal>, les chaînes sont supposées
+     être au format little endian.
     </seg>
    </seglistitem>
    <seglistitem>

--- a/reference/mbstring/functions/mb-convert-kana.xml
+++ b/reference/mbstring/functions/mb-convert-kana.xml
@@ -85,7 +85,7 @@
           <row>
            <entry><literal>A</literal></entry>
            <entry>
-            Convertit les nombres et alphabet "zen-kaku" en "han-kaku".
+            Convertit les nombres et alphabet "han-kaku" en "zen-kaku".
             (Les caractères inclus dans les options "a", "A" sont
             U+0021 - U+007E en excluant U+0022, U+0027, U+005C, U+007E)
            </entry>

--- a/reference/mbstring/functions/mb-encoding-aliases.xml
+++ b/reference/mbstring/functions/mb-encoding-aliases.xml
@@ -38,8 +38,7 @@
   &reftitle.returnvalues;
   <para>
    Retourne un tableau indexé numériquement d'alias d'encodage.
-   &return.falseforfailure;
-  </para>
+</para>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/mbstring/functions/mb-ereg-search-getpos.xml
+++ b/reference/mbstring/functions/mb-ereg-search-getpos.xml
@@ -33,7 +33,7 @@
    <function>mb_ereg_search</function>,
    <function>mb_ereg_search_pos</function> et
    <function>mb_ereg_search_regs</function>. La position est le nombre
-   de caractères depuis le début de la chaîne.
+   d'octets depuis le début de la chaîne.
   </simpara>
  </refsect1>
 

--- a/reference/mbstring/functions/mb-get-info.xml
+++ b/reference/mbstring/functions/mb-get-info.xml
@@ -48,7 +48,7 @@
        <literal>"encoding_translation"</literal>, <literal>"language"</literal>,
        <literal>"detect_order"</literal>, <literal>"substitute_character"</literal>
        ou <literal>"strict_detection"</literal>
-       la paramètre spécifié sera retourné.
+       le paramètre spécifié sera retourné.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/mbstring/functions/mb-rtrim.xml
+++ b/reference/mbstring/functions/mb-rtrim.xml
@@ -41,7 +41,7 @@
    <varlistentry>
     <term><parameter>characters</parameter></term>
     <listitem>
-     &strings.parameter.characters.optional;
+     &strings.parameter.unicode.optional;
     </listitem>
    </varlistentry>
    <varlistentry>

--- a/reference/mbstring/http-inout.xml
+++ b/reference/mbstring/http-inout.xml
@@ -17,7 +17,7 @@
    vaut <literal>multipart/form-data</literal> et que la directive du
    &php.ini; est positionnée à On, les variables et les noms de fichiers
    téléchargés en méthode POST seront convertis avec l'encodage interne.
-   Sinon, la conversion ne sera pas faite.
+   Cependant, la conversion n'est pas appliquée aux clés de la requête.
   </para>
  </note>
  <para>

--- a/reference/mbstring/ini.xml
+++ b/reference/mbstring/ini.xml
@@ -111,7 +111,7 @@
      <para>
       Définit le langage utilisé
       par mbstring. À noter que cette option définit
-      <literal>mbstring.internal_encoding</literal>
+      <literal>mbstring.internal_encoding</literal> et
       <literal>mbstring.internal_encoding</literal>
       doit être placé après <literal>mbstring.language</literal>
       dans le fichier &php.ini;

--- a/reference/mbstring/overloading.xml
+++ b/reference/mbstring/overloading.xml
@@ -5,7 +5,7 @@
 
 <chapter xml:id="mbstring.overload" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>
-  Exploitation des chaînes multioctets en PHP
+  Fonctionnalité de surcharge de fonctions
  </title>
 
  &warn.deprecated.feature-7-2-0.removed-8-0-0;

--- a/reference/mcrypt/ciphers.xml
+++ b/reference/mcrypt/ciphers.xml
@@ -3,9 +3,9 @@
 <!-- EN-Revision: e849a6c4225bd992474793ec6983df7898cae0be Maintainer: yannick Status: ready -->
 <!-- Reviewed: yes -->
 <appendix xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="mcrypt.ciphers">
- <title>Modes de chiffrement Mcrypt</title>
+ <title>Chiffrements Mcrypt</title>
  <para>
-  Voici une liste non exhaustive des modes de chiffrement de l'extension
+  Voici une liste non exhaustive des chiffrements de l'extension
   mcrypt. Pour disposer d'une liste complète des chiffrements supportés,
   voir les définitions dans le fichier <filename>mcrypt.h</filename>. La règle
   générale avec l'API mcrypt-2.2.x est qu'il est possible d'accéder au

--- a/reference/memcache/configure.xml
+++ b/reference/memcache/configure.xml
@@ -12,7 +12,7 @@
  <note>
   <simpara>
    Il est possible de désactiver le support du gestionnaire de sessions memcache.
-   L'option 'pecl install' l'on le permet (activé par défaut), cependant, lors
+   L'option 'pecl install' le demande (activé par défaut), cependant, lors
    de la compilation statique dans PHP, l'option de configuration
    <option role="configure">--disable-memcache-session</option> peut être utilisée.
   </simpara>

--- a/reference/memcache/constants.xml
+++ b/reference/memcache/constants.xml
@@ -15,7 +15,7 @@
      </row>
     </thead>
     <tbody>
-     <row xml:id="constantmemcache-compressed">
+     <row xml:id="constant.memcache-compressed">
       <entry>
        <constant>MEMCACHE_COMPRESSED</constant>
        (<type>int</type>)
@@ -27,7 +27,7 @@
        <function>Memcache::replace</function>.
       </entry>
      </row>
-     <row xml:id="constantmemcache-have-session">
+     <row xml:id="constant.memcache-have-session">
       <entry>
        <constant>MEMCACHE_HAVE_SESSION</constant>
        (<type>int</type>)
@@ -36,7 +36,7 @@
        1 si le gestionnaire de session Memcache est disponible, 0 sinon.
       </entry>
      </row>
-     <row xml:id="constantmemcache-user1">
+     <row xml:id="constant.memcache-user1">
       <entry>
        <constant>MEMCACHE_USER1</constant>
        (<type>int</type>)
@@ -49,7 +49,7 @@
        <function>Memcache::replace</function>.
       </entry>
      </row>
-     <row xml:id="constantmemcache-user2">
+     <row xml:id="constant.memcache-user2">
       <entry>
        <constant>MEMCACHE_USER2</constant>
        (<type>int</type>)
@@ -62,7 +62,7 @@
        <function>Memcache::replace</function>.
       </entry>
      </row>
-     <row xml:id="constantmemcache-user3">
+     <row xml:id="constant.memcache-user3">
       <entry>
        <constant>MEMCACHE_USER3</constant>
        (<type>int</type>)
@@ -75,7 +75,7 @@
        <function>Memcache::replace</function>.
       </entry>
      </row>
-     <row xml:id="constantmemcache-user4">
+     <row xml:id="constant.memcache-user4">
       <entry>
        <constant>MEMCACHE_USER4</constant>
        (<type>int</type>)

--- a/reference/memcache/memcache/decrement.xml
+++ b/reference/memcache/memcache/decrement.xml
@@ -4,6 +4,7 @@
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="memcache.decrement">
  <refnamediv>
   <refname>Memcache::decrement</refname>
+  <refname>memcache_decrement</refname>
   <refpurpose>Décrémente la valeur d'un élément</refpurpose>
  </refnamediv>
 
@@ -82,7 +83,7 @@
 <![CDATA[
 <?php
 
-/* API proécédurale */
+/* API procédurale */
 $memcache_obj = memcache_connect('memcache_host', 11211);
 /* décrémentation de l'élément par 2 */
 $new_value = memcache_decrement($memcache_obj, 'test_item', 2);

--- a/reference/memcache/memcache/flush.xml
+++ b/reference/memcache/memcache/flush.xml
@@ -4,6 +4,7 @@
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="memcache.flush">
  <refnamediv>
   <refname>Memcache::flush</refname>
+  <refname>memcache_flush</refname>
   <refpurpose>Efface tous les éléments existant sur le serveur de cache</refpurpose>
  </refnamediv>
 

--- a/reference/memcache/memcache/getstats.xml
+++ b/reference/memcache/memcache/getstats.xml
@@ -42,7 +42,7 @@
      <simpara>
       Le type de statistiques à récupérer. Les valeurs valides sont {<literal>"reset"</literal>,
       <literal>"malloc"</literal>, <literal>"maps"</literal>, <literal>"cachedump"</literal>,
-      <literal>"slabs"</literal>, <literal>"items"</literal>, <literal>"sizes"</literal>.
+      <literal>"slabs"</literal>, <literal>"items"</literal>, <literal>"sizes"</literal>}.
       Suivant les spécifications du protocole memcached, ces arguments optionnels sont susceptibles
       d'être modifiés suivant les besoins des développeurs de memcache.
      </simpara>

--- a/reference/memcache/memcache/setcompressthreshold.xml
+++ b/reference/memcache/memcache/setcompressthreshold.xml
@@ -4,6 +4,7 @@
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="memcache.setcompressthreshold">
  <refnamediv>
   <refname>Memcache::setCompressThreshold</refname>
+  <refname>memcache_set_compress_threshold</refname>
   <refpurpose>Active la compression automatique des valeurs volumineuses</refpurpose>
  </refnamediv>
 

--- a/reference/memcached/constants.xml
+++ b/reference/memcached/constants.xml
@@ -292,7 +292,7 @@
    <term><constant>Memcached::DISTRIBUTION_CONSISTENT</constant></term>
    <listitem>
     <para>
-     L'algorithme de distribution par hachage cohérent
+     L'algorithme de distribution par hachage cohérent (basé sur libketama)
     </para>
    </listitem>
   </varlistentry>

--- a/reference/memcached/memcached/addbykey.xml
+++ b/reference/memcached/memcached/addbykey.xml
@@ -21,7 +21,8 @@
    <function>Memcached::addByKey</function> est fonctionnellement équivalent
    à <methodname>Memcached::add</methodname>, mais la variable libre
    <parameter>server_key</parameter> peut être utilisée pour diriger 
-   la clé <parameter>key</parameter> sur un serveur spécifique.
+   la clé <parameter>key</parameter> sur un serveur spécifique. Ceci est utile pour
+   conserver un groupe de variables groupées sur un serveur.
   </para>
  </refsect1>
 

--- a/reference/memcached/memcached/addservers.xml
+++ b/reference/memcached/memcached/addservers.xml
@@ -18,7 +18,7 @@
    <function>Memcached::addServers</function> ajoute les serveurs
    <parameter>servers</parameter> au pool de serveurs. Chaque entrée 
    dans <parameter>servers</parameter> doit être un tableau, contenant
-   le nom d'hôte, et optionnellement son poids. Aucune connexion n'est
+   le nom d'hôte, le port, et optionnellement son poids. Aucune connexion n'est
    établie au serveur à ce moment-là.
   </para>
   <para>

--- a/reference/memcached/memcached/cas.xml
+++ b/reference/memcached/memcached/cas.xml
@@ -93,7 +93,7 @@ $m->addServer('localhost', 11211);
 do {
     /* Lit une IP et son CAS */
     $ips = $m->get('ip_block', null, $cas);
-    /* Si l'IP n'existe pas encore, on la crèe et on fait un
+    /* Si l'IP n'existe pas encore, on la crée et on fait un
        ajout atomique qui va échouer si l'IP a déjà été ajoutée */
     if ($m->getResultCode() == Memcached::RES_NOTFOUND) {
         $ips = array($_SERVER['REMOTE_ADDR']);

--- a/reference/memcached/memcached/casbykey.xml
+++ b/reference/memcached/memcached/casbykey.xml
@@ -22,7 +22,8 @@
    <function>Memcached::casByKey</function> est fonctionnellement équivalent
    à <methodname>Memcached::cas</methodname>, mais la variable libre
    <parameter>server_key</parameter> peut être utilisée pour diriger 
-   la clé <parameter>key</parameter> sur un serveur spécifique.
+   la clé <parameter>key</parameter> sur un serveur spécifique. Ceci est utile pour
+   conserver un groupe de variables groupées sur un serveur.
   </para>
  </refsect1>
 

--- a/reference/memcached/memcached/get.xml
+++ b/reference/memcached/memcached/get.xml
@@ -90,7 +90,7 @@
      <row>
       <entry>PECL memcached 3.0.0</entry>
       <entry>
-       Le paramètre <parameter role="reference">cas_tokens</parameter> a été supprimé.
+       Le paramètre <parameter role="reference">cas_token</parameter> a été supprimé.
        <constant>Memcached::GET_EXTENDED</constant> a été ajoutée et quand passé en
        tant que drapeau il s'assure que les jetons CAS sont récupérés.
       </entry>

--- a/reference/memcached/memcached/getbykey.xml
+++ b/reference/memcached/memcached/getbykey.xml
@@ -90,7 +90,7 @@
      <row>
       <entry>PECL memcached 3.0.0</entry>
       <entry>
-       Le paramètre <parameter role="reference">cas_tokens</parameter> a été supprimé.
+       Le paramètre <parameter role="reference">cas_token</parameter> a été supprimé.
        <constant>Memcached::GET_EXTENDED</constant> a été ajoutée et quand passé en
        tant que drapeau il s'assure que les jetons CAS sont récupérés.
       </entry>

--- a/reference/memcached/memcached/getserverlist.xml
+++ b/reference/memcached/memcached/getserverlist.xml
@@ -36,7 +36,7 @@
   &reftitle.examples;
   <para>
    <example>
-    <title>Exemple avec <function>Memcached::getResultCode</function></title>
+    <title>Exemple avec <function>Memcached::getServerList</function></title>
     <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/memcached/memcached/increment.xml
+++ b/reference/memcached/memcached/increment.xml
@@ -77,7 +77,7 @@
   &reftitle.examples;
   <para>
    <example>
-    <title>Exemple avec <function>Memcached::getResultCode</function></title>
+    <title>Exemple avec <function>Memcached::increment</function></title>
     <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/memcached/memcached/replace.xml
+++ b/reference/memcached/memcached/replace.xml
@@ -60,7 +60,7 @@
   <para>
    &return.success;
    La méthode <methodname>Memcached::getResultCode</methodname> retourne
-   <constant>Memcached::RES_NOTFOUND</constant> si la clé n'existe pas.
+   <constant>Memcached::RES_NOTSTORED</constant> si la clé n'existe pas.
   </para>
  </refsect1>
 

--- a/reference/memcached/memcached/set.xml
+++ b/reference/memcached/memcached/set.xml
@@ -84,7 +84,7 @@ $m->addServer('localhost', 11211);
 $m->set('int', 99);
 $m->set('string', 'a simple string');
 $m->set('array', array(11, 12));
-/* L'objet va etre détruit dans 5 minutes */
+/* L'objet va être détruit dans 5 minutes */
 $m->set('object', new stdClass, time() + 300);
 
 

--- a/reference/memcached/sessions.xml
+++ b/reference/memcached/sessions.xml
@@ -24,7 +24,7 @@
     </term>
     <listitem>
      <para>
-      Donnez-lui la valeur de <literal>memcached</literal> pour activer le 
+      Le définir à <literal>memcached</literal> pour activer le
       support des sessions sur memcached.
      </para>
     </listitem>

--- a/reference/mhash/functions/mhash-keygen-s2k.xml
+++ b/reference/mhash/functions/mhash-keygen-s2k.xml
@@ -31,13 +31,13 @@
    dans OpenPGP (<link xlink:href="&url.rfc;2440">RFC 2440</link>).
   </para>
   <para>
-   N'oubliez pas que les mots de passe fournis par les utilisateurs
+   Il est à noter que les mots de passe fournis par les utilisateurs
    ne sont pas conseillés pour faire des clés cryptographiques,
-   étant donné que les utilisateurs normaux retiennent des mots
-   de passe qu'ils peuvent saisir au clavier. Ces mots de passe
+   étant donné que les utilisateurs choisissent normalement des clés
+   qu'ils peuvent saisir au clavier. Ces clés
    utilisent uniquement 6 à 7 des 8 bits d'un caractère (voire moins).
    Il est vivement recommandé d'appliquer une fonction de transformation
-   (comme celle-ci), à un mot de passe utilisateur.
+   (comme celle-ci) à la clé fournie par l'utilisateur.
   </para>
  </refsect1>
 
@@ -70,8 +70,8 @@
        clé qu'on génère, afin de créer des clés différentes.
        Du fait que le paramètre <parameter>salt</parameter>
        doit être connu lorsqu'on vérifie les clés, c'est une
-       bonne idée de l'ajouter à la clé. Le paramètre salt doit avoir
-       une longueur de 8 octets, et sera complété de zéro si l'on en
+       bonne idée d'y ajouter la clé. Le paramètre salt doit avoir
+       une longueur de 8 octets, et sera complété de zéros si l'on en
        fournit un d'une taille inférieure.
       </para>
      </listitem>

--- a/reference/mhash/functions/mhash.xml
+++ b/reference/mhash/functions/mhash.xml
@@ -51,7 +51,7 @@
      <term><parameter>key</parameter></term>
      <listitem>
       <para>
-       Spécifié, la fonction retournera le HMAC résultant. HMAC est un hachage à clé
+       Si spécifié, la fonction retournera le HMAC résultant à la place. HMAC est un hachage à clé
        utilisé pour l'authentification de messages, ou simplement un condensé de
        message qui dépend de la clé spécifiée. Certains algorithmes supportés dans
        mhash ne sont pas compatibles avec le mode HMAC.

--- a/reference/mhash/setup.xml
+++ b/reference/mhash/setup.xml
@@ -10,8 +10,8 @@
  <section xml:id="mhash.requirements">
   &reftitle.required;
   <para>
-   Pour l'utiliser, téléchargez les distributions de mhash depuis
-   ce <link xlink:href="&url.mhash;">site internet</link> et suivez les instructions
+   Pour l'utiliser, télécharger les distributions de mhash depuis
+   ce <link xlink:href="&url.mhash;">site internet</link> et suivre les instructions
    d'installation incluses.
   </para>
  </section>

--- a/reference/misc/functions/eval.xml
+++ b/reference/misc/functions/eval.xml
@@ -34,7 +34,7 @@
     <emphasis>très dangereuse</emphasis> car elle autorise l'exécution
     de code PHP arbitraire. <emphasis>Son utilisation est vivement
     déconseillée.</emphasis> Si on a soigneusement vérifié qu'il
-    n'y a pas d'autres options que de l'utiliser, gardez une attention
+    n'y a pas d'autres options que de l'utiliser, accorder une attention
     toute particulière <emphasis>à ne pas y passer de données provenant
     d'un utilisateur</emphasis> sans les avoir précédemment validées
     minutieusement.
@@ -57,7 +57,7 @@
        <link linkend="language.basic-syntax.phpmode">balises PHP</link>
        ouvrante et fermante, c.-à-d. <literal>'echo "Hi!";'</literal>
        doit être passé au lieu de
-       <literal>'&lt;?php echo "Hi!"; &gt;'</literal>.
+       <literal>'&lt;?php echo "Hi!"; ?&gt;'</literal>.
        Il est toujours possible de quitter et de retourner en mode PHP
        en utilisant les balises PHP appropriées, c.-à-d.
        <literal>'echo "En mode PHP !"; ?&gt;En mode HTML !&lt;?php echo "Retour en mode PHP !";'</literal>.

--- a/reference/misc/functions/exit.xml
+++ b/reference/misc/functions/exit.xml
@@ -179,7 +179,7 @@ echo 'Ceci ne sera jamais affiché.';
    <screen>
 <![CDATA[
 Arrêt : shutdown()
-Destruction : Foo::__destruct()
+Destructeur : Foo::__destruct()
 ]]>
    </screen>
   </example>

--- a/reference/misc/functions/get-browser.xml
+++ b/reference/misc/functions/get-browser.xml
@@ -65,7 +65,7 @@
   <para>
    La valeur <literal>cookies</literal> indique simplement que le
    navigateur est capable d'accepter les cookies, et n'indique pas
-   si l'utilisateur les a activé sur son navigateur. Le seul moyen
+   si l'utilisateur les a activés sur son navigateur. Le seul moyen
    de tester l'activation des cookies est d'en poser un avec
    la fonction <function>setcookie</function>, de recharger la page
    et de vérifier que le cookie existe toujours.

--- a/reference/misc/functions/highlight-string.xml
+++ b/reference/misc/functions/highlight-string.xml
@@ -17,7 +17,7 @@
   </methodsynopsis>
   <simpara>
    Affiche ou retourne le code HTML de la version colorisée du code PHP contenu
-   dans le paramètre <parameter>str</parameter>, en utilisant les couleurs du
+   dans le paramètre <parameter>string</parameter>, en utilisant les couleurs du
    système interne de colorisation de PHP.
   </simpara>
  </refsect1>

--- a/reference/misc/functions/sapi-windows-set-ctrl-handler.xml
+++ b/reference/misc/functions/sapi-windows-set-ctrl-handler.xml
@@ -63,12 +63,12 @@
       <keycombo action='simul'>
        <keycap>CTRL</keycap>
        <keycap>C</keycap>
-      </keycombo>
-      ou
+      </keycombo>,
+      mais pas les événements
       <keycombo action='simul'>
        <keycap>CTRL</keycap>
        <keycap>BREAK</keycap>
-      </keycombo>
+      </keycombo>.
      </para>
     </listitem>
    </varlistentry>

--- a/reference/misc/functions/uniqid.xml
+++ b/reference/misc/functions/uniqid.xml
@@ -18,7 +18,7 @@
   </methodsynopsis>
   <para>
    Génère un identifiant basé sur l'heure actuelle avec une précision à la microseconde,
-   préfixé par le <parameter>préfixe</parameter> donné et ajoutant
+   préfixé par le <parameter>prefix</parameter> donné et ajoutant
    éventuellement une valeur générée aléatoirement.
   </para>
   &caution.cryptographically-insecure;

--- a/reference/misc/functions/unpack.xml
+++ b/reference/misc/functions/unpack.xml
@@ -18,7 +18,7 @@
    <methodparam choice="opt"><type>int</type><parameter>offset</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
   <para>
-   Déconditionne les données <parameter>data</parameter>
+   Déconditionne les données
    depuis une chaîne binaire avec le format <parameter>format</parameter>.
   </para>
   <para>

--- a/reference/mongodb/architecture.xml
+++ b/reference/mongodb/architecture.xml
@@ -744,7 +744,8 @@ class UpperClass implements MongoDB\BSON\Persistable
        </simpara>
 
        <simpara>
-        Si la classe nommée n'existe pas ou n'implémente pas
+        Si la classe nommée n'existe pas, n'est pas concrète (c'est-à-dire
+        qu'elle est abstraite ou une interface), ou n'implémente pas
         l'interface <interfacename>MongoDB\BSON\Unserializable</interfacename>,
         une exception
         <classname>MongoDB\Driver\Exception\InvalidArgumentException</classname>

--- a/reference/mongodb/bson/dbpointer/construct.xml
+++ b/reference/mongodb/bson/dbpointer/construct.xml
@@ -16,7 +16,7 @@
    <void/>
   </methodsynopsis>
   <simpara>
-   Les objets <classname>MongoDB\BSON\DBPointer</classname> sont crées à travers
+   Les objets <classname>MongoDB\BSON\DBPointer</classname> sont créés à travers
    une conversion depuis un type BSON obsolète et ne peuvent pas être construits directement.
   </simpara>
  </refsect1>

--- a/reference/mongodb/bson/document.xml
+++ b/reference/mongodb/bson/document.xml
@@ -3,7 +3,7 @@
 <!-- Reviewed: yes -->
 <reference xml:id="class.mongodb-bson-document" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
- <title>la classe MongoDB\BSON\Document</title>
+ <title>La classe MongoDB\BSON\Document</title>
  <titleabbrev>MongoDB\BSON\Document</titleabbrev>
 
  <partintro>

--- a/reference/mongodb/bson/document/construct.xml
+++ b/reference/mongodb/bson/document/construct.xml
@@ -14,7 +14,7 @@
    <void/>
   </methodsynopsis>
   <simpara>
-   Les objets <classname>MongoDB\BSON\Document</classname> sont crées à travers
+   Les objets <classname>MongoDB\BSON\Document</classname> sont créés à travers
    des méthodes de fabrique statiques et ne peuvent pas être instanciés directement.
   </simpara>
  </refsect1>

--- a/reference/mongodb/bson/iterator/construct.xml
+++ b/reference/mongodb/bson/iterator/construct.xml
@@ -14,7 +14,7 @@
    <void/>
   </methodsynopsis>
   <simpara>
-   Les objets <classname>MongoDB\BSON\Iterator</classname> sont crées en appelant
+   Les objets <classname>MongoDB\BSON\Iterator</classname> sont créés en appelant
    <methodname>MongoDB\BSON\Document::getIterator</methodname> ou
    <methodname>MongoDB\BSON\PackedArray::getIterator</methodname> et ne peuvent pas être
    instanciés directement.

--- a/reference/mongodb/bson/iterator/current.xml
+++ b/reference/mongodb/bson/iterator/current.xml
@@ -27,7 +27,7 @@
   </simpara>
   <note>
    <simpara>
-    Lorsqu'une valeur est encodée en tant qu'entier 64 bits dans la structure BSON est rencontrée,
+    Lorsqu'une valeur encodée en tant qu'entier 64 bits dans la structure BSON est rencontrée,
     la valeur de retour de cette méthode sera une instance de
     <classname>MongoDB\BSON\Int64</classname>.
    </simpara>

--- a/reference/mongodb/bson/iterator/rewind.xml
+++ b/reference/mongodb/bson/iterator/rewind.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="mongodb-bson-iterator.rewind" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>MongoDB\BSON\Iterator::rewind</refname>
-  <refpurpose>Rembobine l'itérateur à l'élément précédent</refpurpose>
+  <refpurpose>Rembobine l'itérateur au premier élément</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/mongodb/bson/packedarray/fromphp.xml
+++ b/reference/mongodb/bson/packedarray/fromphp.xml
@@ -41,7 +41,7 @@
   &reftitle.errors;
   <simplelist>
    &mongodb.throws.argumentparsing;
-   <member>Lance une <classname>MongoDB\Driver\Exception\InvalidArgumentException</classname> si le tableau donné n'est pas une liste (par exemple il a des séquences numériques commençant par <literal>0</literal>).</member>
+   <member>Lance une <classname>MongoDB\Driver\Exception\InvalidArgumentException</classname> si le tableau donné n'est pas une liste (c'est-à-dire il a des clés numériques séquentielles commençant par <literal>0</literal>).</member>
   </simplelist>
  </refsect1>
 

--- a/reference/mongodb/bson/regex/construct.xml
+++ b/reference/mongodb/bson/regex/construct.xml
@@ -39,7 +39,8 @@
     <listitem>
      <simpara>
       Les <link xlink:href="&url.mongodb.docs.regex;#op._S_options">
-      drapeaux de l'expression régulière</link>.
+      drapeaux de l'expression régulière</link>. Les caractères de cet argument
+      seront triés par ordre alphabétique.
      </simpara>
     </listitem>
    </varlistentry>

--- a/reference/mongodb/bson/regex/tostring.xml
+++ b/reference/mongodb/bson/regex/tostring.xml
@@ -43,7 +43,7 @@ var_dump((string) $regex);
 ?>
 ]]>
    </programlisting>
-   &example.outputs.similar;
+   &example.outputs;
    <screen>
 <![CDATA[
 string(8) "/regex/i"

--- a/reference/mongodb/bson/serializable.xml
+++ b/reference/mongodb/bson/serializable.xml
@@ -14,8 +14,8 @@
    &reftitle.intro;
    <simpara>
     Les classes qui implémentent cette interface peuvent retourner des données
-    à sérialiser comme un tableau BSON, ou un document comme propriétés publiques
-    d'objets.
+    à sérialiser comme un tableau ou un document BSON, à la place des propriétés
+    publiques de l'objet.
    </simpara>
   </section>
 <!-- }}} -->

--- a/reference/mongodb/bson/serializable/bsonserialize.xml
+++ b/reference/mongodb/bson/serializable/bsonserialize.xml
@@ -203,8 +203,8 @@ class MyArray implements MongoDB\BSON\Serializable
 }
 
 $value = ['array' => new MyArray];
-$bson = MongoDB\BSON\fromPHP($value);
-echo MongoDB\BSON\toJSON($bson), "\n";
+
+echo MongoDB\BSON\Document::fromPHP($value)->toRelaxedExtendedJSON(), "\n";
 
 ?>
 ]]>

--- a/reference/mongodb/bson/timestamp/construct.xml
+++ b/reference/mongodb/bson/timestamp/construct.xml
@@ -60,7 +60,7 @@ $timestamp = new MongoDB\BSON\Timestamp(1234, 5678);
 ?>
 ]]>
    </programlisting>
-   &example.outputs.similar;
+   &example.outputs;
    <screen>
 <![CDATA[
 object(MongoDB\BSON\Timestamp)#1 (2) {

--- a/reference/mongodb/bson/timestamp/getincrement.xml
+++ b/reference/mongodb/bson/timestamp/getincrement.xml
@@ -16,7 +16,7 @@
    <void />
   </methodsynopsis>
   <simpara>
-   Le composant d'incrémentation d'un Timestamp sont ses 32 bits les moins significatifs,
+   Le composant d'incrémentation d'un Timestamp est ses 32 bits les moins significatifs,
    qui désignent l'ordinal incrémentant pour les opérations pour une seconde donnée.
    Cette valeur est lue comme un entier 32-bits non signé avec un ordre d'octet big-endian.
   </simpara>

--- a/reference/mongodb/bson/timestamp/tostring.xml
+++ b/reference/mongodb/bson/timestamp/tostring.xml
@@ -25,7 +25,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   Retourne la représentation sous forme de chaîne de cet horodatage
+   Retourne la représentation sous forme de chaîne de cet horodatage.
   </simpara>
  </refsect1>
 

--- a/reference/mongodb/bson/unserializable.xml
+++ b/reference/mongodb/bson/unserializable.xml
@@ -13,7 +13,7 @@
   <section xml:id="mongodb-bson-unserializable.intro">
    &reftitle.intro;
    <simpara>
-    Les classes qui implémentent cette interface doivent être spécifiées
+    Les classes qui implémentent cette interface peuvent être spécifiées
     dans une <link linkend="mongodb.persistence.typemaps">carte de type</link>
     pour les tableaux et les documents BSON désérialisés (à la fois racine et
     embarqué).

--- a/reference/mongodb/bson/unserializable/bsonunserialize.xml
+++ b/reference/mongodb/bson/unserializable/bsonunserialize.xml
@@ -20,7 +20,7 @@
    d'un &array;.
   </simpara>
   <simpara>
-   N'oubliez pas de rechercher une propriété <property>_id</property> lors de 
+   Il ne faut pas oublier de rechercher une propriété <property>_id</property> lors de
    la gestion des données à partir d'un document BSON.
   </simpara>
   <note>
@@ -96,7 +96,7 @@ var_dump($bson->toPHP(['root' => 'MyDocument']));
 ?>
 ]]>
    </programlisting>
-   &example.outputs.similar;
+   &example.outputs;
    <screen>
 <![CDATA[
 object(MyDocument)#1 (1) {

--- a/reference/mongodb/configure.xml
+++ b/reference/mongodb/configure.xml
@@ -49,7 +49,7 @@ $ sudo pecl install mongodb
 
   <para>
    Depuis la version 1.17.0 de l'extension, PECL demandera diverses options de
-   <literal>configurations</literal>. Pour installer l'extension avec les options par défaut
+   <literal>configure</literal>. Pour installer l'extension avec les options par défaut
    dans un script non interactif, une entrée vide peut être envoyée à
    <literal>pecl install</literal> en utilisant la commande <literal>yes</literal> :
    <programlisting role="shell">
@@ -62,7 +62,7 @@ $ yes '' | sudo pecl install mongodb
   <para>
    Une liste complète des options <literal>configure</literal> supportées peut être
    trouvée dans le fichier <literal>package.xml</literal> inclus dans le paquet PECL.
-   Pour installer l'extension avec des options de <literal>configurations</literal> spécifiques
+   Pour installer l'extension avec des options de <literal>configure</literal> spécifiques
    dans un script non interactif, l'option
    <literal>--configureoptions</literal> pour
    <literal>pecl install</literal> peut être utilisée :
@@ -126,7 +126,7 @@ extension=mongodb.so
 $ brew install shivammathur/extensions/mongodb@8.4
 ]]>
    </programlisting>
-   Il est a noter que seule la dernière version de l'extension est disponible dans brew.
+   Il est à noter que seule la dernière version de l'extension est disponible dans brew.
   </para>
   <note>
    <title>Installer les dépendances requises</title>
@@ -245,7 +245,7 @@ $ sudo make install
   <simpara>
    Lorsqu'on utilise les versions groupées de libmongoc et libmongocrypt,
    l'extension tentera également de sélectionner une bibliothèque SSL selon
-   l'option de <literal>configuration</literal> <literal>--with-mongodb-ssl</literal>.
+   l'option <literal>configure</literal> <literal>--with-mongodb-ssl</literal>.
    À partir de la version 1.17.0 de l'extension, OpenSSL est toujours préféré par défaut.
    Auparavant, Secure Transport était le défaut sur macOS et OpenSSL était le défaut
    sur toutes les autres plates-formes.

--- a/reference/mongodb/functions/bson/fromphp.xml
+++ b/reference/mongodb/functions/bson/fromphp.xml
@@ -60,7 +60,7 @@
     la valeur PHP ne peut pas être convertie en BSON. Les raisons possibles incluent,
     mais sans s'y limiter à, rencontrer une instance inattendue de
     <interfacename>MongoDB\BSON\Type</interfacename> ou
-    <function>MongoDB\BSON\Serializable::bsonSerialize</function> échouant de
+    <function>MongoDB\BSON\Serializable::bsonSerialize</function> échouant à
     retourner un &array; ou une <classname>stdClass</classname>.
    </member>
   </simplelist>

--- a/reference/mongodb/functions/bson/tocanonicalextendedjson.xml
+++ b/reference/mongodb/functions/bson/tocanonicalextendedjson.xml
@@ -25,7 +25,7 @@
   </methodsynopsis>
   <simpara>
    Convertit une chaîne BSON en sa
-   <link xlink:href="&url.mongodb.specs.extendedjson;#canonical-extendedjson-example">représentation JSON étendue canonique</link>.
+   <link xlink:href="&url.mongodb.specs.extendedjson;#canonical-extended-json-example">représentation JSON étendue canonique</link>.
    Le format canonique privilégie la fidélité des types au détriment de la
    concision de la sortie et est le plus adapté pour produire une sortie qui
    peut être convertie en BSON sans perte d'informations de type (par exemple,

--- a/reference/mongodb/functions/driver/monitoring/removesubscriber.xml
+++ b/reference/mongodb/functions/driver/monitoring/removesubscriber.xml
@@ -19,7 +19,7 @@
   </simpara>
   <note>
    <simpara>
-    Si <parameter>subscriber</parameter> n'est déjà pas enregistré,
+    Si <parameter>subscriber</parameter> n'est pas déjà enregistré globalement,
     cette fonction est un no-op.
    </simpara>
   </note>

--- a/reference/mongodb/mongodb/driver/bulkwrite.xml
+++ b/reference/mongodb/mongodb/driver/bulkwrite.xml
@@ -60,7 +60,7 @@
    &reftitle.examples;
 
    <example>
-    <title>Opérations d'écriture ordonnées par type</title>
+    <title>Opérations d'écriture mixtes regroupées par type</title>
     <simpara>
      Les opérations d'écriture mixtes (c'est-à-dire les insertions, les mises à
      jour et les suppressions) seront assemblées en commandes d'écriture typées

--- a/reference/mongodb/mongodb/driver/bulkwrite/update.xml
+++ b/reference/mongodb/mongodb/driver/bulkwrite/update.xml
@@ -81,7 +81,7 @@
             ne considérera que les plans utilisant l'index suggéré.
            </simpara>
            <simpara>
-            Cette option est disponible dans MongoDB 4.4+ et entraînera une
+            Cette option est disponible dans MongoDB 4.2+ et entraînera une
             exception au moment de l'exécution si elle est spécifiée pour une version de serveur
             plus ancienne.
            </simpara>
@@ -110,7 +110,7 @@
             Cette option ne peut pas être utilisée si <literal>"multi"</literal> est &true;.
            </simpara>
            <simpara>
-            Cette option est disponible dans MongoDB 4.4+ et entraînera une
+            Cette option est disponible dans MongoDB 8.0+ et entraînera une
             exception au moment de l'exécution si elle est spécifiée pour une version de serveur
             plus ancienne.
            </simpara>

--- a/reference/mongodb/mongodb/driver/bulkwritecommand.xml
+++ b/reference/mongodb/mongodb/driver/bulkwritecommand.xml
@@ -98,7 +98,7 @@ $bulk->updateOne('db.coll_one', ['_id' => 1], ['$set' => ['x' => 1]]);
 $result = $manager->executeBulkWriteCommand($bulk);
 
 printf("%d document(s) ont été inséré(s)\n", $result->getInsertedCount());
-printf("%d document(s) ont été mise à jour(s)\n", $result->getModifiedCount());
+printf("%d document(s) ont été mis à jour(s)\n", $result->getModifiedCount());
 
 ?>
 ]]>
@@ -107,7 +107,7 @@ printf("%d document(s) ont été mise à jour(s)\n", $result->getModifiedCount()
     <screen>
 <![CDATA[
 3 document(s) ont été inséré(s)
-1 document(s) ont été mise à jour(s
+1 document(s) ont été mis à jour(s)
 ]]>
     </screen>
    </example>

--- a/reference/mongodb/mongodb/driver/bulkwritecommand/construct.xml
+++ b/reference/mongodb/mongodb/driver/bulkwritecommand/construct.xml
@@ -138,7 +138,7 @@ $bulk->updateOne('db.coll_one', ['_id' => 1], ['$set' => ['x' => 1]]);
 $result = $manager->executeBulkWriteCommand($bulk);
 
 printf("%d document(s) ont été inséré(s)\n", $result->getInsertedCount());
-printf("%d document(s) ont été mise à jour(s)\n", $result->getModifiedCount());
+printf("%d document(s) ont été mis à jour(s)\n", $result->getModifiedCount());
 
 ?>
 ]]>
@@ -147,7 +147,7 @@ printf("%d document(s) ont été mise à jour(s)\n", $result->getModifiedCount()
    <screen>
 <![CDATA[
 3 document(s) ont été inséré(s)
-1 document(s) ont été mise à jour(s)
+1 document(s) ont été mis à jour(s)
 ]]>
    </screen>
   </example>

--- a/reference/mongodb/mongodb/driver/bulkwritecommand/updatemany.xml
+++ b/reference/mongodb/mongodb/driver/bulkwritecommand/updatemany.xml
@@ -65,7 +65,7 @@
             Un tableau de documents de filtre qui détermine quels éléments de tableau
             à modifier pour une opération de mise à jour sur un champ de tableau. Voir
             <link xlink:href="&url.mongodb.docs.command;update/#update-command-arrayfilters">Spécifier arrayFilters pour les opérations de mise à jour de tableau</link>
-            dans le MongoDB manual pour plus d'informations.
+            dans le manuel MongoDB pour plus d'informations.
            </simpara>
           </entry>
          </row>

--- a/reference/mongodb/mongodb/driver/bulkwritecommand/updateone.xml
+++ b/reference/mongodb/mongodb/driver/bulkwritecommand/updateone.xml
@@ -86,9 +86,9 @@
           <entry><type class="union"><type>array</type><type>object</type></type></entry>
           <entry>
            <simpara>
-            Spécifie quel document l'opération remplace si la requête correspond à
+            Spécifie quel document l'opération met à jour si la requête correspond à
             plusieurs documents. Le premier document correspondant à l'ordre de tri
-            sera remplacé.
+            sera mis à jour.
            </simpara>
           </entry>
          </row>

--- a/reference/mongodb/mongodb/driver/bulkwritecommandresult/isacknowledged.xml
+++ b/reference/mongodb/mongodb/driver/bulkwritecommandresult/isacknowledged.xml
@@ -42,7 +42,7 @@
  <refsect1 role="examples">
   &reftitle.examples;
   <example>
-   <title><function>MongoDB\Driver\BulkWriteCommandResult::isAcknowledged</function> avec écriture préoccupante reconnue</title>
+   <title><function>MongoDB\Driver\BulkWriteCommandResult::isAcknowledged</function> avec un write concern reconnu</title>
    <programlisting role="php">
 <![CDATA[
 <?php
@@ -67,7 +67,7 @@ bool(true)
    </screen>
   </example>
   <example>
-   <title><function>MongoDB\Driver\BulkWriteCommandResult::isAcknowledged</function> avec écriture préoccupante non reconnue</title>
+   <title><function>MongoDB\Driver\BulkWriteCommandResult::isAcknowledged</function> avec un write concern non reconnu</title>
    <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/mongodb/mongodb/driver/clientencryption.xml
+++ b/reference/mongodb/mongodb/driver/clientencryption.xml
@@ -179,11 +179,8 @@
         <entry>PECL mongodb 2.0.0</entry>
         <entry>
          <simpara>
-          Supprimer <constant>MongoDB\Driver\ClientEncryption::ALGORITHM_INDEXED</constant>
-          et 
-
-          Removed <constant>MongoDB\Driver\ClientEncryption::ALGORITHM_RANGE_PREVIEW</constant>
-          and <constant>MongoDB\Driver\ClientEncryption::QUERY_TYPE_RANGE_PREVIEW</constant>.
+          Suppression de <constant>MongoDB\Driver\ClientEncryption::ALGORITHM_RANGE_PREVIEW</constant>
+          et <constant>MongoDB\Driver\ClientEncryption::QUERY_TYPE_RANGE_PREVIEW</constant>.
          </simpara>
         </entry>
        </row>

--- a/reference/mongodb/mongodb/driver/clientencryption/encrypt.xml
+++ b/reference/mongodb/mongodb/driver/clientencryption/encrypt.xml
@@ -38,8 +38,8 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   Renvoie la valeur chiffrée en tant qu'un objet 
-   <function>MongoDB\Driver\ClientEncryption::decrypt</function> de sous-type 6.
+   Renvoie la valeur chiffrée en tant qu'objet
+   <classname>MongoDB\BSON\Binary</classname> de sous-type 6.
   </simpara>
  </refsect1>
 

--- a/reference/mongodb/mongodb/driver/clientencryption/encryptexpression.xml
+++ b/reference/mongodb/mongodb/driver/clientencryption/encryptexpression.xml
@@ -32,8 +32,8 @@
      <simpara>
       L'expression de correspondance ou d'agrégation à chiffrer. Les expressions doivent
       utiliser au moins un des opérateurs <literal>$gt</literal>, <literal>$gte</literal>,
-      <literal>$lt</literal> ou <literal>$lte</literal>. Un opérateur de
-      comparaison unique est utilisé.
+      <literal>$lt</literal> ou <literal>$lte</literal>. Un opérateur <literal>$and</literal>
+      de premier niveau est requis, même si un seul opérateur de comparaison est utilisé.
      </simpara>
      <simpara>
       Un exemple d'expression de correspondance prise en charge (s'applique aux requêtes et à l'étape d'agrégation

--- a/reference/mongodb/mongodb/driver/cursor/getid.xml
+++ b/reference/mongodb/mongodb/driver/cursor/getid.xml
@@ -53,7 +53,7 @@
       <row>
        <entry>PECL mongodb 2.0.0</entry>
        <entry>
-        Le type de retour a été changé de <classname>MongoDB\BSON\Int64</classname>
+        Le type de retour a été changé en <classname>MongoDB\BSON\Int64</classname>.
         Le paramètre <parameter>asInt64</parameter> a été supprimé.
        </entry>
       </row>

--- a/reference/mongodb/mongodb/driver/cursor/isdead.xml
+++ b/reference/mongodb/mongodb/driver/cursor/isdead.xml
@@ -19,7 +19,7 @@
    Vérifie s'il n'y a plus aucun résultat supplémentaire disponible sur le
    curseur. Cette méthode est similaire à la méthode
    <link xlink:href="&url.mongodb.docs;reference/method/cursor.isExhausted/">cursor.isExhausted()</link>
-   dans le shell MongoDB et son utilité primaire et lors de l'itération de
+   dans le shell MongoDB et son utilité primaire est lors de l'itération de
    <link xlink:href="&url.mongodb.docs;core/tailable-cursors/">curseurs de queue</link>.
   </simpara>
   <para>

--- a/reference/mongodb/mongodb/driver/cursorid.xml
+++ b/reference/mongodb/mongodb/driver/cursorid.xml
@@ -72,7 +72,7 @@
        </row>
       </thead>
       <tbody>
-       
+       &mongodb.changelog.class-removed;
        <row>
         <entry>PECL mongodb 1.20.0</entry>
         <entry>

--- a/reference/mongodb/mongodb/driver/exception/bulkwritecommandexception/getwriteconcernerrors.xml
+++ b/reference/mongodb/mongodb/driver/exception/bulkwritecommandexception/getwriteconcernerrors.xml
@@ -5,7 +5,7 @@
 <refentry xml:id="mongodb-driver-bulkwritecommandexception.getwriteconcernerrors" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>MongoDB\Driver\Exception\BulkWriteCommandException::getWriteConcernErrors</refname>
-  <refpurpose>Renvoie les erreurs de préoccupation d'écriture</refpurpose>
+  <refpurpose>Renvoie les erreurs de write concern</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/mongodb/mongodb/driver/exception/commandexception.xml
+++ b/reference/mongodb/mongodb/driver/exception/commandexception.xml
@@ -76,7 +76,7 @@
      <term><varname>resultDocument</varname></term>
      <listitem>
       <simpara>
-       Le résultat du document associé à la commande échouée.
+       Le document résultant associé à la commande échouée.
       </simpara>
      </listitem>
     </varlistentry>

--- a/reference/mongodb/mongodb/driver/exception/exception.xml
+++ b/reference/mongodb/mongodb/driver/exception/exception.xml
@@ -5,7 +5,7 @@
 
 <reference xml:id="class.mongodb-driver-exception-exception" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  
- <title>La classe MongoDB\Driver\Exception\Exception</title>
+ <title>L'interface MongoDB\Driver\Exception\Exception</title>
  <titleabbrev>MongoDB\Driver\Exception\Exception</titleabbrev>
  
  <partintro>

--- a/reference/mongodb/mongodb/driver/exception/writeexception.xml
+++ b/reference/mongodb/mongodb/driver/exception/writeexception.xml
@@ -109,6 +109,7 @@
        </row>
       </thead>
       <tbody>
+       &mongodb.changelog.class-removed;
        <row>
         <entry>PECL mongodb 1.20.0</entry>
         <entry>

--- a/reference/mongodb/mongodb/driver/manager/construct.xml
+++ b/reference/mongodb/mongodb/driver/manager/construct.xml
@@ -886,7 +886,7 @@ mongodb://[username:password@]host1[:port1][,host2[:port2],...[,hostN[:portN]]][
   &reftitle.errors;
   <simplelist>
    &mongodb.throws.argumentparsing;
-   <member>Lance une exception <classname>MongoDB\Driver\Exception\InvalidArgumentException</classname> si un paramètre est de type incorrect</member>
+   <member>Lance une exception <classname>MongoDB\Driver\Exception\RuntimeException</classname> si le format de l'<parameter>uri</parameter> est invalide</member>
   </simplelist>
  </refsect1>
 
@@ -905,17 +905,17 @@ mongodb://[username:password@]host1[:port1][,host2[:port2],...[,hostN[:portN]]][
        <entry>PECL mongodb 2.0.0</entry>
        <entry>
         <simpara>
-         L'option d'URI <literal>"authMechanismProperties"</literal> a été supprimée.
+         L'option d'URI <literal>"canonicalizeHostname"</literal> a été supprimée.
          Utiliser la propriété <literal>"CANONICALIZE_HOST_NAME"</literal> de l'option d'URI
          <literal>"authMechanismProperties"</literal> plutôt.
         </simpara>
         <simpara>
-         L'option d'URI <literal>"authMechanism"</literal> a été supprimée.
+         L'option d'URI <literal>"gssapiServiceName"</literal> a été supprimée.
          Utiliser la propriété <literal>"SERVICE_NAME"</literal> de l'option d'URI
          <literal>"authMechanismProperties"</literal> plutôt.
         </simpara>
         <simpara>
-         L'option d'URI <literal>"authSource"</literal> a été supprimée.
+         L'option d'URI <literal>"safe"</literal> a été supprimée.
          Utiliser les options d'URI <literal>"w"</literal> et <literal>"wTimeoutMS"</literal>
          plutôt.
         </simpara>
@@ -1108,7 +1108,7 @@ mongodb://[username:password@]host1[:port1][,host2[:port2],...[,hostN[:portN]]][
        <entry>
         <simpara>
          Ajout des options d'URI <literal>"compressors"</literal>,
-         <literal>"retryWrites"</literal>, er
+         <literal>"retryWrites"</literal>, et
          <literal>"zlibCompressionLevel"</literal>.
         </simpara>
        </entry>

--- a/reference/mongodb/mongodb/driver/manager/executebulkwritecommand.xml
+++ b/reference/mongodb/mongodb/driver/manager/executebulkwritecommand.xml
@@ -5,7 +5,7 @@
 <refentry xml:id="mongodb-driver-manager.executebulkwritecommand" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>MongoDB\Driver\Manager::executeBulkWriteCommand</refname>
-  <refpurpose>Execute les opérations d'écriture en utilisant la commande bulkWrite</refpurpose>
+  <refpurpose>Exécute les opérations d'écriture en utilisant la commande bulkWrite</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -72,7 +72,7 @@
   &reftitle.errors;
   <simplelist>
    <member>Lance une <classname>MongoDB\Driver\Exception\InvalidArgumentException</classname> si <parameter>bulk</parameter> ne contient pas d'opérations d'écriture valides.</member>
-   <member>Lance une <classname>MongoDB\Driver\Exception\InvalidArgumentException</classname> si <parameter>bulk</parameter> a déjà été exécutée. <classname>MongoDB\Driver\BulkWriteCommand</classname> les objets ne peuvent pas être exécutés plusieurs fois.</member>
+   <member>Lance une <classname>MongoDB\Driver\Exception\InvalidArgumentException</classname> si <parameter>bulk</parameter> a déjà été exécutée. Les objets <classname>MongoDB\Driver\BulkWriteCommand</classname> ne peuvent pas être exécutés plusieurs fois.</member>
    &mongodb.throws.session-unacknowledged;
    &mongodb.throws.std;
    &mongodb.throws.bulkwritecommandexception;

--- a/reference/mongodb/mongodb/driver/manager/executecommand.xml
+++ b/reference/mongodb/mongodb/driver/manager/executecommand.xml
@@ -262,9 +262,9 @@ var_dump($cursor->toArray()[0]);
   &reftitle.notes;
   <note>
    <simpara>
-    Si un deuxième <parameter>readPreference</parameter> est utilisé, il est de
+    Si un <parameter>readPreference</parameter> secondaire est utilisé, il est de
     la responsabilité de l'appelant de s'assurer que la
-    <parameter>commande</parameter> peut être exécutée sur un secondaire. Aucune
+    <parameter>command</parameter> peut être exécutée sur un secondaire. Aucune
     validation n'est effectuée par le pilote.
    </simpara>
   </note>

--- a/reference/mongodb/mongodb/driver/monitoring/commandstartedevent/getserverconnectionid.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/commandstartedevent/getserverconnectionid.xml
@@ -16,7 +16,7 @@
   <simpara>
    Renvoie l'identifiant de connexion du serveur pour la commande. L'identifiant de connexion du serveur est
    distinct du serveur (c'est-à-dire
-   <function>MongoDB\Driver\Monitoring\CommandFailedEvent::getServer</function>)
+   <function>MongoDB\Driver\Monitoring\CommandStartedEvent::getServer</function>)
    et est renvoyé dans le champ "connectionId" d'une réponse de commande <literal>hello</literal>
    MongoDB 4.2+.
   </simpara>

--- a/reference/mongodb/mongodb/driver/monitoring/commandsubscriber.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/commandsubscriber.xml
@@ -13,7 +13,7 @@
    <simpara>
     Les classes peuvent implémenter cette interface pour enregistrer un observateur
     d'événements qui est notifié pour chaque événement de commande démarré,
-    <xref linkend="mongodb.tutorial.apm" /> pour plus d'informations.
+    réussi et échoué. Voir <xref linkend="mongodb.tutorial.apm" /> pour plus d'informations.
    </simpara>
   </section>
 <!-- }}} -->

--- a/reference/mongodb/mongodb/driver/monitoring/sdamsubscriber/serveropening.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/sdamsubscriber/serveropening.xml
@@ -14,8 +14,8 @@
    <methodparam><type>MongoDB\Driver\Monitoring\ServerOpeningEvent</type><parameter>event</parameter></methodparam>
   </methodsynopsis>
   <simpara>
-   Si un observateur est enregistré, cette méthode est appelée lorsqu'un serveur existant
-   est retiré de la topologie.
+   Si un observateur est enregistré, cette méthode est appelée lorsqu'un nouveau serveur
+   est ajouté à la topologie.
   </simpara>
  </refsect1>
 

--- a/reference/mongodb/mongodb/driver/query.xml
+++ b/reference/mongodb/mongodb/driver/query.xml
@@ -14,7 +14,7 @@
   <section xml:id="mongodb-driver-query.intro">
    &reftitle.intro;
    <simpara>
-    La classe <classname>MongoDB\Driver\Query</classname> est un objet
+    La classe <classname>MongoDB\Driver\Query</classname> est un objet de valeur
     qui représente une requête de base de données.
    </simpara>
   </section>

--- a/reference/mongodb/mongodb/driver/query/construct.xml
+++ b/reference/mongodb/mongodb/driver/query/construct.xml
@@ -121,7 +121,7 @@
             Le flux de données en aval à pleine puissance dans plusieurs paquets
             "more", en supposant que le client lira entièrement toutes les données
             interrogées. Plus rapide lorsqu'on tire beaucoup de données et
-            savez qu'on veut tout tirer. Remarque : le client n'est pas autorisé
+            qu'on sait qu'on veut tout tirer. Remarque : le client n'est pas autorisé
             à ne pas lire toutes les données sauf s'il ferme la connexion.
            </simpara>
            <simpara>
@@ -371,7 +371,7 @@
         <literal>"allowPartialResults"</literal> à la place.
        </simpara>
        <simpara>
-        L'option <literal>"maxScan"</literal> a été supprimée. Le Support
+        L'option <literal>"maxScan"</literal> a été supprimée. Le support
         pour cette option a été supprimé dans MongoDB 4.2.
        </simpara>
        <simpara>
@@ -474,7 +474,7 @@
    <programlisting role="php">
 <![CDATA[
 <?php
-/* Selectionne uniquement les documents écrits par "bjori" avec au moins 100 vues */
+/* Sélectionne uniquement les documents écrits par "bjori" avec au moins 100 vues */
 $filter = [
     'author' => 'bjori',
     'views' => [

--- a/reference/mongodb/mongodb/driver/readconcern.xml
+++ b/reference/mongodb/mongodb/driver/readconcern.xml
@@ -12,7 +12,7 @@
    &reftitle.intro;
    <para>
     <classname>MongoDB\Driver\ReadConcern</classname> contrôle le niveau
-    d'isolation pour les opérations de lecture pour les ensembles de réplicas et les réplicas de réplicas. Cette
+    d'isolation pour les opérations de lecture pour les ensembles de réplicas et les fragments d'ensembles de réplicas. Cette
     option nécessite MongoDB 3.2 ou ultérieur.
    </para>
   </section>

--- a/reference/mongodb/mongodb/driver/readconcern/construct.xml
+++ b/reference/mongodb/mongodb/driver/readconcern/construct.xml
@@ -27,7 +27,7 @@
     <listitem>
      <simpara>
       Le <link xlink:href="&url.mongodb.docs.readconcern;#read-concern-levels">niveau du read concern</link>.
-      Il est possible d'utiliser, mais n'êtes pas limité à, une des
+      Il est possible d'utiliser, sans toutefois s'y limiter, une des
       <link linkend="mongodb-driver-readconcern.constants">constantes de classe</link>.
      </simpara>
     </listitem>

--- a/reference/mongodb/mongodb/driver/readpreference/construct.xml
+++ b/reference/mongodb/mongodb/driver/readpreference/construct.xml
@@ -137,16 +137,16 @@
           <entry><type class="union"><type>object</type><type>array</type></type></entry>
           <entry>
            <simpara>Spécifie si l'on doit utiliser ou non <link xlink:href="&url.mongodb.docs;core/sharded-cluster-query-router/#mongos-hedged-reads">les lectures
-            croisées</link>, qui sont supportés depuis MongoDB 4.4+ pour les
+            couvertes</link>, qui sont supportées depuis MongoDB 4.4+ pour les
             requêtes partagées.</simpara>
            <simpara>
-            Le serveur des lectures croisées est disponible pour toutes les
-            lectures des références non primaires, et est activé par défaut
+            Les lectures couvertes côté serveur sont disponibles pour toutes les
+            préférences de lecture non primaires, et sont activées par défaut
             lors de l'utilisation du mode <literal>"nearest"</literal>. Cette option
-            permet d'activer explicitement le serveur des lectures croisées
-            pour les lectures des références non primaires en spécifiant
+            permet d'activer explicitement les lectures couvertes côté serveur
+            pour les préférences de lecture non primaires en spécifiant
             <literal>['enabled' => true]</literal>, ou de désactiver explicitement
-            le serveur des lectures croisées pour les lectures des références
+            les lectures couvertes côté serveur pour la préférence de lecture
             <literal>"nearest"</literal> en spécifiant
             <literal>['enabled' => false]</literal>.
            </simpara>
@@ -282,7 +282,7 @@ var_dump(new MongoDB\Driver\ReadPreference(MongoDB\Driver\ReadPreference::SECOND
 ?>
 ]]>
    </programlisting>
-   &example.outputs.similar;
+   &example.outputs;
    <screen>
 <![CDATA[
 object(MongoDB\Driver\ReadPreference)#1 (1) {

--- a/reference/mongodb/mongodb/driver/server.xml
+++ b/reference/mongodb/mongodb/driver/server.xml
@@ -131,22 +131,22 @@
     <varlistentry xml:id="mongodb-driver-server.constants.type-possible-primary">
      <term><constant>MongoDB\Driver\Server::TYPE_POSSIBLE_PRIMARY</constant></term>
      <listitem>
-      <simpara>Jeu de réplique type de serveur principal possible, retourné par <methodname>MongoDB\Driver\Server::getType</methodname>.</simpara>
-      <simpara>Un serveur peut être identifié comme un possible primaire s'il n'a pas encore été vérifié, mais une autre mémoire du jeu de réplique pense qu'il est le principal.</simpara>
+      <simpara>Type de serveur primaire possible du jeu de réplique, retourné par <methodname>MongoDB\Driver\Server::getType</methodname>.</simpara>
+      <simpara>Un serveur peut être identifié comme un possible primaire s'il n'a pas encore été vérifié, mais une autre mémoire du jeu de réplique pense qu'il est le primaire.</simpara>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="mongodb-driver-server.constants.type-rs-primary">
      <term><constant>MongoDB\Driver\Server::TYPE_RS_PRIMARY</constant></term>
      <listitem>
-      <simpara>Type de serveur principal du jeu de réplique, retourné par <methodname>MongoDB\Driver\Server::getType</methodname>.</simpara>
+      <simpara>Type de serveur primaire du jeu de réplique, retourné par <methodname>MongoDB\Driver\Server::getType</methodname>.</simpara>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="mongodb-driver-server.constants.type-rs-secondary">
      <term><constant>MongoDB\Driver\Server::TYPE_RS_SECONDARY</constant></term>
      <listitem>
-      <simpara>Réplique de type de serveur secondaire, retourné par <methodname>MongoDB\Driver\Server::getType</methodname>.</simpara>
+      <simpara>Type de serveur secondaire du jeu de réplique, retourné par <methodname>MongoDB\Driver\Server::getType</methodname>.</simpara>
      </listitem>
     </varlistentry>
 

--- a/reference/mongodb/mongodb/driver/server/executebulkwrite.xml
+++ b/reference/mongodb/mongodb/driver/server/executebulkwrite.xml
@@ -112,7 +112,7 @@
       <entry>
        <classname>MongoDB\Driver\Exception\InvalidArgumentException</classname>
        sera lancé si l'option <literal>"session"</literal> est utilisée
-       conjointement avec une préoccupation d&#39;écriture non reconnu.
+       conjointement avec un write concern non reconnu.
       </entry>
      </row>
      <row>
@@ -126,8 +126,8 @@
      <row>
       <entry>PECL mongodb 1.3.0</entry>
       <entry>
-       <classname>MongoDBDriverExceptionInvalidArgumentException</classname> est
-       maintenant levé si <parameter>Bulk</parameter> ne contient pas
+       <classname>MongoDB\Driver\Exception\InvalidArgumentException</classname> est
+       maintenant levé si <parameter>bulk</parameter> ne contient pas
        d'opérations d'écriture. Auparavant, une
        <classname>MongoDB\Driver\Exception\BulkWriteException</classname> était levée.
       </entry>

--- a/reference/mongodb/mongodb/driver/server/executebulkwritecommand.xml
+++ b/reference/mongodb/mongodb/driver/server/executebulkwritecommand.xml
@@ -16,7 +16,7 @@
    <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>options</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
   <simpara>
-   Exécute une ou plusieurs opérations d'écriture sur le serveur principal en utilisant la
+   Exécute une ou plusieurs opérations d'écriture sur ce serveur en utilisant la
    commande <link xlink:href="&url.mongodb.docs.command;bulkWrite">bulkWrite</link>
    introduite dans MongoDB 8.0.
   </simpara>
@@ -28,7 +28,7 @@
   <simpara>
    La valeur par défaut pour l'option <literal>"writeConcern"</literal> sera
    déduite d'une transaction active (indiquée par l'option
-   <literal>"session"</literal> option), suivie de
+   <literal>"session"</literal>), suivie de
    <link linkend="mongodb-driver-manager.construct-uri">l'URI de connexion</link>.
   </simpara>
  </refsect1>
@@ -72,7 +72,7 @@
   &reftitle.errors;
   <simplelist>
    <member>Lance une <classname>MongoDB\Driver\Exception\InvalidArgumentException</classname> si <parameter>bulk</parameter> ne contient pas d'opérations d'écriture valides.</member>
-   <member>Lance une <classname>MongoDB\Driver\Exception\InvalidArgumentException</classname> si <parameter>bulk</parameter> a déjà été exécutée. <classname>MongoDB\Driver\BulkWriteCommand</classname> les objets ne peuvent pas être exécutés plusieurs fois.</member>
+   <member>Lance une <classname>MongoDB\Driver\Exception\InvalidArgumentException</classname> si <parameter>bulk</parameter> a déjà été exécutée. Les objets <classname>MongoDB\Driver\BulkWriteCommand</classname> ne peuvent pas être exécutés plusieurs fois.</member>
    &mongodb.throws.session-unacknowledged;
    &mongodb.throws.std;
    &mongodb.throws.bulkwritecommandexception;

--- a/reference/mongodb/mongodb/driver/server/executecommand.xml
+++ b/reference/mongodb/mongodb/driver/server/executecommand.xml
@@ -117,7 +117,7 @@
       <entry>
        <classname>MongoDB\Driver\Exception\InvalidArgumentException</classname>
        sera lancé si l'option <literal>"session"</literal> est utilisée
-       conjointement avec une préoccupation d&#39;écriture non reconnu.
+       conjointement avec un write concern non reconnu.
       </entry>
      </row>
      <row>

--- a/reference/mongodb/mongodb/driver/server/executequery.xml
+++ b/reference/mongodb/mongodb/driver/server/executequery.xml
@@ -133,7 +133,7 @@ sgml-always-quote-attributes:t
 sgml-indent-step:1
 sgml-indent-data:t
 indent-tabs-mode:nil
-sgml-parent-document:nisgml-default-dtd-file:"~/.phpdoc/manual.cedk
+sgml-parent-document:nil
 sgml-default-dtd-file:"~/.phpdoc/manual.ced"
 sgml-exposed-tags:nil
 sgml-local-catalogs:nil

--- a/reference/mongodb/mongodb/driver/serverapi.xml
+++ b/reference/mongodb/mongodb/driver/serverapi.xml
@@ -137,8 +137,8 @@ try {
     exit;
 }
 
-/* The buildInfo command returns a single result document, so we need to access
- * the first result in the cursor. */
+/* La commande buildInfo retourne un document unique, nous devons donc accéder
+ * au premier résultat du curseur. */
 $buildInfo = $cursor->toArray()[0];
 
 echo $buildInfo->version, "\n";

--- a/reference/mongodb/mongodb/driver/session/advanceoperationtime.xml
+++ b/reference/mongodb/mongodb/driver/session/advanceoperationtime.xml
@@ -33,7 +33,7 @@
     <term><parameter>operationTime</parameter></term>
     <listitem>
      <simpara>
-      L'opération est un horodatage logique. Typiquement, cette valeur
+      Le temps d'opération est un horodatage logique. Typiquement, cette valeur
       sera obtenue en appelant
       <methodname>MongoDB\Driver\Session::getOperationTime</methodname> sur
       un autre objet de session.

--- a/reference/mongodb/mongodb/driver/session/committransaction.xml
+++ b/reference/mongodb/mongodb/driver/session/committransaction.xml
@@ -40,8 +40,10 @@
    <member>Lance une
    <classname>MongoDB\Driver\Exception\CommandException</classname> si le
    serveur ne peut pas valider la transaction (par exemple, en raison de conflits,
-   de problèmes de réseau). Si l'exception contient un élément
-   <literal>"errorLabels"</literal> et que ce tableau contient une valeur
+   de problèmes de réseau). Si le document retourné par la méthode
+   <methodname>MongoDB\Driver\Exception\CommandException::getResultDocument</methodname>
+   de l'exception contient un élément <literal>"errorLabels"</literal>, et que ce
+   tableau contient une valeur
    <literal>"TransientTransactionError"</literal> ou
    <literal>"UnknownTransactionCommitResult"</literal>, il est sûr de re-essayer
    la <emphasis>totalité</emphasis> de la transaction. Dans les versions plus

--- a/reference/mongodb/mongodb/driver/session/starttransaction.xml
+++ b/reference/mongodb/mongodb/driver/session/starttransaction.xml
@@ -27,7 +27,7 @@
    annulées avec
    <methodname>MongoDB\Driver\Session::abortTransaction</methodname>.
    Les transactions sont également automatiquement annulées lorsque la session est
-   fermée par la collecte des ordures ou en appelant explicitement
+   fermée par le ramasse-miettes ou en appelant explicitement
    <methodname>MongoDB\Driver\Session::endSession</methodname>.
   </simpara>
  </refsect1>

--- a/reference/mongodb/mongodb/driver/writeconcern.xml
+++ b/reference/mongodb/mongodb/driver/writeconcern.xml
@@ -17,8 +17,8 @@
     <classname>MongoDB\Driver\WriteConcern</classname> décrit le niveau 
     d'accusé de réception demandé par MongoDB pour les opérations d'écriture
     à un <literal>mongod</literal> autonome ou à des ensembles de réplicas 
-    ou à des clusters fragmentés. Dans les clusters fragmentés, les instances 
-    de <literal>mongos</literal> transmettent le contrôle d'écriture aux 
+    ou à des clusters fragmentés. Dans les clusters fragmentés, les instances
+    de <literal>mongos</literal> transmettent le write concern aux
     fragments.
    </para>
   </section>
@@ -90,9 +90,9 @@
      <term><varname>w</varname></term>
      <listitem>
       <simpara>
-       La valeur de la préoccupation d'écriture (nombre entier de nœuds, la chaîne
+       La valeur du write concern (nombre entier de nœuds, la chaîne
        <literal>"majority"</literal>, ou un nom personnalisé d'étiquette de
-       préoccupation d'écriture), ou &null; si non définie.
+       write concern), ou &null; si non définie.
       </simpara>
      </listitem>
     </varlistentry>
@@ -109,8 +109,8 @@
      <term><varname>wtimeout</varname></term>
      <listitem>
       <simpara>
-       Le délai d'attente en millisecondes pour l'accusé de réception de la
-       préoccupation d'écriture. Une valeur de <literal>0</literal> signifie
+       Le délai d'attente en millisecondes pour l'accusé de réception du
+       write concern. Une valeur de <literal>0</literal> signifie
        attendre indéfiniment.
       </simpara>
      </listitem>
@@ -130,7 +130,7 @@
       <para>
        La majorité de tous les membres du jeu de répliques ; les arbitres, les membres non-votants,
        les membres passifs, les membres cachés, et les membres en attente sont
-       tous inclus dans la définition d'une préoccupation d'écriture de la majorité.
+       tous inclus dans la définition d'un write concern de la majorité.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/mongodb/mongodb/driver/writeconcern/construct.xml
+++ b/reference/mongodb/mongodb/driver/writeconcern/construct.xml
@@ -30,7 +30,7 @@
     <listitem>
      <para>
       <table>
-       <title>Préoccupation d'écriture</title>
+       <title>Write concern</title>
        <tgroup cols="2">
         <thead>
          <row>
@@ -44,7 +44,7 @@
           <entry>
            Demande l'accusé de réception que l'opération d'écriture s'est propagée 
            au <literal>mongod</literal> autonome ou au principal dans un jeu de 
-           réplicas. Il s'agit de la préoccupation d'écriture par défaut pour 
+           réplicas. Il s'agit du write concern par défaut pour
            MongoDB.
           </entry>
          </row>
@@ -102,9 +102,10 @@
      <simpara>
       <literal>wtimeout</literal> fera que les opérations en écriture vont retourner
       une erreur (<classname>WriteConcernError</classname>) après le
-      délai spécifié. Lorsque ces opérations en écriture retournent, MongoDB
-      ne va pas annuler les données modifiées avant que les préoccupations
-      en écriture n'atteignent le délai limite <literal>wtimeout</literal>.
+      délai spécifié, même si le write concern requis finit par être satisfait.
+      Lorsque ces opérations en écriture retournent, MongoDB
+      ne va pas annuler les modifications de données réussies effectuées avant que
+      le write concern n'ait dépassé le délai limite <literal>wtimeout</literal>.
      </simpara>
      <simpara>
       Si spécifié, <literal>wtimeout</literal> doit être un entier signé 64 bits 
@@ -112,7 +113,7 @@
      </simpara>
      <para>
       <table>
-       <title>Délai d'attente maximal des préoccupations d'écriture</title>
+       <title>Délai d'attente du write concern</title>
        <tgroup cols="2">
         <thead>
          <row>

--- a/reference/mongodb/mongodb/driver/writeconcernerror.xml
+++ b/reference/mongodb/mongodb/driver/writeconcernerror.xml
@@ -15,7 +15,7 @@
    &reftitle.intro;
    <para>
     La classe <classname>MongoDB\Driver\WriteConcernError</classname> 
-    contient des informations relatives à une erreur concernant l'écriture et peut être retournée par
+    contient des informations relatives à une erreur de write concern et peut être retournée par
    <methodname>MongoDB\Driver\WriteResult::getWriteConcernError</methodname>.
    </para>
   </section>

--- a/reference/mongodb/mongodb/driver/writeconcernerror/getinfo.xml
+++ b/reference/mongodb/mongodb/driver/writeconcernerror/getinfo.xml
@@ -51,7 +51,7 @@
 
 $manager = new MongoDB\Driver\Manager("mongodb://rs1.example.com,rs2.example.com/?replicaSet=myReplicaSet");
 
-$bul$bulk
+$bulk = new MongoDB\Driver\BulkWrite;
 $bulk->insert(['x' => 1]);
 
 $writeConcern = new MongoDB\Driver\WriteConcern(2, 1);

--- a/reference/mongodb/mongodb/driver/writeerror/getindex.xml
+++ b/reference/mongodb/mongodb/driver/writeerror/getindex.xml
@@ -29,8 +29,8 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   Retourne l'index de l'opération d'écriture (à partir de 
-   <classname>MongoDBDriverBulkWrite</classname>) correspondant à ce WriteError.
+   Retourne l'index de l'opération d'écriture (à partir de
+   <classname>MongoDB\Driver\BulkWrite</classname>) correspondant à ce WriteError.
   </simpara>
  </refsect1>
 

--- a/reference/mongodb/mongodb/driver/writeresult.xml
+++ b/reference/mongodb/mongodb/driver/writeresult.xml
@@ -123,7 +123,7 @@
      <listitem>
       <simpara>
        Le nombre de documents insérés (à l'exclusion des upserts), ou &null; si
-       la préoccupation d'écriture n'a pas demandé d'accusé de réception.
+       le write concern n'a pas demandé d'accusé de réception.
       </simpara>
      </listitem>
     </varlistentry>
@@ -132,7 +132,7 @@
      <listitem>
       <simpara>
        Le nombre de documents correspondant aux opérations de mise à jour et de
-       remplacement, ou &null; si la préoccupation d'écriture n'a pas demandé
+       remplacement, ou &null; si le write concern n'a pas demandé
        d'accusé de réception.
       </simpara>
      </listitem>
@@ -142,7 +142,7 @@
      <listitem>
       <simpara>
        Le nombre de documents modifiés par les opérations de mise à jour et de
-       remplacement, ou &null; si la préoccupation d'écriture n'a pas demandé
+       remplacement, ou &null; si le write concern n'a pas demandé
        d'accusé de réception ou si le serveur n'a pas signalé cette information.
       </simpara>
      </listitem>
@@ -151,8 +151,8 @@
      <term><varname>deletedCount</varname></term>
      <listitem>
       <simpara>
-       Le nombre de documents supprimés, ou &null; si la préoccupation
-       d'écriture n'a pas demandé d'accusé de réception.
+       Le nombre de documents supprimés, ou &null; si le write concern
+       n'a pas demandé d'accusé de réception.
       </simpara>
      </listitem>
     </varlistentry>
@@ -160,8 +160,8 @@
      <term><varname>upsertedCount</varname></term>
      <listitem>
       <simpara>
-       Le nombre de documents upsertés, ou &null; si la préoccupation
-       d'écriture n'a pas demandé d'accusé de réception.
+       Le nombre de documents upsertés, ou &null; si le write concern
+       n'a pas demandé d'accusé de réception.
       </simpara>
      </listitem>
     </varlistentry>
@@ -197,7 +197,7 @@
      <listitem>
       <simpara>
        Le <classname>MongoDB\Driver\WriteConcernError</classname> survenu, ou
-       &null; si aucune erreur de préoccupation d'écriture n'est survenue.
+       &null; si aucune erreur de write concern n'est survenue.
       </simpara>
      </listitem>
     </varlistentry>

--- a/reference/mongodb/mongodb/driver/writeresult/getupsertedids.xml
+++ b/reference/mongodb/mongodb/driver/writeresult/getupsertedids.xml
@@ -29,7 +29,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   Retourne un tableau d'identificateurs (par exemple la valeur du champ <literal> "_id"</literal>) pour les documents upserted. Les clés de tableau correspondent à l'index de l'opération d'écriture (à partir de <classname>MongoDBDriverBulkWrite</classname>) responsable du upsert.
+   Retourne un tableau d'identificateurs (par exemple la valeur du champ <literal>"_id"</literal>) pour les documents upserted. Les clés de tableau correspondent à l'index de l'opération d'écriture (à partir de <classname>MongoDB\Driver\BulkWrite</classname>) responsable du upsert.
   </simpara>
  </refsect1>
 

--- a/reference/mongodb/mongodb/driver/writeresult/getwriteconcernerror.xml
+++ b/reference/mongodb/mongodb/driver/writeresult/getwriteconcernerror.xml
@@ -28,7 +28,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   Retourne un <classname>MongoDBDriverWriteConcernError</classname> si une erreur de préoccupation d'écriture a été rencontrée pendant l'opération d'écriture, et &null; sinon.
+   Retourne un <classname>MongoDB\Driver\WriteConcernError</classname> si une erreur de write concern a été rencontrée pendant l'opération d'écriture, et &null; sinon.
   </simpara>
  </refsect1>
 

--- a/reference/mongodb/mongodb/driver/writeresult/getwriteerrors.xml
+++ b/reference/mongodb/mongodb/driver/writeresult/getwriteerrors.xml
@@ -29,8 +29,8 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   Retourne un tableau d'objets <classname>MongoDBDriverWriteError</classname> 
-   pour toutes les erreurs d'écriture rencontrées pendant l'opération 
+   Retourne un tableau d'objets <classname>MongoDB\Driver\WriteError</classname>
+   pour toutes les erreurs d'écriture rencontrées pendant l'opération
    d'écriture. Le tableau sera vide si aucune erreur d'écriture n'est survenue.
   </simpara>
  </refsect1>

--- a/reference/mongodb/mongodb/driver/writeresult/isacknowledged.xml
+++ b/reference/mongodb/mongodb/driver/writeresult/isacknowledged.xml
@@ -44,7 +44,7 @@
  <refsect1 role="examples">
   &reftitle.examples;
   <example>
-   <title><function>MongoDB\Driver\WriteResult::isAcknowledged</function> avec la préoccupation d'écriture reconnue</title>
+   <title><function>MongoDB\Driver\WriteResult::isAcknowledged</function> avec le write concern reconnu</title>
    <programlisting role="php">
 <![CDATA[
 <?php
@@ -69,7 +69,7 @@ bool(true)
    </screen>
   </example>
   <example>
-   <title><function>MongoDB\Driver\WriteResult::isAcknowledged</function> avec la préoccupation d'écriture non reconnue</title>
+   <title><function>MongoDB\Driver\WriteResult::isAcknowledged</function> avec le write concern non reconnu</title>
    <programlisting role="php">
 <![CDATA[
 <?php
@@ -102,7 +102,7 @@ bool(false)
   &reftitle.seealso;
   <simplelist>
    <member><classname>MongoDB\Driver\WriteConcern</classname></member>
-   <member><link xlink:href="&url.mongodb.docs.writeconcern;">Référence sur la Préoccupation d'Écriture</link></member>
+   <member><link xlink:href="&url.mongodb.docs.writeconcern;">Référence Write Concern</link></member>
   </simplelist>
  </refsect1>
 

--- a/reference/mongodb/security.xml
+++ b/reference/mongodb/security.xml
@@ -23,7 +23,7 @@
   <simpara>
    Cela fonctionne bien, mais quelqu'un pourrait subvertir cela en passant
    <emphasis>http://www.example.com?username[$ne]=foo</emphasis>, que PHP
-   transformera magiquement en un tableau associatif, transformant le requête en
+   transformera magiquement en un tableau associatif, transformant la requête en
    <literal>$q = new \MongoDB\Driver\Query( [ 'username' => [ '$ne' => 'foo' ] ] )</literal>,
    qui renverra tous les utilisateurs dont le nom n'est pas "foo" (tous les utilisateurs, probablement).
   </simpara>
@@ -67,7 +67,7 @@
 <?php
 $m = new MongoDB\Driver\Manager;
 
-// Ne faites pas ca !!!
+// Ne faites pas ça !!!
 $username = $_GET['field'];
 
 $cmd = new \MongoDB\Driver\Command( [
@@ -86,9 +86,9 @@ $r = $m->executeCommand( 'dramio', $cmd );
 <?php
 $m = new MongoDB\Driver\Manager;
 
-// Ne faites pas ca !!!
+// Ne faites pas ça !!!
 $username = $_GET['field'];
-// $username equivaut à "'); db.users.drop(); print('"
+// $username équivaut à "'); db.users.drop(); print('"
 
 $cmd = new \MongoDB\Driver\Command( [
     'eval' => "print('Hello, $username!');"

--- a/reference/mongodb/setup.xml
+++ b/reference/mongodb/setup.xml
@@ -35,10 +35,10 @@
   </simpara>
   <note>
    <simpara>
-    A cause de problèmes potentiels de représentation des entiers 64 bits sur des
+    À cause de problèmes potentiels de représentation des entiers 64 bits sur des
     plateformes 32 bits, il est conseillé aux utilisateurs d'utiliser des
-    environnements 64 bits. Lors de l'utilisation d'une plateforme 32 bits, soyez
-    conscient que tout entier 64 bits lu depuis la base de données sera retourné
+    environnements 64 bits. Lors de l'utilisation d'une plateforme 32 bits, il faut
+    être conscient que tout entier 64 bits lu depuis la base de données sera retourné
     sous la forme d'une instance <classname>MongoDB\BSON\Int64</classname> au
     lieu d'un type entier PHP.
    </simpara>


### PR DESCRIPTION
Corrections de langue et de traduction dans reference/, de info to mongodb (orthographe, grammaire, fidélité à l'anglais).