### PR TITLE
Nits translation: reference/ (session to solr)

### DIFF
--- a/reference/session/examples.xml
+++ b/reference/session/examples.xml
@@ -227,7 +227,7 @@ if (empty($_SESSION['count'])) {
    des méthodes appelées par PHP pendant le cycle de vie de la session: <parameter>open</parameter>,
    <parameter>read</parameter>, <parameter>write</parameter> et <parameter>close</parameter>
    ainsi que les fonctions de ménage <parameter>destroy</parameter> pour supprimer une session
-   et <parameter>gc</parameter> pour une collecte périodique des gabarits.
+   et <parameter>gc</parameter> pour une collecte périodique des ordures.
   </para>
   <para>
    Ainsi, PHP a toujours besoin d'un gestionnaire de sessions. Par défaut il s'agit du gestionnaire
@@ -255,7 +255,7 @@ if (empty($_SESSION['count'])) {
    PHP appelera la fonction de rappel <parameter>gc</parameter> de temps en temps pour nettoyer
    les sessions expirées en fonction de leur
    temps de vie maximum. Cet appel devrait mener à la destruction des enregistrements dans
-   le support de stockage qui n'ont été accédés depuis <parameter>$lifetime</parameter>.
+   le support de stockage qui n'ont pas été accédés depuis plus de <parameter>$lifetime</parameter>.
   </para>
  </section>
 </appendix>

--- a/reference/session/functions/session-create-id.xml
+++ b/reference/session/functions/session-create-id.xml
@@ -43,7 +43,7 @@
         Si <parameter>prefix</parameter> est spécifié, le nouvel ID de session
         est préfixé par <parameter>prefix</parameter>. Tous
         les caractères ne sont pas autorisés dans l'ID de session. Les caractères
-        parmi <literal>[a-z A-Z 0-9]</literal> sont autorisés. La longueur maximale est de 256 caractères.
+        parmi <literal>[a-zA-Z0-9,-]</literal> sont autorisés. La longueur maximale est de 256 caractères.
        </para> 
       </listitem>
      </varlistentry>

--- a/reference/session/functions/session-destroy.xml
+++ b/reference/session/functions/session-destroy.xml
@@ -42,7 +42,7 @@
    est activé. Il n'est pas nécessaire d'effacer le cookie d'ID de session
    obsolète car le module de session n'accepte pas les cookies d'ID de sessions
    quand il n'y a pas de données associées à cet ID de session et définira un
-   nouvel cookie d'ID de session.
+   nouveau cookie d'ID de session.
    Activer <link linkend="ini.session.use-strict-mode">session.use_strict_mode</link>
    est recommandé pour tous les sites.
   </para>
@@ -90,7 +90,7 @@
 <![CDATA[
 <?php
 // Initialisation de la session.
-// Si vous utiliser un autre nom
+// Si vous utilisez un autre nom
 // session_name("autrenom")
 session_start();
 

--- a/reference/session/functions/session-gc.xml
+++ b/reference/session/functions/session-gc.xml
@@ -76,7 +76,7 @@ session_start();
 // Exécuter le Ramasse Miette immédiatement
 session_gc();
 
-// Effacer l'ID de session créé par session_gc()
+// Effacer l'ID de session créé par session_start()
 session_destroy();
 ?>
 ]]>

--- a/reference/session/functions/session-name.xml
+++ b/reference/session/functions/session-name.xml
@@ -119,7 +119,7 @@
 <![CDATA[
 <?php
 
-/* choisi le nom de session  : WebsiteID */
+/* choisit le nom de session : WebsiteID */
 
 $previous_name = session_name("WebsiteID");
 

--- a/reference/session/security.xml
+++ b/reference/session/security.xml
@@ -380,7 +380,7 @@
      Utiliser des données en lecture seule lorsque les données de session
      n'ont pas besoin d'être mises à jour. Utiliser l'option 'read_and_close'
      avec la fonction <function>session_start</function>.
-     <code>session_start(['read_and_close'=>1]);</code> va clôre
+     <code>session_start(['read_and_close'=>1]);</code> va clore
      la session aussi vite que possible après la mise à jour de la variable
      globale $_SESSION en utilisant la fonction <function>session_commit</function>.
     </para>
@@ -559,8 +559,8 @@
     </para>
     <para>
      Si une fonctionnalité d'auto-identification est désirée, les développeurs
-     doivent implémenter leur propre système d'auto-identification sécurité.
-     N'utiliser pas des identifiants de session à longue durée pour cela.
+     doivent implémenter leur propre système d'auto-identification sécurisé.
+     Ne pas utiliser d'identifiants de session à longue durée pour cela.
      Pour plus d'informations, se rapporter à la bonne section
      de cette documentation.
     </para>
@@ -744,10 +744,10 @@
    
    <listitem>
     <para>
-     <link linkend="ini.session.trans-sid-tags">session.trans_sid_tags</link>=[drapeaux limités]
+     <link linkend="ini.session.trans-sid-tags">session.trans_sid_tags</link>=[balises limitées]
     </para>
     <para>
-     (PHP 7.1.0 &gt;=) Les développeurs ne doivent pas réécrire de drapeaux HTML
+     (PHP 7.1.0 &gt;=) Les développeurs ne devraient pas réécrire de balises HTML
      non nécessaires. La valeur par défaut doit être suffisante pour la
      plupart des utilisations. Pour les versions de PHP plus anciennes,
      utiliser plutôt

--- a/reference/session/sessionhandler.xml
+++ b/reference/session/sessionhandler.xml
@@ -32,8 +32,8 @@
     Lorsqu'une instance complète de <classname>SessionHandler</classname> est définie comme
     gestionnaire de sauvegarde en utilisant <function>session_set_save_handler</function>, elle
     remplacera le gestionnaire de sauvegarde courant. Une classe étendue depuis la classe
-    <classname>SessionHandler</classname> permet d'écraser les méthodes, des intercepter,
-    ou des filtrer en appelant la méthode de la classe parent qui remplace en dernier lieu
+    <classname>SessionHandler</classname> permet d'écraser les méthodes, de les intercepter,
+    ou de les filtrer en appelant la méthode de la classe parent qui remplace en dernier lieu
     le gestionnaire de session interne de PHP.
    </para>
    <para>

--- a/reference/session/sessionhandler/destroy.xml
+++ b/reference/session/sessionhandler/destroy.xml
@@ -15,7 +15,7 @@
   </methodsynopsis>
   <para>
    Détruit une session. Cette fonction est appelée en interne par PHP au moyen de
-   <function>session_regenerate_id</function> (en supposant que <parameter>$destory</parameter> est
+   <function>session_regenerate_id</function> (en supposant que <parameter>$destroy</parameter> est
    mis à &true;) <function>session_destroy</function> ou lorsque la fonction
    <function>session_decode</function> échoue.
   </para>

--- a/reference/session/sessionhandler/write.xml
+++ b/reference/session/sessionhandler/write.xml
@@ -33,7 +33,7 @@
    <parameter>write</parameter> invoquera ce gestionnaire pour cette méthode, mais
    aussi, la fonction de rappel interne associée. Ce mécanisme permet à cette méthode
    de surcharger, intercepter et/ou filtrer les données (par exemple, crypter la valeur
-   du paramètre <parameter>$data</parameter> value avant de l'envoyer à la méthode parente
+   du paramètre <parameter>$data</parameter> avant de l'envoyer à la méthode parente
    <parameter>write</parameter>).
   </para>
   <para>

--- a/reference/session/sessionhandlerinterface/read.xml
+++ b/reference/session/sessionhandlerinterface/read.xml
@@ -23,7 +23,7 @@
    retourner les données de session lues depuis le support de stockage en fonction de l'ID de
    session. La chaîne retournée devrait être encodée par le même mécanisme de sérialisation que
    celui utilisé pour écrire les données lors de <function>SessionHandlerInterface::write</function>.
-   Si rien n'est lu, une chaîne vide est retournée.
+   Si l'enregistrement n'est pas trouvé, &false; est retourné.
   </para>
   <para>
    Les données retournées par cette méthode seront décodées en interne par PHP en utilisant le

--- a/reference/session/sessionidinterface/create-sid.xml
+++ b/reference/session/sessionidinterface/create-sid.xml
@@ -29,7 +29,7 @@
   &reftitle.returnvalues;
   <para>
    Le nouvel ID de session.
-   Il est à noter que cette valeur est retournée internement à PHP pour du
+   Il est à noter que cette valeur est retournée en interne à PHP pour du
    traitement.
   </para>
  </refsect1>

--- a/reference/simplexml/examples.xml
+++ b/reference/simplexml/examples.xml
@@ -82,7 +82,7 @@ echo $movies->movie[0]->plot;
   </para>
   <para>
    L'accès aux éléments d'un document XML qui contient des caractères non permis par
-   rapport à la convention de nommage de PHP (e.g. les mots clés) est possible
+   rapport à la convention de nommage de PHP (e.g. le tiret) est possible
    en encapsulant le nom de l'élément entre crochets et apostrophes.
    <example>
     <title>Récupération de <literal>&lt;line&gt;</literal></title>

--- a/reference/simplexml/functions/simplexml-import-dom.xml
+++ b/reference/simplexml/functions/simplexml-import-dom.xml
@@ -17,7 +17,7 @@
   <para>
    <function>simplexml_import_dom</function> prend un nœud
    d'un document <link linkend="book.dom">DOM</link>
-   et la transforme en nœud <classname>SimpleXML</classname>.
+   et le transforme en nœud <classname>SimpleXML</classname>.
    Ce nouvel objet peut alors être utilisé comme un objet natif 
    <classname>SimpleXML</classname>.
   </para>
@@ -99,7 +99,7 @@
   &reftitle.examples;
   <para>
    <example>
-    <title>Import un <classname>DOMDocument</classname></title>
+    <title>Import d'un <classname>DOMDocument</classname></title>
     <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/simplexml/functions/simplexml-load-file.xml
+++ b/reference/simplexml/functions/simplexml-load-file.xml
@@ -112,7 +112,7 @@ if (file_exists('examples/book.xml')) {
 
     print_r($xml);
 } else {
-    exit('Échec lors de l\'ouverture du fichier examples/test.xml.');
+    exit('Échec lors de l\'ouverture du fichier examples/book.xml.');
 }
 ?>
 ]]>

--- a/reference/simplexml/simplexmlelement/children.xml
+++ b/reference/simplexml/simplexmlelement/children.xml
@@ -54,7 +54,7 @@
   &reftitle.returnvalues;
   <para>
    Retourne un élément <classname>SimpleXMLElement</classname>
-   que le nœud possède un fils ou pas, sauf si le nœud représente un attribut,
+   indiquant si le nœud possède un fils ou pas, sauf si le nœud représente un attribut,
    auquel cas &null; est retourné.
   </para>
  </refsect1>

--- a/reference/simplexml/simplexmlelement/getDocNamespaces.xml
+++ b/reference/simplexml/simplexmlelement/getDocNamespaces.xml
@@ -51,7 +51,7 @@
   &reftitle.returnvalues;
   <para>
    La méthode <literal>getDocNamespaces</literal> retourne un tableau d'espaces de noms
-   avec leurs URL associées.
+   avec leurs URI associées.
   </para>
  </refsect1>
 

--- a/reference/simplexml/simplexmlelement/getNamespaces.xml
+++ b/reference/simplexml/simplexmlelement/getNamespaces.xml
@@ -40,7 +40,7 @@
   &reftitle.returnvalues;
   <para>
    La méthode <literal>getNamespaces</literal> retourne un tableau d'espaces de noms
-   avec leurs URL associées.
+   avec leurs URI associées.
   </para>
  </refsect1>
 

--- a/reference/simplexml/simplexmlelement/registerXPathNamespace.xml
+++ b/reference/simplexml/simplexmlelement/registerXPathNamespace.xml
@@ -109,7 +109,7 @@ Chapter 2
 ]]>
     </screen>
     <para>
-     Notez comment le document XML montré dans cet exemple fixe un espace de
+     Il est à noter que le document XML montré dans cet exemple fixe un espace de
      nom avec le préfixe <literal>chap</literal>. Imaginez que ce document (ou
      un autre similaire) puisse avoir utilisé un préfixe <literal>c</literal>
      dans le passé pour le même espace de noms. Puisqu'il a changé, la requête

--- a/reference/simplexml/simplexmlelement/xpath.xml
+++ b/reference/simplexml/simplexmlelement/xpath.xml
@@ -14,8 +14,8 @@
    <methodparam><type>string</type><parameter>expression</parameter></methodparam>
   </methodsynopsis>
   <para>
-   La méthode <literal>xpath</literal> cherche dans le nœud SimpleXML des
-   enfants qui correspondent au <parameter>expression</parameter>
+   La méthode <literal>xpath</literal> cherche dans le nœud SimpleXML les
+   enfants qui correspondent à l'<parameter>expression</parameter>
    <acronym>Xpath</acronym>.
   </para>
  </refsect1>

--- a/reference/snmp/functions/snmp3-get.xml
+++ b/reference/snmp/functions/snmp3-get.xml
@@ -76,8 +76,7 @@
     <term><parameter>privacy_protocol</parameter></term>
     <listitem>
      <simpara>
-      Le protocole d'authentification (<literal>"MD5"</literal>, <literal>"SHA"</literal>,
-      <literal>"SHA256"</literal> ou <literal>"SHA512"</literal>).
+      Le protocole de confidentialité (<literal>"DES"</literal> ou <literal>"AES"</literal>).
      </simpara>
     </listitem>
    </varlistentry>
