### PR TITLE
Nits translation: reference/ (ps to sem)

### DIFF
--- a/reference/ps/functions/ps-add-locallink.xml
+++ b/reference/ps/functions/ps-add-locallink.xml
@@ -29,7 +29,7 @@
   <para>
    La position source de l'hyperlien est un rectangle avec son coin inférieur gauche à
    (<parameter>llx</parameter>, <parameter>lly</parameter>) et son coin
-   supérieur droit à (<parameter>urx</parameter>, <parameter>lly</parameter>). Le
+   supérieur droit à (<parameter>urx</parameter>, <parameter>ury</parameter>). Le
    rectangle a par défaut une mince bordure bleue. 
   </para>
   &ps.note.visible;

--- a/reference/ps/functions/ps-add-pdflink.xml
+++ b/reference/ps/functions/ps-add-pdflink.xml
@@ -30,7 +30,7 @@
   <para>
    La position source de l'hyperlien est un rectangle avec son coin inférieur gauche à
    (<parameter>llx</parameter>, <parameter>lly</parameter>) et son coin
-   supérieur droit à (<parameter>urx</parameter>, <parameter>lly</parameter>). Le
+   supérieur droit à (<parameter>urx</parameter>, <parameter>ury</parameter>). Le
    rectangle a par défaut une mince bordure bleue. 
   </para>
   &ps.note.visible;
@@ -44,7 +44,8 @@
      <term><parameter>psdoc</parameter></term>
      <listitem>
       <para>
-
+       Identifiant d'un fichier postscript retourné par
+       <function>ps_new</function>.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/ps/functions/ps-begin-page.xml
+++ b/reference/ps/functions/ps-begin-page.xml
@@ -19,7 +19,7 @@
   </methodsynopsis>
   <para>
    Démarre une nouvelle page. Bien que les paramètres
-   <parameter>width</parameter> et <parameter>height</parameter> implique une
+   <parameter>width</parameter> et <parameter>height</parameter> impliquent une
    taille différente des feuilles pour chaque page, cela n'est pas possible
    dans PostScript. Le premier appel de <function>ps_begin_page</function>
    fixera la taille des pages pour le document entier. Des appels consécutifs

--- a/reference/ps/functions/ps-begin-pattern.xml
+++ b/reference/ps/functions/ps-begin-pattern.xml
@@ -24,7 +24,7 @@
    Démarre un nouveau motif. Un motif est comme une page contenant par exemple
    un dessin qui peut être utilisé pour remplir des secteurs. Il est utilisé
    comme une couleur en appelant <function>ps_setcolor</function> et en
-   configurant l'emplacement de la couleur au <literal>motif</literal>.
+   configurant l'espace de couleur à <literal>pattern</literal>.
   </para>
  </refsect1>
 

--- a/reference/ps/functions/ps-begin-template.xml
+++ b/reference/ps/functions/ps-begin-template.xml
@@ -19,7 +19,7 @@
   </methodsynopsis>
   <para>
    <function>ps_begin_template</function> démarre un nouveau modèle. 
-   Un modèle est appelé par un formulaire dans le langage PostScript. 
+   Un modèle s'appelle un formulaire dans le langage PostScript.
    Il est créé de la même manière qu'un motif, mais est
    utilisé comme une image. Les modèles sont souvent utilisés pour les dessins
    qui sont placés plusieurs fois dans le document, par exemple un logo de

--- a/reference/ps/functions/ps-clip.xml
+++ b/reference/ps/functions/ps-clip.xml
@@ -6,7 +6,7 @@
 <refentry xml:id="function.ps-clip" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>ps_clip</refname>
-  <refpurpose>Attache le dessin au chemin courant</refpurpose>
+  <refpurpose>Découpe le dessin selon le chemin courant</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -16,8 +16,8 @@
    <methodparam><type>resource</type><parameter>psdoc</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Prend le chemin courant et l'utilise pour définir la bordure du secteur à
-   attacher. Tout ce qui est dessiné à l'extérieur de ce secteur ne sera pas
+   Prend le chemin courant et l'utilise pour définir la bordure du secteur de
+   découpe. Tout ce qui est dessiné à l'extérieur de ce secteur ne sera pas
    visible.
   </para>
  </refsect1>

--- a/reference/ps/functions/ps-curveto.xml
+++ b/reference/ps/functions/ps-curveto.xml
@@ -23,7 +23,7 @@
   </methodsynopsis>
   <para>
    <function>ps_curveto</function> ajoute une section d'une courbe Bézier
-   cubique décrit par les trois points de contrôle donnés au chemin courant.
+   cubique décrite par les trois points de contrôle donnés au chemin courant.
   </para>
  </refsect1>
 

--- a/reference/ps/functions/ps-findfont.xml
+++ b/reference/ps/functions/ps-findfont.xml
@@ -43,7 +43,7 @@
    document entier. Normalement, le BoundingBox est fixé avec le premier appel
    de <function>ps_begin_page</function> qui vient maintenant après
    <function>ps_findfont</function>. En conséquence, le BoundingBox n'a pas
-   été fixée et une erreur sera lancée lorsque
+   été fixé et un avertissement sera émis lorsque
    <function>ps_findfont</function> sera appelée. Afin de prévenir cette
    situation, il est recommandé d'appeler la fonction
    <function>ps_set_parameter</function> pour fixer le BoundingBox avant que
@@ -90,7 +90,7 @@
       </para>
       <para>
        Si l'encodage est fixé à <literal>builtin</literal> alors il n'y aura
-       pas d'encodage à nouveau et l'encodage spécifique de police sera
+       pas de réencodage et l'encodage spécifique de police sera
        utilisé. Cela est très utile pour les polices avec symboles.
       </para>
      </listitem>

--- a/reference/ps/functions/ps-hyphenate.xml
+++ b/reference/ps/functions/ps-hyphenate.xml
@@ -5,7 +5,7 @@
 <refentry xml:id="function.ps-hyphenate" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>ps_hyphenate</refname>
-  <refpurpose>Relie un mot</refpurpose>
+  <refpurpose>Effectue la césure d'un mot</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -18,7 +18,7 @@
   <para>
    Effectue la césure du mot passé. <function>ps_hyphenate</function> évalue la valeur
    hyphenminchars (fixé par <function>ps_set_value</function>) et le paramètre
-   hyphendic (fixé par <function>ps_set_parameter</function>). hyphendict doit
+   hyphendict (fixé par <function>ps_set_parameter</function>). hyphendict doit
    être fixé avant d'appeler cette fonction.
   </para>
   <para>

--- a/reference/ps/functions/ps-set-text-pos.xml
+++ b/reference/ps/functions/ps-set-text-pos.xml
@@ -18,8 +18,8 @@
    <methodparam><type>float</type><parameter>y</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Fixe la position pour la prochaine écriture de texte. Il est recommandé de
-   alternativement fixer la valeur x et y séparément en appelant
+   Fixe la position pour la prochaine écriture de texte. Il est recommandé
+   d'alternativement fixer la valeur x et y séparément en appelant
    <function>ps_set_value</function> et choisir <literal>textx</literal>
    respectivement <literal>texty</literal> comme nom de valeur.
   </para>

--- a/reference/ps/functions/ps-set-value.xml
+++ b/reference/ps/functions/ps-set-value.xml
@@ -38,7 +38,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term>textx</term>
+     <term><parameter>name</parameter></term>
      <listitem>
       <para>
        Le paramètre <parameter>name</parameter> peut être une des valeurs suivantes :

--- a/reference/ps/functions/ps-setcolor.xml
+++ b/reference/ps/functions/ps-setcolor.xml
@@ -65,7 +65,7 @@
      <term><parameter>c1</parameter></term>
      <listitem>
       <para>
-       Dépendemment de l'espace colorimétrique, cette valeur peut être le
+       Dépendamment de l'espace colorimétrique, cette valeur peut être le
        composant rouge (rgb), le composant cyan (cmyk), la valeur de gris
        (gris), l'identifiant de la tache de couleur ou l'identifiant du motif.
       </para>
@@ -75,7 +75,7 @@
      <term><parameter>c2</parameter></term>
      <listitem>
       <para>
-       Dépendemment de l'espace colorimétrique, cette valeur peut être le
+       Dépendamment de l'espace colorimétrique, cette valeur peut être le
        composant vert (rgb) ou le composant magenta (cmyk).
       </para>
      </listitem>
@@ -84,8 +84,8 @@
      <term><parameter>c3</parameter></term>
      <listitem>
       <para>
-       Dépendemment de l'espace colorimétrique, cette valeur peut être le
-       composant bleu (rgb) ou le composant jaune (cymk).
+       Dépendamment de l'espace colorimétrique, cette valeur peut être le
+       composant bleu (rgb) ou le composant jaune (cmyk).
       </para>
      </listitem>
     </varlistentry>
@@ -93,7 +93,7 @@
      <term><parameter>c4</parameter></term>
      <listitem>
       <para>
-       Ce paramètre doit être fixé seulement dans l'espace colorimétrique cymk
+       Ce paramètre doit être fixé seulement dans l'espace colorimétrique cmyk
        et spécifie le composant noir.
       </para>
      </listitem>

--- a/reference/ps/functions/ps-setflat.xml
+++ b/reference/ps/functions/ps-setflat.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="function.ps-setflat" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>ps_setflat</refname>
-  <refpurpose>Fixe la position à plat</refpurpose>
+  <refpurpose>Fixe la planéité</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/ps/functions/ps-setlinejoin.xml
+++ b/reference/ps/functions/ps-setlinejoin.xml
@@ -6,7 +6,7 @@
 <refentry xml:id="function.ps-setlinejoin" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>ps_setlinejoin</refname>
-  <refpurpose>Fixe comment les lignes connectés sont jointes</refpurpose>
+  <refpurpose>Fixe comment les lignes connectées sont jointes</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/ps/functions/ps-shading.xml
+++ b/reference/ps/functions/ps-shading.xml
@@ -30,7 +30,7 @@
    <function>ps_shading_pattern</function>.
   </para>
   <para>
-   La couleur du ton peut être n'importe quelle couleur d'espace excepté pour
+   La couleur du ton peut être dans n'importe quel espace de couleur excepté pour
    <literal>pattern</literal>.
   </para>
  </refsect1>

--- a/reference/ps/functions/ps-show-xy.xml
+++ b/reference/ps/functions/ps-show-xy.xml
@@ -48,7 +48,7 @@
      <term><parameter>x</parameter></term>
      <listitem>
       <para>
-       La position x du coin inférieur droit de la boîte entourant le texte.
+       La position x du coin inférieur gauche de la boîte entourant le texte.
       </para>
      </listitem>
     </varlistentry>
@@ -56,7 +56,7 @@
      <term><parameter>y</parameter></term>
      <listitem>
       <para>
-       La position y du coin inférieur droit de la boîte entourant le texte.
+       La position y du coin inférieur gauche de la boîte entourant le texte.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/ps/reference.xml
+++ b/reference/ps/reference.xml
@@ -11,7 +11,7 @@
    <title>Contact Information</title>
    <para>
     Si l'on a des commentaires, résolutions de bogues, améliorations pour
-    soit cette extension ou pslib alors laissez moi un message à 
+    soit cette extension ou pslib alors laissez-moi un message à
     <link xlink:href="mailto:steinm@php.net">steinm@php.net</link>. Toute aide est
     la bienvenue.
    </para>

--- a/reference/pspell/functions/pspell-add-to-personal.xml
+++ b/reference/pspell/functions/pspell-add-to-personal.xml
@@ -37,7 +37,7 @@
      <term><parameter>word</parameter></term>
      <listitem>
       <para>
