### PR TITLE
Nits translation: reference/ (pdo to posix)

### DIFF
--- a/reference/pdo/constants.fetch-modes.xml
+++ b/reference/pdo/constants.fetch-modes.xml
@@ -1244,8 +1244,8 @@ Array
    </screen>
   </informalexample>
   <simpara>
-   Dans l'exemple ci-dessus, il est notable que la première colonne est omise de
-   l'array pour chaque ligne, n'étant disponible que comme clé. Elle peut être incluse en
+   Dans l'exemple ci-dessus, il est notable que la première colonne est omise du
+   tableau pour chaque ligne, n'étant disponible que comme clé. Elle peut être incluse en
    répétant la colonne, comme dans l'exemple suivant :
   </simpara>
   <informalexample>

--- a/reference/pdo/pdo/commit.xml
+++ b/reference/pdo/pdo/commit.xml
@@ -79,7 +79,7 @@ $dbh->commit();
   </para>
   <para>
    <example>
-    <title>Committing a DDL transaction</title>
+    <title>Valide une transaction DDL</title>
     <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/pdo/pdo/intransaction.xml
+++ b/reference/pdo/pdo/intransaction.xml
@@ -5,7 +5,7 @@
  <refnamediv>
   <refname>PDO::inTransaction</refname>
   <refpurpose>
-   Vérifie si nous sommes dans une transaction
+   Vérifie si l'on est dans une transaction
   </refpurpose>
  </refnamediv>
 

--- a/reference/pdo/pdo/prepare.xml
+++ b/reference/pdo/pdo/prepare.xml
@@ -56,7 +56,7 @@
   <para>
    PDO émule les requêtes préparées / les paramètres liés pour les pilotes
    qui ne le supportent pas nativement, et peut également réécrire les
-   paramètres nommés ou les marqueurs en quelques choses de plus
+   paramètres nommés ou les marqueurs en quelque chose de plus
    approprié, si le pilote supporte un style et pas l'autre.
   </para>
   <note>

--- a/reference/pdo/pdo/rollback.xml
+++ b/reference/pdo/pdo/rollback.xml
@@ -78,7 +78,7 @@ $sth = $dbh->exec("UPDATE dessert
 /* On s'aperçoit d'une erreur et on annule les modifications */
 $dbh->rollBack();
 
-/* La connexion à la base de donnés revient en mode autocommit */
+/* La connexion à la base de données revient en mode autocommit */
 ?>
 ]]>
     </programlisting>

--- a/reference/pdo/pdostatement/bindcolumn.xml
+++ b/reference/pdo/pdostatement/bindcolumn.xml
@@ -115,9 +115,9 @@
    <example>
     <title>Lie l'affichage du jeu de résultats à des variables PHP</title>
     <para>
-     Lie les colonnes du jeu de résultats aux variables PHP est une façon
-     agréable de rendre les données contenues dans chaque ligne 
-     immédiatement disponible à l'application. L'exemple suivant
+     Lier les colonnes du jeu de résultats aux variables PHP est une façon
+     agréable de rendre les données contenues dans chaque ligne
+     immédiatement disponibles à l'application. L'exemple suivant
      montre comment PDO autorise à lier et récupérer les colonnes
      avec une variété d'options.
     </para>

--- a/reference/pdo/pdostatement/bindparam.xml
+++ b/reference/pdo/pdostatement/bindparam.xml
@@ -28,7 +28,7 @@
   <para>
    La plupart des paramètres sont des paramètres d'entrées, et sont utilisés
    en lecture seule pour construire la requête (mais peuvent néanmoins être
-   transtypés en fonction de <parameter>data_type</parameter>). Quelques drivers
+   transtypés en fonction de <parameter>type</parameter>). Quelques drivers
    supportent l'invocation de procédures stockées qui retournent des données en
    tant que paramètres de sortie, et quelques autres en tant que paramètres
    entrées / sorties qui sont envoyés ensemble et sont mis à jour pour les
@@ -68,7 +68,7 @@
        Type explicite de données pour le paramètre utilisant les constantes
        <link linkend="pdo.constants"><literal>PDO::PARAM_*</literal></link>.
        Pour retourner un paramètre INOUT depuis une procédure
-       stockée, utiliser l'opérateur OR pour définir l'octet <constant>PDO::PARAM_INPUT_OUTPUT</constant>
+       stockée, utiliser l'opérateur OR pour définir les bits <constant>PDO::PARAM_INPUT_OUTPUT</constant>
        pour le paramètre <parameter>type</parameter>.
       </para>
      </listitem>

--- a/reference/pdo/pdostatement/bindvalue.xml
+++ b/reference/pdo/pdostatement/bindvalue.xml
@@ -34,9 +34,8 @@
         Identifiant du paramètre. Pour une requête préparée utilisant les
         marqueurs, cela sera un nom de paramètre de la forme
         <varname>:nom</varname>. Pour une requête préparée utilisant les
-        points d'interrogation (comme paramètre fictif), cela sera un
-        tableau indexé numériquement qui commence à la position 1 du
-        paramètre.
+        points d'interrogation (comme paramètre fictif), cela sera la
+        position du paramètre, indexée à partir de 1.
        </para>
       </listitem>
      </varlistentry>

--- a/reference/pdo/pdostatement/execute.xml
+++ b/reference/pdo/pdostatement/execute.xml
@@ -88,7 +88,7 @@ $sth = $dbh->prepare('SELECT nom, couleur, calories
     WHERE calories < :calories AND couleur LIKE :couleur');
 $sth->bindParam('calories', $calories, PDO::PARAM_INT);
 /* Les noms peuvent aussi être préfixés par des deux-points ":" (facultatif) */
-$sth->bindValue(':colour', "%$colour%");
+$sth->bindValue(':couleur', "%$couleur%");
 $sth->execute();
 ?>
 ]]>
@@ -106,7 +106,7 @@ $couleur = 'rouge';
 $sth = $dbh->prepare('SELECT nom, couleur, calories
     FROM fruit
     WHERE calories < :calories AND couleur = :couleur');
-$sth->execute(array('calories' => $calories, 'colour' => $colour));
+$sth->execute(array('calories' => $calories, 'couleur' => $couleur));
 /* Les clés du tableau peuvent aussi être préfixées par des deux-points ":" (facultatif) */
 $sth->execute(array(':calories' => $calories, ':couleur' => $couleur));
 ?>
@@ -121,7 +121,7 @@ $sth->execute(array(':calories' => $calories, ':couleur' => $couleur));
 <?php
 /* Exécute une requête préparée en passant un tableau de valeurs */
 $calories = 150;
-$colour = 'rouge';
+$couleur = 'rouge';
 $sth = $dbh->prepare('SELECT nom, couleur, calories
     FROM fruit
     WHERE calories < ? AND couleur = ?');

--- a/reference/pdo/pdostatement/fetch.xml
+++ b/reference/pdo/pdostatement/fetch.xml
@@ -188,7 +188,7 @@ print "\n";
 print "PDO::FETCH_OBJ: ";
 print "Retourne la ligne suivante en tant qu'objet anonyme ayant les noms de colonnes comme propriétés\n";
 $result = $sth->fetch(PDO::FETCH_OBJ);
-print $result->name;
+print $result->nom;
 print "\n";
 ?>
 ]]>

--- a/reference/pdo/pdostatement/fetchall.xml
+++ b/reference/pdo/pdostatement/fetchall.xml
@@ -130,11 +130,11 @@
   <para>
    L'utilisation de cette méthode pour récupérer de gros jeux de résultats
    peut entraîner une charge importante sur les ressources du système et du réseau.
-   Plutôt que de récupérer toutes les données et des manipuler avec PHP,
+   Plutôt que de récupérer toutes les données et de les manipuler avec PHP,
    utiliser le serveur de base de données pour manipuler les jeux de résultats.
-   Par exemple, utiliser les clauses <literal>WHERE</literal> et 
+   Par exemple, utiliser les clauses <literal>WHERE</literal> et
    <literal>ORDER BY</literal> dans les requêtes SQL pour restreindre les résultats
-   avant des récupérer et des traiter avec PHP.
+   avant de les récupérer et de les traiter avec PHP.
   </para>
  </refsect1>
 

--- a/reference/pdo/pdostatement/fetchcolumn.xml
+++ b/reference/pdo/pdostatement/fetchcolumn.xml
@@ -84,7 +84,7 @@ $sth->execute();
 /* Récupère la première colonne depuis la première ligne d'un jeu de résultats */
 print "Récupère la première colonne depuis la première ligne d'un jeu de résultats :\n";
 $result = $sth->fetchColumn();
-print "nom=$result\n");
+print "nom=$result\n";
 
 print "Récupère la deuxième colonne depuis la seconde ligne d'un jeu de résultats :\n";
 $result = $sth->fetchColumn(1);

--- a/reference/pdo/pdostatement/nextrowset.xml
+++ b/reference/pdo/pdostatement/nextrowset.xml
@@ -46,7 +46,7 @@
      L'exemple suivant montre comment appeler une procédure stockée,
      <literal>MULTIPLE_ROWSETS</literal>, qui retourne trois lignes de résultats.
      Une boucle <link linkend="control-structures.do.while">do-while</link>
-     est utilisé pour parcourir la méthode
+     est utilisée pour parcourir la méthode
      <methodname>PDOStatement::nextRowset</methodname>, qui retourne &false; et
      termine la boucle quand il n'y a plus de ligne de résultats disponible.
     </para>

--- a/reference/pdo/pdostatement/rowcount.xml
+++ b/reference/pdo/pdostatement/rowcount.xml
@@ -26,13 +26,13 @@
    associé est une requête de type SELECT, quelques bases de données
    retourneront le nombre de lignes retournées par cette requête. Néanmoins, 
    ce comportement n'est pas garanti pour toutes les bases de données