@@ -85,7 +84,7 @@
     <term><parameter>privacy_passphrase</parameter></term>
     <listitem>
      <simpara>
-      La phrase secrète privée.
+      La phrase secrète de confidentialité.
      </simpara>
     </listitem>
    </varlistentry>

--- a/reference/snmp/functions/snmp3-getnext.xml
+++ b/reference/snmp/functions/snmp3-getnext.xml
@@ -77,8 +77,7 @@
     <term><parameter>privacy_protocol</parameter></term>
     <listitem>
      <simpara>
-      Le protocole d'authentification (<literal>"MD5"</literal>, <literal>"SHA"</literal>,
-      <literal>"SHA256"</literal> ou <literal>"SHA512"</literal>).
+      Le protocole de confidentialité (DES ou AES).
      </simpara>
     </listitem>
    </varlistentry>

--- a/reference/snmp/functions/snmp3-set.xml
+++ b/reference/snmp/functions/snmp3-set.xml
@@ -125,7 +125,7 @@
     <term><parameter>timeout</parameter></term>
     <listitem>
      <simpara>
-      Le nombre de millisecondes avant le premier délai d'expiration.
+      Le nombre de microsecondes avant le premier délai d'expiration.
      </simpara>
     </listitem>
    </varlistentry>

--- a/reference/snmp/functions/snmp3-walk.xml
+++ b/reference/snmp/functions/snmp3-walk.xml
@@ -25,7 +25,7 @@
   <simpara>
    La fonction <function>snmp3_walk</function> est utilisée pour lire
    toutes les valeurs depuis un agent <acronym>SNMP</acronym> spécifié
-   par le paramètre <parameter>host</parameter>.
+   par le paramètre <parameter>hostname</parameter>.
   </simpara>
   <simpara>
    Même si le niveau de sécurité n'utilise pas de protocole

--- a/reference/snmp/functions/snmpset.xml
+++ b/reference/snmp/functions/snmpset.xml
@@ -42,7 +42,7 @@
     <term><parameter>community</parameter></term>
     <listitem>
      <simpara>
-      La communauté de lecture.
+      La communauté d'écriture.
      </simpara>
     </listitem>
    </varlistentry>

--- a/reference/snmp/snmp.xml
+++ b/reference/snmp/snmp.xml
@@ -220,7 +220,7 @@
       </simpara>
       <simpara>
        Permet d'indiquer à walk/get etc. s'ils doivent automatiquement
-       chercher les valeurs enum dans le MIIB et les retourner en plus de leurs
+       chercher les valeurs enum dans le MIB et les retourner en plus de leurs
        chaînes humainement lisibles.
       </simpara>
      </listitem>
@@ -311,7 +311,7 @@
      <varlistentry xml:id="snmp.constants.errno-timeout">
       <term><constant>SNMP::ERRNO_TIMEOUT</constant></term>
       <listitem>
-       <simpara>Demande à l'agent <acronym>SNMP</acronym> d'atteindre le délai d'expiration.</simpara>
+       <simpara>La requête vers l'agent <acronym>SNMP</acronym> a expiré.</simpara>
       </listitem>
      </varlistentry>
 

--- a/reference/snmp/snmp/getnext.xml
+++ b/reference/snmp/snmp/getnext.xml
@@ -24,7 +24,7 @@
   &reftitle.parameters;
   <simpara>
    Si <parameter>objectId</parameter> est une &string;, alors
-   <methodname>SNMP::get</methodname> retournera un objet
+   <methodname>SNMP::getnext</methodname> retournera un objet
    <acronym>SNMP</acronym> sous la forme d'une &string;.
    Si <parameter>objectId</parameter> est un tableau, tous les
    objets <acronym>SNMP</acronym> demandés seront retournés sous la

--- a/reference/snmp/snmp/setsecurity.xml
+++ b/reference/snmp/snmp/setsecurity.xml
@@ -56,7 +56,7 @@
     <term><parameter>privacyProtocol</parameter></term>
     <listitem>
      <simpara>
-      le protocole privé (DES ou AES)
+      le protocole de confidentialité (DES ou AES)
      </simpara>
     </listitem>
    </varlistentry>
@@ -64,7 +64,7 @@
     <term><parameter>privacyPassphrase</parameter></term>
     <listitem>
      <simpara>
-      la passphrase pour le protocole privé
+      la phrase secrète de confidentialité
      </simpara>
     </listitem>
    </varlistentry>

--- a/reference/snmp/snmp/walk.xml
+++ b/reference/snmp/snmp/walk.xml
@@ -4,7 +4,7 @@
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="snmp.walk">
  <refnamediv>
   <refname>SNMP::walk</refname>
-  <refpurpose>Récupère le sous-objet d'un objet <acronym>SNMP</acronym></refpurpose>
+  <refpurpose>Récupère le sous-arbre d'un objet <acronym>SNMP</acronym></refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -18,8 +18,8 @@
    <methodparam choice="opt"><type>int</type><parameter>nonRepeaters</parameter><initializer>-1</initializer></methodparam>
   </methodsynopsis>
   <simpara>
-   <methodname>SNMP::walk</methodname> est utilisé pour lire le sous-objet <acronym>SNMP</acronym> dont la profondeur est
-   spécifiée par le paramètre <parameter>object_id</parameter>.
+   <methodname>SNMP::walk</methodname> est utilisé pour lire le sous-arbre <acronym>SNMP</acronym>
+   enraciné à l'<parameter>objectId</parameter> spécifié.
   </simpara>
  </refsect1>
 
@@ -30,7 +30,7 @@
     <term><parameter>objectId</parameter></term>
     <listitem>
      <simpara>
-      Racine du sous-objet à lire
+      Racine du sous-arbre à lire
      </simpara>
     </listitem>
    </varlistentry>
@@ -40,7 +40,7 @@
      <simpara>
       Par défaut, la notation complète de l'OID est utilisée pour les
       clés dans le tableau résultant. Si défini à &true;, le préfixe
-      du sous-objet sera supprimé des clés, ne laissant ainsi que le
+      du sous-arbre sera supprimé des clés, ne laissant ainsi que le
       suffixe de object_id.
      </simpara>
     </listitem>
@@ -73,8 +73,8 @@
   <simpara>
    Retourne un tableau associatif d'identifiants d'objets <acronym>SNMP</acronym>
    ainsi que leurs valeurs en cas de succès ou &false; si une erreur survient.