-       Le Mot ajouté.
+       Le mot ajouté.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/pspell/functions/pspell-add-to-session.xml
+++ b/reference/pspell/functions/pspell-add-to-session.xml
@@ -16,7 +16,7 @@
   </methodsynopsis>
   <simpara>
    <function>pspell_add_to_session</function> ajoute un mot au dictionnaire
-   personnel associé à la version courante. C'est une fonction
+   personnel associé à la session courante. C'est une fonction
    similaire à <function>pspell_add_to_personal</function>.
   </simpara>
  </refsect1>

--- a/reference/pthreads/book.xml
+++ b/reference/pthreads/book.xml
@@ -111,7 +111,7 @@
    après sérialisation ; les types simples sont stockés sous leur forme initiale. Les types complexes,
    les tableaux et les objets qui ne sont pas Threadés, sont stockés sérialisés ; ils peuvent être lus
    et écrits dans l'objet Threadé depuis n'importe quel contexte avec une référence.
-   A l'exception des objets Threadés, toute référence utilisée pour définir un membre d'un objet Threadé
+   À l'exception des objets Threadés, toute référence utilisée pour définir un membre d'un objet Threadé
    est séparée de la référence dans l'objet Threadé ; les mêmes données peuvent être lues directement
    depuis l'objet Threadé à tout moment par n'importe quel contexte avec une référence vers l'objet Threadé.
   </simpara>

--- a/reference/pthreads/pool/collect.xml
+++ b/reference/pthreads/pool/collect.xml
@@ -79,7 +79,7 @@ for ($i = 0; $i < 15; ++$i) {
     $pool->submit(new class extends Threaded {});
 }
 
-while ($pool->collect()); // blocks until all tasks have finished executing
+while ($pool->collect()); // bloque jusqu'à ce que toutes les tâches aient fini de s'exécuter
 
 $pool->shutdown();
 ]]>

--- a/reference/pthreads/pool/shutdown.xml
+++ b/reference/pthreads/pool/shutdown.xml
@@ -35,7 +35,7 @@
  <refsect1 role="examples">
   &reftitle.examples;
   <example>
-   <title>Shutting down a pool</title>
+   <title>Arrêt d'un pool</title>
    <programlisting role="php">
 <![CDATA[
 <?php
@@ -53,7 +53,7 @@ for ($i = 0; $i < 10; ++$i) {
     $pool->submit(new Task());
 }
 
-$pool->shutdown(); // blocs jusqu'à ce que toutes les tâches soumises aient terminé l'exécution
+$pool->shutdown(); // bloque jusqu'à ce que toutes les tâches soumises aient terminé l'exécution
 ]]>
    </programlisting>
   </example>

--- a/reference/pthreads/pool/submit.xml
+++ b/reference/pthreads/pool/submit.xml
@@ -23,7 +23,7 @@
   &reftitle.parameters;
   <variablelist>
    <varlistentry>
-    <term><parameter>size</parameter></term>
+    <term><parameter>task</parameter></term>
     <listitem>
      <simpara>
       La tâche pour exécution

--- a/reference/pthreads/pool/submitTo.xml
+++ b/reference/pthreads/pool/submitTo.xml
@@ -34,7 +34,7 @@
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term><parameter>size</parameter></term>
+    <term><parameter>task</parameter></term>
     <listitem>
      <simpara>
       La tâche, pour exécution

--- a/reference/pthreads/thread/getcurrentthreadid.xml
+++ b/reference/pthreads/thread/getcurrentthreadid.xml
@@ -40,7 +40,7 @@
 <?php
 class My extends Thread {
     public function run() {
-        printf("%s is Thread #%lu\n", __CLASS__, Thread::getCurrentThreadId());
+        printf("%s est le Thread #%lu\n", __CLASS__, Thread::getCurrentThreadId());
     }
 }
 $my = new My();
@@ -51,7 +51,7 @@ $my->start();
    &example.outputs;
    <screen>
 <![CDATA[
-My is Thread #123456778899
+My est le Thread #123456778899
 ]]>
    </screen>
   </example>

--- a/reference/pthreads/threaded/notify.xml
+++ b/reference/pthreads/threaded/notify.xml
@@ -49,7 +49,7 @@ class My extends Thread {
 }
 $my = new My();
 $my->start();