-   et ne devrait pas être exécuté pour des applications portables.
+   et il ne faut pas s'y fier pour des applications portables.
   </para>
   <note>
    <para>
     Cette méthode retourne toujours "0" (zéro) avec le pilote PostgreSQL,
     quand l'attribut de déclaration
-    <constant>PDO::ATTR_CURSOR</constant> est définie à
+    <constant>PDO::ATTR_CURSOR</constant> est défini à
     <constant>PDO::CURSOR_SCROLL</constant>.
    </para>
   </note>
@@ -110,7 +110,7 @@ print "Il y a " .  $count . " ligne(s) correspondante(s).";
     &example.outputs.similar;
      <screen>
 <![CDATA[
-Il y  2 ligne(s) correspondante(s).
+Il y a 2 ligne(s) correspondante(s).
 ]]>
      </screen>
     </example>

--- a/reference/pdo/transactions.xml
+++ b/reference/pdo/transactions.xml
@@ -18,7 +18,7 @@
  </para>
  <para>
   Les transactions sont typiquement implémentées pour appliquer
-  toutes les modifications en une seule fois ; ceci a le bel effet d'éprouver
+  toutes les modifications en une seule fois ; ceci a le bel effet d'améliorer
   radicalement l'efficacité des mises à jour. En d'autres termes,
   les transactions rendent les scripts plus rapides et potentiellement plus
   robustes (il faut les utiliser correctement pour jouir de ces bénéfices).
@@ -72,7 +72,7 @@
 $pdo->beginTransaction();
 $pdo->exec("INSERT INTO users (name) VALUES ('Rasmus')");
 $pdo->exec("CREATE TABLE test (id INT PRIMARY KEY)"); // Un COMMIT implicite se produit ici
-$pdo->rollBack(); // Cela NE annulera PAS l'INSERT/CREATE pour MySQL ou Oracle
+$pdo->rollBack(); // Cela N'annulera PAS l'INSERT/CREATE pour MySQL ou Oracle
 ?>
 ]]>
     </programlisting>
@@ -138,7 +138,7 @@ try {
 
 } catch (Exception $e) {
   $dbh->rollBack();
-  echo "Failed: " . $e->getMessage();
+  echo "Échec : " . $e->getMessage();
 }
 ?>
 ]]>

--- a/reference/pdo_cubrid/constants.xml
+++ b/reference/pdo_cubrid/constants.xml
@@ -157,7 +157,7 @@
       </row>
       <row xml:id="pdo.constants.cubrid-sch-sub-table">
        <entry><constant>PDO::CUBRID_SCH_SUB_TABLE</constant></entry>
-       <entry>Récupère le nom et le type de la table dont les attributs héritent.</entry>
+       <entry>Récupère le nom et le type de la table qui hérite des attributs de cette table.</entry>
       </row>
       <row xml:id="pdo.constants.cubrid-sch-constraint">
        <entry><constant>PDO::CUBRID_SCH_CONSTRAINT</constant></entry>

--- a/reference/pdo_cubrid/reference.xml
+++ b/reference/pdo_cubrid/reference.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e3654dc683c7a5b73df80549057ddbfceea00266 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 59ce48edd7eb51e3f9bc19828386ce053dd95690 Maintainer: yannick Status: ready -->
 <!-- Reviewed: no -->
 <reference xmlns="http://docbook.org/ns/docbook" xml:id="ref.pdo-cubrid"><?phpdoc extension-membership="pecl" ?>
  <title>Fonctions du pilote PDO CUBRID (PDO_CUBRID)</title>

--- a/reference/pdo_ibm/ini.xml
+++ b/reference/pdo_ibm/ini.xml
@@ -21,13 +21,13 @@
       <entry><link linkend="ini.pdo-ibm.i5-dbcs-alloc">pdo_ibm.i5_dbcs_alloc</link></entry>
       <entry>"0"</entry>
       <entry><constant>INI_SYSTEM</constant></entry>
-      <entry>Ajouter dans PDO_IBM 1.5.0</entry>
+      <entry>Ajouté dans PDO_IBM 1.5.0</entry>
      </row>
      <row>
       <entry><link linkend="ini.pdo-ibm.i5-override-ccsid">pdo_ibm.i5_override_ccsid</link></entry>
       <entry>"0"</entry>
       <entry><constant>INI_SYSTEM</constant></entry>
-      <entry>Ajouter dans PDO_IBM 1.5.0</entry>
+      <entry>Ajouté dans PDO_IBM 1.5.0</entry>
      </row>
     </tbody>
    </tgroup>

--- a/reference/pdo_ibm/reference.xml
+++ b/reference/pdo_ibm/reference.xml
@@ -146,7 +146,7 @@ Servicename=56789
      <title>Exemple avec PDO_IBM DSN en utilisant une chaîne complète de connexion</title>
      <para>
       L'exemple suivant montre l'utilisation de PDO_IBM DSN pour la connexion à une