-   Lorsqu'une erreur <acronym>SNMP</acronym> survient, <methodname>SNMP::get_errno</methodname> et
-   <methodname>SNMP::get_error</methodname> peuvent être utilisées pour récupérer
+   Lorsqu'une erreur <acronym>SNMP</acronym> survient, <methodname>SNMP::getErrno</methodname> et
+   <methodname>SNMP::getError</methodname> peuvent être utilisées pour récupérer
    respectivement le numéro de l'erreur (spécifique à l'extension SNMP, voir les constantes de la
    classe) ainsi que le message d'erreur.
   </simpara>

--- a/reference/soap/functions/is-soap-fault.xml
+++ b/reference/soap/functions/is-soap-fault.xml
@@ -36,7 +36,7 @@
   <para>
    <variablelist>
     <varlistentry>
-     <term><parameter>objet</parameter></term>
+     <term><parameter>object</parameter></term>
      <listitem>
       <para>
        L'objet à tester.
@@ -50,7 +50,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   &return.success;
+   Cette fonction retourne &true; en cas d'erreur, &false; sinon.
   </para>
  </refsect1>
 

--- a/reference/soap/soapclient/getlastrequestheaders.xml
+++ b/reference/soap/soapclient/getlastrequestheaders.xml
@@ -33,7 +33,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Les dernières en-têtes SOAP.
+   Les derniers en-têtes SOAP.
   </para>
  </refsect1>
 

--- a/reference/soap/soapclient/setsoapheaders.xml
+++ b/reference/soap/soapclient/setsoapheaders.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="soapclient.setsoapheaders" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>SoapClient::__setSoapHeaders</refname>
-  <refpurpose>Ajoute un en-tête SOAP pour les requêtes suivantes</refpurpose>
+  <refpurpose>Définit les en-têtes SOAP pour les requêtes suivantes</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/soap/soapclient/soapcall.xml
+++ b/reference/soap/soapclient/soapcall.xml
@@ -103,7 +103,7 @@
    <literal>__soapCall</literal> sera une valeur simple (e.g. un entier, une chaîne
    de caractères, etc.). Si plusieurs valeurs sont retournées,
    <literal>__soapCall</literal> retournera un tableau associatif contenant les
-   noms des paramètres affichés.
+   paramètres de sortie nommés.
   </para>
   <para>
    En cas d'erreur, si l'objet <classname>SoapClient</classname> a été construit

--- a/reference/soap/soapserver/handle.xml
+++ b/reference/soap/soapserver/handle.xml
@@ -14,7 +14,7 @@
    <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>request</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
   <para>
-   Effectue une requête SOAP, appelle les fonctions nécessaires et envoie
+   Traite une requête SOAP, appelle les fonctions nécessaires et envoie
    une réponse en retour.
   </para>
  </refsect1>

--- a/reference/soap/soapvar.xml
+++ b/reference/soap/soapvar.xml
@@ -12,7 +12,7 @@
   <section xml:id="soapvar.intro">
    &reftitle.intro;
    <para>
-    Une classe représentant une variable ou un objet qui utilise des services SOAP.
+    Une classe représentant une variable ou un objet à utiliser avec des services SOAP.
    </para>
   </section>
   <!-- }}} -->

--- a/reference/sockets/functions/socket-accept.xml
+++ b/reference/sockets/functions/socket-accept.xml
@@ -25,7 +25,7 @@
    S'il y a plusieurs connexions en attente, la première sera utilisée. S'il
    n'y a pas de connexion en attente, <function>socket_accept</function> se
    bloquera jusqu'à ce qu'une connexion se présente. Si
-   <parameter>socket</parameter> a été rendue non-bloquante, grâce à
+   <parameter>socket</parameter> a été rendu non-bloquant, grâce à
    <function>socket_set_blocking</function> ou
    <function>socket_set_nonblock</function>, &false; sera retourné.
   </para>