-/** envoi la notification au thread qui attend **/
+/** envoie la notification au thread qui attend **/
 $my->synchronized(function($thread){
     $thread->done = true;
     $thread->notify();

--- a/reference/pthreads/threaded/notifyone.xml
+++ b/reference/pthreads/threaded/notifyone.xml
@@ -41,7 +41,7 @@
 <?php
 class My extends Thread {
     public function run() {
-        /** cause this thread to wait **/
+        /** fait que le thread patiente **/
         $this->synchronized(function($thread){
             if (!$thread->done)
                 $thread->wait();

--- a/reference/pthreads/threaded/run.xml
+++ b/reference/pthreads/threaded/run.xml
@@ -15,7 +15,7 @@
    <void/>
   </methodsynopsis>
   <simpara>
-   Le développeur doit toujours implémenter la méthode run pour les objets
+   Le développeur devrait toujours implémenter la méthode run pour les objets
    qui doivent être exécutés.
   </simpara>
  </refsect1>

--- a/reference/pthreads/threaded/wait.xml
+++ b/reference/pthreads/threaded/wait.xml
@@ -58,7 +58,7 @@ class My extends Thread {
 }
 $my = new My();
 $my->start();
-/** Envoi la notification au threadé qui attend **/
+/** Envoie la notification au threadé qui attend **/
 $my->synchronized(function($thread){
     $thread->done = true;
     $thread->notify();

--- a/reference/pthreads/worker.xml
+++ b/reference/pthreads/worker.xml
@@ -13,8 +13,8 @@
   <section xml:id="worker.intro">
    &reftitle.intro;
    <simpara>
-    Les Threads Worker ont un contexte persistent, aussi,
-    ils peuvent être utilisés via Threads dans la plupart des cas.
+    Les Threads Worker ont un contexte persistant, aussi,
+    ils devraient être utilisés de préférence aux Threads dans la plupart des cas.
    </simpara>
    <simpara>
     Quand un Worker est démarré, la méthode <methodname>run</methodname> sera

--- a/reference/pthreads/worker/collect.xml
+++ b/reference/pthreads/worker/collect.xml
@@ -51,19 +51,19 @@
 <?php
 $worker = new Worker();
 
-echo "There are currently {$worker->collect()} tasks on the stack to be collected\n";
+echo "Il y a actuellement {$worker->collect()} tâches sur la pile à collecter\n";
 
 for ($i = 0; $i < 15; ++$i) {
     $worker->stack(new class extends Threaded {});
 }
 
-echo "There are {$worker->collect()} tasks remaining on the stack to be collected\n";
+echo "Il reste {$worker->collect()} tâches sur la pile à collecter\n";
 
 $worker->start();
 
 while ($worker->collect()); // bloque jusqu'à ce que toutes les tâches soient terminées
 
-echo "There are now {$worker->collect()} tasks on the stack to be collected\n";
+echo "Il y a maintenant {$worker->collect()} tâches sur la pile à collecter\n";
 
 $worker->shutdown();
 ]]>
@@ -71,9 +71,9 @@ $worker->shutdown();
    &example.outputs;
    <screen>
 <![CDATA[
-There are currently 0 tasks on the stack to be collected
-There are 15 tasks remaining on the stack to be collected
-There are now 0 tasks on the stack to be collected
+Il y a actuellement 0 tâches sur la pile à collecter
+Il reste 15 tâches sur la pile à collecter
+Il y a maintenant 0 tâches sur la pile à collecter
 ]]>
    </screen>
   </example>

--- a/reference/pthreads/worker/shutdown.xml
+++ b/reference/pthreads/worker/shutdown.xml
@@ -34,7 +34,7 @@
  <refsect1 role="examples">
   &reftitle.examples;
   <example>
-   <title>Eteint le worker référencé</title>
+   <title>Éteint le worker référencé</title>
    <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/pthreads/worker/stack.xml
+++ b/reference/pthreads/worker/stack.xml
@@ -47,7 +47,6 @@
    <programlisting role="php">
 <![CDATA[
 <?php
-<?php
 $worker = new Worker();
 $work = new class extends Threaded {};
 

--- a/reference/quickhash/quickhashinthash/add.xml
+++ b/reference/quickhash/quickhashinthash/add.xml
@@ -58,7 +58,7 @@
    <programlisting role="php">
 <![CDATA[
 <?php
-echo "without dupe checking\n";
+echo "sans vérification des doublons\n";
 $hash = new QuickHashIntHash( 1024 );
 var_dump( $hash->exists( 4 ) );
 var_dump( $hash->get( 4 ) );
@@ -67,7 +67,7 @@ var_dump( $hash->exists( 4 ) );
 var_dump( $hash->get( 4 ) );
 var_dump( $hash->add( 4, 12 ) );
 
-echo "\nwith dupe checking\n";
+echo "\navec vérification des doublons\n";
 $hash = new QuickHashIntHash( 1024, QuickHashIntHash::CHECK_FOR_DUPES );
 var_dump( $hash->exists( 4 ) );
 var_dump( $hash->get( 4 ) );
@@ -76,7 +76,7 @@ var_dump( $hash->exists( 4 ) );
 var_dump( $hash->get( 4 ) );
 var_dump( $hash->add( 4, 9 ) );
 
-echo "\ndefault value\n";
+echo "\nvaleur par défaut\n";
 var_dump( $hash->add( 5 ) );
 var_dump( $hash->get( 5 ) );
 ?>
@@ -85,7 +85,7 @@ var_dump( $hash->get( 5 ) );
    &example.outputs.similar;
    <screen>
 <![CDATA[
-without dupe checking
+sans vérification des doublons
 bool(false)
 bool(false)
 bool(true)
@@ -93,7 +93,7 @@ bool(true)
 int(22)
 bool(true)
 
-with dupe checking
+avec vérification des doublons
 bool(false)
 bool(false)
 bool(true)
@@ -101,7 +101,7 @@ bool(true)
 int(78)
 bool(false)
 
-default value
+valeur par défaut
 bool(true)
 int(1)
 ]]>

--- a/reference/quickhash/quickhashinthash/exists.xml
+++ b/reference/quickhash/quickhashinthash/exists.xml
@@ -54,30 +54,30 @@ $existingEntries = array_rand( array_flip( $array ), 180000 );
 $testForEntries = array_rand( array_flip( $array ), 1000 );
 $foundCount = 0;
 
-echo "Creating hash: ", microtime( true ), "\n";
+echo "Création du hachage : ", microtime( true ), "\n";
 $hash = new QuickHashIntHash( 100000 );
-echo "Adding elements: ", microtime( true ), "\n";
+echo "Ajout des éléments : ", microtime( true ), "\n";
 foreach( $existingEntries as $key )
 {
      $hash->add( $key, 56 );
 }
 
-echo "Doing 1000 tests: ", microtime( true ), "\n";
+echo "Exécution de 1000 tests : ", microtime( true ), "\n";
 foreach( $testForEntries as $key )
 {
      $foundCount += $hash->exists( $key );
 }
-echo "Done, $foundCount found: ", microtime( true ), "\n";
+echo "Terminé, $foundCount trouvés : ", microtime( true ), "\n";
 ?>
 ]]>
    </programlisting>
    &example.outputs.similar;
    <screen>
 <![CDATA[
-Creating hash: 1263588703.0748
-Adding elements: 1263588703.0757
-Doing 1000 tests: 1263588703.7851
-Done, 898 found: 1263588703.7897
+Création du hachage : 1263588703.0748
+Ajout des éléments : 1263588703.0757
+Exécution de 1000 tests : 1263588703.7851
+Terminé, 898 trouvés : 1263588703.7897
 ]]>
    </screen>
   </example>

--- a/reference/quickhash/quickhashintset/add.xml
+++ b/reference/quickhash/quickhashintset/add.xml
@@ -48,14 +48,14 @@
    <programlisting role="php">
 <![CDATA[
 <?php
-echo "without dupe checking\n";
+echo "sans vérification des doublons\n";
 $set = new QuickHashIntSet( 1024 );
 var_dump( $set->exists( 4 ) );
 var_dump( $set->add( 4 ) );
 var_dump( $set->exists( 4 ) );
 var_dump( $set->add( 4 ) );
 
-echo "\nwith dupe checking\n";
+echo "\navec vérification des doublons\n";
 $set = new QuickHashIntSet( 1024, QuickHashIntSet::CHECK_FOR_DUPES );
 var_dump( $set->exists( 4 ) );
 var_dump( $set->add( 4 ) );
@@ -67,13 +67,13 @@ var_dump( $set->add( 4 ) );
    &example.outputs.similar;
    <screen>
 <![CDATA[
-without dupe checking
+sans vérification des doublons
 bool(false)
 bool(true)
 bool(true)
 bool(true)
 
-with dupe checking
+avec vérification des doublons
 bool(false)
 bool(true)
 bool(true)

--- a/reference/quickhash/quickhashintset/exists.xml
+++ b/reference/quickhash/quickhashintset/exists.xml
@@ -54,30 +54,30 @@ $existingEntries = array_rand( array_flip( $array ), 180000 );
 $testForEntries = array_rand( array_flip( $array ), 1000 );
 $foundCount = 0;
 
-echo "Creating set: ", microtime( true ), "\n";
+echo "Création de l'ensemble : ", microtime( true ), "\n";
 $set = new QuickHashIntSet( 100000 );
-echo "Adding elements: ", microtime( true ), "\n";
+echo "Ajout des éléments : ", microtime( true ), "\n";
 foreach( $existingEntries as $key )
 {
      $set->add( $key );
 }
 
-echo "Doing 1000 tests: ", microtime( true ), "\n";
+echo "Exécution de 1000 tests : ", microtime( true ), "\n";
 foreach( $testForEntries as $key )
 {
      $foundCount += $set->exists( $key );
 }
-echo "Done, $foundCount found: ", microtime( true ), "\n";
+echo "Terminé, $foundCount trouvés : ", microtime( true ), "\n";
 ?>
 ]]>
    </programlisting>
    &example.outputs.similar;
    <screen>
 <![CDATA[
-Creating set: 1263588703.0748
-Adding elements: 1263588703.0757
-Doing 1000 tests: 1263588703.7851
-Done, 898 found: 1263588703.7897
+Création de l'ensemble : 1263588703.0748
+Ajout des éléments : 1263588703.0757
+Exécution de 1000 tests : 1263588703.7851
+Terminé, 898 trouvés : 1263588703.7897
 ]]>
    </screen>
   </example>

--- a/reference/quickhash/quickhashintstringhash/add.xml
+++ b/reference/quickhash/quickhashintstringhash/add.xml
@@ -58,7 +58,7 @@
    <programlisting role="php">
 <![CDATA[
 <?php
-echo "without dupe checking\n";
+echo "sans vérification des doublons\n";
 $hash = new QuickHashIntStringHash( 1024 );
 var_dump( $hash->exists( 4 ) );
 var_dump( $hash->get( 4 ) );
@@ -67,7 +67,7 @@ var_dump( $hash->exists( 4 ) );
 var_dump( $hash->get( 4 ) );
 var_dump( $hash->add( 4, "twelve" ) );
 
-echo "\nwith dupe checking\n";
+echo "\navec vérification des doublons\n";
 $hash = new QuickHashIntStringHash( 1024, QuickHashIntStringHash::CHECK_FOR_DUPES );
 var_dump( $hash->exists( 4 ) );
 var_dump( $hash->get( 4 ) );
@@ -81,7 +81,7 @@ var_dump( $hash->add( 4, "nine" ) );
    &example.outputs.similar;
    <screen>
 <![CDATA[
-without dupe checking
+sans vérification des doublons
 bool(false)
 bool(false)
 bool(true)
@@ -89,7 +89,7 @@ bool(true)
 string(10) "twenty two"
 bool(true)
 
-with dupe checking
+avec vérification des doublons
 bool(false)
 bool(false)
 bool(true)

--- a/reference/quickhash/quickhashstringinthash/add.xml
+++ b/reference/quickhash/quickhashstringinthash/add.xml
@@ -57,7 +57,7 @@
    <programlisting role="php">
 <![CDATA[
 <?php
-echo "without dupe checking\n";
+echo "sans vérification des doublons\n";
 $hash = new QuickHashStringIntHash( 1024 );
 var_dump( $hash );
 var_dump( $hash->exists( "four" ) );
@@ -67,7 +67,7 @@ var_dump( $hash->exists( "four" ) );
 var_dump( $hash->get( "four" ) );
 var_dump( $hash->add( "four", 12 ) );
 
-echo "\nwith dupe checking\n";
+echo "\navec vérification des doublons\n";
 $hash = new QuickHashStringIntHash( 1024, QuickHashStringIntHash::CHECK_FOR_DUPES );
 var_dump( $hash );
 var_dump( $hash->exists( "four" ) );
@@ -82,7 +82,7 @@ var_dump( $hash->add( "four", 9 ) );
    &example.outputs.similar;
    <screen>
 <![CDATA[
-without dupe checking
+sans vérification des doublons
 object(QuickHashStringIntHash)#1 (0) {
 }
 bool(false)
@@ -92,7 +92,7 @@ bool(true)
 int(22)
 bool(true)
 
-with dupe checking
+avec vérification des doublons
 object(QuickHashStringIntHash)#2 (0) {
 }
 bool(false)

--- a/reference/radius/book.xml
+++ b/reference/radius/book.xml
@@ -13,12 +13,12 @@
    Ce paquet est basé sur la bibliothèque libradius
    (<literal>Remote Authentication Dial In User Service</literal>)
    de FreeBSD. Il permet aux clients d'effectuer des identifications
-   et représentations par le biais de requêtes réseau
+   et de la comptabilité par le biais de requêtes réseau
    sur des serveurs distants.
   </simpara>
   <simpara>
    Cette extension PECL supporte tout le protocole Radius Authentication
-   complet pour les identifications
+   complet pour l'authentification
    (<link xlink:href="&url.rfc;2865">RFC 2865</link>) et Radius Accounting
    (<link xlink:href="&url.rfc;2866">RFC 2866</link>). Ce paquet est
    disponible pour Unix (testé sous FreeBSD et Linux) mais aussi pour Windows.

--- a/reference/radius/functions/radius-create-request.xml
+++ b/reference/radius/functions/radius-create-request.xml
@@ -23,7 +23,7 @@
   </simpara>
   <note>
    <simpara>
-    Attention : Il faut appeler cette fonction avant de passer n'importe quel argument !
+    Attention : Il faut appeler cette fonction avant de passer n'importe quel attribut !
    </simpara>
   </note>
  </refsect1>

--- a/reference/radius/functions/radius-demangle-mppe-key.xml
+++ b/reference/radius/functions/radius-demangle-mppe-key.xml
@@ -17,9 +17,9 @@
   </methodsynopsis>
   <simpara>
    Lors de l'utilisation de MPPE avec MS-CHAPv2, les clés reçues et envoyées
-   sont "séchées" (voir la <link xlink:href="&url.rfc;2548">RFC 2548</link>),
-   cependant, cette fonction est utile, car je ne sais pas s'il y a ou pas une
-   implémentation de PPTP-MPPE dans PHP.
+   sont déformées (voir la <link xlink:href="&url.rfc;2548">RFC 2548</link>),
+   cependant, cette fonction est inutile, car il n'existe pas et n'existera
+   probablement pas d'implémentation de PPTP-MPPE dans PHP.
   </simpara>
  </refsect1>
 

--- a/reference/radius/functions/radius-demangle.xml
+++ b/reference/radius/functions/radius-demangle.xml
@@ -5,7 +5,7 @@
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.radius-demangle">
  <refnamediv>
   <refname>radius_demangle</refname>
-  <refpurpose>Assèche des données</refpurpose>
+  <refpurpose>Déchiffre des données déformées</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -16,8 +16,8 @@
    <methodparam><type>string</type><parameter>mangled</parameter></methodparam>
   </methodsynopsis>
   <simpara>
-   Quelques données (mots de passe, clés MS-CHAPv1 MPPE) sont "séchées" pour
-   des raisons de sécurité et doivent être "asséchées" avant de pouvoir les utiliser.
+   Quelques données (mots de passe, clés MS-CHAPv1 MPPE) sont déformées pour
+   des raisons de sécurité et doivent être déchiffrées avant de pouvoir les utiliser.
   </simpara>
  </refsect1>
 
@@ -39,7 +39,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   Retourne la chaîne "asséchée" ou &false; si une erreur survient.
+   Retourne la chaîne déchiffrée ou &false; si une erreur survient.
   </simpara>
  </refsect1>
 </refentry>

--- a/reference/radius/functions/radius-get-tagged-attr-tag.xml
+++ b/reference/radius/functions/radius-get-tagged-attr-tag.xml
@@ -62,7 +62,7 @@ while ($resa = radius_get_attr($res)) {
     $tag = radius_get_tagged_attr_tag($data);
     $value = radius_get_tagged_attr_data($data);
 
-    printf("Récupération de l'attribut contennant le tag %d et la valeur %s\n", $tag, $value);
+    printf("Récupération de l'attribut contenant le tag %d et la valeur %s\n", $tag, $value);
 }
 ?>
 ]]>

--- a/reference/radius/functions/radius-put-vendor-int.xml
+++ b/reference/radius/functions/radius-put-vendor-int.xml
@@ -22,6 +22,7 @@
   <simpara>
    Attache un attribut spécifique au vendeur à la requête courante RADIUS.
   </simpara>
+  &radius.request.required;
  </refsect1>
 
  <refsect1 role="parameters">

--- a/reference/radius/functions/radius-put-vendor-string.xml
+++ b/reference/radius/functions/radius-put-vendor-string.xml
@@ -24,6 +24,7 @@
    En général, <function>radius_put_vendor_attr</function> est une fonction plus
    pratique pour attacher des attributs, sachant qu'elle est sécurisée au niveau binaire.
   </simpara>
+  &radius.request.required;
  </refsect1>
 
  <refsect1 role="parameters">

--- a/reference/radius/functions/radius-request-authenticator.xml
+++ b/reference/radius/functions/radius-request-authenticator.xml
@@ -5,7 +5,7 @@
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.radius-request-authenticator">
  <refnamediv>
   <refname>radius_request_authenticator</refname>
-  <refpurpose>Retourne l'identifiant demandé</refpurpose>
+  <refpurpose>Retourne l'authentificateur de requête</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -15,7 +15,7 @@
    <methodparam><type>resource</type><parameter>radius_handle</parameter></methodparam>
   </methodsynopsis>
   <simpara>
-   L'identifiant demandé est nécessaire pour le rétablissement des données
+   L'authentificateur de requête est nécessaire pour le déchiffrement des données
    comme les mots de passe et les clés de chiffrement.
   </simpara>
  </refsect1>
@@ -30,7 +30,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   Retourne l'identificateur demandé en tant que chaîne de caractères ou
+   Retourne l'authentificateur de requête en tant que chaîne de caractères ou
    &false; si une erreur survient.
   </simpara>
  </refsect1>

--- a/reference/random/examples.xml
+++ b/reference/random/examples.xml
@@ -38,8 +38,8 @@ echo "Valeurs : ", implode(', ', $selection), "\n";
  <screen>
 <![CDATA[
 j87fzv1p0daiwmlo.example.com
-Salade: 🥝, 🍇, 🍎, 🍌, 🍑
-Valeurs: 🍌, 🍑
+Salade : 🥝, 🍇, 🍎, 🍌, 🍑
+Valeurs : 🍌, 🍑
 ]]>
   </screen>
  </example>

--- a/reference/random/functions/mt-rand.xml
+++ b/reference/random/functions/mt-rand.xml
@@ -116,8 +116,8 @@
        <entry>
         <function>mt_rand</function>
         <link linkend="migration71.incompatible.fixes-to-mt_rand-algorithm">a été mis à jour</link>
-        pour utiliser la version corrigée, correcte, de l'algorithme Twister
-        Mersenne. Pour revenir à l'ancien comportement, utiliser
+        pour utiliser la version corrigée, correcte, de l'algorithme Mersenne
+        Twister. Pour revenir à l'ancien comportement, utiliser
         <function>mt_srand</function> avec <constant>MT_RAND_PHP</constant>
         comme deuxième paramètre.
        </entry>
@@ -161,7 +161,7 @@ echo mt_rand(5, 15), "\n";
    <para>
     La plage <parameter>min</parameter> <parameter>max</parameter> doit se situer
     dans la plage <function>mt_getrandmax</function>. C.-à-d.
-    <parameter>max</parameter> - <parameter>min</parameter>) &lt;=
+    (<parameter>max</parameter> - <parameter>min</parameter>) &lt;=
     <function>mt_getrandmax</function> sinon, <function>mt_rand</function> peut
     retourner des nombres aléatoires plus pauvres qu'il ne le devrait.
    </para>

--- a/reference/random/functions/mt-srand.xml
+++ b/reference/random/functions/mt-srand.xml
@@ -41,7 +41,7 @@
       </para>
       <para>
        Si <parameter>seed</parameter> est omis ou &null;, un entier non signé
-       de 32 bits sera utilisé de manière aléatoire.
+       aléatoire de 32 bits sera utilisé.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/random/functions/rand.xml
+++ b/reference/random/functions/rand.xml
@@ -33,7 +33,7 @@
     Avant PHP 7.1.0, <function>getrandmax</function> valait seulement 32767 sur certaines plateformes
     (comme Windows). En cas de besoin d’une plage supérieure à 32767, il est recommandé de spécifier
     une valeur limite supérieure à 32767, en spécifiant <parameter>min</parameter> et
-    <parameter>max</parameter>, l'on sera autorisés à utiliser un intervalle
+    <parameter>max</parameter>, l'on sera autorisé à utiliser un intervalle
     plus grand que <function>mt_getrandmax</function>, ou bien, utiliser la fonction
     <function>mt_rand</function> à la place.
    </simpara>

--- a/reference/random/functions/srand.xml
+++ b/reference/random/functions/srand.xml
@@ -42,7 +42,7 @@
       </para>
       <para>
        Si <parameter>seed</parameter> est omis ou &null;, un entier non signé
-       de 32 bits sera utilisé de manière aléatoire.
+       aléatoire de 32 bits sera utilisé.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/random/random.intervalboundary.xml
+++ b/reference/random/random.intervalboundary.xml
@@ -27,7 +27,7 @@
      <enumitem>
       <enumidentifier>ClosedOpen</enumidentifier>
       <enumitemdescription>
-      Un intervalle fermé à droite.
+      Un intervalle ouvert à droite.
       La limite inférieure est incluse dans l'intervalle,
       la limite supérieure ne l'est pas.
      </enumitemdescription>
@@ -44,7 +44,7 @@
      <enumitem>
       <enumidentifier>OpenClosed</enumidentifier>
       <enumitemdescription>
-      Un intervalle fermé à gauche.
+      Un intervalle ouvert à gauche.
       La limite supérieure est incluse dans l'intervalle,
       la limite inférieure ne l'est pas.
      </enumitemdescription>

--- a/reference/random/random/engine/xoshiro256starstar/construct.xml
+++ b/reference/random/random/engine/xoshiro256starstar/construct.xml
@@ -102,7 +102,7 @@
    <programlisting role="php">
 <![CDATA[
 <?php
-// Uses a random 256 Bit seed.
+// Utilise une graine aléatoire de 256 bits.
 $e = new \Random\Engine\Xoshiro256StarStar();
 
 $r = new \Random\Randomizer($e);

--- a/reference/random/random/randomizer/nextfloat.xml
+++ b/reference/random/random/randomizer/nextfloat.xml
@@ -105,14 +105,14 @@ $chance = 0.5;
 
 $bool = $r->nextFloat() < $chance;
 
-echo ($bool ? "You won" : "You lost"), "\n";
+echo ($bool ? "Vous avez gagné" : "Vous avez perdu"), "\n";
 ?>
 ]]>
    </programlisting>
    &example.outputs.similar;
    <screen>
 <![CDATA[
-You won
+Vous avez gagné
 ]]>
    </screen>
   </example>
@@ -137,7 +137,7 @@ $max = 4.5;
 //
 // Cela affichera 4.5, malgré le fait que nextFloat() échantillonne
 // à partir d'un intervalle ouvert à droite, qui ne retournera jamais 1.
-printf("Wrong scaling: %.17g", $randomizer->nextFloat() * ($max - $min) + $min);
+printf("Mauvaise mise à l'échelle : %.17g", $randomizer->nextFloat() * ($max - $min) + $min);
 
 // Correct:
 // $randomizer->getFloat($min, $max, \Random\IntervalBoundary::ClosedOpen);
@@ -147,7 +147,7 @@ printf("Wrong scaling: %.17g", $randomizer->nextFloat() * ($max - $min) + $min);
    &example.outputs;
    <screen>
 <![CDATA[
-Wrong scaling: 4.5
+Mauvaise mise à l'échelle : 4.5
 ]]>
    </screen>
   </example>

--- a/reference/random/random/randomizer/pickarraykeys.xml
+++ b/reference/random/random/randomizer/pickarraykeys.xml
@@ -90,18 +90,18 @@ $r = new \Random\Randomizer();
 $fruits = [ 'red' => '🍎', 'green' => '🥝', 'yellow' => '🍌', 'pink' => '🍑', 'purple' => '🍇' ];
 
 // Prend 2 clés de tableau aléatoires:
-echo "Keys: ", implode(', ', $r->pickArrayKeys($fruits, 2)), "\n";
+echo "Clés : ", implode(', ', $r->pickArrayKeys($fruits, 2)), "\n";
 
 // Prend 3 autres clés:
-echo "Keys: ", implode(', ', $r->pickArrayKeys($fruits, 3)), "\n";
+echo "Clés : ", implode(', ', $r->pickArrayKeys($fruits, 3)), "\n";
 ?>
 ]]>
    </programlisting>
    &example.outputs.similar;
    <screen>
 <![CDATA[
-Keys: yellow, purple
-Keys: red, green, yellow
+Clés : yellow, purple
+Clés : red, green, yellow
 ]]>
    </screen>
   </example>
@@ -121,14 +121,14 @@ $selection = array_map(
     $keys
 );
 
-echo "Values: ", implode(', ', $selection), "\n";
+echo "Valeurs : ", implode(', ', $selection), "\n";
 ?>
 ]]>
    </programlisting>
    &example.outputs.similar;
    <screen>
 <![CDATA[
-Values: 🍎, 🍇
+Valeurs : 🍎, 🍇
 ]]>
    </screen>
   </example>

--- a/reference/random/random/randomizer/shufflearray.xml
+++ b/reference/random/random/randomizer/shufflearray.xml
@@ -69,18 +69,18 @@ $r = new \Random\Randomizer();
 $fruits = [ 'red' => '🍎', 'green' => '🥝', 'yellow' => '🍌', 'pink' => '🍑', 'purple' => '🍇' ];
 
 // Mélanger le tableau :
-echo "Salad: ", implode(', ', $r->shuffleArray($fruits)), "\n";
+echo "Salade : ", implode(', ', $r->shuffleArray($fruits)), "\n";
 
 // Mélanger à nouveau:
-echo "Another Salad: ", implode(', ', $r->shuffleArray($fruits)), "\n";
+echo "Autre salade : ", implode(', ', $r->shuffleArray($fruits)), "\n";
 ?>
 ]]>
    </programlisting>
    &example.outputs.similar;
    <screen>
 <![CDATA[
-Salad: 🍎, 🥝, 🍇, 🍌, 🍑
-Another Salad: 🍑, 🍇, 🥝, 🍎, 🍌
+Salade : 🍎, 🥝, 🍇, 🍌, 🍑
+Autre salade : 🍑, 🍇, 🥝, 🍎, 🍌
 ]]>
    </screen>
   </example>

--- a/reference/random/random/randomizer/shufflebytes.xml
+++ b/reference/random/random/randomizer/shufflebytes.xml
@@ -88,18 +88,18 @@ $shuffled = $r->shuffleBytes( $unicode );
 // ce qui entraîne des séquences invalides (indiquées par le caractère
 // de remplacement Unicode) ou même l'apparition de caractères
 // entièrement différents dans la sortie.
-echo "Original: ", $unicode, "\n";
-echo "Shuffled: «", $shuffled, "»\n";
-echo "Shuffled Bytes: ", bin2hex($shuffled), "\n";
+echo "Original : ", $unicode, "\n";
+echo "Mélangé : «", $shuffled, "»\n";
+echo "Octets mélangés : ", bin2hex($shuffled), "\n";
 ?>
 ]]>
    </programlisting>
    &example.outputs.similar;
    <screen>
 <![CDATA[
-Original: 🍎, 🥝, 🍌, 🍑, 🍇
-Shuffled: «� ��,�����🍟,� �� �, �,��»
-Shuffled Bytes: 87208e912c8d9fa5f0f0f09f8d9f2cf09f208c9d20f02c209f2c8d8d
+Original : 🍎, 🥝, 🍌, 🍑, 🍇
+Mélangé : «� ��,�����🍟,� �� �, �,��»
+Octets mélangés : 87208e912c8d9fa5f0f0f09f8d9f2cf09f208c9d20f02c209f2c8d8d
 ]]>
    </screen>
   </example>

--- a/reference/random/reference.xml
+++ b/reference/random/reference.xml
@@ -2,7 +2,7 @@
 <!-- EN-Revision: 2166824858a40ea664c558f2930b63b8f4fd89c6 Maintainer: pierrick Status: ready -->
 <!-- Reviewed: no -->
 <reference xml:id="ref.random" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
- <title>Random &Functions;</title>
+ <title>&Functions; Random</title>
 
  &reference.random.entities.functions;
 

--- a/reference/rar/examples.xml
+++ b/reference/rar/examples.xml
@@ -120,8 +120,8 @@ while (!feof($fp)) {
   </programlisting>
  </example>
  <simpara>
-  Cet exemple ouvre l'archive RAR et extrait chacune des entrées dans
-  un dossier spécifié.
+  Cet exemple ouvre un fichier RAR et présente le fichier demandé contenu
+  dans l'archive RAR pour téléchargement par le client.
  </simpara>
 
  <example>
@@ -130,13 +130,13 @@ while (!feof($fp)) {
 <![CDATA[
 <?php
 
-$rar_file = rar_open('example.rar') or die("Can't open Rar archive");
+$rar_file = rar_open('example.rar') or die("Impossible d'ouvrir l'archive Rar");
 
 $entries = rar_list($rar_file);
 
 foreach ($entries as $entry) {
     echo 'Nom du fichier : ' . $entry->getName() . "\n";
-    echo 'Taille de l'archive : ' . $entry->getPackedSize() . "\n";
+    echo 'Taille compressée : ' . $entry->getPackedSize() . "\n";
     echo 'Taille après décompression : ' . $entry->getUnpackedSize() . "\n";
 
     $entry->extract('/dir/extract/to/');

--- a/reference/rar/rararchive/getcomment.xml
+++ b/reference/rar/rararchive/getcomment.xml
@@ -23,7 +23,7 @@
   </methodsynopsis>
   <simpara>
    Récupère le commentaire global stocké dans l'archive RAR.
-   Il peut être supérieur à une longueur de 64 Ko.
+   Il peut atteindre 64 Ko de long.
   </simpara>
   <note>
    <simpara>

--- a/reference/rar/rararchive/getentry.xml
+++ b/reference/rar/rararchive/getentry.xml
@@ -31,7 +31,7 @@
     la méthode <methodname>RarArchive::getEntries</methodname>.
    </simpara>
    <simpara>
-    Notez qu'une archive RAR peut avoir plusieurs entrées portant le même nom ;
+    Il est à noter qu'une archive RAR peut avoir plusieurs entrées portant le même nom ;
     cette méthode ne récupérera que la première.
    </simpara>
   </note>

--- a/reference/rar/rararchive/isbroken.xml
+++ b/reference/rar/rararchive/isbroken.xml
@@ -6,7 +6,7 @@
  <refnamediv>
   <refname>RarArchive::isBroken</refname>
   <refname>rar_broken_is</refname>
-  <refpurpose>Test si une archive est corrompue (incomplète)</refpurpose>
+  <refpurpose>Teste si une archive est corrompue (incomplète)</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/rar/rararchive/issolid.xml
+++ b/reference/rar/rararchive/issolid.xml
@@ -66,8 +66,8 @@ echo "$arch2: " . ($arch2->isSolid()?'oui':'non') . "\n";
     &example.outputs.similar;
     <screen>
 <![CDATA[
-RAR Archive "C:\php_rar\trunk\tests\store_method.rar": no
-RAR Archive "C:\php_rar\trunk\tests\solid.rar": yes
+RAR Archive "C:\php_rar\trunk\tests\store_method.rar": non
+RAR Archive "C:\php_rar\trunk\tests\solid.rar": oui
 ]]>
    </screen>
   </example>

--- a/reference/rar/rararchive/open.xml
+++ b/reference/rar/rararchive/open.xml
@@ -54,8 +54,8 @@
      <simpara>
       Un mot de passe en texte brut, si nécessaire pour déchiffrer l'en-tête.
       Il sera également utilisé par défaut si des fichiers cryptés sont trouvés.
-      Noter que les fichiers peuvent avoir un mot de passe différent, et ce,
-      en respectant les en-têtes.
+      Il est à noter que les fichiers peuvent avoir un mot de passe
+      différent de celui des en-têtes et différents entre eux.
      </simpara>
     </listitem>
    </varlistentry>

--- a/reference/rar/rarentry.xml
+++ b/reference/rar/rarentry.xml
@@ -361,7 +361,7 @@
       <term><constant>RarEntry::ATTRIBUTE_WIN_READONLY</constant></term>
       <listitem>
        <simpara>
-        Octet représentant une entrée Windows avec un attribut en lecture seule.
+        Bit représentant une entrée Windows avec un attribut en lecture seule.
         À utiliser avec la méthode <methodname>RarEntry::getAttr</methodname>
         sur les entrées dont l'OS hôte est Microsoft Windows.
        </simpara>
@@ -372,7 +372,7 @@
       <term><constant>RarEntry::ATTRIBUTE_WIN_HIDDEN</constant></term>
       <listitem>
        <simpara>
-        Octet représentant une entrée Windows avec un attribut caché.
+        Bit représentant une entrée Windows avec un attribut caché.
         À utiliser avec la méthode <methodname>RarEntry::getAttr</methodname>
         sur les entrées dont l'OS hôte est Microsoft Windows.
        </simpara>
@@ -383,7 +383,7 @@
       <term><constant>RarEntry::ATTRIBUTE_WIN_SYSTEM</constant></term>
       <listitem>
        <simpara>
-        Octet représentant une entrée Windows avec un attribut système.
+        Bit représentant une entrée Windows avec un attribut système.
         À utiliser avec la méthode <methodname>RarEntry::getAttr</methodname>
         sur les entrées dont l'OS hôte est Microsoft Windows.
        </simpara>
@@ -394,7 +394,7 @@
       <term><constant>RarEntry::ATTRIBUTE_WIN_DIRECTORY</constant></term>
       <listitem>
        <simpara>
-        Octet représentant une entrée Windows avec un attribut dossier (l'entrée
+        Bit représentant une entrée Windows avec un attribut dossier (l'entrée
         est un dossier).
         À utiliser avec la méthode <methodname>RarEntry::getAttr</methodname>
         sur les entrées dont l'OS hôte est Microsoft Windows. Voir aussi la méthode
@@ -408,7 +408,7 @@
       <term><constant>RarEntry::ATTRIBUTE_WIN_ARCHIVE</constant></term>
       <listitem>
        <simpara>
-        Octet représentant une entrée Windows avec un attribut d'archive.
+        Bit représentant une entrée Windows avec un attribut d'archive.
         À utiliser avec la méthode <methodname>RarEntry::getAttr</methodname>
         sur les entrées dont l'OS hôte est Microsoft Windows.
        </simpara>
@@ -419,7 +419,7 @@
       <term><constant>RarEntry::ATTRIBUTE_WIN_DEVICE</constant></term>
       <listitem>
        <simpara>
-        Octet représentant une entrée Windows avec un attribut de périphérique.
+        Bit représentant une entrée Windows avec un attribut de périphérique.
         À utiliser avec la méthode <methodname>RarEntry::getAttr</methodname>
         sur les entrées dont l'OS hôte est Microsoft Windows.
        </simpara>
@@ -430,7 +430,7 @@
       <term><constant>RarEntry::ATTRIBUTE_WIN_NORMAL</constant></term>
       <listitem>
        <simpara>
-        Octet représentant une entrée Windows avec un attribut de fichier normal
+        Bit représentant une entrée Windows avec un attribut de fichier normal
         (l'entrée n'est pas un dossier).
         À utiliser avec la méthode <methodname>RarEntry::getAttr</methodname>
         sur les entrées dont l'OS hôte est Microsoft Windows. Voir aussi la méthode
@@ -444,7 +444,7 @@
       <term><constant>RarEntry::ATTRIBUTE_WIN_TEMPORARY</constant></term>
       <listitem>
        <simpara>
-        Octet représentant une entrée Windows avec un attribut temporaire.
+        Bit représentant une entrée Windows avec un attribut temporaire.
         À utiliser avec la méthode <methodname>RarEntry::getAttr</methodname>
         sur les entrées dont l'OS hôte est Microsoft Windows.
        </simpara>
@@ -455,7 +455,7 @@
       <term><constant>RarEntry::ATTRIBUTE_WIN_SPARSE_FILE</constant></term>
       <listitem>
        <simpara>
-        Octet représentant une entrée Windows avec un attribut de fichier fragmenté
+        Bit représentant une entrée Windows avec un attribut de fichier fragmenté
         (le fichier est un fichier NTFS fragmenté).
         À utiliser avec la méthode <methodname>RarEntry::getAttr</methodname>
         sur les entrées dont l'OS hôte est Microsoft Windows.
@@ -467,7 +467,7 @@
       <term><constant>RarEntry::ATTRIBUTE_WIN_REPARSE_POINT</constant></term>
       <listitem>
        <simpara>
-        Octet représentant une entrée Windows avec un attribut de point d'analyse
+        Bit représentant une entrée Windows avec un attribut de point d'analyse
         (le fichier est un point d'analyse NTFS ; c.-à-d. une jonction de dossier ou un système
         de fichier monté).
         À utiliser avec la méthode <methodname>RarEntry::getAttr</methodname>
@@ -480,7 +480,7 @@
       <term><constant>RarEntry::ATTRIBUTE_WIN_COMPRESSED</constant></term>
       <listitem>
        <simpara>
-        Octet représentant une entrée Windows avec un attribut compressé
+        Bit représentant une entrée Windows avec un attribut compressé
         (NTFS uniquement).
         À utiliser avec la méthode <methodname>RarEntry::getAttr</methodname>
         sur les entrées dont l'OS hôte est Microsoft Windows.
@@ -492,7 +492,7 @@
       <term><constant>RarEntry::ATTRIBUTE_WIN_OFFLINE</constant></term>
       <listitem>
        <simpara>
-        Octet représentant une entrée Windows avec un attribut hors-ligne
+        Bit représentant une entrée Windows avec un attribut hors-ligne
         (le fichier est hors-ligne et non accessible).
         À utiliser avec la méthode <methodname>RarEntry::getAttr</methodname>
         sur les entrées dont l'OS hôte est Microsoft Windows.
@@ -504,7 +504,7 @@
       <term><constant>RarEntry::ATTRIBUTE_WIN_NOT_CONTENT_INDEXED</constant></term>
       <listitem>
        <simpara>
-        Octet représentant une entrée Windows avec un attribut dont le contenu n'est pas indexé
+        Bit représentant une entrée Windows avec un attribut dont le contenu n'est pas indexé
         (l'entrée doit être indexée).
         À utiliser avec la méthode <methodname>RarEntry::getAttr</methodname>
         sur les entrées dont l'OS hôte est Microsoft Windows.
@@ -516,7 +516,7 @@
       <term><constant>RarEntry::ATTRIBUTE_WIN_ENCRYPTED</constant></term>
       <listitem>
        <simpara>
-        Octet représentant une entrée Windows avec un attribut crypté
+        Bit représentant une entrée Windows avec un attribut crypté
         (NTFS uniquement).
         À utiliser avec la méthode <methodname>RarEntry::getAttr</methodname>
         sur les entrées dont l'OS hôte est Microsoft Windows.
@@ -528,7 +528,7 @@
       <term><constant>RarEntry::ATTRIBUTE_WIN_VIRTUAL</constant></term>
       <listitem>
        <simpara>
-        Octet représentant une entrée Windows avec un attribut virtuel.
+        Bit représentant une entrée Windows avec un attribut virtuel.
         À utiliser avec la méthode <methodname>RarEntry::getAttr</methodname>
         sur les entrées dont l'OS hôte est Microsoft Windows.
        </simpara>
@@ -539,7 +539,7 @@
       <term><constant>RarEntry::ATTRIBUTE_UNIX_WORLD_EXECUTE</constant></term>
       <listitem>
        <simpara>
-        Octet représentant une entrée UNIX qui est exécutable par tous.
+        Bit représentant une entrée UNIX qui est exécutable par tous.
         À utiliser avec la méthode <methodname>RarEntry::getAttr</methodname>
         sur les entrées dont l'OS hôte est UNIX.
        </simpara>
@@ -550,7 +550,7 @@
       <term><constant>RarEntry::ATTRIBUTE_UNIX_WORLD_WRITE</constant></term>
       <listitem>
        <simpara>
-        Octet représentant une entrée UNIX qui est accessible en écriture par tous.
+        Bit représentant une entrée UNIX qui est accessible en écriture par tous.
         À utiliser avec la méthode <methodname>RarEntry::getAttr</methodname>
         sur les entrées dont l'OS hôte est UNIX.
        </simpara>
@@ -561,7 +561,7 @@
       <term><constant>RarEntry::ATTRIBUTE_UNIX_WORLD_READ</constant></term>
       <listitem>
        <simpara>
-        Octet représentant une entrée UNIX qui est accessible en lecture par tous.
+        Bit représentant une entrée UNIX qui est accessible en lecture par tous.
         À utiliser avec la méthode <methodname>RarEntry::getAttr</methodname>
         sur les entrées dont l'OS hôte est UNIX.
        </simpara>
@@ -572,7 +572,7 @@
       <term><constant>RarEntry::ATTRIBUTE_UNIX_GROUP_EXECUTE</constant></term>
       <listitem>
        <simpara>
-        Octet représentant une entrée UNIX qui est dans le groupe des exécutables.
+        Bit représentant une entrée UNIX qui est dans le groupe des exécutables.
         À utiliser avec la méthode <methodname>RarEntry::getAttr</methodname>
         sur les entrées dont l'OS hôte est UNIX.
        </simpara>
@@ -583,7 +583,7 @@
       <term><constant>RarEntry::ATTRIBUTE_UNIX_GROUP_WRITE</constant></term>
       <listitem>
        <simpara>
-        Octet représentant une entrée UNIX qui est dans le groupe des accessibles en écriture.
+        Bit représentant une entrée UNIX qui est dans le groupe des accessibles en écriture.
         À utiliser avec la méthode <methodname>RarEntry::getAttr</methodname>
         sur les entrées dont l'OS hôte est UNIX.
        </simpara>
@@ -594,7 +594,7 @@
       <term><constant>RarEntry::ATTRIBUTE_UNIX_GROUP_READ</constant></term>
       <listitem>
        <simpara>
-        Octet représentant une entrée UNIX qui est dans le groupe des accessibles en lecture.
+        Bit représentant une entrée UNIX qui est dans le groupe des accessibles en lecture.
         À utiliser avec la méthode <methodname>RarEntry::getAttr</methodname>
         sur les entrées dont l'OS hôte est UNIX.
        </simpara>
@@ -605,7 +605,7 @@
       <term><constant>RarEntry::ATTRIBUTE_UNIX_OWNER_EXECUTE</constant></term>
       <listitem>
        <simpara>
-        Octet représentant une entrée UNIX dont le propriétaire est exécutable.
+        Bit représentant une entrée UNIX dont le propriétaire est exécutable.
         À utiliser avec la méthode <methodname>RarEntry::getAttr</methodname>
         sur les entrées dont l'OS hôte est UNIX.
        </simpara>
@@ -616,7 +616,7 @@
       <term><constant>RarEntry::ATTRIBUTE_UNIX_OWNER_WRITE</constant></term>
       <listitem>
        <simpara>
-        Octet représentant une entrée UNIX dont le propriétaire est accessible en écriture.
+        Bit représentant une entrée UNIX dont le propriétaire est accessible en écriture.
         À utiliser avec la méthode <methodname>RarEntry::getAttr</methodname>
         sur les entrées dont l'OS hôte est UNIX.
        </simpara>
@@ -627,7 +627,7 @@
       <term><constant>RarEntry::ATTRIBUTE_UNIX_OWNER_READ</constant></term>
       <listitem>
        <simpara>
-        Octet représentant une entrée UNIX dont le propriétaire est accessible en lecture.
+        Bit représentant une entrée UNIX dont le propriétaire est accessible en lecture.
         À utiliser avec la méthode <methodname>RarEntry::getAttr</methodname>
         sur les entrées dont l'OS hôte est UNIX.
        </simpara>
@@ -638,7 +638,7 @@
       <term><constant>RarEntry::ATTRIBUTE_UNIX_STICKY</constant></term>
       <listitem>
        <simpara>
-        Octet représentant une entrée UNIX ayant l'octet sticky.
+        Bit représentant une entrée UNIX ayant le bit sticky.
         À utiliser avec la méthode <methodname>RarEntry::getAttr</methodname>
         sur les entrées dont l'OS hôte est UNIX.
        </simpara>
@@ -649,7 +649,7 @@
       <term><constant>RarEntry::ATTRIBUTE_UNIX_SETGID</constant></term>
       <listitem>
        <simpara>
-        Octet représentant un attribut UNIX setgid.
+        Bit représentant un attribut UNIX setgid.
         À utiliser avec la méthode <methodname>RarEntry::getAttr</methodname>
         sur les entrées dont l'OS hôte est UNIX.
        </simpara>
@@ -660,7 +660,7 @@
       <term><constant>RarEntry::ATTRIBUTE_UNIX_SETUID</constant></term>
       <listitem>
        <simpara>
-        Octet représentant un attribut UNIX setuid.
+        Bit représentant un attribut UNIX setuid.
         À utiliser avec la méthode <methodname>RarEntry::getAttr</methodname>
         sur les entrées dont l'OS hôte est UNIX.
        </simpara>
@@ -671,7 +671,7 @@
       <term><constant>RarEntry::ATTRIBUTE_UNIX_FINAL_QUARTET</constant></term>
       <listitem>
        <simpara>
-        Masque permettant d'isoler les 4 derniers octets (nibble) des attributs UNIX
+        Masque permettant d'isoler les 4 derniers bits (nibble) des attributs UNIX
         (_S_IFMT, le type du masque de fichier).
         À utiliser avec la méthode <methodname>RarEntry::getAttr</methodname>
         sur les entrées dont l'OS hôte est UNIX et avec les constantes
@@ -689,7 +689,7 @@
       <term><constant>RarEntry::ATTRIBUTE_UNIX_FIFO</constant></term>
       <listitem>
        <simpara>
-        Attributs FIFOs Unix dont les 4 derniers octets ont cette valeur.
+        Attributs FIFOs Unix dont les 4 derniers bits ont cette valeur.
         À utiliser avec la méthode <methodname>RarEntry::getAttr</methodname>
         sur les entrées dont l'OS hôte est UNIX et avec la constante
         <link linkend="rarentry.constants.attribute-unix-final-quartet">
@@ -702,7 +702,7 @@
       <term><constant>RarEntry::ATTRIBUTE_UNIX_CHAR_DEV</constant></term>
       <listitem>
        <simpara>
-        Attributs des périphériques Unix dont les 4 derniers octets ont cette valeur.
+        Attributs des périphériques Unix dont les 4 derniers bits ont cette valeur.
         À utiliser avec la méthode <methodname>RarEntry::getAttr</methodname>
         sur les entrées dont l'OS hôte est UNIX et avec la constante <link linkend="rarentry.constants.attribute-unix-final-quartet">
         <constant>RarEntry::ATTRIBUTE_UNIX_FINAL_QUARTET</constant></link>.
@@ -714,7 +714,7 @@
       <term><constant>RarEntry::ATTRIBUTE_UNIX_DIRECTORY</constant></term>
       <listitem>
        <simpara>
-        Attributs des dossiers Unix dont les 4 derniers octets ont cette valeur.
+        Attributs des dossiers Unix dont les 4 derniers bits ont cette valeur.
         À utiliser avec la méthode <methodname>RarEntry::getAttr</methodname>
         sur les entrées dont l'OS hôte est UNIX et avec la constante <link linkend="rarentry.constants.attribute-unix-final-quartet">
         <constant>RarEntry::ATTRIBUTE_UNIX_FINAL_QUARTET</constant></link>.
@@ -729,7 +729,7 @@
       <term><constant>RarEntry::ATTRIBUTE_UNIX_BLOCK_DEV</constant></term>
       <listitem>
        <simpara>
-        Attributs des périphériques de bloc Unix dont les 4 derniers octets ont cette valeur.
+        Attributs des périphériques de bloc Unix dont les 4 derniers bits ont cette valeur.
         À utiliser avec la méthode <methodname>RarEntry::getAttr</methodname>
         sur les entrées dont l'OS hôte est UNIX et avec la constante <link linkend="rarentry.constants.attribute-unix-final-quartet">
         <constant>RarEntry::ATTRIBUTE_UNIX_FINAL_QUARTET</constant></link>.
@@ -741,7 +741,7 @@
       <term><constant>RarEntry::ATTRIBUTE_UNIX_REGULAR_FILE</constant></term>
       <listitem>
        <simpara>
-        Attributs des fichiers réguliers (pas de dossiers) Unix dont les 4 derniers octets ont cette valeur.
+        Attributs des fichiers réguliers (pas de dossiers) Unix dont les 4 derniers bits ont cette valeur.
         À utiliser avec la méthode <methodname>RarEntry::getAttr</methodname>
         sur les entrées dont l'OS hôte est UNIX et avec la constante <link linkend="rarentry.constants.attribute-unix-final-quartet">
         <constant>RarEntry::ATTRIBUTE_UNIX_FINAL_QUARTET</constant></link>.
@@ -756,7 +756,7 @@
       <term><constant>RarEntry::ATTRIBUTE_UNIX_SYM_LINK</constant></term>
       <listitem>
        <simpara>
-        Attributs des liens symboliques Unix dont les 4 derniers octets ont cette valeur.
+        Attributs des liens symboliques Unix dont les 4 derniers bits ont cette valeur.
         À utiliser avec la méthode <methodname>RarEntry::getAttr</methodname>
         sur les entrées dont l'OS hôte est UNIX et avec la constante <link linkend="rarentry.constants.attribute-unix-final-quartet">
         <constant>RarEntry::ATTRIBUTE_UNIX_FINAL_QUARTET</constant></link>.
@@ -768,7 +768,7 @@
       <term><constant>RarEntry::ATTRIBUTE_UNIX_SOCKET</constant></term>
       <listitem>
        <simpara>
-        Attributs des sockets Unix dont les 4 derniers octets ont cette valeur.
+        Attributs des sockets Unix dont les 4 derniers bits ont cette valeur.
         À utiliser avec la méthode <methodname>RarEntry::getAttr</methodname>
         sur les entrées dont l'OS hôte est UNIX et avec la constante <link linkend="rarentry.constants.attribute-unix-final-quartet">
         <constant>RarEntry::ATTRIBUTE_UNIX_FINAL_QUARTET</constant></link>.

--- a/reference/rar/rarentry/getname.xml
+++ b/reference/rar/rarentry/getname.xml
@@ -63,14 +63,14 @@
 <![CDATA[
 <?php
 
-// Cet exemple fonctionne aussi pour les pages encodées en UTF-8.
-// Aussi, l'appel à la fonction mb_convert_encoding n'est pas nécessaire
+// Cet exemple est sûr même pour les pages non encodées en UTF-8.
+// Pour celles encodées en UTF-8, l'appel à la fonction mb_convert_encoding n'est pas nécessaire
 
 $rar_file = rar_open('example.rar') or die("Erreur lors de l'ouverture de l'archive Rar");
 
 $entry = rar_entry_get($rar_file, 'Dir/file.txt') or die("Entrée non trouvée");
 
-echo "Entry name: " . mb_convert_encoding(
+echo "Nom de l'entrée : " . mb_convert_encoding(
     htmlentities(
         $entry->getName(),
         ENT_COMPAT,

--- a/reference/rar/rarentry/getpackedsize.xml
+++ b/reference/rar/rarentry/getpackedsize.xml
@@ -15,7 +15,7 @@
    <void/>
   </methodsynopsis>
   <simpara>
-   Récupère la taille décompressée d'une entrée.
+   Récupère la taille compressée d'une entrée d'archive.
   </simpara>
   <note>
    <simpara>

--- a/reference/rar/rarexception/isusingexceptions.xml
+++ b/reference/rar/rarexception/isusingexceptions.xml
@@ -16,8 +16,9 @@
   </methodsynopsis>
   <simpara>
    Vérifie si les fonctions RAR émettent des alertes et retournent des valeurs d'erreur
-   ou bien si elles émettent des exceptions (n'incluent pas des erreurs de syntaxe
-   telles que le fait de passer des types incorrects comme arguments).
+   ou bien si elles émettent des exceptions dans la plupart des cas (cela n'inclut pas
+   certaines erreurs de programmation telles que le fait de passer des types incorrects
+   comme arguments).
   </simpara>
  </refsect1>
 

--- a/reference/readline/functions/readline-callback-handler-install.xml
+++ b/reference/readline/functions/readline-callback-handler-install.xml
@@ -71,7 +71,7 @@ function rl_callback($ret)
 {
     global $c, $prompting;
 
-    echo "You entered: $ret\n";
+    echo "Vous avez entré : $ret\n";
     $c++;
 
     if ($c > 10) {

--- a/reference/readline/functions/readline-completion-function.xml
+++ b/reference/readline/functions/readline-completion-function.xml
@@ -28,7 +28,7 @@
     <listitem>
      <simpara>
       Il faut fournir le nom d'une fonction qui accepte un nom
-      partiel de commande, et retourne une liste de fonctions complète
+      partiel de commande, et retourne un tableau de correspondances
       possibles.
      </simpara>
     </listitem>

--- a/reference/readline/functions/readline-on-new-line.xml
+++ b/reference/readline/functions/readline-on-new-line.xml
@@ -35,7 +35,7 @@
   &reftitle.notes;
   <note>
    <simpara>
-    Cette fonction n'est disponible uniquement si elle est supportée par la
+    Cette fonction n'est disponible que si elle est supportée par la
     bibliothèque readline sous-jacente. Elle n'est pas supportée sur Windows.
    </simpara>
   </note>

--- a/reference/readline/functions/readline.xml
+++ b/reference/readline/functions/readline.xml
@@ -15,7 +15,7 @@
    <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>prompt</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
   <simpara>
-   Retourne une ligne entrée par l'utilisateur.
+   Lit une seule ligne saisie par l'utilisateur.
    Il faut ajouter cette ligne à l'historique soi-même,
    avec la fonction <function>readline_add_history</function>.
   </simpara>

--- a/reference/recode/configure.xml
+++ b/reference/recode/configure.xml
@@ -20,7 +20,7 @@
   <title>PHP &lt; 7.4</title>
   <simpara>
    Pour utiliser les fonctions définies dans ce module PHP doit être compilé
-   avec l'option<option role="configure">--with-recode[=DIR]</option>.
+   avec l'option <option role="configure">--with-recode[=DIR]</option>.
   </simpara>
   <warning>
    <simpara>

--- a/reference/recode/reference.xml
+++ b/reference/recode/reference.xml
@@ -4,7 +4,7 @@
 <!-- Reviewed: yes -->
 
 <reference xml:id="ref.recode" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
- <title>Recode &Functions;</title>
+ <title>&Functions; Recode</title>
 
  &reference.recode.entities.functions;
 

--- a/reference/reflection/reflectionclass.xml
+++ b/reference/reflection/reflectionclass.xml
@@ -103,31 +103,6 @@
       </para>
      </listitem>
     </varlistentry>
-    <varlistentry xml:id="reflectionclass.constants.skip-initialization-on-serialize">
-     <term>
-       <constant>ReflectionClass::SKIP_INITIALIZATION_ON_SERIALIZE</constant>
-       <type>int</type>
-      </term>
-     <listitem>
-      <simpara>
-       Indique que <function>serialize</function> ne doit pas déclencher
-       l'initialisation d'un objet en chargement paresseux.
-      </simpara>
-     </listitem>
-    </varlistentry>
-
-    <varlistentry xml:id="reflectionclass.constants.skip-destructor">
-     <term>
-       <constant>ReflectionClass::SKIP_DESTRUCTOR</constant>
-       <type>int</type>
-      </term>
-     <listitem>
-      <simpara>
-       Indique qu'un destructeur d'objet ne doit pas être appelé lors de sa réinitialisation en tant
-       qu'objet paresseux.
-      </simpara>
-     </listitem>
-    </varlistentry>
    </variablelist>
   </section>
   <!-- }}} -->
@@ -187,6 +162,32 @@
        <para>
         Indique si la classe est <link linkend="language.oop5.basic.class.readonly">readonly</link>.
        </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry xml:id="reflectionclass.constants.skip-initialization-on-serialize">
+      <term>
+       <constant>ReflectionClass::SKIP_INITIALIZATION_ON_SERIALIZE</constant>
+       <type>int</type>
+      </term>
+      <listitem>
+       <simpara>
+        Indique que <function>serialize</function> ne doit pas déclencher
+        l'initialisation d'un objet en chargement paresseux.
+       </simpara>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry xml:id="reflectionclass.constants.skip-destructor">
+      <term>
+       <constant>ReflectionClass::SKIP_DESTRUCTOR</constant>
+       <type>int</type>
+      </term>
+      <listitem>
+       <simpara>
+        Indique qu'un destructeur d'objet ne doit pas être appelé lors de sa réinitialisation en tant
+        qu'objet paresseux.
+       </simpara>
       </listitem>
      </varlistentry>
 

--- a/reference/reflection/reflectionclass/getconstant.xml
+++ b/reference/reflection/reflectionclass/getconstant.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e5c8e7add9291c70be2ecd046de6ecfd034545a9 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: ec2fe9a592f794978114ef5021db9f1d00c2e05d Maintainer: yannick Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="reflectionclass.getconstant" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>

--- a/reference/reflection/reflectionclass/gettraits.xml
+++ b/reference/reflection/reflectionclass/gettraits.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 93906cd3b6cf8f7217503dba4d994a1ebd32d4ac Maintainer: jpauli Status: ready -->
+<!-- EN-Revision: ca840c9a6d665e60a7de48b57a5b6440c0d3b0c1 Maintainer: jpauli Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="reflectionclass.gettraits" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,9 +13,9 @@
    <modifier>public</modifier> <type>array</type><methodname>ReflectionClass::getTraits</methodname>
    <void/>
   </methodsynopsis>
-  <simpara>
+  <para>
    Retourne un tableau des traits utilisés par cette classe.
-  </simpara>
+  </para>
 
  </refsect1>
 
@@ -26,10 +26,11 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <simpara>
+  <para>
    Retourne un tableau avec le nom du trait en clé et des instances
    <classname>ReflectionClass</classname> des traits en question en valeurs.
-  </simpara>
+   Retourne &null; en cas d'erreur.
+  </para>
  </refsect1>
 
 </refentry>

--- a/reference/reflection/reflectionclass/isinstantiable.xml
+++ b/reference/reflection/reflectionclass/isinstantiable.xml
@@ -72,13 +72,13 @@ $classes = array(
     "ifaceImpl",
     "abstractClass",
     "D",
-    "T"
+    "T",
     "privateConstructor",
 );
 
 foreach($classes  as $class ) {
     $reflectionClass = new ReflectionClass($class);
-    echo "Est-ce que la classe $class est instanciable  ?  ";
+    echo "Est-ce que $class est instanciable ?  ";
     var_dump($reflectionClass->isInstantiable()); 
 }
 

--- a/reference/reflection/reflectionclass/istrait.xml
+++ b/reference/reflection/reflectionclass/istrait.xml
@@ -14,7 +14,7 @@
    <void/>
   </methodsynopsis>
   <para>
-   Détermine si cette <type>ReflectionClass</type> s'agit d'un trait.
+   Détermine si cette <type>ReflectionClass</type> fait référence à un trait.
   </para>
 
  </refsect1>

--- a/reference/reflection/reflectionclass/newlazyproxy.xml
+++ b/reference/reflection/reflectionclass/newlazyproxy.xml
@@ -62,7 +62,6 @@
       que le proxy, la classe du proxy doit être une sous-classe de la classe de l'instance
       réelle, sans propriétés supplémentaires, et ne doit pas remplacer les méthodes
       <methodname>__destruct</methodname> ou <methodname>__clone</methodname>.
-      methods.
      </simpara>
     </listitem>
    </varlistentry>

--- a/reference/reflection/reflectionclassconstant.xml
+++ b/reference/reflection/reflectionclassconstant.xml
@@ -162,7 +162,7 @@
       </term>
       <listitem>
        <para>
-        Indique les constantes <link linkend="language.oop5.final">final</link>
+        Indique les constantes <link linkend="language.oop5.final">final</link>.
         Disponible à partir de PHP 8.1.0.
        </para>
       </listitem>

--- a/reference/reflection/reflectionclassconstant/getattributes.xml
+++ b/reference/reflection/reflectionclassconstant/getattributes.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="reflectionclassconstant.getattributes" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>ReflectionClassConstant::getAttributes</refname>
-  <refpurpose>Vérifie les attributs</refpurpose>
+  <refpurpose>Récupère les attributs</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -15,7 +15,7 @@
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
   <para>
-   Vérifie tous les attributs déclarés sur cette constante de classe sous forme d'un tableau de <type>ReflectionAttribute</type>.
+   Retourne tous les attributs déclarés sur cette constante de classe sous forme d'un tableau de <type>ReflectionAttribute</type>.
   </para>
  </refsect1>
 

--- a/reference/reflection/reflectionfiber/getcallable.xml
+++ b/reference/reflection/reflectionfiber/getcallable.xml
@@ -15,7 +15,7 @@
   </methodsynopsis>
   <para>
    Renvoie le callable utilisé pour créer la <classname>Fiber</classname>. Si la <classname>Fiber</classname> a été terminée, une
-   <classname>Erreur</classname> est lancée.
+   <classname>Error</classname> est lancée.
   </para>
  </refsect1>
 

--- a/reference/reflection/reflectionfiber/getexecutingfile.xml
+++ b/reference/reflection/reflectionfiber/getexecutingfile.xml
@@ -15,7 +15,7 @@
   </methodsynopsis>
   <para>
    Renvoie le chemin complet et le nom du fichier du point d'exécution actuel de la <classname>Fiber</classname> reflétée.
-   Si la fibre n'a pas été démarrée ou s'est terminée, une <classname>Erreur</classname> est lancée.
+   Si la fibre n'a pas été démarrée ou s'est terminée, une <classname>Error</classname> est lancée.
   </para>
  </refsect1>
 

--- a/reference/reflection/reflectionfiber/getexecutingline.xml
+++ b/reference/reflection/reflectionfiber/getexecutingline.xml
@@ -16,7 +16,7 @@
   <para>
    Renvoie le numéro de ligne du point d'exécution actuel de la <classname>Fiber</classname> reflétée.
    Si la fibre reflétée est utilisée en dehors d'une fonction définie par l'utilisateur, &null; est renvoyé.
-   Si la fibre n'a pas été démarrée ou s'est terminée, une <classname>Erreur</classname> est lancée.
+   Si la fibre n'a pas été démarrée ou s'est terminée, une <classname>Error</classname> est lancée.
   </para>
  </refsect1>
 

--- a/reference/reflection/reflectionmethod.xml
+++ b/reference/reflection/reflectionmethod.xml
@@ -136,7 +136,7 @@
       </term>
       <listitem>
        <para>
-        Indique que la méthode est statique
+        Indique que la méthode est statique.
         Antérieur à PHP 7.4.0, la valeur était <literal>1</literal>.
        </para>
       </listitem>
@@ -149,7 +149,7 @@
       </term>
       <listitem>
        <para>
-        Indique que la méthode est publique
+        Indique que la méthode est publique.
         Antérieur à PHP 7.4.0, la valeur était <literal>256</literal>.
        </para>
       </listitem>
@@ -162,7 +162,7 @@
       </term>
       <listitem>
        <para>
-        Indique que la méthode est protégée
+        Indique que la méthode est protégée.
         Antérieur à PHP 7.4.0, la valeur était <literal>512</literal>.
        </para>
       </listitem>
@@ -175,7 +175,7 @@
       </term>
       <listitem>
        <para>
-        Indique que la méthode est privée
+        Indique que la méthode est privée.
         Antérieur à PHP 7.4.0, la valeur était <literal>1024</literal>.
        </para>
       </listitem>
@@ -188,7 +188,7 @@
       </term>
       <listitem>
        <para>
-        Indique que la méthode est abstraite
+        Indique que la méthode est abstraite.
         Antérieur à PHP 7.4.0, la valeur était <literal>2</literal>.
        </para>
       </listitem>
@@ -201,7 +201,7 @@
       </term>
       <listitem>
        <para>
-        Indique que la méthode est finale
+        Indique que la méthode est finale.
         Antérieur à PHP 7.4.0, la valeur était <literal>4</literal>.
        </para>
       </listitem>

--- a/reference/reflection/reflectionmethod/setaccessible.xml
+++ b/reference/reflection/reflectionmethod/setaccessible.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e5c8e7add9291c70be2ecd046de6ecfd034545a9 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: ce98b568f85353c4bf263133f09c4db9294833f9 Maintainer: yannick Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="reflectionmethod.setaccessible" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>

--- a/reference/reflection/reflectionparameter/canbepassedbyvalue.xml
+++ b/reference/reflection/reflectionparameter/canbepassedbyvalue.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 93906cd3b6cf8f7217503dba4d994a1ebd32d4ac Maintainer: yannick Status: ready -->
+<!-- EN-Revision: ec2fe9a592f794978114ef5021db9f1d00c2e05d Maintainer: yannick Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="reflectionparameter.canbepassedbyvalue" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,10 +22,11 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <simpara>
+  <para>
    Retourne &true; si le paramètre peut être passé par valeur,
    &false; sinon.
-  </simpara>
+   Retourne &null; si une erreur survient.
+  </para>
  </refsect1>
 
 </refentry>

--- a/reference/reflection/reflectionparameter/getclass.xml
+++ b/reference/reflection/reflectionparameter/getclass.xml
@@ -40,7 +40,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Un objet <classname>ReflectionClass</classname>, ou &null; si aucun type est déclaré,
+   Un objet <classname>ReflectionClass</classname>, ou &null; si aucun type n'est déclaré,
    ou le type déclaré n'est pas une classe ou interface.
   </para>
  </refsect1>

--- a/reference/reflection/reflectionproperty.xml
+++ b/reference/reflection/reflectionproperty.xml
@@ -162,7 +162,7 @@
       <listitem>
        <para>
         Indique que la propriété est
-        <link linkend="language.oop5.static">static</link>
+        <link linkend="language.oop5.static">static</link>.
         Antérieur à PHP 7.4.0, la valeur était <literal>1</literal>.
        </para>
       </listitem>
@@ -176,7 +176,7 @@
       <listitem>
        <para>
         Indique que la propriété est
-        <link linkend="language.oop5.properties.readonly-properties">readonly</link>
+        <link linkend="language.oop5.properties.readonly-properties">readonly</link>.
         Disponible à partir de PHP 8.1.0.
        </para>
       </listitem>

--- a/reference/reflection/reflectionproperty/getdefaultvalue.xml
+++ b/reference/reflection/reflectionproperty/getdefaultvalue.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e5c8e7add9291c70be2ecd046de6ecfd034545a9 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 9f89eee340331eb13a38a95ea64f47dfe866d46e Maintainer: Fan2Shrek Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="reflectionproperty.getdefaultvalue" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>

--- a/reference/reflection/reflectionproperty/getdoccomment.xml
+++ b/reference/reflection/reflectionproperty/getdoccomment.xml
@@ -56,7 +56,7 @@ var_dump($prop->getDocComment());
     &example.outputs.similar;
     <screen>
 <![CDATA[
-string(53) "/**
+string(66) "/**
      * @var int  La taille de la chaîne de caractère
      */"
 ]]>

--- a/reference/reflection/reflectionproperty/setaccessible.xml
+++ b/reference/reflection/reflectionproperty/setaccessible.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e5c8e7add9291c70be2ecd046de6ecfd034545a9 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: ce98b568f85353c4bf263133f09c4db9294833f9 Maintainer: yannick Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="reflectionproperty.setaccessible" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>

--- a/reference/reflection/reflectionproperty/setrawvalue.xml
+++ b/reference/reflection/reflectionproperty/setrawvalue.xml
@@ -81,7 +81,6 @@ $rClass = new \ReflectionClass(Example::class);
 $rProp = $rClass->getProperty('age');
 
 // Ceci passerait par le hook set, et lancerait une exception.
-$example->age = -2;
 try {
     $example->age = -2;
 } catch (InvalidArgumentException) {

--- a/reference/rnp/constants.xml
+++ b/reference/rnp/constants.xml
@@ -213,7 +213,7 @@
    </term>
    <listitem>
     <simpara>
-     Affiche les valeurs MPI (entiers multi-précision)
+     Affiche les valeurs MPI (entiers multi-précision).
     </simpara>
    </listitem>
   </varlistentry>

--- a/reference/rnp/functions/rnp-dump-packets-to-json.xml
+++ b/reference/rnp/functions/rnp-dump-packets-to-json.xml
@@ -45,7 +45,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   Une chaîne JSON avec les informations&return.falseforfailure;
+   Une chaîne JSON avec les informations&return.falseforfailure;.
   </simpara>
  </refsect1>
 

--- a/reference/rnp/functions/rnp-load-keys.xml
+++ b/reference/rnp/functions/rnp-load-keys.xml
@@ -63,7 +63,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   Renvoie &true; en cas de succès&return.falseforfailure;
+   Renvoie &true; en cas de succès&return.falseforfailure;.
   </simpara>
  </refsect1>
 

--- a/reference/rpminfo/functions/rpmdbinfo.xml
+++ b/reference/rpminfo/functions/rpmdbinfo.xml
@@ -44,7 +44,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   Un <type>array</type> d'<type>array</type> d'informations ou NULL en cas d'erreur.
+   Un <type>array</type> d'<type>array</type> d'informations ou &null; en cas d'erreur.
   </simpara>
  </refsect1>
 

--- a/reference/rrd/book.xml
+++ b/reference/rrd/book.xml
@@ -12,7 +12,7 @@
   <simpara>
    L'extension PECL/rrd propose un lien avec la bibliothèque C RRDtool.
    RRDtool est une norme dans l'industrie open source, fournissant
-   une historisation des données d'authentification à haute performance,
+   une historisation des données à haute performance,
    ainsi qu'un système de représentation graphique des données de séries
    chronologiques.
   </simpara>

--- a/reference/rrd/functions/rrd-last.xml
+++ b/reference/rrd/functions/rrd-last.xml
@@ -5,7 +5,7 @@
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.rrd-last">
  <refnamediv>
   <refname>rrd_last</refname>
-  <refpurpose>Récupère le timestamp unix du premier échantillon</refpurpose>
+  <refpurpose>Récupère le timestamp unix du dernier échantillon</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/runkit7/functions/runkit7-import.xml
+++ b/reference/runkit7/functions/runkit7-import.xml
@@ -46,7 +46,7 @@
     <term><parameter>flags</parameter></term>
     <listitem>
      <simpara>
-       Une opération bit à bit bin de la famille de constantes
+       Une opération bit à bit OU de la famille de constantes
        <link linkend="runkit7.constants"><literal>RUNKIT7_IMPORT_*</literal></link>.
      </simpara>
     </listitem>

--- a/reference/seaslog/seaslog/emergency.xml
+++ b/reference/seaslog/seaslog/emergency.xml
@@ -77,7 +77,6 @@
 
 var_dump(SeasLog::emergency('log message'));
 
-//with content
 //avec contenu
 var_dump(SeasLog::emergency('log message from {NAME}',array('NAME' => 'neeke')));
 

--- a/reference/seaslog/seaslog/getlastlogger.xml
+++ b/reference/seaslog/seaslog/getlastlogger.xml
@@ -4,7 +4,7 @@
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="seaslog.getlastlogger">
  <refnamediv>
   <refname>SeasLog::getLastLogger</refname>
-  <refpurpose>Définit le dernier journalisateur de SeasLog</refpurpose>
+  <refpurpose>Renvoie le dernier journalisateur de SeasLog</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/seaslog/seaslog/setrequestid.xml
+++ b/reference/seaslog/seaslog/setrequestid.xml
@@ -16,7 +16,7 @@
   <simpara>
     Pour distinguer une seule requête, en n'invoquant pas la fonction
     <methodname>SeasLog::setRequestId</methodname>,
-    la valeur unique générée par la fonction intégrée `static char *get_uniqid ()
+    la valeur unique générée par la fonction intégrée `static char *get_uniqid ()`
     est utilisée lors de l'initialisation de la requête.
   </simpara>
  </refsect1>

--- a/reference/sem/functions/ftok.xml
+++ b/reference/sem/functions/ftok.xml
@@ -18,7 +18,7 @@
   <simpara>
    Convertit le paramètre <parameter>filename</parameter>
    d'un fichier existant, et de l'identifiant de projet
-   <parameter>proj</parameter>, en un entier <literal>integer</literal> à utiliser
+   <parameter>project_id</parameter>, en un entier <literal>integer</literal> à utiliser
    avec la fonction <function>shmop_open</function> et d'autres fonctions
    System V IPC.
   </simpara>

--- a/reference/sem/functions/msg-receive.xml
+++ b/reference/sem/functions/msg-receive.xml
@@ -142,7 +142,7 @@
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term><parameter>errorcode</parameter></term>
+    <term><parameter>error_code</parameter></term>
     <listitem>
      <simpara>
       Si la fonction échoue, le paramètre optionnel

--- a/reference/sem/functions/msg-send.xml
+++ b/reference/sem/functions/msg-send.xml
@@ -112,9 +112,9 @@
   </simpara>
   <simpara>
    Lors de l'émission réussie d'un message, la file est mise à jour
-   comme ceci : <literal>msg_lrpid</literal> prend la valeur de l'identifiant
+   comme ceci : <literal>msg_lspid</literal> prend la valeur de l'identifiant
    de processus du processus appelant, <literal>msg_qnum</literal> est incrémenté de
-   1 et <literal>msg_rtime</literal> prend la date et l'heure courante.
+   1 et <literal>msg_stime</literal> prend la date et l'heure courante.
   </simpara>
  </refsect1>
 

--- a/reference/sem/functions/sem-get.xml
+++ b/reference/sem/functions/sem-get.xml
@@ -28,7 +28,7 @@
    d'accéder au même sémaphore.
   </simpara>
   <simpara>
-   Si <parameter>key</parameter> est <literal>0</literal>, un nouvel sémaphore
+   Si <parameter>key</parameter> est <literal>0</literal>, un nouveau sémaphore
    privé est créé pour chaque appel à <function>sem_get</function>.
   </simpara>
  </refsect1>

--- a/reference/sem/functions/sem-release.xml
+++ b/reference/sem/functions/sem-release.xml
@@ -16,7 +16,7 @@
   </methodsynopsis>
   <simpara>
    <function>sem_release</function> libère le sémaphore
-   <parameter>sem_identifier</parameter>, s'il a été réservé par le
+   <parameter>semaphore</parameter>, s'il a été réservé par le
    processus courant, sinon génère une erreur.
   </simpara>
   <simpara>

--- a/reference/sem/functions/shm-get-var.xml
+++ b/reference/sem/functions/shm-get-var.xml
@@ -17,8 +17,8 @@
   </methodsynopsis>
   <simpara>
    <function>shm_get_var</function> retourne la variable
-   repérée par <parameter>variable_key</parameter>, dans
-   le segment de mémoire partagée identifié par <parameter>shm_identifier</parameter>.
+   repérée par <parameter>key</parameter>, dans
+   le segment de mémoire partagée identifié par <parameter>shm</parameter>.
    La variable est toujours présente en mémoire
    partagée.
   </simpara>


### PR DESCRIPTION
Corrections de langue et de traduction dans reference/, de ps to sem (orthographe, grammaire, fidélité à l'anglais).