-      base de données DB2 nommé <userinput>testdb</userinput> en utilisant
+      base de données DB2 nommée <userinput>testdb</userinput> en utilisant
       la chaîne complète de connexion DB2 CLI :
       <programlisting>
 <![CDATA[

--- a/reference/pdo_informix/configure.xml
+++ b/reference/pdo_informix/configure.xml
@@ -15,7 +15,7 @@
   PDO_INFORMIX est une extension &link.pecl;, alors
   suivez les instructions dans <xref linkend='install.pecl' /> pour installer
   l'extension PDO_INFORMIX. Écrivez la commande <command>configure</command>
-  pour pointer au chemin du fichiers d'en-têtes SDK Client Informix ainsi
+  pour pointer au chemin des fichiers d'en-têtes SDK Client Informix ainsi
   que les bibliothèques comme suit :
   <screen>
 <![CDATA[

--- a/reference/pdo_informix/reference.xml
+++ b/reference/pdo_informix/reference.xml
@@ -65,7 +65,7 @@
         <para>
          Le DSN peut soit être une source de données de configuration en
          utilisant <filename>odbc.ini</filename> ou une <link
-         xlink:href="&url.informix.connectionstring;">chaînes de caractères de
+         xlink:href="&url.informix.connectionstring;">chaîne de caractères de
          connexion</link> complète.
         </para>
        </listitem>

--- a/reference/pdo_mysql/configure.xml
+++ b/reference/pdo_mysql/configure.xml
@@ -23,10 +23,10 @@
  </para>
 
  <para>
-  Lors de la compilation utilise <option role="configure">--with-pdo-mysql[=DIR]</option>
+  Lors de la compilation, utiliser <option role="configure">--with-pdo-mysql[=DIR]</option>
   pour installer l'extension PDO MySQL, où <literal>[=DIR]</literal> est le chemin
   de la bibliothèque de base de MySQL.
-  <link linkend="book.mysqlnd">Mysqlnd</link> et la bibliothèque par défaut.
+  <link linkend="book.mysqlnd">Mysqlnd</link> est la bibliothèque par défaut.
   Pour plus de détails à propos du choix de la bibliothèque, voir
   <link linkend="mysqlinfo.library.choosing">Choisir une bibliothèque MySQL</link>.
  </para>

--- a/reference/pdo_oci/reference.xml
+++ b/reference/pdo_oci/reference.xml
@@ -38,9 +38,9 @@
        <term><literal>dbname</literal> (Oracle Instant Client)</term>
        <listitem>
         <para>
-         Le URI de la connexion Oracle Instant Client prend la forme de
+         L'URI de la connexion Oracle Instant Client prend la forme de
          <code>dbname=//<varname>hostname</varname>:<varname>port-number</varname>/<varname>database</varname></code>.
-         Si l'on l'on se connecte sur une base de données définies dans
+         Si l'on se connecte sur une base de données définie dans
          <filename>tnsnames.ora</filename>, utiliser seulement le nom de la
          base de données :
          <code>dbname=<varname>database</varname></code>.

--- a/reference/pdo_odbc/configure.xml
+++ b/reference/pdo_odbc/configure.xml
@@ -28,8 +28,8 @@
         en-têtes de développement de l'application DB2 sont une option
         d'installation dans les serveurs DB2 et sont aussi disponibles
         en tant que <literal>DB2 Application Development Client</literal> gratuitement
-        disponibles pour téléchargement à partir du 
-        <link xlink:href="&url.ibm.db2.client;">site</link>.
+        disponibles pour téléchargement à partir du
+        <link xlink:href="&url.ibm.db2.client;">site</link>
         <literal>IBM developerWorks</literal>.
        </para>
        <para>

--- a/reference/pdo_odbc/ini.xml
+++ b/reference/pdo_odbc/ini.xml
@@ -61,10 +61,10 @@
      exemple) des serveurs virtuels.
     </para>
     <para>
-     Cette configuration peut seulement être changé à partir du fichier
+     Cette configuration peut seulement être changée à partir du fichier
      &php.ini; et affecte le processus entier; n'importe quels autres modules
-     chargé dans le processus qui utilisent les bibliothèques ODBC sera aussi
-     affecté, en incluant l'<link linkend="ref.uodbc">extension unifié
+     chargés dans le processus qui utilisent les bibliothèques ODBC seront aussi
+     affectés, en incluant l'<link linkend="ref.uodbc">extension unifiée
      ODBC</link>.
     </para>
     <warning>

--- a/reference/pdo_odbc/reference.xml
+++ b/reference/pdo_odbc/reference.xml
@@ -162,7 +162,7 @@
       <title>Exemple avec PDO_ODBC DSN (pilote ODBC Manager)</title>
       <para>
        L'exemple suivant montre PDO_ODBC DSN pour se connecter à une base
-       de données ODBC catalogué comme étant testdb dans le pilote ODBC
+       de données ODBC cataloguée comme étant testdb dans le pilote ODBC
        Manager :
       </para>
       <programlisting><![CDATA[

--- a/reference/pdo_pgsql/pdo-pgsql.xml
+++ b/reference/pdo_pgsql/pdo-pgsql.xml
@@ -140,7 +140,7 @@
      <term><constant>Pdo\Pgsql::ATTR_DISABLE_PREPARES</constant></term>
      <listitem>
       <simpara>
-       Envoie la requête et les paramètres au serveur en une seule fois ,
+       Envoie la requête et les paramètres au serveur en une seule fois,
        évitant le besoin de créer une instruction préparée nommée séparément.
        Si la requête va être exécutée une seule fois, cela peut réduire la latence
        en évitant un aller-retour inutile au serveur.

--- a/reference/pdo_pgsql/pdo/pgsql/copyfromarray.xml
+++ b/reference/pdo_pgsql/pdo/pgsql/copyfromarray.xml
@@ -18,7 +18,7 @@
    <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>fields</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
   <simpara>
-   Copie des données du <parameter>rows</parameter> tableau dans la table
+   Copie des données du tableau <parameter>rows</parameter> dans la table
    <parameter>tableName</parameter> en utilisant <parameter>separator</parameter>
    comme délimiteur de champs et la liste <parameter>fields</parameter>.
   </simpara>
@@ -49,7 +49,7 @@
     <listitem>
      <simpara>
       Un délimiteur utilisé pour séparer les champs dans une entrée du
-      dans le <parameter>rows</parameter> tableau.
+      tableau <parameter>rows</parameter>.
      </simpara>
     </listitem>
    </varlistentry>

--- a/reference/pdo_sqlsrv/constants.xml
+++ b/reference/pdo_sqlsrv/constants.xml
@@ -27,7 +27,7 @@
    <listitem>
     <simpara>
      Cette constante est une valeur possible pour la clé "TransactionIsolation" du DSN pour SQLSRV.
-     Cette constante positionne le niveau d'isolation de la transaction à "Read Uncommitted".
+     Cette constante positionne le niveau d'isolation de la transaction à "Read Committed".
     </simpara>
    </listitem>
   </varlistentry>

--- a/reference/pdo_sqlsrv/reference.xml
+++ b/reference/pdo_sqlsrv/reference.xml
@@ -68,8 +68,8 @@
       <term><literal>Encrypt</literal></term>
       <listitem>
        <simpara>
-        Spécifie si la communication avec le server SQL Server est encryptée
-        (1 ou &true;) ou non-encryptée (0 ou &false;).
+        Spécifie si la communication avec le serveur SQL Server est chiffrée
+        (1 ou &true;) ou non chiffrée (0 ou &false;).
        </simpara>
       </listitem>
      </varlistentry>
@@ -77,7 +77,7 @@
       <term><literal>Failover_Partner</literal></term>
       <listitem>
        <simpara>
-        Sépcifie le serveur et l'instance de la base de données miroir (si elle
+        Spécifie le serveur et l'instance de la base de données miroir (si elle
         est activée et configurée) à utiliser quand le serveur principal est
         inaccessible.
        </simpara>
@@ -96,7 +96,7 @@
       <term><literal>MultipleActiveResultSets</literal></term>
       <listitem>
        <simpara>
-        Désactive, ou active explictement, le support pour des jeux de résultats
+        Désactive, ou active explicitement, le support pour des jeux de résultats
         multiples (Multiple Active Result Sets, MARS).
        </simpara>
       </listitem>
@@ -139,7 +139,7 @@
       <term><literal>TransactionIsolation</literal></term>
       <listitem>
        <simpara>
-        Spécifie le niveau d'icolation de la transaction. les valeurs possibles
+        Spécifie le niveau d'isolation de la transaction. Les valeurs possibles
         pour cette option sont
         PDO::SQLSRV_TXN_READ_UNCOMMITTED, PDO::SQLSRV_TXN_READ_COMMITTED,
         PDO::SQLSRV_TXN_REPEATABLE_READ, PDO::SQLSRV_TXN_SNAPSHOT, et

--- a/reference/pgsql/functions/pg-cancel-query.xml
+++ b/reference/pgsql/functions/pg-cancel-query.xml
@@ -82,7 +82,7 @@
   echo "$res1 a $rows1 enregistrements\n\n";
   
   // Annule la requête en cours de fonctionnement. Ce sera la deuxième requête
-  // elle fonctionne encore.
+  // si elle fonctionne encore.
   pg_cancel_query($dbconn);
 ?>
 ]]>

--- a/reference/pgsql/functions/pg-client-encoding.xml
+++ b/reference/pgsql/functions/pg-client-encoding.xml
@@ -88,7 +88,7 @@
     <programlisting role="php">
 <![CDATA[
 <?php
-// Assume $conn étant une connexion à une base de données ISO-8859-1
+// On suppose que $conn est une connexion à une base de données ISO-8859-1
 $encoding = pg_client_encoding($conn);
 
 echo "L'encodage du client est : ", $encoding, "\n";

--- a/reference/pgsql/functions/pg-close.xml
+++ b/reference/pgsql/functions/pg-close.xml
@@ -27,7 +27,7 @@
    </para>
   </note>
   <para>
-   Si des instances de <classname>PgSql\Lob</classname> qui ont été ouvertes
+   S'il y a des instances de <classname>PgSql\Lob</classname> ouvertes
    avec cette connexion, ne fermez pas la connexion avant d'avoir fermé toutes
    les instances de <classname>PgSql\Lob</classname>.
   </para>

--- a/reference/pgsql/functions/pg-connect-poll.xml
+++ b/reference/pgsql/functions/pg-connect-poll.xml
@@ -5,7 +5,7 @@
  <refnamediv>
   <refname>pg_connect_poll</refname>
   <refpurpose>
-   Test le statut d'une tentative de connexion asynchrone PostgreSQL en cours
+   Teste le statut d'une tentative de connexion asynchrone PostgreSQL en cours
   </refpurpose>
  </refnamediv>
 

--- a/reference/pgsql/functions/pg-consume-input.xml
+++ b/reference/pgsql/functions/pg-consume-input.xml
@@ -35,8 +35,8 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   &true; en cas de succès, ou &false; si une erreur survient. Notez
-   que &true; n'indique pas forcément que l'entrée est en attente
+   &true; en cas de succès, ou &false; si une erreur survient. Il est
+   à noter que &true; n'indique pas forcément que l'entrée est en attente
    d'être lue.
   </para>
  </refsect1>

--- a/reference/pgsql/functions/pg-copy-to.xml
+++ b/reference/pgsql/functions/pg-copy-to.xml
@@ -19,10 +19,10 @@
    <methodparam choice="opt"><type>string</type><parameter>null_as</parameter><initializer>"\\\\N"</initializer></methodparam>
   </methodsynopsis>
   <para>
-   <function>pg_copy_to</function> copie la table 
+   <function>pg_copy_to</function> copie la table
    <parameter>table_name</parameter> dans un tableau.
    Cette fonction utilise la commande interne
-   SQL <literal>COPY TO</literal> pour insérer les tableaux.
+   SQL <literal>COPY TO</literal> pour récupérer les enregistrements.
   </para>
  </refsect1>
 
@@ -40,13 +40,13 @@
      <term><parameter>table_name</parameter></term>
      <listitem>
       <para>
-       Nom de la table à partir de laquelle les données dans
-       <parameter>rows</parameter> seront copiées.
+       Nom de la table depuis laquelle les données seront copiées dans
+       <parameter>rows</parameter>.
       </para>
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>delimiter</parameter></term>
+     <term><parameter>separator</parameter></term>
      <listitem>
       <para>
        Le marqueur qui sépare les valeurs pour chaque champ dans chaque

--- a/reference/pgsql/functions/pg-delete.xml
+++ b/reference/pgsql/functions/pg-delete.xml
@@ -127,8 +127,8 @@
 <?php 
  $db = pg_connect ('dbname=foo');
  // Ceci est sûr quelque peu, car toutes les valeurs sont échappées
- // Cependant PostgreSQL supporte les JSON/Tableaux. Ceci ne sont pas
- // sûr ni par échappement ni par les requêtes préparés.
+ // Cependant PostgreSQL supporte les JSON/Tableaux. Ceux-ci ne sont pas
+ // sûrs ni par échappement ni par les requêtes préparées.
  $res = pg_delete($db, 'post_log', $_POST, PG_DML_ESCAPE);
  if ($res) {
      echo "Les données POSTées ont été effacées : $res\n";

--- a/reference/pgsql/functions/pg-execute.xml
+++ b/reference/pgsql/functions/pg-execute.xml
@@ -5,7 +5,7 @@
  <refnamediv>
   <refname>pg_execute</refname>
   <refpurpose>
-   Exécute une requête préparée PostGreSQL
+   Exécute une requête préparée PostgreSQL
   </refpurpose>
  </refnamediv>
 

--- a/reference/pgsql/functions/pg-fetch-array.xml
+++ b/reference/pgsql/functions/pg-fetch-array.xml
@@ -127,7 +127,7 @@ echo $arr[1] . " <- Ligne 1 E-mail\n";
 
 // Le paramètre row est optionnel ; NULL peut être passé à la place,
 // pour passer un mode. Les appels successifs à pg_fetch_array
-// retournera la ligne suivante.
+// retourneront la ligne suivante.
 $arr = pg_fetch_array($result, NULL, PGSQL_ASSOC);
 echo $arr["auteur"] . " <- Ligne 2 Auteur\n";
 echo $arr["email"] . " <- Ligne 2 E-mail\n";

--- a/reference/pgsql/functions/pg-fetch-assoc.xml
+++ b/reference/pgsql/functions/pg-fetch-assoc.xml
@@ -22,7 +22,7 @@
   </para>
   <para>
    <function>pg_fetch_assoc</function> est équivalent d'appeler
-   <function>pg_fetch_row</function> avec <constant>PGSQL_ASSOC</constant>
+   <function>pg_fetch_array</function> avec <constant>PGSQL_ASSOC</constant>
    comme troisième paramètre (qui est optionnel). Cela retournera seulement un
    tableau associatif. En cas de besoin d'indices numériques, utiliser
    <function>pg_fetch_row</function>.

--- a/reference/pgsql/functions/pg-fetch-result.xml
+++ b/reference/pgsql/functions/pg-fetch-result.xml
@@ -27,7 +27,7 @@
   </para>
   <note>
    <para>
-    Cette fonction peut s'appeler <function>pg_result</function>.
+    Cette fonction s'appelait auparavant <function>pg_result</function>.
    </para>
   </note>
  </refsect1>

--- a/reference/pgsql/functions/pg-field-is-null.xml
+++ b/reference/pgsql/functions/pg-field-is-null.xml
@@ -49,7 +49,7 @@
      <listitem>
       <para>
        Numéro de la ligne à récupérer. Les lignes sont numérotées de 0 en
-       montant. Si l'argument est omis, la ligne suivante est récupérée.
+       montant. Si l'argument est omis, la ligne courante est récupérée.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/pgsql/functions/pg-field-name.xml
+++ b/reference/pgsql/functions/pg-field-name.xml
@@ -109,7 +109,7 @@ Type de champ : varchar
 
 colonne 1
 Champ : annee
-Taille affichée : 4 caractère
+Taille affichée : 4 caractères
 Taille de stockage : 2 octets
 Type de champ : int2 
 

--- a/reference/pgsql/functions/pg-field-num.xml
+++ b/reference/pgsql/functions/pg-field-num.xml
@@ -43,7 +43,7 @@
       <listitem>
        <para>
         Le nom du champ.
-        Le nom donné est traité comme un identifiant dans une commande SQL, c'est-à-dire qu'il est mis en minuscule sauf s'il est cité deux fois.
+        Le nom donné est traité comme un identifiant dans une commande SQL, c'est-à-dire qu'il est mis en minuscule sauf s'il est entre guillemets doubles.
        </para>
      </listitem>
     </varlistentry>

--- a/reference/pgsql/functions/pg-get-notify.xml
+++ b/reference/pgsql/functions/pg-get-notify.xml
@@ -83,7 +83,7 @@ if (!$conn) {
   exit;
 }
 
-// ecoute le message 'author_updated' des autres processus
+// écoute le message 'author_updated' des autres processus
 pg_query($conn, 'LISTEN author_updated;');
 $notify = pg_get_notify($conn);
 if (!$notify) {

--- a/reference/pgsql/functions/pg-insert.xml
+++ b/reference/pgsql/functions/pg-insert.xml
@@ -153,10 +153,10 @@
     <programlisting role="php">
 <![CDATA[
 <?php 
-  $db = pg_connect ('dbname=foo');
+  $dbconn = pg_connect ('dbname=foo');
   // Ceci est sûr quelque peu, car toutes les valeurs sont échappées
-  // Cependant PostgreSQL supporte les JSON/Tableaux. Ceci ne sont pas
-  // sûr ni par échappement ni par les requêtes préparés.
+  // Cependant PostgreSQL supporte les JSON/Tableaux. Ceux-ci ne sont pas
+  // sûrs ni par échappement ni par les requêtes préparées.
   $res = pg_insert($dbconn, 'post_log', $_POST, PGSQL_DML_ESCAPE);
   if ($res) {
       echo "Les données POSTées ont pu être enregistrées avec succès.\n";

--- a/reference/pgsql/functions/pg-last-oid.xml
+++ b/reference/pgsql/functions/pg-last-oid.xml
@@ -94,13 +94,13 @@
     <programlisting role="php">
 <![CDATA[
 <?php
-  // Connect to the database
+  // Connexion à la base de données
   pg_connect("dbname=mark host=localhost");
 
-  // Create a sample table
+  // Création d'une table exemple
   pg_query("CREATE TABLE test (a INTEGER) WITH OIDS");
 
-  // Insert some data into it
+  // Insertion de quelques données
   $res = pg_query("INSERT INTO test VALUES (1)");
 
   $oid = pg_last_oid($res);

--- a/reference/pgsql/functions/pg-lo-create.xml
+++ b/reference/pgsql/functions/pg-lo-create.xml
@@ -32,7 +32,7 @@
    nécessaire de le faire dans une transaction.
   </para>
   <para>
-   Au lieu d'utiliser l'interface d'objet de grande taille ((qui n'a aucun contrôle
+   Au lieu d'utiliser l'interface d'objet de grande taille (qui n'a aucun contrôle
    d'accès et qui est encombrant à utiliser), essayez la colonne de type
    <varname>bytea</varname> de PostgreSQL et
    <function>pg_escape_bytea</function>.

--- a/reference/pgsql/functions/pg-lo-open.xml
+++ b/reference/pgsql/functions/pg-lo-open.xml
@@ -24,7 +24,7 @@
   </para>
   <warning>
    <para>
-    Ne fermer pas la connexion à la base de données avant de fermer l'instance <classname>PgSql\Lob</classname>.
+    Ne pas fermer la connexion à la base de données avant de fermer l'instance <classname>PgSql\Lob</classname>.
    </para>
   </warning>
   <para>

--- a/reference/pgsql/functions/pg-lo-seek.xml
+++ b/reference/pgsql/functions/pg-lo-seek.xml
@@ -100,7 +100,7 @@
    $handle = pg_lo_open($database, $doc_oid, "r");
    // Saute les 50000 premiers octets
    pg_lo_seek($handle, 50000, PGSQL_SEEK_SET);
-   // Lit les prochains 10000 octetss
+   // Lit les prochains 10000 octets
    $data = pg_lo_read($handle, 10000);
    pg_query($database, "commit");
    echo $data;

--- a/reference/pgsql/functions/pg-lo-tell.xml
+++ b/reference/pgsql/functions/pg-lo-tell.xml
@@ -17,7 +17,7 @@
   </methodsynopsis>
   <para>
    <function>pg_lo_tell</function> retourne la position courante (à partir du
-   début) du pointeur de lecture sur l'objet de grande taille <parameter>large_object</parameter>.
+   début) du pointeur de lecture sur l'objet de grande taille <parameter>lob</parameter>.
   </para>
   <para>
    Pour utiliser une interface avec un objet de grande taille, il est

--- a/reference/pgsql/functions/pg-lo-truncate.xml
+++ b/reference/pgsql/functions/pg-lo-truncate.xml
@@ -20,7 +20,7 @@
   </para>
   <para>
    Pour utiliser l'interface des objets larges, il est nécessaire de
-   l'enfermer dans un verrou de transaction.
+   l'enfermer dans un bloc de transaction.
   </para>
  </refsect1>
 

--- a/reference/pgsql/functions/pg-lo-write.xml
+++ b/reference/pgsql/functions/pg-lo-write.xml
@@ -89,7 +89,7 @@
      <row>
       <entry>8.0.0</entry>
       <entry>
-       <parameter>connection</parameter> est désormais nullable.
+       <parameter>length</parameter> est désormais nullable.
       </entry>
      </row>
     </tbody>

--- a/reference/pgsql/functions/pg-pconnect.xml
+++ b/reference/pgsql/functions/pg-pconnect.xml
@@ -141,7 +141,7 @@ $dbconn2 = pg_pconnect("host=localhost port=5432 dbname=marie");
 
 // connexion à une base de données nommée "marie" sur l'hôte "mouton" avec un
 // nom d'utilisateur et un mot de passe
-$dk
+$dbconn3 = pg_pconnect("host=mouton port=5432 dbname=marie user=agneau password=foo");
 
 // connexion à une base de données nommée "test" sur l'hôte "mouton" avec un
 // nom d'utilisateur et un mot de passe

--- a/reference/pgsql/functions/pg-result-seek.xml
+++ b/reference/pgsql/functions/pg-result-seek.xml
@@ -15,9 +15,8 @@
    <methodparam><type>int</type><parameter>row</parameter></methodparam>
   </methodsynopsis>
   <para>
-   <function>pg_result_seek</function> choisit la ligne 
-   <parameter>offset</parameter> comme ligne courante dans le
-   résultat <parameter>result</parameter>.
+   <function>pg_result_seek</function> définit la position interne de la
+   ligne dans le résultat <parameter>result</parameter>.
   </para>
  </refsect1>
 

--- a/reference/pgsql/functions/pg-select.xml
+++ b/reference/pgsql/functions/pg-select.xml
@@ -29,7 +29,7 @@
   <para>
    Si <parameter>flags</parameter> est spécifié,
    <function>pg_convert</function> est appliqué à
-   <parameter>values</parameter> avec les drapeaux fournis.
+   <parameter>conditions</parameter> avec les drapeaux fournis.
   </para>
   <para>
    Si le paramètre <parameter>mode</parameter> est défini,
@@ -39,10 +39,10 @@
    ou les deux avec <constant>PGSQL_BOTH</constant>.
   </para>
   <para>
-   Par défaut <function>pg_delete</function> passe des valeurs brutes. Les valeurs
+   Par défaut <function>pg_select</function> passe des valeurs brutes. Les valeurs
    doivent être échappées ou l'option PGSQL_DML_ESCAPE doit être fournie.
    PGSQL_DML_ESCAPE met des guillemets et échappe les paramètres/identifiants.
-   Par conséquent, les noms de table/colonnes doivent être sensibles à la casse.
+   Par conséquent, les noms de table/colonnes deviennent sensibles à la casse.
   </para>
   <para>
    Il est à noter que ni l'échappement ni les requêtes préparées peuvent protéger des
@@ -163,8 +163,8 @@
 <?php 
   $db = pg_connect ('dbname=foo');
   // Ceci est sûr quelque peu, car toutes les valeurs sont échappées
-  // Cependant PostgreSQL supporte les JSON/Tableaux. Ceci ne sont pas
-  // sûr ni par échappement ni par les requêtes préparés.
+  // Cependant PostgreSQL supporte les JSON/Tableaux. Ceux-ci ne sont pas
+  // sûrs ni par échappement ni par les requêtes préparées.
   $rec = pg_select($db, 'post_log', $_POST, PG_DML_ESCAPE);
   if ($rec) {
     echo "Lignes lues\n";

--- a/reference/pgsql/functions/pg-set-chunked-rows-size.xml
+++ b/reference/pgsql/functions/pg-set-chunked-rows-size.xml
@@ -78,7 +78,7 @@ pg_set_chunked_rows_size($conn, 1);
 $result = pg_get_result($conn);
 var_dump(pg_num_rows($result));
 
-:: Pas d'effet après que le résultat soit récupéré
+// Pas d'effet après que le résultat soit récupéré
 var_dump(pg_set_chunked_rows_size($conn, 10));
 ]]>
    </programlisting>

--- a/reference/pgsql/functions/pg-set-error-verbosity.xml
+++ b/reference/pgsql/functions/pg-set-error-verbosity.xml
@@ -25,12 +25,12 @@
    <function>pg_set_error_verbosity</function> fixe le degré d'erreur et
    retourne le paramètre précédent de la connexion. Avec le mode
    <constant>PGSQL_ERRORS_TERSE</constant>, les messages retournés incluent la
-   sévérité, le texte primaire et la position seulement; normalement, cela va
+   sévérité, le texte primaire et la position seulement ; normalement, cela va
    entrer sur une seule ligne. Le mode par défaut
    (<constant>PGSQL_ERRORS_DEFAULT</constant>) produit des messages qui incluent
    les messages ci-dessus et des détails, des astuces ou les champs en
    contexte (ces messages peuvent être étendus sur plusieurs lignes). Le mode
-   <constant>PGSQL_ERRORS_VERBOSE</constant> tous les champs disponibles. Le
+   <constant>PGSQL_ERRORS_VERBOSE</constant> inclut tous les champs disponibles. Le
    changement du degré des messages n'affecte pas les messages disponibles qui
    proviennent des résultats déjà existants, mais seulement les messages des
    résultats créés par la suite.

--- a/reference/pgsql/functions/pg-trace.xml
+++ b/reference/pgsql/functions/pg-trace.xml
@@ -25,7 +25,7 @@
    de communication interne à PostgreSQL.
   </para>
   <para>   
-   Pour ceux qui le ne sont pas, elles peuvent être utiles pour suivre les
+   Pour ceux qui ne le sont pas, elles peuvent être utiles pour suivre les
    requêtes et les erreurs : avec la commande
    <command>grep '^To backend' trace.log</command>, il sera possible de voir les
    requêtes réellement envoyées au serveur PostgreSQL. Pour plus

--- a/reference/pgsql/functions/pg-tty.xml
+++ b/reference/pgsql/functions/pg-tty.xml
@@ -21,7 +21,7 @@
   </para>
   <note>
    <para>
-    <function>pg_tty</function> est obsolète, depuis le serveur ne fait plus
+    <function>pg_tty</function> est obsolète, puisque le serveur ne fait plus
     attention à la configuration TTY, mais demeure pour des raisons de
     compatibilité.
    </para>

--- a/reference/pgsql/functions/pg-unescape-bytea.xml
+++ b/reference/pgsql/functions/pg-unescape-bytea.xml
@@ -17,7 +17,7 @@
   </methodsynopsis>
   <para>
    <function>pg_unescape_bytea</function> supprime la protection des
-   caractères de type bytea. Elle retourne la &string; protégée, pouvant
+   caractères de type bytea. Elle retourne la &string; déprotégée, pouvant
    contenir des données binaires.
   </para>
   <note>
@@ -50,7 +50,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Une &string; contenant les données protégées.
+   Une &string; contenant les données déprotégées.
   </para>
  </refsect1>
 

--- a/reference/pgsql/functions/pg-update.xml
+++ b/reference/pgsql/functions/pg-update.xml
@@ -141,8 +141,8 @@
   $data = array('field1'=>'AA', 'field2'=>'BB');
   
   // Ceci est sûr quelque peu, car toutes les valeurs sont échappées
-  // Cependant PostgreSQL supporte les JSON/Tableaux. Ceci ne sont pas
-  // sûr ni par échappement ni par les requêtes préparés.
+  // Cependant PostgreSQL supporte les JSON/Tableaux. Ceux-ci ne sont pas
+  // sûrs ni par échappement ni par les requêtes préparées.
   $res = pg_update($db, 'post_log', $_POST, $data);
   if ($res) {
       echo "Les données ont été modifiées : $res\n";

--- a/reference/pgsql/ini.xml
+++ b/reference/pgsql/ini.xml
@@ -85,7 +85,7 @@
     </term>
     <listitem>
      <para>
-      Le nombre maximum de connexions persistantes Postgre par
+      Le nombre maximum de connexions persistantes Postgres par
       processus.
      </para>
     </listitem>
@@ -98,7 +98,7 @@
     </term>
     <listitem>
      <para>
-      Le nombre maximum de connexions Postgre par
+      Le nombre maximum de connexions Postgres par
       processus, y compris les connexions persistantes.
      </para>
     </listitem>

--- a/reference/pgsql/reference.xml
+++ b/reference/pgsql/reference.xml
@@ -14,7 +14,7 @@
      Les fonctions ne sont pas toutes supportées par toutes les versions.
      Cela dépend de la version de libpq (la bibliothèque cliente de
      PostgreSQL C) et comment libpq est compilée. Si les extensions PHP
-     PostGreSQL sont manquantes, alors c'est parce que la version de
+     PostgreSQL sont manquantes, alors c'est parce que la version de
      libpq ne les supporte pas.
     </para>
    </note>

--- a/reference/pgsql/setup.xml
+++ b/reference/pgsql/setup.xml
@@ -34,7 +34,7 @@
   &reftitle.resources;
   <para>
    Antérieur à PHP 8.1.0, il y avait deux types de ressources utilisés dans le module PostgreSQL.
-   La première est l'identifiant pour la connexion à la base de données
+   Le premier est l'identifiant pour la connexion à la base de données
    et le second est une ressource qui contient le résultat d'une requête.
   </para>
  </section>

--- a/reference/phar/Phar/addFile.xml
+++ b/reference/phar/Phar/addFile.xml
@@ -20,7 +20,7 @@
    le second paramètre optionnel <parameter>localName</parameter> est une &string;,
    le fichier sera stocké dans l'archive de ce nom, sinon le paramètre
    <parameter>filename</parameter> est utilisé comme chemin vers lequel stocker l'archive.
-   Les URL doivent être locales, sans quoi une exception est levée.
+   Les URL doivent avoir un nom local, sans quoi une exception est levée.
    Cette méthode est identique à <function>ZipArchive::addFile</function>.
   </para>
   

--- a/reference/phar/Phar/apiVersion.xml
+++ b/reference/phar/Phar/apiVersion.xml
@@ -37,7 +37,7 @@
   &reftitle.examples;
   <para>
    <example>
-    <title>Un exemple avec<function>Phar::apiVersion</function></title>
+    <title>Un exemple avec <function>Phar::apiVersion</function></title>
     <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/phar/Phar/buildFromDirectory.xml
+++ b/reference/phar/Phar/buildFromDirectory.xml
@@ -94,7 +94,7 @@
  <refsect1 role="examples">
   &reftitle.examples;
   <example>
-   <title>Un exemple avec<function>Phar::buildFromDirectory</function></title>
+   <title>Un exemple avec <function>Phar::buildFromDirectory</function></title>
   <para>
    
   </para>

--- a/reference/phar/Phar/buildFromIterator.xml
+++ b/reference/phar/Phar/buildFromIterator.xml
@@ -68,7 +68,7 @@
   <para>
    Cette méthode émet une exception <classname>UnexpectedValueException</classname>
    quand l'itérateur retourne des valeurs fausses, telles qu'une clé
-   entière à la place d'une chaîne; une exception
+   entière à la place d'une chaîne ; une exception
    <classname>BadMethodCallException</classname> quand un itérateur
    basé sur <classname>SplFileInfo</classname> est passé sans paramètre
    <parameter>baseDirectory</parameter>, ou une exception
@@ -155,7 +155,7 @@ $phar->setStub($phar->createDefaultStub('cli/index.php', 'www/index.php'));
   <para>
    Le fichier projet.phar peut alors être utilisé immédiatement. 
    <function>Phar::buildFromIterator</function> ne règle pas les 
-   paramètres tels que la compression ou les métadonnées; ceci 
+   paramètres tels que la compression ou les métadonnées ; ceci
    peut cependant être fait après avoir créé l'archive phar.
   </para>
   <para>

--- a/reference/phar/Phar/canCompress.xml
+++ b/reference/phar/Phar/canCompress.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="phar.cancompress" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>Phar::canCompress</refname>
-  <refpurpose>Détermine si l'extension phar supporte la compression en utilisant soit zip soit bzip2</refpurpose>
+  <refpurpose>Détermine si l'extension phar supporte la compression en utilisant soit zlib soit bzip2</refpurpose>
  </refnamediv>
  <refsect1 role="description">
   &reftitle.description;

--- a/reference/phar/Phar/compress.xml
+++ b/reference/phar/Phar/compress.xml
@@ -29,7 +29,7 @@
    <link linkend="ini.phar.readonly">phar.readonly</link> doit être à off pour fonctionner.
   </para>
   <para>
-   En plus, cette méthode renomme automatiquement l'archive, en suffisant son nom par <literal>.gz</literal>,
+   En plus, cette méthode renomme automatiquement l'archive, en ajoutant à son nom <literal>.gz</literal>,
    <literal>.bz2</literal> ou en enlevant l'extension si <literal>Phar::NONE</literal> est passée pour supprimer
    la compression. Sinon, une extension de fichier peut aussi être spécifiée en utilisant le second
    paramètre.

--- a/reference/phar/Phar/compressFiles.xml
+++ b/reference/phar/Phar/compressFiles.xml
@@ -99,19 +99,19 @@ foreach ($p as $file) {
     &example.outputs;
     <screen>
 <![CDATA[
-string(10) "monfichier.txt"
+string(14) "monfichier.txt"
 bool(false)
 bool(false)
 bool(false)
-string(11) "monfichier2.txt"
+string(15) "monfichier2.txt"
 bool(false)
 bool(false)
 bool(false)
-string(10) "monfichier.txt"
+string(14) "monfichier.txt"
 int(4096)
 bool(false)
 bool(true)
-string(11) "monfichier2.txt"
+string(15) "monfichier2.txt"
 int(4096)
 bool(false)
 bool(true)

--- a/reference/phar/Phar/construct.xml
+++ b/reference/phar/Phar/construct.xml
@@ -69,7 +69,7 @@
 <![CDATA[
 <?php
 try {
-    $p = new Phar('/path/to/my.phar', FilesystemIterator::CURRENT_AS_FILEINFO | FilesystemIterator::KEY_AS_FILENAME,
+    $p = new Phar('/chemin/vers/mon.phar', FilesystemIterator::CURRENT_AS_FILEINFO | FilesystemIterator::KEY_AS_FILENAME,
                   'mon.phar');
 } catch (UnexpectedValueException $e) {
     die('Ne peut pas ouvrir mon.phar');

--- a/reference/phar/Phar/count.xml
+++ b/reference/phar/Phar/count.xml
@@ -55,7 +55,7 @@
 // on s'assure que le phar n'existe pas
 @unlink('lenouveauphar.phar');
 try {
-    $p = new Phar(dirname(__FILE__) . '/lenouveauphar.phar', 0, 'le nouveauphar.phar');
+    $p = new Phar(dirname(__FILE__) . '/lenouveauphar.phar', 0, 'lenouveauphar.phar');
 } catch (Exception $e) {
     echo 'Ne peut pas créer le phar:', $e;
 }

--- a/reference/phar/Phar/decompress.xml
+++ b/reference/phar/Phar/decompress.xml
@@ -30,7 +30,7 @@
   <para>
    De plus, cette méthode change automatiquement l'extension de l'archive,
    <literal>.phar</literal>
-   Par défaut pour les archives phar, ou <literal>.phar.tar</literal> pour les archives phar basées sur tar.
+   par défaut pour les archives phar, ou <literal>.phar.tar</literal> pour les archives phar basées sur tar.
    Sinon, une extension de fichier peut aussi être spécifiée en utilisant le second
    paramètre.
   </para>
@@ -108,7 +108,7 @@
 <?php
 $p = new Phar('/chemin/vers/mon.phar', 0, 'mon.phar.gz');
 $p['monfichier.txt'] = 'salut';
-$p['monfichier.txt'] = 'salut';
+$p['monfichier2.txt'] = 'salut';
 $p3 = $p2->decompress(); // crée /chemin/vers/mon.phar
 ?>
 ]]>

--- a/reference/phar/Phar/decompressFiles.xml
+++ b/reference/phar/Phar/decompressFiles.xml
@@ -87,19 +87,19 @@ foreach ($p as $file) {
     &example.outputs;
     <screen>
 <![CDATA[
-string(10) "monfichier.txt"
+string(14) "monfichier.txt"
 int(4096)
 bool(false)
 bool(true)
-string(11) "monfichier2.txt"
+string(15) "monfichier2.txt"
 int(4096)
 bool(false)
 bool(true)
-string(10) "monfichier.txt"
+string(14) "monfichier.txt"
 bool(false)
 bool(false)
 bool(false)
-string(11) "monfichier2.txt"
+string(15) "monfichier2.txt"
 bool(false)
 bool(false)
 bool(false)

--- a/reference/phar/Phar/delMetadata.xml
+++ b/reference/phar/Phar/delMetadata.xml
@@ -67,7 +67,7 @@ try {
     <screen>
 <![CDATA[
 NULL
-string(8) "salut"
+string(5) "salut"
 NULL
 ]]>
     </screen>

--- a/reference/phar/Phar/getMetadata.xml
+++ b/reference/phar/Phar/getMetadata.xml
@@ -91,7 +91,7 @@ try {
 <![CDATA[
 array(1) {
   ["bootstrap"]=>
-  string(8) "fichier.php"
+  string(11) "fichier.php"
 }
 ]]>
     </screen>

--- a/reference/phar/Phar/getSignature.xml
+++ b/reference/phar/Phar/getSignature.xml
@@ -29,7 +29,7 @@
    Un tableau avec la signature de l'archive ouverte avec le <literal>hash</literal> en guise de clé et
    "<literal>MD5</literal>", "<literal>SHA-1</literal>", "<literal>SHA-256</literal>"
    ou "<literal>SHA-512</literal>" comme <literal>hash_type</literal>. Cette signature est un hachage
-   calculé à partir du contenu de l'archive entière; elle peut être utilisée pour vérifier
+   calculé à partir du contenu de l'archive entière ; elle peut être utilisée pour vérifier
    l'intégrité de l'archive. Une signature valide est absolument requise pour toutes les archives phar
    exécutables si la variable INI <link linkend="ini.phar.require-hash">phar.require_hash</link> vaut &true;.
    S'il n'y a pas de signature, la fonction retourne &false;

--- a/reference/phar/Phar/getVersion.xml
+++ b/reference/phar/Phar/getVersion.xml
@@ -26,7 +26,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   La version de l'API de l'archive ouverte. A ne pas confondre avec la version d'API
+   La version de l'API de l'archive ouverte. À ne pas confondre avec la version d'API
    que l'extension phar chargée utilisera pour créer de nouveaux phar.
    Chaque archive Phar a la version d'API codée en dur dans son manifeste. Pour davantage
    d'information, regardez <link linkend="phar.fileformat">le format de fichier Phar</link>.

--- a/reference/phar/Phar/interceptFileFuncs.xml
+++ b/reference/phar/Phar/interceptFileFuncs.xml
@@ -73,7 +73,7 @@ echo file_get_contents('fichier2.txt');
    </example>
   </para>
   <para>
-   Normalement, PHP chercherait dans le répertoire courant le fichier nommé <literal>file2.txt</literal>,
+   Normalement, PHP chercherait dans le répertoire courant le fichier nommé <literal>fichier2.txt</literal>,
    c'est-à-dire dans le répertoire de fichier.php ou le répertoire courant de l'utilisateur de la ligne
    de commande. <function>Phar::interceptFileFuncs</function> dit à
    PHP de considérer <literal>phar:///chemin/vers/monphar.phar/</literal> comme répertoire courant

--- a/reference/phar/Phar/isBuffering.xml
+++ b/reference/phar/Phar/isBuffering.xml
@@ -19,7 +19,7 @@
    est nécessaire pour inscrire les modifications.
   </para>
   <para>
-   La mise en tampon de l'écriture du Phar se fait par archive; la mise en tampon de
+   La mise en tampon de l'écriture du Phar se fait par archive ; la mise en tampon de
    l'archive Phar <literal>foo.phar</literal> n'affecte en rien les changements faits sur
    l'archive Phar <literal>bar.phar</literal>.
   </para>

--- a/reference/phar/Phar/offsetGet.xml
+++ b/reference/phar/Phar/offsetGet.xml
@@ -42,7 +42,7 @@
   &reftitle.returnvalues;
   <para>
    Un objet <classname>PharFileInfo</classname> est retourné et 
-   peut être utilisé pour intégrer le contenu d'un fichier ou pour
+   peut être utilisé pour parcourir le contenu d'un fichier ou pour
    récupérer des informations sur le fichier courant.
   </para>
  </refsect1>

--- a/reference/phar/Phar/setStub.xml
+++ b/reference/phar/Phar/setStub.xml
@@ -134,7 +134,7 @@ try {
     include 'phar://nouveau.phar/b.php';
     var_dump($p->getStub());
 } catch (Exception $e) {
-    echo 'Erreur lors de l'écriture de nouveau.phar: ', $e;
+    echo 'Erreur lors de l\'écriture de nouveau.phar: ', $e;
 }
 ?>
 ]]>

--- a/reference/phar/Phar/stopBuffering.xml
+++ b/reference/phar/Phar/stopBuffering.xml
@@ -89,7 +89,7 @@ var_dump($p->getStub());
     <screen>
 <![CDATA[
 string(24) "<?php __HALT_COMPILER();"
-string(195) "<?php
+string(187) "<?php
 function __autoload($class)
 {
     include 'phar://' . str_replace('_', '/', $class);

--- a/reference/phar/Phar/webPhar.xml
+++ b/reference/phar/Phar/webPhar.xml
@@ -126,7 +126,7 @@ $mimes = array(
      <term><parameter>rewrite</parameter></term>
      <listitem>
       <para>
-       La fonction de ré-écriture est passée prend comme seul paramètre une chaîne
+       La fonction de ré-écriture prend comme seul paramètre une chaîne
        et doit retourner une &string; ou &false;.
       </para>
       <para>

--- a/reference/phar/PharData/buildFromDirectory.xml
+++ b/reference/phar/PharData/buildFromDirectory.xml
@@ -41,7 +41,7 @@
      <listitem>
       <para>
        Une expression rationnelle optionnelle qui est utilisée pour filtrer la liste des
-       fichiers. Seuls les fichiers dont le nom satisfont l'expression seront inclus
+       fichiers. Seuls les fichiers dont le nom satisfait l'expression seront inclus
        dans l'archive.
       </para>
      </listitem>

--- a/reference/phar/PharData/buildFromIterator.xml
+++ b/reference/phar/PharData/buildFromIterator.xml
@@ -63,7 +63,7 @@
    Cette méthode retourne une exception <classname>UnexpectedValueException</classname> quand
    l'itérateur retourne des valeurs incorrectes, comme une clé entière plutôt qu'une chaîne,
    une exception <classname>BadMethodCallException</classname> quand un itérateur basé sur
-   SplFileInfo-based est passé sans paramètre <parameter>baseDirectory</parameter>, ou une
+   SplFileInfo est passé sans paramètre <parameter>baseDirectory</parameter>, ou une
    exception <classname>PharException</classname> si des erreurs ont été rencontrées lors de 
    la sauvegarde de l'archive phar.
   </para>
@@ -144,7 +144,7 @@ $phar->buildFromIterator(
     </programlisting>
    </para>
    <para>
-    Le fichier <literal>projet.tar</literal> peut alors être effacé
+    Le fichier <literal>projet.tar</literal> peut alors être utilisé
     immédiatement. <function>PharData::buildFromIterator</function>
     ne règle pas les paramètres tels que la compression, les métadonnées,
     ce qui peut être fait après avoir créé l'archive tar/zip.

--- a/reference/phar/PharData/compress.xml
+++ b/reference/phar/PharData/compress.xml
@@ -109,9 +109,9 @@
 $p = new PharData('/chemin/vers/mon.tar');
 $p['monfichier.txt'] = 'salut';
 $p['monfichier2.txt'] = 'salut';
-$p1 = $p->compress(Phar::GZ); // copies vers /path/to/my.tar.gz
-$p2 = $p->compress(Phar::BZ2); // copies vers /path/to/my.tar.bz2
-$p3 = $p2->compress(Phar::NONE); // exception : /path/to/my.tar existe déjà
+$p1 = $p->compress(Phar::GZ); // copie vers /chemin/vers/mon.tar.gz
+$p2 = $p->compress(Phar::BZ2); // copie vers /chemin/vers/mon.tar.bz2
+$p3 = $p2->compress(Phar::NONE); // exception : /chemin/vers/mon.tar existe déjà
 ?>
 ]]>
     </programlisting>

--- a/reference/phar/PharData/construct.xml
+++ b/reference/phar/PharData/construct.xml
@@ -80,7 +80,7 @@
 <![CDATA[
 <?php
 try {
-    $p = new PharData('/path/to/my.tar', Phar::CURRENT_AS_FILEINFO | Phar::KEY_AS_FILENAME);
+    $p = new PharData('/chemin/vers/mon.tar', Phar::CURRENT_AS_FILEINFO | Phar::KEY_AS_FILENAME);
 } catch (UnexpectedValueException $e) {
     die('Ne peut pas ouvrir mon.tar');
 } catch (BadMethodCallException $e) {

--- a/reference/phar/PharData/copy.xml
+++ b/reference/phar/PharData/copy.xml
@@ -55,7 +55,7 @@
   <para>
    lève une exception <classname>UnexpectedValueException</classname> si le fichier source n'existe
    pas, si le fichier de destination existe déjà, si le support en écriture est désactivé, si l'ouverture
-   d'un des deux fichiers échoue ou si la lecture du fichier source échoue; ou lève une exception
+   d'un des deux fichiers échoue ou si la lecture du fichier source échoue ; ou lève une exception
    <classname>PharException</classname> si l'écriture des changements de l'archive phar échoue.
   </para>
  </refsect1>

--- a/reference/phar/PharData/decompress.xml
+++ b/reference/phar/PharData/decompress.xml
@@ -42,7 +42,7 @@
        Pour décompresser, l'extension par défaut est
        <literal>.tar</literal>. Utiliser ce paramètre
        pour spécifier une autre extension de fichier. Gardez
-       à l'esprit que seul les archives exécutables peuvent
+       à l'esprit que seules les archives exécutables peuvent
        contenir <literal>.phar</literal> dans leur nom de fichier.
       </para>
      </listitem>

--- a/reference/phar/PharData/delMetadata.xml
+++ b/reference/phar/PharData/delMetadata.xml
@@ -36,7 +36,7 @@
  <refsect1 role="errors">
   &reftitle.errors;
   <para>
-   Soulève une exception <classname>PharException</classname> si des erreurs sont rencontrés lors
+   Soulève une exception <classname>PharException</classname> si des erreurs sont rencontrées lors
    de l'écriture des changements sur le disque.
   </para>
  </refsect1>

--- a/reference/phar/PharData/delete.xml
+++ b/reference/phar/PharData/delete.xml
@@ -47,7 +47,7 @@
  <refsect1 role="errors">
   &reftitle.errors;
   <para>
-   Soulève une exception <classname>PharException</classname> si des erreurs sont rencontrés lors
+   Soulève une exception <classname>PharException</classname> si des erreurs sont rencontrées lors
    de l'écriture des changements sur le disque.
   </para>
  </refsect1>
@@ -65,7 +65,7 @@ try {
     $phar = new PharData('monphar.zip');
     $phar->delete('efface/moi.php');
     // c'est l'équivalent de :
-    unlink('phar://monphar.phar/efface/mon.php');
+    unlink('phar://monphar.phar/efface/moi.php');
 } catch (Exception $e) {
     // on traite les erreurs
 }

--- a/reference/phar/PharFileInfo/construct.xml
+++ b/reference/phar/PharFileInfo/construct.xml
@@ -72,7 +72,7 @@ try {
         echo "ligne numéro $line: $text";
     }
 } catch (Exception $e) {
-    echo 'L'opération Phar a échoué : ', $e;
+    echo 'L\'opération Phar a échoué : ', $e;
 }
 ?>
 ]]>

--- a/reference/phar/PharFileInfo/getCompressedSize.xml
+++ b/reference/phar/PharFileInfo/getCompressedSize.xml
@@ -45,7 +45,7 @@ try {
     $file = $p['monfichier.txt'];
     echo $file->getCompressedSize();
 } catch (Exception $e) {
-    echo 'L'écriture de mon.phar a échoué : ', $e;
+    echo 'L\'écriture de mon.phar a échoué : ', $e;
 }
 ?>
 ]]>
@@ -53,7 +53,7 @@ try {
     &example.outputs;
     <screen>
 <![CDATA[
-2
+5
 ]]>
     </screen>
    </example>

--- a/reference/phar/PharFileInfo/getMetadata.xml
+++ b/reference/phar/PharFileInfo/getMetadata.xml
@@ -64,7 +64,7 @@
     <programlisting role="php">
 <![CDATA[
 <?php
-// on s'assure que le phar n'est pas déjà
+// on s'assure que le phar n'existe pas déjà
 @unlink('nouveauphar.phar');
 try {
     $p = new Phar(dirname(__FILE__) . '/nouveauphar.phar', 0, 'nouveauphar.phar');

--- a/reference/phar/PharFileInfo/setMetadata.xml
+++ b/reference/phar/PharFileInfo/setMetadata.xml
@@ -18,7 +18,7 @@
    personnalisées dans un fichier qui ne peuvent pas l'être avec des informations normalement stockées
    avec le fichier. Les métadonnées peuvent dégrader les performances de chargement d'une archive phar 
    si les données sont trop lourdes ou s'il y a beaucoup de fichiers avec des métadonnées.
-   Il est important de noter que les permissions de fichiers sont supportées nativement dans un phar; il
+   Il est important de noter que les permissions de fichiers sont supportées nativement dans un phar ; il
    est possible de les fixer avec la méthode <function>PharFileInfo::chmod</function>. Comme avec toutes
    les fonctionnalités qui modifient le contenu du phar, la variable INI
    <link linkend="ini.phar.readonly">phar.readonly</link> doit être à off pour réussir si le fichier est au 

--- a/reference/phar/fileformat.xml
+++ b/reference/phar/fileformat.xml
@@ -245,7 +245,7 @@ __HALT_COMPILER();
    Le manifeste Phar est un format hautement optimisé qui permet la spécification fichier par fichier
    de la compression, des permissions et même des métadonnées utilisateur tels que l'utilisateur ou le
    groupe propriétaire. Toutes les valeurs de plus d'un octet sont stockées sous forme petit-boutiste,
-   A l'exception de la version de l'API qui est stockée pour des raisons historiques en 3 morceaux
+   à l'exception de la version de l'API qui est stockée pour des raisons historiques en 3 morceaux
    grand-boutistes.
   </para>
   <para>

--- a/reference/phar/ini.xml
+++ b/reference/phar/ini.xml
@@ -126,7 +126,7 @@
       sur disque.
       <example>
        <title>Exemple d'utilisation de phar.cache_list</title>
-       <programlisting role="php">
+       <programlisting>
 <![CDATA[
 dans php.ini (windows):
 phar.cache_list =C:\chemin\vers\phar1.phar;C:\chemin\vers\phar2.phar

--- a/reference/phar/using.xml
+++ b/reference/phar/using.xml
@@ -51,7 +51,7 @@ include 'bibliothequesympa.phar';
 <?php
 include 'phar://bibliothequesympa.phar/fichier/interne.php';
 header('Content-type: image/jpeg');
-// les phars peuvent être atteint via le chemin complet ou via des alias
+// les phars peuvent être atteints via le chemin complet ou via des alias
 echo file_get_contents('phar:///chemin/complet/vers/bibliothequesympa.phar/images/wow.jpg');
 ?>
 ]]>
@@ -153,7 +153,7 @@ openssl_pkey_export($public, $pkey);
   dire aux applications d'utiliser ces valeurs. <function>Phar::interceptFileFuncs</function> dit à Phar d'intercepter les appels à
   <function>fopen</function>, <function>file_get_contents</function>, <function>opendir</function>, et
   à toutes les fonctions basées sur stat (<function>file_exists</function>, <function>is_readable</function>, etc) et
-  route tous les chemins relatif vers les bons endroits de l'archive phar.
+  route tous les chemins relatifs vers les bons endroits de l'archive phar.
  </para>
  <para>
   Par exemple, empaqueter une version de la célèbre application phpMyAdmin dans une archive phar nécessite

--- a/reference/phpdbg/reference.xml
+++ b/reference/phpdbg/reference.xml
@@ -4,7 +4,7 @@
 <!-- Reviewed: no -->
 
 <reference xml:id="ref.phpdbg" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
- <title>phpdbg &Functions;</title>
+ <title>&Functions; phpdbg</title>
 
  &reference.phpdbg.entities.functions;
 

--- a/reference/posix/constants.xml
+++ b/reference/posix/constants.xml
@@ -75,7 +75,7 @@
     </term>
     <listitem>
      <simpara>
-      Bloque les fichiers spéciaux
+      Fichier spécial de bloc
      </simpara>
     </listitem>
    </varlistentry>
@@ -86,7 +86,7 @@
     </term>
     <listitem>
      <simpara>
-      Caractère des fichiers spéciaux
+      Fichier spécial de caractère
      </simpara>
     </listitem>
    </varlistentry>
@@ -97,7 +97,7 @@
     </term>
     <listitem>
      <simpara>
-      FIFO (pipe nommé) des fichiers spéciaux
+      Fichier spécial FIFO (pipe nommé)
      </simpara>
     </listitem>
    </varlistentry>

--- a/reference/posix/functions/posix-access.xml
+++ b/reference/posix/functions/posix-access.xml
@@ -47,7 +47,7 @@
        </para>
        <para>
         <constant>POSIX_R_OK</constant>, <constant>POSIX_W_OK</constant> et
-        <constant>POSIX_X_OK</constant> vérifie si, respectivement, le fichier
+        <constant>POSIX_X_OK</constant> vérifient si, respectivement, le fichier
         existe et a les permissions en lecture, écriture et exécution.
         <constant>POSIX_F_OK</constant> vérifie uniquement si le fichier existe.
        </para>

--- a/reference/posix/functions/posix-getgid.xml
+++ b/reference/posix/functions/posix-getgid.xml
@@ -6,7 +6,7 @@
 <refentry xml:id="function.posix-getgid" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>posix_getgid</refname>
-  <refpurpose>Retourne l'UID du groupe du processus courant</refpurpose>
+  <refpurpose>Retourne l'ID réel du groupe du processus courant</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/posix/functions/posix-getgrgid.xml
+++ b/reference/posix/functions/posix-getgrgid.xml
@@ -60,7 +60,7 @@
       <row>
        <entry>passwd</entry>
        <entry>
-        Cet élément contient le mot de passe du groupe, crypté.
+        Cet élément contient le mot de passe du groupe, chiffré.
         Par exemple, sous les systèmes employant les mots de passe
         "shadow", un astérisque est retourné.
        </entry>

--- a/reference/posix/functions/posix-getgrnam.xml
+++ b/reference/posix/functions/posix-getgrnam.xml
@@ -63,7 +63,7 @@
       <row>
        <entry>passwd</entry>
        <entry>
-        Cet élément contient le mot de passe du groupe, crypté.
+        Cet élément contient le mot de passe du groupe, chiffré.
         Par exemple, sous un système utilisant les mots de passe
         "shadow", un astérisque est retourné.
        </entry>

--- a/reference/posix/functions/posix-getrlimit.xml
+++ b/reference/posix/functions/posix-getrlimit.xml
@@ -59,9 +59,9 @@
       <row>
        <entry>core</entry>
        <entry>
-        La taille maximale du cœur du fichier. Lorsqu'elle vaut 0,
-        aucun cœur de fichier n'est créé. Lorsque le cœur des fichiers
-        est plus grand que sa taille, il sera tronqué à cette taille.
+        La taille maximale du fichier core. Lorsqu'elle vaut 0,
+        aucun fichier core n'est créé. Lorsqu'un fichier core
+        est plus grand que cette taille, il sera tronqué à cette taille.
        </entry>
       </row>
       <row>
@@ -91,7 +91,7 @@
       <row>
        <entry>rss</entry>
        <entry>
-        Le nombre maximal de pages virtuelles résident en RAM.
+        Le nombre maximal de pages virtuelles résidentes en RAM.
        </entry>
       </row>
       <row>

--- a/reference/posix/functions/posix-getsid.xml
+++ b/reference/posix/functions/posix-getsid.xml
@@ -17,7 +17,7 @@
   <para>
    Retourne l'ID de session du processus <parameter>process_id</parameter>.
    L'ID de session d'un processus est l'ID du groupe du processus du
-   gestionnaire de session.
+   chef de session.
   </para>
  </refsect1>
 

--- a/reference/posix/functions/posix-mknod.xml
+++ b/reference/posix/functions/posix-mknod.xml
@@ -40,7 +40,7 @@
      <term><parameter>flags</parameter></term>
      <listitem>
       <para>
-       Ce paramètre est construit par une manipulation de bits ou par des types
+       Ce paramètre est construit par un OU bit à bit entre les types
        de fichier (une des constantes suivantes : <constant>POSIX_S_IFREG</constant>,
        <constant>POSIX_S_IFCHR</constant>, <constant>POSIX_S_IFBLK</constant>,
        <constant>POSIX_S_IFIFO</constant> ou

--- a/reference/posix/functions/posix-setegid.xml
+++ b/reference/posix/functions/posix-setegid.xml
@@ -6,7 +6,7 @@
 <refentry xml:id="function.posix-setegid" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>posix_setegid</refname>
-  <refpurpose>Modifie le GID réel du processus courant</refpurpose>
+  <refpurpose>Modifie le GID effectif du processus courant</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -16,8 +16,8 @@
    <methodparam><type>int</type><parameter>group_id</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Modifie l'identifiant de groupe réel du processus courant.
-   C'est une fonction de haut niveau, et on aura besoin
+   Modifie l'identifiant de groupe effectif du processus courant.
+   C'est une fonction privilégiée, et on aura besoin
    des droits appropriés (généralement ceux du super utilisateur),
    sur le système, pour l'utiliser.
   </para>

--- a/reference/posix/functions/posix-seteuid.xml
+++ b/reference/posix/functions/posix-seteuid.xml
@@ -6,7 +6,7 @@
 <refentry xml:id="function.posix-seteuid" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>posix_seteuid</refname>
-  <refpurpose>Modifie l'identifiant d'utilisateur réel (UID) du processus courant</refpurpose>
+  <refpurpose>Modifie l'identifiant d'utilisateur effectif (UID) du processus courant</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -16,8 +16,8 @@
    <methodparam><type>int</type><parameter>user_id</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Définit l'identifiant du véritable utilisateur du processus courant.
-   C'est une fonction de haut niveau, et on aura besoin des
+   Définit l'identifiant de l'utilisateur effectif du processus courant.
+   C'est une fonction privilégiée, et on aura besoin des
    droits appropriés (généralement ceux du super utilisateur),
    sur le système, pour l'utiliser.
   </para>

--- a/reference/posix/functions/posix-setgid.xml
+++ b/reference/posix/functions/posix-setgid.xml
@@ -6,7 +6,7 @@
 <refentry xml:id="function.posix-setgid" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>posix_setgid</refname>
-  <refpurpose>Fixe le GID effectif du processus courant</refpurpose>
+  <refpurpose>Fixe le GID réel du processus courant</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -16,7 +16,7 @@
    <methodparam><type>int</type><parameter>group_id</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Fixe le GID effectif du processus courant. C'est une fonction
+   Fixe le GID réel du processus courant. C'est une fonction
    privilégiée et il faut avoir les privilèges appropriés (habituellement
    root) sur le système pour pouvoir l'exécuter. L'ordre approprié
    est d'abord <function>posix_setgid</function>, puis

--- a/reference/posix/functions/posix-setuid.xml
+++ b/reference/posix/functions/posix-setuid.xml
@@ -6,7 +6,7 @@
 <refentry xml:id="function.posix-setuid" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>posix_setuid</refname>
-  <refpurpose>Fixe l'UID effective du processus courant</refpurpose>
+  <refpurpose>Fixe l'UID réel du processus courant</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -16,7 +16,7 @@
    <methodparam><type>int</type><parameter>user_id</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Fixe l'UID effective de l'utilisateur du processus courant.
+   Fixe l'UID réel de l'utilisateur du processus courant.
    Il faut avoir les privilèges nécessaires
    (traditionnellement ceux du root) sur le système
    pour le faire.

--- a/reference/posix/functions/posix-sysconf.xml
+++ b/reference/posix/functions/posix-sysconf.xml
@@ -47,7 +47,7 @@
  <refsect1 role="examples">
   &reftitle.examples;
   <example xml:id="function.posix-sysconf.example.basic">
-   <title><function>posix_sysconf</function> example</title>
+   <title>Exemple avec <function>posix_sysconf</function></title>
    <para>
     Renvoie le nombre de processeurs actifs.
    </para>

--- a/reference/posix/functions/posix-ttyname.xml
+++ b/reference/posix/functions/posix-ttyname.xml
@@ -16,7 +16,7 @@
   </methodsynopsis>
   <para>
    Retourne une &string; pour le chemin absolu du terminal courant qui
-   est ouvert sur le pointeur de fichier.
+   est ouvert sur le pointeur de fichier
    <parameter>file_descriptor</parameter>.
   </para>
  </refsect1>


### PR DESCRIPTION
Corrections de langue et de traduction dans reference/, de pdo to posix (orthographe, grammaire, fidélité à l'anglais).