--- a/reference/sockets/functions/socket-atmark.xml
+++ b/reference/sockets/functions/socket-atmark.xml
@@ -87,7 +87,7 @@ socket_close( $socket );
     &example.outputs;
     <screen>
 <![CDATA[
-Donnée normale reçue : (28) Ceci est une donnée normale.
+Donnée normale reçue : (29) Ceci est une donnée normale.
 Donnée urgente reçue : (1) !
 Donnée normale reçue : (14) Pas si urgent.
 Donnée normale reçue : (0)

--- a/reference/sockets/functions/socket-connect.xml
+++ b/reference/sockets/functions/socket-connect.xml
@@ -77,7 +77,7 @@
   <note>
    <para>
     Si le socket est non-bloquant, alors cette fonction retourne &false;
-    avec l'erreur suivant : <literal>Operation now in progress</literal>.
+    avec l'erreur suivante : <literal>Operation now in progress</literal>.
    </para>
   </note>
  </refsect1>

--- a/reference/sockets/functions/socket-create.xml
+++ b/reference/sockets/functions/socket-create.xml
@@ -18,7 +18,7 @@
   </methodsynopsis>
   <para>
    <function>socket_create</function> crée un point de communication 
-   (une socket) et retourne une instance de <classname>Socket</classname>
+   (une socket) et retourne une instance de <classname>Socket</classname>.
    Une connexion typique réseau est composée de deux sockets :
    une qui joue le rôle de client et l'autre celui du serveur.
   </para>

--- a/reference/sockets/functions/socket-get-option.xml
+++ b/reference/sockets/functions/socket-get-option.xml
@@ -148,8 +148,8 @@
          <row>
           <entry><constant>SO_OOBINLINE</constant></entry>
           <entry>
-           Reporte si le socket <parameter>socket</parameter> part sur des données en
-           ligne out-of-band ou pas.
+           Reporte si le socket <parameter>socket</parameter> laisse les données
+           hors bande intégrées au flux normal ou pas.
           </entry>
           <entry>
            <type>int</type>
@@ -289,7 +289,7 @@
          <row>
           <entry><constant>MCAST_BLOCK_SOURCE</constant></entry>
           <entry>
-           Paquets de bloc arrivant depuis une source spécifique
+           Bloque les paquets arrivant depuis une source spécifique
            vers un groupe multicast spécifique, qui aura dû être joint
            auparavant.
           </entry>

--- a/reference/sockets/functions/socket-getpeername.xml
+++ b/reference/sockets/functions/socket-getpeername.xml
@@ -72,7 +72,7 @@
   &reftitle.returnvalues;
   <para>
    &return.success; <function>socket_getpeername</function> peut aussi
-   retourner &false; si le type du socket n'est ni <constant>AF_INET</constant>
+   retourner &false; si le type du socket n'est ni <constant>AF_INET</constant>, ni
    <constant>AF_INET6</constant>, ni <constant>AF_UNIX</constant>, auquel cas le
    dernier code d'erreur socket n'est <emphasis>pas</emphasis> modifié.
   </para>
@@ -99,7 +99,7 @@
   &reftitle.notes;
   <note>
    <para>
-    <function>socket_getsockname</function> ne doit pas être utilisée avec les sockets
+    <function>socket_getpeername</function> ne doit pas être utilisée avec les sockets
     <constant>AF_UNIX</constant> créés avec <function>socket_accept</function>.
     Seules les sockets créées avec <function>socket_connect</function> ou une socket
     serveur primaire suivant un appel à <function>socket_bind</function> retournent

--- a/reference/sockets/functions/socket-getsockname.xml
+++ b/reference/sockets/functions/socket-getsockname.xml
@@ -20,8 +20,9 @@
    <simpara>
     <function>socket_getsockname</function> ne doit pas être utilisée avec les sockets
     <constant>AF_UNIX</constant> créés avec <function>socket_connect</function>.
-    Seules les sockets suivant un appel de <function>socket_bind</function> retournent
-    des valeurs logiques.
+    Seules les sockets créés avec <function>socket_accept</function> ou un
+    socket serveur principal après un appel à <function>socket_bind</function>
+    retournent des valeurs logiques.
    </simpara>
   </note>
  </refsect1>
@@ -76,7 +77,7 @@
   <para>
    &return.success; <function>socket_getsockname</function> peut aussi
    retourner &false; si le type du socket n'est ni <constant>AF_INET</constant>,
-   ni <constant>AF_INET</constant>, ni <constant>AF_UNIX</constant>, auquel cas
+   ni <constant>AF_INET6</constant>, ni <constant>AF_UNIX</constant>, auquel cas
    le dernier code d'erreur socket n'est <emphasis>pas</emphasis> modifié.
   </para>
  </refsect1>

--- a/reference/sockets/functions/socket-listen.xml
+++ b/reference/sockets/functions/socket-listen.xml
@@ -18,7 +18,7 @@
   <para>
    Une fois que le socket <parameter>socket</parameter> a été
    créé avec la fonction <function>socket_create</function>
-   et liée à un nom avec la fonction
+   et lié à un nom avec la fonction
    <function>socket_bind</function>, il peut être mis en attente de la
    connexion entrante.
   </para>

--- a/reference/sockets/functions/socket-recv.xml
+++ b/reference/sockets/functions/socket-recv.xml
@@ -103,7 +103,7 @@
          <row>
           <entry><constant>MSG_WAITALL</constant></entry>
           <entry>
-           Bloque avant qu'au moins <parameter>length</parameter> soient reçues.
+           Bloque jusqu'à ce qu'au moins <parameter>length</parameter> soient reçues.
            Cependant, si un signal est intercepté ou si la connexion est
            terminée, la fonction pourra retourner moins de données.
           </entry>
@@ -193,7 +193,7 @@ if ($result === false) {
 
 $in = "HEAD / HTTP/1.1\r\n";
 $in .= "Host: www.example.com\r\n";
-$in .= "Connexion: Fermée\r\n\r\n";
+$in .= "Connection: close\r\n\r\n";
 $out = '';
 
 echo "Envoi d'une requête HTTP HEAD...";
@@ -230,7 +230,7 @@ Last-Modified: Tue, 15 Nov 2005 13:24:10 GMT
 ETag: "b80f4-1b6-80bfd280"
 Accept-Ranges: bytes
 Content-Length: 438
-Connexion : Fermée
+Connection: close
 Content-Type: text/html; charset=UTF-8
 
 OK.

--- a/reference/sockets/functions/socket-recvfrom.xml
+++ b/reference/sockets/functions/socket-recvfrom.xml
@@ -21,7 +21,7 @@
   </methodsynopsis>
   <para>
    La fonction <function>socket_recvfrom</function> reçoit
-   <parameter>length</parameter> octets de données du buffer <parameter>data</parameter>
+   <parameter>length</parameter> octets de données dans <parameter>data</parameter>
    depuis <parameter>address</parameter> sur le port <parameter>port</parameter> (si le socket
    n'est pas du type <constant>AF_UNIX</constant>), en utilisant
    <parameter>socket</parameter>. <function>socket_recvfrom</function> peut être utilisée
@@ -95,7 +95,7 @@
          <row>
           <entry><constant>MSG_OOB</constant></entry>
           <entry>
-           Processus en dehors de la bande de données.
+           Traite les données hors bande.
           </entry>
          </row>
          <row>
@@ -198,7 +198,7 @@ $from = '';
 $port = 0;
 socket_recvfrom($socket, $buf, 12, 0, $from, $port);
 
-echo "Réception de $buf depuis l'adresse distant $from et du port distant $port" . PHP_EOL;
+echo "Réception de $buf depuis l'adresse distante $from et du port distant $port" . PHP_EOL;
 ?>
 ]]>
     </programlisting>

--- a/reference/sockets/functions/socket-set-block.xml
+++ b/reference/sockets/functions/socket-set-block.xml
@@ -21,9 +21,8 @@
   </para>
   <para>
    Lorsqu'une opération (e.g. réception, envoi, connexion, acceptation, ...)
-   est effectuée sur un socket non-bloquant, le script ne se met pas en pause
-   tant qu'elle reçoit un signal. Au lieu de cela, si l'opération doit résulter en
-   un blocage, la fonction appelée échouera.
+   est effectuée sur un socket bloquant, le script met son exécution en pause
+   jusqu'à recevoir un signal ou à pouvoir effectuer l'opération.
   </para>
  </refsect1>
 
@@ -86,7 +85,7 @@ socket_accept($socket);
     <para>
      Cet exemple crée un socket écoutant toutes les interfaces du port 1223 et
      définit le socket en mode <constant>O_BLOCK</constant>.
-     <function>socket_accept</function> patientera tant qu'il y aura une
+     <function>socket_accept</function> patientera jusqu'à ce qu'il y ait une
      connexion à accepter.
     </para>
    </example>

--- a/reference/sockets/functions/socket-set-nonblock.xml
+++ b/reference/sockets/functions/socket-set-nonblock.xml
@@ -22,7 +22,7 @@
   <para>
    Lorsqu'une opération (e.g. réception, envoi, connexion, acceptation, ...)
    est effectuée sur un socket non-bloquant, le script ne se met pas en pause
-   tant qu'elle reçoit un signal. Au lieu de cela, si l'opération doit résulter en
+   tant qu'il reçoit un signal. Au lieu de cela, si l'opération doit résulter en
    un blocage, la fonction appelée échouera.
   </para>
  </refsect1>

--- a/reference/sockets/functions/socket-set-option.xml
+++ b/reference/sockets/functions/socket-set-option.xml
@@ -48,7 +48,7 @@
        la couche socket, un niveau égal à <constant>SOL_SOCKET</constant>
        va être utilisé. Les autres niveaux, comme TCP, peuvent être
        utilisés en spécifiant un numéro de protocole pour ce niveau.
-       Les numéros de protocoles peuvent être utilisés en utilisant la fonction
+       Les numéros de protocoles peuvent être trouvés en utilisant la fonction
        <function>getprotobyname</function>.
       </para>
      </listitem>

--- a/reference/sockets/functions/socket-strerror.xml
+++ b/reference/sockets/functions/socket-strerror.xml
@@ -37,7 +37,7 @@
      <term><parameter>error_code</parameter></term>
      <listitem>
       <para>
-       Une numéro d'erreur de socket valide, comme produit par la fonction
+       Un numéro d'erreur de socket valide, comme produit par la fonction
        <function>socket_last_error</function>.
       </para>
      </listitem>

--- a/reference/sockets/functions/socket-write.xml
+++ b/reference/sockets/functions/socket-write.xml
@@ -107,7 +107,7 @@
    <para>
     <function>socket_write</function> n'écrit pas nécessairement tous
     les octets de <parameter>data</parameter> fourni. Il est valide que, suivant certaines
-    configuration de buffer réseau, seulement une certaine quantité
+    configurations de buffer réseau, seulement une certaine quantité
     de données, même un octet, soit écrit, y compris si <parameter>data</parameter> est plus grand.
     Une boucle doit être utilisée pour s'assurer que tout le reste de <parameter>data</parameter>
     est transmis.

--- a/reference/sockets/functions/socket-wsaprotocol-info-release.xml
+++ b/reference/sockets/functions/socket-wsaprotocol-info-release.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="function.socket-wsaprotocol-info-release" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>socket_wsaprotocol_info_release</refname>
-  <refpurpose>Sort une structure WSAPROTOCOL_INFO exportée</refpurpose>
+  <refpurpose>Libère une structure WSAPROTOCOL_INFO exportée</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -14,7 +14,7 @@
    <methodparam><type>string</type><parameter>info_id</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Sort la mémoire partagée correspondant à l'<parameter>info_id</parameter> donné.
+   Libère la mémoire partagée correspondant à l'<parameter>info_id</parameter> donné.
   </para>
   <note>
    <simpara>

--- a/reference/sodium/functions/sodium-add.xml
+++ b/reference/sodium/functions/sodium-add.xml
@@ -17,7 +17,7 @@
   <simpara>
    Ceci ajoute le paramètre <parameter>string2</parameter> à <parameter>string1</parameter>, en écrasant
    la valeur stockée dans <parameter>string1</parameter>. Cette fonction suppose que les deux paramètres
-   sont des chaînes binaires qui représentent des entiers non signés en octets d'ordre faible.
+   sont des chaînes binaires qui représentent des entiers non signés en petit-boutiste.
   </simpara>
  </refsect1>
 
@@ -28,7 +28,7 @@
     <term><parameter>string1</parameter></term>
     <listitem>
      <simpara>
-      La chaîne représentant un entier non signé de longueur arbitraire en octets d'ordre faible.
+      La chaîne représentant un entier non signé de longueur arbitraire en petit-boutiste.
       Ce paramètre est passé par référence et contiendra la somme des deux paramètres.
      </simpara>
     </listitem>
@@ -37,7 +37,7 @@
     <term><parameter>string2</parameter></term>
     <listitem>
      <simpara>
-      La chaîne représentant un entier non signé de longueur arbitraire en octets d'ordre faible.
+      La chaîne représentant un entier non signé de longueur arbitraire en petit-boutiste.
      </simpara>
     </listitem>
    </varlistentry>

--- a/reference/sodium/functions/sodium-compare.xml
+++ b/reference/sodium/functions/sodium-compare.xml
@@ -15,7 +15,7 @@
    <methodparam><modifier role="attribute">#[\SensitiveParameter]</modifier><type>string</type><parameter>string2</parameter></methodparam>
   </methodsynopsis>
   <simpara>
-   Compare deux chaînes comme si elles étaient des entiers non signés de longueur arbitraire, en octets d'ordre faible, sans fuite de canal secondaire.
+   Compare deux chaînes comme si elles étaient des entiers non signés de longueur arbitraire, en petit-boutiste, sans fuite de canal secondaire.
   </simpara>
 
  </refsect1>
@@ -27,7 +27,7 @@
     <term><parameter>string1</parameter></term>
     <listitem>
      <simpara>
-      Left operand
+      Opérande de gauche
      </simpara>
     </listitem>
    </varlistentry>
@@ -35,7 +35,7 @@
     <term><parameter>string2</parameter></term>
     <listitem>
      <simpara>
-      Right operand
+      Opérande de droite
      </simpara>
     </listitem>
    </varlistentry>

--- a/reference/sodium/functions/sodium-crypto-aead-aegis256-encrypt.xml
+++ b/reference/sodium/functions/sodium-crypto-aead-aegis256-encrypt.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="function.sodium-crypto-aead-aegis256-encrypt" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>sodium_crypto_aead_aegis256_encrypt</refname>
-  <refpurpose>Chiffré puis authentifie un message avec AEGIS-256</refpurpose>
+  <refpurpose>Chiffre puis authentifie un message avec AEGIS-256</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/sodium/functions/sodium-crypto-aead-aes256gcm-decrypt.xml
+++ b/reference/sodium/functions/sodium-crypto-aead-aes256gcm-decrypt.xml
@@ -31,7 +31,7 @@
     <listitem>
      <simpara>
       Doit être au format fourni par <function>sodium_crypto_aead_aes256gcm_encrypt</function>
-      (chiffrer et étiqueter, concaténés).
+      (texte chiffré et étiquette, concaténés).
      </simpara>
     </listitem>
    </varlistentry>
@@ -39,7 +39,7 @@
     <term><parameter>additional_data</parameter></term>
     <listitem>
      <simpara>
-      Additionnel, données authentifiées. Cela est utilisé dans la vérification de l'étiquette d'authentification
+      Données supplémentaires authentifiées. Cela est utilisé dans la vérification de l'étiquette d'authentification
       ajoutée au texte chiffré, mais il n'est pas chiffré ou stocké dans le texte chiffré.
      </simpara>
     </listitem>

--- a/reference/sodium/functions/sodium-crypto-aead-aes256gcm-encrypt.xml
+++ b/reference/sodium/functions/sodium-crypto-aead-aes256gcm-encrypt.xml
@@ -38,7 +38,7 @@
     <term><parameter>additional_data</parameter></term>
     <listitem>
      <simpara>
-      Additionnel, données authentifiées. Cela est utilisé dans la vérification de l'étiquette d'authentification
+      Données supplémentaires authentifiées. Cela est utilisé dans la vérification de l'étiquette d'authentification
       ajoutée au texte chiffré, mais il n'est pas chiffré ou stocké dans le texte chiffré.
      </simpara>
     </listitem>

--- a/reference/sodium/functions/sodium-crypto-aead-chacha20poly1305-decrypt.xml
+++ b/reference/sodium/functions/sodium-crypto-aead-chacha20poly1305-decrypt.xml
@@ -30,7 +30,7 @@
     <listitem>
      <simpara>
       Doit être au format fourni par <function>sodium_crypto_aead_chacha20poly1305_encrypt</function>
-      (chiffrer et étiqueter, concaténés).
+      (texte chiffré et étiquette, concaténés).
      </simpara>
     </listitem>
    </varlistentry>
@@ -38,7 +38,7 @@
     <term><parameter>additional_data</parameter></term>
     <listitem>
      <simpara>
-      Additionnel, données authentifiées. Cela est utilisé dans la vérification de l'étiquette d'authentification
+      Données supplémentaires authentifiées. Cela est utilisé dans la vérification de l'étiquette d'authentification
       ajoutée au texte chiffré, mais il n'est pas chiffré ou stocké dans le texte chiffré.
      </simpara>
     </listitem>

--- a/reference/sodium/functions/sodium-crypto-aead-chacha20poly1305-ietf-decrypt.xml
+++ b/reference/sodium/functions/sodium-crypto-aead-chacha20poly1305-ietf-decrypt.xml
@@ -41,7 +41,7 @@
     <term><parameter>additional_data</parameter></term>
     <listitem>
      <simpara>
-      Additionnel, données authentifiées. Cela est utilisé dans la vérification de l'étiquette d'authentification
+      Données supplémentaires authentifiées. Cela est utilisé dans la vérification de l'étiquette d'authentification
       ajoutée au texte chiffré, mais il n'est pas chiffré ou stocké dans le texte chiffré.
      </simpara>
     </listitem>

--- a/reference/sodium/functions/sodium-crypto-aead-chacha20poly1305-ietf-encrypt.xml
+++ b/reference/sodium/functions/sodium-crypto-aead-chacha20poly1305-ietf-encrypt.xml
@@ -40,7 +40,7 @@
     <term><parameter>additional_data</parameter></term>
     <listitem>
      <simpara>
-      Additionnel, données authentifiées. Cela est utilisé dans la vérification de l'étiquette d'authentification
+      Données supplémentaires authentifiées. Cela est utilisé dans la vérification de l'étiquette d'authentification
       ajoutée au texte chiffré, mais il n'est pas chiffré ou stocké dans le texte chiffré.
      </simpara>
     </listitem>
@@ -67,7 +67,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   Renvoie la clé de chiffrement et l'étiquette en cas de succès, &return.falseforfailure;.
+   Renvoie le texte chiffré et l'étiquette en cas de succès, &return.falseforfailure;.
   </simpara>
  </refsect1>
 

--- a/reference/sodium/functions/sodium-crypto-aead-chacha20poly1305-ietf-keygen.xml
+++ b/reference/sodium/functions/sodium-crypto-aead-chacha20poly1305-ietf-keygen.xml
@@ -4,7 +4,7 @@
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.sodium-crypto-aead-chacha20poly1305-ietf-keygen">
  <refnamediv>
   <refname>sodium_crypto_aead_chacha20poly1305_ietf_keygen</refname>
-  <refpurpose>Génère un clé ChaCha20-Poly1305 (IETF) aléatoire</refpurpose>
+  <refpurpose>Génère une clé ChaCha20-Poly1305 (IETF) aléatoire</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/sodium/functions/sodium-crypto-aead-xchacha20poly1305-ietf-decrypt.xml
+++ b/reference/sodium/functions/sodium-crypto-aead-xchacha20poly1305-ietf-decrypt.xml
@@ -41,7 +41,7 @@
     <term><parameter>additional_data</parameter></term>
     <listitem>
      <simpara>
-      Additionnel, données authentifiées. Cela est utilisé dans la vérification de l'étiquette d'authentification
+      Données supplémentaires authentifiées. Cela est utilisé dans la vérification de l'étiquette d'authentification
       ajoutée au texte chiffré, mais il n'est pas chiffré ou stocké dans le texte chiffré.
      </simpara>
     </listitem>
@@ -69,7 +69,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   Renvoie la clé de chiffrement et l'étiquette en cas de succès, &return.falseforfailure;.
+   Renvoie le texte en clair en cas de succès, &return.falseforfailure;.
   </simpara>
  </refsect1>
 

--- a/reference/sodium/functions/sodium-crypto-aead-xchacha20poly1305-ietf-encrypt.xml
+++ b/reference/sodium/functions/sodium-crypto-aead-xchacha20poly1305-ietf-encrypt.xml
@@ -40,7 +40,7 @@
     <term><parameter>additional_data</parameter></term>
     <listitem>
      <simpara>
-      Additionnel, données authentifiées. Cela est utilisé dans la vérification de l'étiquette d'authentification
+      Données supplémentaires authentifiées. Cela est utilisé dans la vérification de l'étiquette d'authentification
       ajoutée au texte chiffré, mais il n'est pas chiffré ou stocké dans le texte chiffré.
      </simpara>
     </listitem>
@@ -68,7 +68,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   Renvoie la clé de chiffrement et l'étiquette en cas de succès, &return.falseforfailure;.
+   Renvoie le texte chiffré et l'étiquette en cas de succès, &return.falseforfailure;.
   </simpara>
  </refsect1>
 

--- a/reference/sodium/functions/sodium-crypto-aead-xchacha20poly1305-ietf-keygen.xml
+++ b/reference/sodium/functions/sodium-crypto-aead-xchacha20poly1305-ietf-keygen.xml
@@ -4,7 +4,7 @@
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.sodium-crypto-aead-xchacha20poly1305-ietf-keygen">
  <refnamediv>
   <refname>sodium_crypto_aead_xchacha20poly1305_ietf_keygen</refname>
-  <refpurpose>Génère une clé ChaCha20-Poly1305 aléatoire</refpurpose>
+  <refpurpose>Génère une clé XChaCha20-Poly1305 aléatoire.</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/sodium/functions/sodium-crypto-auth.xml
+++ b/reference/sodium/functions/sodium-crypto-auth.xml
@@ -15,7 +15,7 @@
    <methodparam><modifier role="attribute">#[\SensitiveParameter]</modifier><type>string</type><parameter>key</parameter></methodparam>
   </methodsynopsis>
   <simpara>
-   Le message symétrique d'authentification via <function>sodium_crypto_auth</function> fournit
+   L'authentification symétrique de message via <function>sodium_crypto_auth</function> fournit
    l'intégrité, mais pas la confidentialité.
   </simpara>
   <simpara>
@@ -51,7 +51,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   La clé d'authentification
+   L'étiquette d'authentification
   </simpara>
  </refsect1>
 

--- a/reference/sodium/functions/sodium-crypto-box-keypair-from-secretkey-and-publickey.xml
+++ b/reference/sodium/functions/sodium-crypto-box-keypair-from-secretkey-and-publickey.xml
@@ -17,7 +17,7 @@
   <simpara>
    Cette fonction existe pour satisfaire les exigences de l'API de <function>crypto_box</function>.
    Passer la clé secrète d'une partie et la clé publique de l'autre, et on obtiendra une "paire de clés"
-   pour le conversation.
+   pour la conversation.
   </simpara>
 
  </refsect1>

--- a/reference/sodium/functions/sodium-crypto-box-seal.xml
+++ b/reference/sodium/functions/sodium-crypto-box-seal.xml
@@ -59,7 +59,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   Un texte chiffré sous la forme de (clé publique unique, message chiffré, étiquette d'authentification).
+   Un texte chiffré sous la forme de (clé publique à usage unique, message chiffré, étiquette d'authentification).
   </simpara>
  </refsect1>
 

--- a/reference/sodium/functions/sodium-crypto-box-seed-keypair.xml
+++ b/reference/sodium/functions/sodium-crypto-box-seed-keypair.xml
@@ -14,7 +14,7 @@
    <methodparam><modifier role="attribute">#[\SensitiveParameter]</modifier><type>string</type><parameter>seed</parameter></methodparam>
   </methodsynopsis>
   <simpara>
-   Attache la graine pour former une clé secrète, dérive la clé publique, et renvoie les deux en tant que paire de clés.
+   Conditionne la graine pour former une clé secrète, dérive la clé publique, et renvoie les deux en tant que paire de clés.
   </simpara>
   <simpara>
    Les fonctions <literal>*_seed_keypair</literal> sont idéales pour générer une paire de clés à partir

--- a/reference/sodium/functions/sodium-crypto-kdf-derive-from-key.xml
+++ b/reference/sodium/functions/sodium-crypto-kdf-derive-from-key.xml
@@ -40,7 +40,7 @@
     <term><parameter>subkey_id</parameter></term>
     <listitem>
      <simpara>
-      Renvoie le sous-clé N-ième d'une clé racine donnée. Utile pour la recherche.
+      Renvoie la N-ième sous-clé d'une clé racine donnée. Utile pour la recherche.
      </simpara>
     </listitem>
    </varlistentry>

--- a/reference/sodium/functions/sodium-crypto-kx-client-session-keys.xml
+++ b/reference/sodium/functions/sodium-crypto-kx-client-session-keys.xml
@@ -46,7 +46,7 @@
   &reftitle.returnvalues;
   <simpara>
    Un tableau composé de deux chaînes. La première doit être utilisée pour recevoir des données
-   du server. La seconde doit être utilisée pour envoyer des données au serveur.
+   du serveur. La seconde doit être utilisée pour envoyer des données au serveur.
   </simpara>
  </refsect1>
 

--- a/reference/sodium/functions/sodium-crypto-pwhash.xml
+++ b/reference/sodium/functions/sodium-crypto-pwhash.xml
@@ -50,7 +50,7 @@
     <term><parameter>salt</parameter></term>
     <listitem>
      <simpara>
-      Un sel à ajouter au mot de passe avant le hachage. Le sel doit être imprévisible, idéalement généré à partir d'une bonne source de nombres aléatoires telle que <function>random_bytes</function>, et avoir une longueur d'au moins <constant>SODIUM_CRYPTO_PWHASH_SALTBYTES</constant> octets.
+      Un sel à ajouter au mot de passe avant le hachage. Le sel doit être imprévisible, idéalement généré à partir d'une bonne source de nombres aléatoires telle que <function>random_bytes</function>, et avoir une longueur d'exactement <constant>SODIUM_CRYPTO_PWHASH_SALTBYTES</constant> octets.
      </simpara>
     </listitem>
    </varlistentry>

--- a/reference/sodium/functions/sodium-crypto-secretstream-xchacha20poly1305-push.xml
+++ b/reference/sodium/functions/sodium-crypto-secretstream-xchacha20poly1305-push.xml
@@ -55,7 +55,7 @@
     <listitem>
      <simpara>
       Optionnel. Peut être utilisé pour affirmer le comportement de déchiffrement
-      (c'est-à-dire le ré-arrangement ou l'indication du dernier morceau dans un flux).
+      (c'est-à-dire le renouvellement de la clé ou l'indication du dernier morceau dans un flux).
      </simpara>
      <simplelist>
       <member>

--- a/reference/sodium/functions/sodium-crypto-secretstream-xchacha20poly1305-rekey.xml
+++ b/reference/sodium/functions/sodium-crypto-secretstream-xchacha20poly1305-rekey.xml
@@ -4,7 +4,7 @@
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.sodium-crypto-secretstream-xchacha20poly1305-rekey">
  <refnamediv>
   <refname>sodium_crypto_secretstream_xchacha20poly1305_rekey</refname>
-  <refpurpose>Pivote explicitement la clé dans l'état secretstream</refpurpose>
+  <refpurpose>Renouvelle explicitement la clé dans l'état secretstream</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -14,7 +14,7 @@
    <methodparam><type>string</type><parameter role="reference">state</parameter></methodparam>
   </methodsynopsis>
   <simpara>
-   Pivote explicitement la clé dans l'état secretstream. Remplace la valeur passée en paramètre.
+   Renouvelle explicitement la clé dans l'état secretstream. Remplace la valeur passée en paramètre.
   </simpara>
 
  </refsect1>

--- a/reference/sodium/functions/sodium-crypto-sign-seed-keypair.xml
+++ b/reference/sodium/functions/sodium-crypto-sign-seed-keypair.xml
@@ -14,7 +14,7 @@
    <methodparam><modifier role="attribute">#[\SensitiveParameter]</modifier><type>string</type><parameter>seed</parameter></methodparam>
   </methodsynopsis>
   <simpara>
-   Attache la graine pour former une clé secrète, dérive la clé publique et renvoie les deux en tant que paire de clés.
+   Conditionne la graine pour former une clé secrète, dérive la clé publique et renvoie les deux en tant que paire de clés.
   </simpara>
   <simpara>
    Les fonctions <literal>*_seed_keypair</literal> sont idéales pour générer une paire de clés à partir

--- a/reference/sodium/functions/sodium-crypto-stream-xchacha20.xml
+++ b/reference/sodium/functions/sodium-crypto-stream-xchacha20.xml
@@ -16,7 +16,7 @@
    <methodparam><modifier role="attribute">#[\SensitiveParameter]</modifier><type>string</type><parameter>key</parameter></methodparam>
   </methodsynopsis>
   <simpara>
-   Développe la <parameter>clé</parameter> et le <parameter>nonce</parameter> en un flux de clés de bytes pseudo-aléatoires.
+   Développe la <parameter>key</parameter> et le <parameter>nonce</parameter> en un flux de clés d'octets pseudo-aléatoires.
   </simpara>
  </refsect1>
 

--- a/reference/sodium/functions/sodium-crypto-stream-xor.xml
+++ b/reference/sodium/functions/sodium-crypto-stream-xor.xml
@@ -16,8 +16,8 @@
    <methodparam><modifier role="attribute">#[\SensitiveParameter]</modifier><type>string</type><parameter>key</parameter></methodparam>
   </methodsynopsis>
   <simpara>
-   Cette fonction chiffre un message avec XSalsa20, mais ne fournit aucune garantie sur
-   le texte chiffré.
+   Cette fonction chiffre un message avec XSalsa20, mais ne fournit aucune garantie
+   d'intégrité du texte chiffré sur le texte en clair.
   </simpara>
 
  </refsect1>

--- a/reference/sodium/functions/sodium-hex2bin.xml
+++ b/reference/sodium/functions/sodium-hex2bin.xml
@@ -19,7 +19,7 @@
   </simpara>
   <simpara>
    Comme <function>sodium_bin2hex</function>, <function>sodium_hex2bin</function>
-   sont résistants aux attaques par canaux secondaires tandis que <function>hex2bin</function> ne l'est pas.
+   est résistant aux attaques par canaux secondaires tandis que <function>hex2bin</function> ne l'est pas.
   </simpara>
 
  </refsect1>

--- a/reference/sodium/functions/sodium-memzero.xml
+++ b/reference/sodium/functions/sodium-memzero.xml
@@ -4,7 +4,7 @@
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.sodium-memzero">
  <refnamediv>
   <refname>sodium_memzero</refname>
-  <refpurpose>Surcharge une chaîne avec des caractères NUL</refpurpose>
+  <refpurpose>Écrase une chaîne avec des caractères NUL</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/sodium/functions/sodium-pad.xml
+++ b/reference/sodium/functions/sodium-pad.xml
@@ -35,7 +35,7 @@
     <term><parameter>block_size</parameter></term>
     <listitem>
      <simpara>
-      La chaîne sera remplie jusqu'à ce qu'elle soit un multiple pair de la taille du bloc.
+      La chaîne sera remplie jusqu'à ce qu'elle soit un multiple entier de la taille du bloc.
      </simpara>
     </listitem>
    </varlistentry>

--- a/reference/sodium/reference.xml
+++ b/reference/sodium/reference.xml
@@ -4,7 +4,7 @@
 <!-- Reviewed: yes -->
 
 <reference xml:id="ref.sodium" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
- <title>Sodium &Functions;</title>
+ <title>&Functions; Sodium</title>
 
  &reference.sodium.entities.functions;
 

--- a/reference/solr/solrclient/adddocument.xml
+++ b/reference/solr/solrclient/adddocument.xml
@@ -121,7 +121,7 @@ $doc->addField('cat', 'Lucene');
 
 $updateResponse = $client->addDocument($doc);
 
-// vous devriez valider ces modifications si vous n'utiliser pas $commitWithin
+// vous devriez valider ces modifications si vous n'utilisez pas $commitWithin
 $client->commit();
 
 print_r($updateResponse->getResponse());

--- a/reference/solr/solrclient/construct.xml
+++ b/reference/solr/solrclient/construct.xml
@@ -39,7 +39,7 @@
  - port            (Le numéro du port)
  - path            (Le chemin vers solr)
  - wt              (Le nom du gestionnaire d'écriture i.e. xml, json)
- - login           (Le nom d'utilisateur à utiliser pour l'authentification HTTP Authentication, si nécessaire)
+ - login           (Le nom d'utilisateur à utiliser pour l'authentification HTTP, si nécessaire)
  - password        (Le mot de passe pour l'authentification HTTP)
  - proxy_host      (Le nom d'hôte du serveur de proxy, si nécessaire)
  - proxy_port      (Le port du proxy)

--- a/reference/solr/solrclientexception/getinternalinfo.xml
+++ b/reference/solr/solrclientexception/getinternalinfo.xml
@@ -30,7 +30,7 @@
   &reftitle.returnvalues;
   <para>
    Retourne un tableau contenant des informations internes sur l'endroit d'où est lancée l'exception.
-   Utilisé uniquement par les developpeurs de l'extension.
+   Utilisé uniquement par les développeurs de l'extension.
   </para>
  </refsect1>
 

--- a/reference/solr/solrcollapsefunction/getfield.xml
+++ b/reference/solr/solrcollapsefunction/getfield.xml
@@ -14,7 +14,7 @@
    <void />
   </methodsynopsis>
   <para>
-    Renvoie le champ sur lequel la réduction est effectué.
+    Renvoie le champ sur lequel la réduction est effectuée.
   </para>
 
  </refsect1>

--- a/reference/solr/solrdocument/getinputdocument.xml
+++ b/reference/solr/solrdocument/getinputdocument.xml
@@ -17,7 +17,7 @@
   </methodsynopsis>
   <para>
    Retourne un objet SolrInputDocument équivalent à l'objet.
-   Utile pour re-soumettre/mettre à jour un document issue d'une requête.
+   Utile pour re-soumettre/mettre à jour un document issu d'une requête.
   </para>
   
  </refsect1>

--- a/reference/solr/solrinputdocument/addchilddocument.xml
+++ b/reference/solr/solrinputdocument/addchilddocument.xml
@@ -103,7 +103,7 @@ $product->addChildDocument($large);
 // ajoute le bloc de document produit à l'index
 $updateResponse = $client->addDocument(
         $product,
-        true, // surchage si le document existe
+        true, // surcharge si le document existe
         10000 // commit dans les 10 secondes
 );
 

--- a/reference/solr/solrinputdocument/addchilddocuments.xml
+++ b/reference/solr/solrinputdocument/addchilddocuments.xml
@@ -103,7 +103,7 @@ $product->addChildDocuments($skus);
 // ajoute le bloc de document produit à l'index
 $updateResponse = $client->addDocument(
         $product,
-        true, // surchage si le document existe
+        true, // surcharge si le document existe
         10000 // valide le commit dans 10 secondes
 );
 

--- a/reference/solr/solrinputdocument/toarray.xml
+++ b/reference/solr/solrinputdocument/toarray.xml
@@ -6,7 +6,7 @@
 <refentry xml:id="solrinputdocument.toarray" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>SolrInputDocument::toArray</refname>
-  <refpurpose>Retourne un représentation sous forme de tableau du document d'entrée</refpurpose>
+  <refpurpose>Retourne une représentation sous forme de tableau du document d'entrée</refpurpose>
  </refnamediv>
  
  <refsect1 role="description">
@@ -16,7 +16,7 @@
    <void />
   </methodsynopsis>
   <para>
-   Retourne un représentation sous forme de tableau du document d'entrée.
+   Retourne une représentation sous forme de tableau du document d'entrée.
   </para>
   
  </refsect1>

--- a/reference/solr/solrobject/offsetset.xml
+++ b/reference/solr/solrobject/offsetset.xml
@@ -19,7 +19,7 @@
   <para>
    Définit la valeur de la propriété. Cette méthode est utilisée lorsque
    l'objet est traité comme un tableau. Cet objet est en lecture seule.
-   On ne devriez jamais utiliser cette méthode.
+   On ne devrait jamais utiliser cette méthode.
   </para>
 
  </refsect1>

--- a/reference/solr/solrobject/offsetunset.xml
+++ b/reference/solr/solrobject/offsetunset.xml
@@ -18,7 +18,7 @@
   <para>
    Supprime la valeur de la propriété. Cette méthode est utilisée lorsque
    l'objet est traité comme un tableau. Cet objet est en lecture seule.
-   On ne devriez jamais utiliser cette méthode.
+   On ne devrait jamais utiliser cette méthode.
   </para>
 
  </refsect1>

--- a/reference/solr/solrpingresponse.xml
+++ b/reference/solr/solrpingresponse.xml
@@ -106,7 +106,7 @@
     <varlistentry xml:id="solrpingresponse.props.http-raw-request-headers">
      <term><varname>http_raw_request_headers</varname></term>
      <listitem>
-      <para>Une chaîne d'en-têtes brutes envoyée lors de la requête.</para>
+      <para>Une chaîne d'en-têtes bruts envoyée lors de la requête.</para>
      </listitem>
     </varlistentry>
     <varlistentry xml:id="solrpingresponse.props.http-raw-request">

--- a/reference/solr/solrquery/addfacetdateother.xml
+++ b/reference/solr/solrquery/addfacetdateother.xml
@@ -6,7 +6,7 @@
 <refentry xml:id="solrquery.addfacetdateother" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>SolrQuery::addFacetDateOther</refname>
-  <refpurpose>Ajoute une autre paramètre facet.date.other</refpurpose>
+  <refpurpose>Ajoute un autre paramètre facet.date.other</refpurpose>
  </refnamediv>
  
  <refsect1 role="description">

--- a/reference/solr/solrquery/getgroupqueries.xml
+++ b/reference/solr/solrquery/getgroupqueries.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="solrquery.getgroupqueries" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>SolrQuery::getGroupQueries</refname>
-  <refpurpose>Renvoie toutes les valeurs du paramètres group.query</refpurpose>
+  <refpurpose>Renvoie toutes les valeurs du paramètre group.query</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/solr/solrquery/gethighlight.xml
+++ b/reference/solr/solrquery/gethighlight.xml
@@ -6,7 +6,7 @@
 <refentry xml:id="solrquery.gethighlight" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>SolrQuery::getHighlight</refname>
-  <refpurpose>Récupère l'état du paramètre h1</refpurpose>
+  <refpurpose>Récupère l'état du paramètre hl</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/solr/solrquery/gethighlightfragsize.xml
+++ b/reference/solr/solrquery/gethighlightfragsize.xml
@@ -17,7 +17,7 @@
   </methodsynopsis>
   <para>
    Retourne le nombre de caractères des fragments à considérer pour la mise en
-   évidence. Zéro signifie aucun fragments. Le champ entier devrait être utilisé.
+   évidence. Zéro signifie aucun fragment. Le champ entier devrait être utilisé.
   </para>  
  </refsect1>
 

--- a/reference/solr/solrquery/gethighlightregexslop.xml
+++ b/reference/solr/solrquery/gethighlightregexslop.xml
@@ -16,7 +16,7 @@
   </methodsynopsis>
   <para>
    Retourne le facteur utilisé par l'expression rationnelle de fragmentation
-   pour la déviation depuis la taille idéal du fragment afin d'accommoder
+   pour la déviation depuis la taille idéale du fragment afin d'accommoder
    l'expression rationnelle.
   </para>
 

--- a/reference/solr/solrquery/gethighlightsimplepost.xml
+++ b/reference/solr/solrquery/gethighlightsimplepost.xml
@@ -6,7 +6,7 @@
 <refentry xml:id="solrquery.gethighlightsimplepost" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>SolrQuery::getHighlightSimplePost</refname>
-  <refpurpose>Récupère le texte qui doit apparaître après le terme mise en évidence</refpurpose>
+  <refpurpose>Récupère le texte qui doit apparaître après le terme mis en évidence</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -16,7 +16,7 @@
    <methodparam choice="opt"><type>string</type><parameter>field_override</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Récupère le texte qui doit apparaître après le terme mise en évidence.
+   Récupère le texte qui doit apparaître après le terme mis en évidence.
    Accepte un champ optionnel permettant l'écrasement.
   </para>
 </refsect1>

--- a/reference/solr/solrquery/gethighlightsimplepre.xml
+++ b/reference/solr/solrquery/gethighlightsimplepre.xml
@@ -6,7 +6,7 @@
 <refentry xml:id="solrquery.gethighlightsimplepre" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>SolrQuery::getHighlightSimplePre</refname>
-  <refpurpose>Retourne le texte qui doit apparaître avant le terme mise en évidence</refpurpose>
+  <refpurpose>Retourne le texte qui doit apparaître avant le terme mis en évidence</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -16,7 +16,7 @@
    <methodparam choice="opt"><type>string</type><parameter>field_override</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Retourne le texte qui doit apparaître avant le terme mise en évidence.
+   Retourne le texte qui doit apparaître avant le terme mis en évidence.
    Accepte un champ optionnel permettant l'écrasement.
   </para>
  </refsect1>

--- a/reference/solr/solrquery/gethighlightsnippets.xml
+++ b/reference/solr/solrquery/gethighlightsnippets.xml
@@ -16,7 +16,7 @@
    <methodparam choice="opt"><type>string</type><parameter>field_override</parameter></methodparam>
   </methodsynopsis>
   <para>
-   >Récupère le nombre maximal d'extraits mis en évidence à générer par champ.
+   Récupère le nombre maximal d'extraits mis en évidence à générer par champ.
    Accepte un champ optionnel permettant l'écrasement.
   </para>
  </refsect1>

--- a/reference/solr/solrquery/getmltmaxwordlength.xml
+++ b/reference/solr/solrquery/getmltmaxwordlength.xml
@@ -6,7 +6,7 @@
 <refentry xml:id="solrquery.getmltmaxwordlength" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>SolrQuery::getMltMaxWordLength</refname>
-  <refpurpose>Retourne la longueur minimale des mots en deçà de laquelle ils seront ignorés</refpurpose>
+  <refpurpose>Retourne la longueur maximale des mots au-delà de laquelle ils seront ignorés</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -16,7 +16,7 @@
    <void />
   </methodsynopsis>
   <para>
-   Retourne la longueur minimale des mots en deçà de laquelle ils seront ignorés.
+   Retourne la longueur maximale des mots au-delà de laquelle ils seront ignorés.
   </para>
 
  </refsect1>

--- a/reference/solr/solrquery/gettermsreturnraw.xml
+++ b/reference/solr/solrquery/gettermsreturnraw.xml
@@ -6,7 +6,7 @@
 <refentry xml:id="solrquery.gettermsreturnraw" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>SolrQuery::getTermsReturnRaw</refname>
-  <refpurpose>Si l'on doit retourner ou non les caractères brutes</refpurpose>
+  <refpurpose>Si l'on doit retourner ou non les caractères bruts</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -17,7 +17,7 @@
   </methodsynopsis>
   <para>
    Retourne un booléen indiquant si l'on doit retourner
-   ou non les caractères brutes des termes indexés, suivant s'ils
+   ou non les caractères bruts des termes indexés, suivant s'ils
    sont humainement lisibles.
   </para>
   

--- a/reference/solr/solrquery/gettermssort.xml
+++ b/reference/solr/solrquery/gettermssort.xml
@@ -6,7 +6,7 @@
 <refentry xml:id="solrquery.gettermssort" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>SolrQuery::getTermsSort</refname>
-  <refpurpose>Retourne un entier indiquant le nombre de termes stockés</refpurpose>
+  <refpurpose>Retourne un entier indiquant comment les termes sont triés</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -19,7 +19,7 @@
    SolrQuery::TERMS_SORT_INDEX indique que les termes
    sont retournés triés sur l'index.
    SolrQuery::TERMS_SORT_COUNT implique que les termes
-   sont stockés par la fréquence des termes (le plus grand nombre en premier).
+   sont triés par la fréquence des termes (le plus grand nombre en premier).
   </para>
  </refsect1>
 

--- a/reference/solr/solrquery/sethighlightfragsize.xml
+++ b/reference/solr/solrquery/sethighlightfragsize.xml
@@ -17,7 +17,7 @@
    <methodparam choice="opt"><type>string</type><parameter>field_override</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Définit la taille, en caractères, du fragments à considérer pour la coloration.
+   Définit la taille, en caractères, du fragment à considérer pour la coloration.
    "0" indique que la valeur du champ complet doit être utilisée (aucune fragmentation).
   </para>
  </refsect1>

--- a/reference/solr/solrquery/sethighlightmaxanalyzedchars.xml
+++ b/reference/solr/solrquery/sethighlightmaxanalyzedchars.xml
@@ -29,7 +29,7 @@
      <term><parameter>value</parameter></term>
      <listitem>
       <para>
-       Le nombre de caractères dans un document pour y chercher des extraites correspondants
+       Le nombre de caractères dans un document pour y chercher des extraits correspondants
       </para>
      </listitem>
     </varlistentry>

--- a/reference/solr/solrquery/sethighlightquery.xml
+++ b/reference/solr/solrquery/sethighlightquery.xml
@@ -18,7 +18,7 @@
    Ce paramètre permet de mettre en évidence des termes ou des champs différents de ceux utilisés pour récupérer les documents.
   </para>
 
-  <para>La valeur par défaut si non définit: la valeur du paramètre q de la requête</para>
+  <para>La valeur par défaut si non défini: la valeur du paramètre q de la requête</para>
   <para>Référence du paramètre Solr: hl.q</para>
  </refsect1>
 

--- a/reference/solr/solrquery/sethighlightregexmaxanalyzedchars.xml
+++ b/reference/solr/solrquery/sethighlightregexmaxanalyzedchars.xml
@@ -17,7 +17,7 @@
   </methodsynopsis>
   <para>
    Spécifie le nombre maximal de caractères à analyser dans un champ lors
-   de l'utilisateur du formatteur regex.
+   de l'utilisation du formatteur regex.
   </para>
 
  </refsect1>
@@ -31,7 +31,7 @@
      <listitem>
       <para>
        Le nombre maximal de caractères à analyser dans un champ lors
-       de l'utilisateur du formatteur regex.
+       de l'utilisation du formatteur regex.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/solr/solrquery/sethighlightregexpattern.xml
+++ b/reference/solr/solrquery/sethighlightregexpattern.xml
@@ -17,7 +17,7 @@
   </methodsynopsis>
   <para>
    Spécifie l'expression rationnelle pour la fragmentation.
-   Peut être utilisé pour extraire des phrases.
+   Peut être utilisée pour extraire des phrases.
   </para>
 
  </refsect1>
@@ -30,7 +30,7 @@
      <term><parameter>value</parameter></term>
      <listitem>
       <para>
-       L'expression rationnelle pour la fragmentation. Peut être utilisé pour
+       L'expression rationnelle pour la fragmentation. Peut être utilisée pour
        extraire des phrases.
       </para>
      </listitem>

--- a/reference/solr/solrquery/settermsincludelowerbound.xml
+++ b/reference/solr/solrquery/settermsincludelowerbound.xml
@@ -6,7 +6,7 @@
 <refentry xml:id="solrquery.settermsincludelowerbound" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>SolrQuery::setTermsIncludeLowerBound</refname>
-  <refpurpose>Inclut le terme inférieure liée dans le jeu de résultat</refpurpose>
+  <refpurpose>Inclut le terme inférieur lié dans le jeu de résultat</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -16,7 +16,7 @@
    <methodparam><type>bool</type><parameter>flag</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Inclut le terme inférieure liée dans le jeu de résultat.
+   Inclut le terme inférieur lié dans le jeu de résultat.
   </para>
 
  </refsect1>
@@ -29,7 +29,7 @@
      <term><parameter>flag</parameter></term>
      <listitem>
       <para>
-       Inclut le terme inférieure liée dans le jeu de résultat.
+       Inclut le terme inférieur lié dans le jeu de résultat.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/solr/solrquery/settermsincludeupperbound.xml
+++ b/reference/solr/solrquery/settermsincludeupperbound.xml
@@ -6,7 +6,7 @@
 <refentry xml:id="solrquery.settermsincludeupperbound" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>SolrQuery::setTermsIncludeUpperBound</refname>
-  <refpurpose>Inclut le terme supérieure liée dans le jeu de résultat</refpurpose>
+  <refpurpose>Inclut le terme supérieur lié dans le jeu de résultat</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -16,7 +16,7 @@
    <methodparam><type>bool</type><parameter>flag</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Inclut le terme supérieure liée dans le jeu de résultat.
+   Inclut le terme supérieur lié dans le jeu de résultat.
   </para>
 
  </refsect1>

--- a/reference/solr/solrquery/settermsreturnraw.xml
+++ b/reference/solr/solrquery/settermsreturnraw.xml
@@ -6,7 +6,7 @@
 <refentry xml:id="solrquery.settermsreturnraw" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>SolrQuery::setTermsReturnRaw</refname>
-  <refpurpose>Retourne les caractères brutes d'un terme indexé</refpurpose>
+  <refpurpose>Retourne les caractères bruts d'un terme indexé</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -16,8 +16,8 @@
    <methodparam><type>bool</type><parameter>flag</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Si vaut &true;, retourne les caractères brutes d'un terme
-   indexé, suivant s'ils sont humainement lisibles.
+   Si vaut &true;, retourne les caractères bruts d'un terme
+   indexé, qu'ils soient lisibles ou non par un humain.
   </para>
 
  </refsect1>

--- a/reference/solr/solrquery/settermssort.xml
+++ b/reference/solr/solrquery/settermssort.xml
@@ -18,7 +18,7 @@
   <para>
    Si SolrQuery::TERMS_SORT_COUNT, les termes seront triés par leur fréquence
    (ceux dont la fréquence est la plus élevée en premier).
-   Si SolrQuery::TERMS_SORT_INDEX, retourne les termes suivants leurs index.
+   Si SolrQuery::TERMS_SORT_INDEX, retourne les termes suivant leur index.
   </para>
 
  </refsect1>

--- a/reference/solr/solrquery/settimeallowed.xml
+++ b/reference/solr/solrquery/settimeallowed.xml
@@ -6,7 +6,7 @@
 <refentry xml:id="solrquery.settimeallowed" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>SolrQuery::setTimeAllowed</refname>
-  <refpurpose>Le temps allouée pour faire une recherche</refpurpose>
+  <refpurpose>Le temps alloué pour faire une recherche</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -16,7 +16,7 @@
    <methodparam><type>int</type><parameter>timeAllowed</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Le temps allouée pour faire une recherche. Cette valeur ne s'applique
+   Le temps alloué pour faire une recherche. Cette valeur ne s'applique
    qu'aux recherches et non aux requêtes en général. Le temps est en millisecondes.
    Les valeurs inférieures ou égales à zéro impliquent aucune restriction de temps.
    Les résultats partiels peuvent être retournés, s'il y en a.
@@ -32,7 +32,7 @@
      <term><parameter>timeAllowed</parameter></term>
      <listitem>
       <para>
-       Le temps allouée pour faire une recherche.
+       Le temps alloué pour faire une recherche.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/solr/solrresponse.xml
+++ b/reference/solr/solrresponse.xml
@@ -146,7 +146,7 @@
     <varlistentry xml:id="solrresponse.props.http-raw-request-headers">
      <term><varname>http_raw_request_headers</varname></term>
      <listitem>
-      <para>Une chaîne d'en-têtes brutes envoyée lors de la requête.</para>
+      <para>Une chaîne d'en-têtes bruts envoyée lors de la requête.</para>
      </listitem>
     </varlistentry>
     <varlistentry xml:id="solrresponse.props.http-raw-request">

--- a/reference/solr/solrresponse/getrawrequest.xml
+++ b/reference/solr/solrresponse/getrawrequest.xml
@@ -6,7 +6,7 @@
 <refentry xml:id="solrresponse.getrawrequest" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>SolrResponse::getRawRequest</refname>
-  <refpurpose>Récupère la requête brute envpyée au serveur Solr</refpurpose>
+  <refpurpose>Récupère la requête brute envoyée au serveur Solr</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -16,7 +16,7 @@
    <void />
   </methodsynopsis>
   <para>
-   Récupère la requête brute envpyée au serveur Solr.
+   Récupère la requête brute envoyée au serveur Solr.
   </para>
 
  </refsect1>
@@ -29,7 +29,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Retourne la requête brute envpyée au serveur Solr.
+   Retourne la requête brute envoyée au serveur Solr.
   </para>
  </refsect1>
 

--- a/reference/solr/solrresponse/getrawrequestheaders.xml
+++ b/reference/solr/solrresponse/getrawrequestheaders.xml
@@ -6,7 +6,7 @@
 <refentry xml:id="solrresponse.getrawrequestheaders" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>SolrResponse::getRawRequestHeaders</refname>
-  <refpurpose>Récupère les en-têtes brutes de la requête envoyée au serveur Solr</refpurpose>
+  <refpurpose>Récupère les en-têtes bruts de la requête envoyée au serveur Solr</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -16,7 +16,7 @@
    <void />
   </methodsynopsis>
   <para>
-   Récupère les en-têtes brutes de la requête envoyée au serveur Solr.
+   Récupère les en-têtes bruts de la requête envoyée au serveur Solr.
   </para>
 
  </refsect1>
@@ -29,7 +29,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Retourne les en-têtes brutes de la requête envoyée au serveur Solr.
+   Retourne les en-têtes bruts de la requête envoyée au serveur Solr.
   </para>
  </refsect1>
 

--- a/reference/solr/solrresponse/getrawresponseheaders.xml
+++ b/reference/solr/solrresponse/getrawresponseheaders.xml
@@ -6,7 +6,7 @@
 <refentry xml:id="solrresponse.getrawresponseheaders" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>SolrResponse::getRawResponseHeaders</refname>
-  <refpurpose>Récupère les en-têtes brutes de la réponse du serveur</refpurpose>
+  <refpurpose>Récupère les en-têtes bruts de la réponse du serveur</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -16,7 +16,7 @@
    <void />
   </methodsynopsis>
   <para>
-   Récupère les en-têtes brutes de la réponse du serveur.
+   Récupère les en-têtes bruts de la réponse du serveur.
   </para>
 
  </refsect1>
@@ -29,7 +29,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Retourne les en-têtes brutes de la réponse du serveur.
+   Retourne les en-têtes bruts de la réponse du serveur.
   </para>
  </refsect1>
 

--- a/reference/solr/solrutils/escapequerychars.xml
+++ b/reference/solr/solrutils/escapequerychars.xml
@@ -16,7 +16,7 @@
    <methodparam><type>string</type><parameter>str</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Le support Lucene protège les caractères spéciaux faisant partis
+   Le support Lucene protège les caractères spéciaux faisant partie
    de la syntaxe de la requête.
   </para>  
   <para>
@@ -30,7 +30,7 @@
 ]]>
   </para>
   <para>
-   Ces caractères font partis de la syntaxe de la requête et doivent
+   Ces caractères font partie de la syntaxe de la requête et doivent
    être échappés.
   </para>  
  </refsect1>


### PR DESCRIPTION
Corrections de langue et de traduction dans reference/, de session to solr (orthographe, grammaire, fidélité à l'anglais).