### PR TITLE
Nits translation: reference/ (spl to stream)

### DIFF
--- a/reference/spl/arrayiterator/count.xml
+++ b/reference/spl/arrayiterator/count.xml
@@ -16,7 +16,7 @@
   </methodsynopsis>
   <para>
    Récupère le nombre d'éléments d'un &array; ou le nombre de propriétés
-   publiques d'un &object;..
+   publiques d'un &object;.
   </para>
 
   &warn.undocumented.func;

--- a/reference/spl/arrayiterator/getflags.xml
+++ b/reference/spl/arrayiterator/getflags.xml
@@ -16,7 +16,7 @@
   <para>
    Récupère les drapeaux de comportement de <classname>ArrayIterator</classname>. Voir la méthode
    <link linkend="arrayiterator.setflags">ArrayIterator::setFlags</link>
-   pour une liste des drapeaux disponible.
+   pour une liste des drapeaux disponibles.
   </para>
  </refsect1>
 

--- a/reference/spl/arrayiterator/offsetunset.xml
+++ b/reference/spl/arrayiterator/offsetunset.xml
@@ -20,13 +20,13 @@
   <para>
    Si une itération est en cours, et que
    <methodname>ArrayIterator::offsetUnset</methodname> est utilisé pour unset
-   l'index actuel de l'itération, la position de l'itération sera avancé au
+   l'index actuel de l'itération, la position de l'itération sera avancée au
    prochain index.
    Comme la position de l'itération est aussi avancée à la fin de la déclaration
    de boucle &foreach;, l'utilisation de
    <methodname>ArrayIterator::offsetUnset</methodname> à l'intérieur d'une boucle
    <link linkend="control-structures.foreach"><literal>foreach</literal></link>
-   peut résulter en des index qui seront omit.
+   peut résulter en des index qui seront omis.
   </para>
 
  </refsect1>

--- a/reference/spl/arrayiterator/serialize.xml
+++ b/reference/spl/arrayiterator/serialize.xml
@@ -30,7 +30,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Un <classname>ArrayIterator</classname>, Sérialisé.
+   Un <classname>ArrayIterator</classname>, sérialisé.
   </para>
  </refsect1>
 

--- a/reference/spl/arrayobject/getarraycopy.xml
+++ b/reference/spl/arrayobject/getarraycopy.xml
@@ -46,7 +46,7 @@ $fruits = array("citrons" => 1, "oranges" => 4, "bananes" => 5, "pommes" => 10);
 $fruitsArrayObject = new ArrayObject($fruits);
 $fruitsArrayObject['poires'] = 4;
 
-// Crée un copie des tableaux
+// Crée une copie du tableau
 $copy = $fruitsArrayObject->getArrayCopy();
 var_dump($copy);
 

--- a/reference/spl/arrayobject/getiteratorclass.xml
+++ b/reference/spl/arrayobject/getiteratorclass.xml
@@ -54,7 +54,7 @@ $className = $fruitsArrayObject->getIteratorClass();
 var_dump($className);
 
 // Configure le nom de la nouvelle classe
-$fruitsArrayObject->setIteratorClass('MyArrayIterator');
+$fruitsArrayObject->setIteratorClass('MonArrayIterator');
 
 // Lit le nom de la classe du nouvel itérateur
 $className = $fruitsArrayObject->getIteratorClass();
@@ -65,8 +65,8 @@ var_dump($className);
     &example.outputs;
     <screen>
 <![CDATA[
-tring(13) "ArrayIterator"
-string(15) "MonArrayIterator"
+string(13) "ArrayIterator"
+string(16) "MonArrayIterator"
 ]]>
     </screen>
    </example>

--- a/reference/spl/arrayobject/natcasesort.xml
+++ b/reference/spl/arrayobject/natcasesort.xml
@@ -121,7 +121,7 @@ object(ArrayObject)#2 (1) {
 ]]>
     </screen>
     <para>
-     Pour plus d'information, voir la page la
+     Pour plus d'information, voir la page
      <link xlink:href="&url.strnatcmp;">comparaison de chaînes en ordre naturel</link>
      de Martin Pool.
     </para>

--- a/reference/spl/arrayobject/offsetexists.xml
+++ b/reference/spl/arrayobject/offsetexists.xml
@@ -34,7 +34,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   &true; if the requested index exists, otherwise &false;
+   &true; si l'index demandé existe, &false; sinon.
   </para>
  </refsect1>
 

--- a/reference/spl/arrayobject/setflags.xml
+++ b/reference/spl/arrayobject/setflags.xml
@@ -101,7 +101,7 @@ var_dump($fruitsArrayObject->citrons);
     &example.outputs.similar;
     <screen>
 <![CDATA[
-Warning: Undefined property: ArrayObject::$lemons in ...
+Warning: Undefined property: ArrayObject::$citrons in ...
 NULL
 int(1)
 ]]>

--- a/reference/spl/arrayobject/unserialize.xml
+++ b/reference/spl/arrayobject/unserialize.xml
@@ -15,7 +15,7 @@
    <methodparam><type>string</type><parameter>data</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Désérialise d'un objet <classname>ArrayObject</classname> sérialisé.
+   Désérialise un objet <classname>ArrayObject</classname> sérialisé.
   </para>
 
   &warn.undocumented.func;

--- a/reference/spl/callbackfilteriterator/accept.xml
+++ b/reference/spl/callbackfilteriterator/accept.xml
@@ -5,7 +5,7 @@
 <refentry xml:id="callbackfilteriterator.accept" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>CallbackFilterIterator::accept</refname>
-  <refpurpose>Appel la fonction de rappel avec la valeur courante, la clé courante,
+  <refpurpose>Appelle la fonction de rappel avec la valeur courante, la clé courante,
    et l'itérateur interne comme arguments</refpurpose>
  </refnamediv>
 

--- a/reference/spl/callbackfilteriterator/construct.xml
+++ b/reference/spl/callbackfilteriterator/construct.xml
@@ -42,7 +42,7 @@
       Voir aussi les <link linkend="callbackfilteriterator.examples">exemples</link>.
      </para>
      <para>
-      Peut être n'importe quelle valeur vaide de type <type>callable</type>.
+      Peut être n'importe quelle valeur valide de type <type>callable</type>.
      </para>
     </listitem>
    </varlistentry>

--- a/reference/spl/datastructures.xml
+++ b/reference/spl/datastructures.xml
@@ -11,11 +11,11 @@
   </para>
 
   <section>
-   <title>Liste doublement chaînées</title>
+   <title>Listes doublement chaînées</title>
 
    <para>
     Une liste doublement chaînée (<literal>Doubly Linked List</literal> ou DLL) 
-    est une liste de nœud liés dans les deux sens aux autres nœuds. Les opérations
+    est une liste de nœuds liés dans les deux sens aux autres nœuds. Les opérations
     d'itérateurs peuvent se faire dans les deux sens, en addition ou en suppression,
     avec un coût de O(1) lorsque la structure sous-jacente est une DLL.
     Elle fournit également un support pratique pour les piles et les queues.
@@ -86,8 +86,8 @@
 
    <para>
     Une carte est une structure de données qui stocke des paires clé/valeur.
-    Les tableaux PHP peuvent très bien servir de cartes entre des chaînes ou 
-    entiers et des valeurs. SPL fournit un objet de type carte pour les données.
+    Les tableaux PHP peuvent très bien servir de cartes entre des chaînes ou
+    entiers et des valeurs. SPL fournit une carte allant des objets vers des données.
     Cette carte peut aussi servir d'ensemble d'objets.
    </para>
 

--- a/reference/spl/directoryiterator/getbasename.xml
+++ b/reference/spl/directoryiterator/getbasename.xml
@@ -5,7 +5,7 @@
 <refentry xml:id="directoryiterator.getbasename" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>DirectoryIterator::getBasename</refname>
-  <refpurpose>Lit le nom de dossier de l'élément <classname>DirectoryIterator</classname></refpurpose>
+  <refpurpose>Lit le nom de base de l'élément <classname>DirectoryIterator</classname></refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -15,7 +15,7 @@
    <methodparam choice="opt"><type>string</type><parameter>suffix</parameter><initializer>""</initializer></methodparam>
   </methodsynopsis>
   <para>
-   Lit le nom de dossier de l'élément <classname>DirectoryIterator</classname>.
+   Lit le nom de base de l'élément <classname>DirectoryIterator</classname>.
   </para>
  </refsect1>
 
@@ -27,7 +27,7 @@
      <term><parameter>suffix</parameter></term>
      <listitem>
       <para>
-       Si le nom du dossier se termine par le suffixe <parameter>suffix</parameter>, 
+       Si le nom de base se termine par le suffixe <parameter>suffix</parameter>,
        il sera retiré.
       </para>
      </listitem>
@@ -39,7 +39,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Le nom du dossier courant.
+   Le nom de base courant.
   </para>
  </refsect1>
 
@@ -49,7 +49,7 @@
    <example>
     <title>Exemple avec <methodname>DirectoryIterator::getBasename</methodname></title>
     <para>
-     Cet exemple va retourner le chemin complet et le nom de dossier sans le
+     Cet exemple va retourner le chemin complet et le nom de base sans le
      suffixe <literal>.jpg</literal>, pour les fichiers dans le dossier 
      contenant le script.
     </para>

--- a/reference/spl/directoryiterator/rewind.xml
+++ b/reference/spl/directoryiterator/rewind.xml
@@ -44,7 +44,7 @@ $iterator = new DirectoryIterator(dirname(__FILE__));
 $iterator->next();
 echo $iterator->key(); //1
 
-$iterator->rewind(); //rewinding to the beginning
+$iterator->rewind(); // retour au début
 echo $iterator->key(); //0
 ?>
 ]]>

--- a/reference/spl/directoryiterator/valid.xml
+++ b/reference/spl/directoryiterator/valid.xml
@@ -27,7 +27,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Retourne &true; si la position est valide, et &false; sinon;
+   Retourne &true; si la position est valide, et &false; sinon.
   </para>
  </refsect1>
 

--- a/reference/spl/filesystemiterator.xml
+++ b/reference/spl/filesystemiterator.xml
@@ -186,7 +186,7 @@
     <varlistentry xml:id="filesystemiterator.constants.follow-symlinks">
      <term><constant>FilesystemIterator::FOLLOW_SYMLINKS</constant></term>
      <listitem>
-      <para>Makes <methodname>RecursiveDirectoryIterator::hasChildren</methodname> follow symlinks.</para>
+      <para>Fait suivre les liens symboliques à <methodname>RecursiveDirectoryIterator::hasChildren</methodname>.</para>
      </listitem>
     </varlistentry>
     <varlistentry xml:id="filesystemiterator.constants.key-mode-mask">

--- a/reference/spl/functions/class-parents.xml
+++ b/reference/spl/functions/class-parents.xml
@@ -106,7 +106,7 @@ Array
   <note>
    <simpara>
     Il est préférable d'utiliser &instanceof; ou la fonction <function>is_a</function>
-    pour vérifier qu'un objet implémente une interface.
+    pour vérifier qu'un objet étend une classe.
    </simpara>
   </note>
  </refsect1>

--- a/reference/spl/functions/iterator-count.xml
+++ b/reference/spl/functions/iterator-count.xml
@@ -7,7 +7,7 @@
  <refnamediv>
   <refname>iterator_count</refname>
   <refpurpose>
-   Compte de nombre d'éléments dans un itérateur
+   Compte le nombre d'éléments dans un itérateur
   </refpurpose>
  </refnamediv>
  <refsect1 role="description">
@@ -18,7 +18,7 @@
   </methodsynopsis>
   <para>
    Compte les éléments dans un itérateur.
-   Il n'est pas garantie que la fonction <function>iterator_count</function>
+   Il n'est pas garanti que la fonction <function>iterator_count</function>
    conserve la position courante de l'itérateur <parameter>iterator</parameter>.
   </para>
  </refsect1>

--- a/reference/spl/functions/iterator-to-array.xml
+++ b/reference/spl/functions/iterator-to-array.xml
@@ -38,7 +38,7 @@
      <term><parameter>preserve_keys</parameter></term>
      <listitem>
       <para>
-       S'il faut utiliser les éléments de l'itérateur comme clé.
+       S'il faut utiliser les clés des éléments de l'itérateur comme index.
       </para>
       <para>
        Si une clé est un <type>array</type> ou un

--- a/reference/spl/functions/spl-autoload-call.xml
+++ b/reference/spl/functions/spl-autoload-call.xml
@@ -6,7 +6,7 @@
  <refnamediv>
   <refname>spl_autoload_call</refname>
   <refpurpose>
-   Essai toutes les fonctions __autoload() enregistrées pour charger la classe demandée
+   Essaie toutes les fonctions __autoload() enregistrées pour charger la classe demandée
   </refpurpose>
  </refnamediv>
  <refsect1 role="description">

--- a/reference/spl/functions/spl-autoload-unregister.xml
+++ b/reference/spl/functions/spl-autoload-unregister.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: e5c8e7add9291c70be2ecd046de6ecfd034545a9 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 60809ebcf7d0c261b2f00e093e4fab70326ffc7b Maintainer: yannick Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.spl-autoload-unregister" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -21,7 +21,7 @@
    alors elle sera désactivée.
   </para>
   <para>
-   Lorsque cette fonction active une pile autoload,
+   Lorsque cette fonction désactive la pile autoload,
    toutes les fonctions __autoload existantes ne seront pas réactivées.
   </para>
  </refsect1>

--- a/reference/spl/functions/spl-object-hash.xml
+++ b/reference/spl/functions/spl-object-hash.xml
@@ -73,7 +73,7 @@ $storage[$id] = $object;
   </note>
   <note>
    <para>
-    Les hachage d'objet devraient être comparé pour leur identité avec <code>===</code>
+    Les hachages d'objet devraient être comparés pour leur identité avec <code>===</code>
     et <code>!==</code>, car le hachage retourné pourrait être
     une <link linkend="language.types.numeric-strings">chaîne numérique</link>.
     Par exemple: <literal>0000000000000e600000000000000000</literal>.

--- a/reference/spl/globiterator/count.xml
+++ b/reference/spl/globiterator/count.xml
@@ -49,7 +49,7 @@ printf("Trouvé %d élément(s)\r\n", $iterator->count());
     &example.outputs.similar;
     <screen>
 <![CDATA[
-Matched 8 item(s)
+Trouvé 8 élément(s)
 ]]>
     </screen>
    </example>

--- a/reference/spl/iteratoriterator/construct.xml
+++ b/reference/spl/iteratoriterator/construct.xml
@@ -37,7 +37,7 @@
       <para>
        Le nom de classe à utiliser pour l'itérateur intérieur. Ceci permet de
        spécifier une classe d'itérateur différente pour envelopper l'itérateur fourni.
-       Par défaut, la class <code>IteratorIterator</code> elle-même sera utilisée.
+       Par défaut, la classe <code>IteratorIterator</code> elle-même sera utilisée.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/spl/limititerator.xml
+++ b/reference/spl/limititerator.xml
@@ -58,7 +58,7 @@
 <![CDATA[
 <?php
 
-// Creér un itérateur à limiter
+// Créer un itérateur à limiter
 $fruits = new ArrayIterator(array(
     'apple',
     'banana',

--- a/reference/spl/limititerator/construct.xml
+++ b/reference/spl/limititerator/construct.xml
@@ -17,8 +17,8 @@
    <methodparam choice="opt"><type>int</type><parameter>limit</parameter><initializer>-1</initializer></methodparam>
   </constructorsynopsis>
   <para>
-   Construit un nouvel objet <classname>LimitIterator</classname>,depuis <parameter>iterator</parameter> avec
-   un <parameter>offset</parameter> et une limite maximum <parameter>limit</parameter>
+   Construit un nouvel objet <classname>LimitIterator</classname>, depuis <parameter>iterator</parameter> avec
+   un <parameter>offset</parameter> et une limite maximum <parameter>limit</parameter>.
   </para>
  </refsect1>
 
@@ -46,7 +46,7 @@
      <term><parameter>limit</parameter></term>
      <listitem>
       <para>
-       Nombre optionnelle de la limite.
+       Nombre optionnel de la limite.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/spl/multipleiterator.xml
+++ b/reference/spl/multipleiterator.xml
@@ -13,7 +13,7 @@
   <section xml:id="multipleiterator.intro">
    &reftitle.intro;
    <para>
-    Un intérateur qui itère séquentiellement sur plusieurs itérateurs.
+    Un itérateur qui itère séquentiellement sur plusieurs itérateurs.
    </para>
   </section>
   <!-- }}} -->
@@ -99,7 +99,7 @@
      <term><constant>MultipleIterator::MIT_KEYS_NUMERIC</constant></term>
      <listitem>
       <para>
-       Les clés sont créés à partir des positions des itérateurs.
+       Les clés sont créées à partir des positions des itérateurs.
       </para>
      </listitem>
     </varlistentry>
@@ -108,7 +108,7 @@
      <term><constant>MultipleIterator::MIT_KEYS_ASSOC</constant></term>
      <listitem>
       <para>
-       Les clés sont créés à partir des informations associées des itérateurs.
+       Les clés sont créées à partir des informations associées des itérateurs.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/spl/multipleiterator/current.xml
+++ b/reference/spl/multipleiterator/current.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="multipleiterator.current" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>MultipleIterator::current</refname>
-  <refpurpose>Récupère les instantes des itérateurs attachés</refpurpose>
+  <refpurpose>Récupère les instances des itérateurs attachés</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -14,7 +14,7 @@
    <void/>
   </methodsynopsis>
   <para>
-   Récupère les instantes courantes des itérateurs attachés.
+   Récupère les instances courantes des itérateurs attachés.
   </para>
 
   &warn.undocumented.func;
@@ -58,7 +58,7 @@
      <row>
       <entry>8.1.0</entry>
       <entry>
-       Une <classname>RuntimeException</classname> est désormais lancé quand
+       Une <classname>RuntimeException</classname> est désormais lancée quand
        <methodname>MultipleIterator::current</methodname> est appelé sur un
        itérateur invalide. Auparavant, &false; était retourné.
       </entry>

--- a/reference/spl/multipleiterator/key.xml
+++ b/reference/spl/multipleiterator/key.xml
@@ -60,7 +60,7 @@
      <row>
       <entry>8.1.0</entry>
       <entry>
-       Une <classname>RuntimeException</classname> est désormais lancé quand
+       Une <classname>RuntimeException</classname> est désormais lancée quand
        <methodname>MultipleIterator::key</methodname> est appelé sur un
        itérateur invalide. Auparavant, &false; était retourné.
       </entry>

--- a/reference/spl/norewinditerator.xml
+++ b/reference/spl/norewinditerator.xml
@@ -13,7 +13,7 @@
    &reftitle.intro;
    <para>
     Cet itérateur ignore les opérations de remise à zéro.
-    Ceci permet de traiter un itérateur dans plusieurs boucle &foreach; partielles.
+    Ceci permet de traiter un itérateur dans plusieurs boucles &foreach; partielles.
    </para>
   </section>
 <!-- }}} -->

--- a/reference/spl/norewinditerator/rewind.xml
+++ b/reference/spl/norewinditerator/rewind.xml
@@ -5,7 +5,7 @@
 <refentry xml:id="norewinditerator.rewind" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>NoRewindIterator::rewind</refname>
-  <refpurpose>Réinitialise l'itérateur interne</refpurpose>
+  <refpurpose>Empêche l'opération de réinitialisation sur l'itérateur interne</refpurpose>
  </refnamediv>
  <refsect1 role="description">
   &reftitle.description;
@@ -14,7 +14,7 @@
    <void/>
   </methodsynopsis>
   <para>
-   Réinitialise l'itérateur interne.
+   Empêche l'opération de réinitialisation sur l'itérateur interne.
   </para>
 
  </refsect1>

--- a/reference/spl/recursivecachingiterator/getchildren.xml
+++ b/reference/spl/recursivecachingiterator/getchildren.xml
@@ -5,7 +5,7 @@
 <refentry xml:id="recursivecachingiterator.getchildren" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>RecursiveCachingIterator::getChildren</refname>
-  <refpurpose>Retourne le fils de l'itérateur interne comme un CachingRecursiveIterator</refpurpose>
+  <refpurpose>Retourne le fils de l'itérateur interne comme un RecursiveCachingIterator</refpurpose>
  </refnamediv>
  <refsect1 role="description">
   &reftitle.description;

--- a/reference/spl/recursivecallbackfilteriterator.xml
+++ b/reference/spl/recursivecallbackfilteriterator.xml
@@ -80,7 +80,7 @@
  * @param $current   La valeur de l'élément courant
  * @param $key       La clé de l'élément courant
  * @param $iterator  Itérateur à filtrer
- * @return boolean   TRUE pour accepter l'élément courant, FASLE sinon
+ * @return boolean   TRUE pour accepter l'élément courant, FALSE sinon
  */
 function my_callback($current, $key, $iterator) {
     // Votre filtre ici

--- a/reference/spl/recursivedirectoryiterator/construct.xml
+++ b/reference/spl/recursivedirectoryiterator/construct.xml
@@ -39,7 +39,7 @@
        Drapeaux à passer pour changer le comportement de l'itérateur. Une liste
        de drapeaux peut être trouvée dans <link linkend="filesystemiterator.constants">
        la liste des constantes de FilesystemIterator</link>. Elles peuvent aussi être
-       renseignées plus tard au moyen de <methodname>FilesystemIterator::setFlags</methodname>       
+       renseignées plus tard au moyen de <methodname>FilesystemIterator::setFlags</methodname>.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/spl/recursivefilteriterator.xml
+++ b/reference/spl/recursivefilteriterator.xml
@@ -12,7 +12,7 @@
   <section xml:id="recursivefilteriterator.intro">
    &reftitle.intro;
    <para>
-    Cet itérateur abstrait filtre les valeurs non souhaitée d'un <classname>RecursiveIterator</classname>.
+    Cet itérateur abstrait filtre les valeurs non souhaitées d'un <classname>RecursiveIterator</classname>.
     Cette classe devrait être étendue afin d'implémenter des filtres personnalisés.
     La méthode <methodname>RecursiveFilterIterator::accept</methodname> est abstraite, et doit 
     être implémentée dans la classe étendant <classname>RecursiveIterator</classname>.

--- a/reference/spl/recursiveiterator/haschildren.xml
+++ b/reference/spl/recursiveiterator/haschildren.xml
@@ -27,7 +27,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Retourne &true; si l'entrée courante peut être parcouru, &false; sinon.
+   Retourne &true; si l'entrée courante peut être parcourue, &false; sinon.
   </para>
  </refsect1>
 

--- a/reference/spl/recursiveiteratoriterator/beginchildren.xml
+++ b/reference/spl/recursiveiteratoriterator/beginchildren.xml
@@ -18,7 +18,7 @@
    Est appelé après l'appel à la méthode
    <methodname>RecursiveIteratorIterator::getChildren</methodname>,
    ainsi qu'à la méthode <methodname>RecursiveIteratorIterator::rewind</methodname>
-   associé.
+   associée.
   </para>
 
   &warn.undocumented.func;

--- a/reference/spl/recursiveiteratoriterator/construct.xml
+++ b/reference/spl/recursiveiteratoriterator/construct.xml
@@ -29,8 +29,8 @@
      <term><parameter>iterator</parameter></term>
      <listitem>
       <para>
-       L'itérateur utilisé pour la construction. Soit la méthode
-       <classname>RecursiveIterator</classname> ou de la méthode
+       L'itérateur utilisé pour la construction. Soit un
+       <classname>RecursiveIterator</classname>, soit un
        <classname>IteratorAggregate</classname>.
       </para>
      </listitem>

--- a/reference/spl/regexiterator.xml
+++ b/reference/spl/regexiterator.xml
@@ -4,7 +4,7 @@
 <!-- Reviewed: yes -->
 <reference xml:id="class.regexiterator" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>&class.theclass; <classname>RegexIterator</classname></title>
- <titleabbrev></titleabbrev>
+ <titleabbrev>RegexIterator</titleabbrev>
 
  <partintro>
 

--- a/reference/spl/regexiterator/construct.xml
+++ b/reference/spl/regexiterator/construct.xml
@@ -68,7 +68,7 @@
      <term><parameter>pregFlags</parameter></term>
      <listitem>
       <para>
-       Les drapeaux de l'expression rationnelle. Ils dépendant du mode de l'opération :
+       Les drapeaux de l'expression rationnelle. Ils dépendent du mode de l'opération :
       </para>
       <para>
       <table>

--- a/reference/spl/seekableiterator.xml
+++ b/reference/spl/seekableiterator.xml
@@ -65,10 +65,10 @@ class MySeekableIterator implements SeekableIterator {
         "premier élément",
         "second élément",
         "troisième élément",
-        "quatriéme élément"
+        "quatrième élément"
     );
 
-    /* Méthode requis pour l'interface SeekableIterator */
+    /* Méthode requise pour l'interface SeekableIterator */
 
     public function seek($position) {
       if (!isset($this->array[$position])) {

--- a/reference/spl/seekableiterator/seek.xml
+++ b/reference/spl/seekableiterator/seek.xml
@@ -45,7 +45,7 @@
  <refsect1 role="errors">
   &reftitle.errors;
   <simpara>
-   L'implémentations doit émettre une exception <classname>OutOfBoundsException</classname>
+   Les implémentations devraient émettre une exception <classname>OutOfBoundsException</classname>
    si la position <parameter>offset</parameter> n'est pas atteignable.
   </simpara>
  </refsect1>

--- a/reference/spl/spldoublylinkedlist/offsetset.xml
+++ b/reference/spl/spldoublylinkedlist/offsetset.xml
@@ -30,7 +30,7 @@
      <term><parameter>index</parameter></term>
      <listitem>
       <para>
-       L'index à définir. Si &null; la prochaine valeur sera ajouté après la
+       L'index à définir. Si &null; la prochaine valeur sera ajoutée après la
        dernière valeur.
       </para>
      </listitem>

--- a/reference/spl/splfileinfo/getowner.xml
+++ b/reference/spl/splfileinfo/getowner.xml
@@ -47,7 +47,7 @@
 <![CDATA[
 <?php
 $info = new SplFileInfo('example.jpg');
-echo info->getFilename() . ' appartient à l'utilisateur id ' . $info->getOwner() . "\n";
+echo info->getFilename() . ' appartient à l\'utilisateur id ' . $info->getOwner() . "\n";
 print_r(posix_getpwuid($info->getOwner()));
 ?>
 ]]>

--- a/reference/spl/splfileinfo/setinfoclass.xml
+++ b/reference/spl/splfileinfo/setinfoclass.xml
@@ -52,7 +52,7 @@
     <programlisting role="php">
 <![CDATA[
 <?php
-// Define a class which extends SplFileInfo
+// Définit une classe qui étend SplFileInfo
 class MyFoo extends SplFileInfo {}
 
 $info = new SplFileInfo('foo');

--- a/reference/spl/splfileobject/construct.xml
+++ b/reference/spl/splfileobject/construct.xml
@@ -102,7 +102,7 @@ foreach ($file as $line_num => $line) {
 La ligne n°0 est : <?php
 La ligne n°1 est : $file = new SplFileObject(__FILE__);
 La ligne n°2 est : foreach ($file as $line_num => $line) {
-La ligne n°3 est :     echo "Line $line_num is $line";
+La ligne n°3 est :     echo "La ligne n°$line_num est : $line";
 La ligne n°4 est : }
 La ligne n°5 est : ?>
 ]]>

--- a/reference/spl/splfileobject/fgetcsv.xml
+++ b/reference/spl/splfileobject/fgetcsv.xml
@@ -52,8 +52,8 @@
      <term><parameter>escape</parameter></term>
      <listitem>
       <para>
-       Le caractère d'encadrement de champ (un seul caractère sur un octet).
-       Par défaut, <literal>"</literal> ou la valeur définie par un appel précédent à
+       Le caractère d'échappement (un seul caractère sur un octet).
+       Par défaut, <literal>\</literal> ou la valeur définie par un appel précédent à
        <methodname>SplFileObject::setCsvControl</methodname>.
        Une &string; vide (<literal>""</literal>) désactive le mécanisme d'échappement propriétaire.
       </para>

--- a/reference/spl/splfileobject/fgetss.xml
+++ b/reference/spl/splfileobject/fgetss.xml
@@ -64,7 +64,7 @@
 <?php
 $str = <<<EOD
 <html><body>
- <p>Bienvenue ! Aujourdh'ui, nous sommes le <?php echo(date('jS')); ?> de <?= date('F'); ?>.</p>
+ <p>Bienvenue ! Aujourd'hui, nous sommes le <?php echo(date('jS')); ?> de <?= date('F'); ?>.</p>
 </body></html>
 Texte en dehors d'un bloc HTML.
 EOD;
@@ -81,7 +81,7 @@ while (!$file->eof()) {
     <screen>
 <![CDATA[
 
- Bienvenue ! Aujourdh'ui, nous sommes le  de .
+ Bienvenue ! Aujourd'hui, nous sommes le  de .
 
 Texte en dehors d'un bloc HTML.
 ]]>

--- a/reference/spl/splfileobject/fpassthru.xml
+++ b/reference/spl/splfileobject/fpassthru.xml
@@ -49,11 +49,11 @@
 // Ouvre le fichier en mode binaire
 $file = new SplFileObject("./img/ok.png", "rb");
 
-// Envoi les en-têtes
+// Envoie les en-têtes
 header("Content-Type: image/png");
 header("Content-Length: " . $file->getSize());
 
-// Envoi l'image et met fin au script
+// Envoie l'image et met fin au script
 $file->fpassthru();
 exit;
 

--- a/reference/spl/splfileobject/ftell.xml
+++ b/reference/spl/splfileobject/ftell.xml
@@ -15,7 +15,7 @@
    <void/>
   </methodsynopsis>
   <para>
-   Retourne la position du pointeur de fichier, qui représentant
+   Retourne la position du pointeur de fichier, qui représente
    la position courante dans le flux du fichier.
   </para>
  </refsect1>

--- a/reference/spl/splfileobject/key.xml
+++ b/reference/spl/splfileobject/key.xml
@@ -5,7 +5,7 @@
 <refentry xml:id="splfileobject.key" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>SplFileObject::key</refname>
-  <refpurpose>Récupère le numéro de la ligne courant</refpurpose>
+  <refpurpose>Récupère le numéro de la ligne courante</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -15,7 +15,7 @@
    <void/>
   </methodsynopsis>
   <para>
-   Récupère le numéro de la ligne courant.
+   Récupère le numéro de la ligne courante.
   </para>
   <note>
    <para>

--- a/reference/spl/splfileobject/setcsvcontrol.xml
+++ b/reference/spl/splfileobject/setcsvcontrol.xml
@@ -67,7 +67,7 @@
        <entry>7.4.0</entry>
        <entry>
         Le paramètre <parameter>escape</parameter> accepte désormais une chaîne de
-        caractères vides afin de désactiver le mécanisme d'échappement propriétaire.
+        caractères vide afin de désactiver le mécanisme d'échappement propriétaire.
        </entry>
       </row>
      </tbody>

--- a/reference/spl/splfileobject/setmaxlinelen.xml
+++ b/reference/spl/splfileobject/setmaxlinelen.xml
@@ -66,7 +66,7 @@ foreach ($file as $line) {
 ?>
 ]]>
     </programlisting>
-    <para>Contents of lipsum.txt</para>
+    <para>Contenu de lipsum.txt</para>
     <programlisting role="txt">
 <![CDATA[
 Lorem ipsum dolor sit amet, consectetur adipiscing elit.

--- a/reference/spl/splfileobject/tostring.xml
+++ b/reference/spl/splfileobject/tostring.xml
@@ -16,7 +16,7 @@
    <void/>
   </methodsynopsis>
   <para>
-   Cette méthode la ligne courante sous forme de chaîne de caractères.
+   Cette méthode retourne la ligne courante sous forme de chaîne de caractères.
   </para>
  </refsect1>
 

--- a/reference/spl/splfixedarray.xml
+++ b/reference/spl/splfixedarray.xml
@@ -150,9 +150,9 @@ try {
 NULL
 int(2)
 string(3) "foo"
-RuntimeException: Index invalid or out of range
-RuntimeException: Index invalid or out of range
-RuntimeException: Index invalid or out of range
+RuntimeException : Index invalid or out of range
+RuntimeException : Index invalid or out of range
+RuntimeException : Index invalid or out of range
 ]]>
      </screen>
     </example>

--- a/reference/spl/splfixedarray/count.xml
+++ b/reference/spl/splfixedarray/count.xml
@@ -66,7 +66,7 @@ echo count($array) . "\n";
   </note>
   <note>
    <para>
-    Le nombre d'éléments est toujours égal à la taille du jeu, parce que toutes
+    Le nombre d'éléments est toujours égal à la taille définie, parce que toutes
     les valeurs sont initialisées avec la valeur &null;.
    </para>
   </note>

--- a/reference/spl/splfixedarray/fromarray.xml
+++ b/reference/spl/splfixedarray/fromarray.xml
@@ -37,7 +37,7 @@
      <term><parameter>preserveKeys</parameter></term>
      <listitem>
       <para>
-       Tente de préserver les index numérique du tableau original.
+       Tente de préserver les index numériques du tableau original.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/spl/splheap/compare.xml
+++ b/reference/spl/splheap/compare.xml
@@ -22,7 +22,7 @@
   <warning>
    <para>
     L'envoi d'exception dans <methodname>SplHeap::compare</methodname> peut
-    le corrompre et le placer dans un statut bloqué. Il est possible du débloquer
+    le corrompre et le placer dans un statut bloqué. Il est possible de le débloquer
     en appelant la méthode <methodname>SplHeap::recoverFromCorruption</methodname>.
     Cependant, des éléments peuvent ne pas avoir été placés correctement.
    </para>

--- a/reference/spl/splheap/iscorrupted.xml
+++ b/reference/spl/splheap/iscorrupted.xml
@@ -24,7 +24,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Retourne &true; si la tas est corrompu, &false; sinon.
+   Retourne &true; si le tas est corrompu, &false; sinon.
   </para>
  </refsect1>
 

--- a/reference/spl/splheap/next.xml
+++ b/reference/spl/splheap/next.xml
@@ -16,7 +16,7 @@
   </methodsynopsis>
   <para>
    Se déplace au nœud suivant.
-   Ceci va supprimer le plus haut nœud de la pile.
+   Ceci va supprimer le plus haut nœud du tas.
   </para>
  </refsect1>
 

--- a/reference/spl/splobjectstorage.xml
+++ b/reference/spl/splobjectstorage.xml
@@ -14,7 +14,7 @@
    &reftitle.intro;
    <para>
     La classe <classname>SplObjectStorage</classname> fournit une carte
-    d'objets ou de données, ou encore, en ignorant les index, un ensemble
+    allant des objets vers des données, ou encore, en ignorant les données, un ensemble
     d'objets. Ce double objectif est utile dans de nombreuses situations,
     où il faut identifier de manière unique des objets.
    </para>

--- a/reference/spl/splobjectstorage/attach.xml
+++ b/reference/spl/splobjectstorage/attach.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e5c8e7add9291c70be2ecd046de6ecfd034545a9 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: a0d62151102e4bf83e2bb4068782757d20ba086d Maintainer: yannick Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="splobjectstorage.attach" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>

--- a/reference/spl/splobjectstorage/contains.xml
+++ b/reference/spl/splobjectstorage/contains.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e5c8e7add9291c70be2ecd046de6ecfd034545a9 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: ce98b568f85353c4bf263133f09c4db9294833f9 Maintainer: yannick Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="splobjectstorage.contains" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>

--- a/reference/spl/splobjectstorage/detach.xml
+++ b/reference/spl/splobjectstorage/detach.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e5c8e7add9291c70be2ecd046de6ecfd034545a9 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: ce98b568f85353c4bf263133f09c4db9294833f9 Maintainer: dams Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="splobjectstorage.detach" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>

--- a/reference/spl/splobjectstorage/gethash.xml
+++ b/reference/spl/splobjectstorage/gethash.xml
@@ -25,7 +25,7 @@
   <para>
    Cet objet de stockage ne doit pas contenir plus d'un objet avec le même identifiant.
    Aussi, il peut être utilisé pour implémenter un jeu (une collection de valeurs uniques)
-   où la qualité d'un objet unique est déterminé par la valeur retournée par
+   où la qualité d'un objet unique est déterminée par la valeur retournée par
    cette fonction.
   </para>
 

--- a/reference/spl/splobjectstorage/getinfo.xml
+++ b/reference/spl/splobjectstorage/getinfo.xml
@@ -5,7 +5,7 @@
 <refentry xml:id="splobjectstorage.getinfo" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>SplObjectStorage::getInfo</refname>
-  <refpurpose>Retourne les données associés à l'élément en cours</refpurpose>
+  <refpurpose>Retourne les données associées à l'élément en cours</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/spl/splobjectstorage/offsetget.xml
+++ b/reference/spl/splobjectstorage/offsetget.xml
@@ -46,7 +46,7 @@
   &reftitle.errors;
   <para>
    Lance une exception <classname>UnexpectedValueException</classname>
-   lorsque <parameter>object</parameter> n'a pû être trouvé.
+   lorsque <parameter>object</parameter> n'a pu être trouvé.
   </para>
  </refsect1><!-- }}} -->
 

--- a/reference/spl/splobjectstorage/removeall.xml
+++ b/reference/spl/splobjectstorage/removeall.xml
@@ -5,7 +5,7 @@
 <refentry xml:id="splobjectstorage.removeall" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>SplObjectStorage::removeAll</refname>
-  <refpurpose>Retire les objets d'un stockage qui appartienne à un autre stockage</refpurpose>
+  <refpurpose>Retire les objets d'un stockage qui appartiennent à un autre stockage</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -15,7 +15,7 @@
    <methodparam><type>SplObjectStorage</type><parameter>storage</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Retire les objets d'un stockage qui appartienne à un autre stockage.
+   Retire les objets d'un stockage qui appartiennent à un autre stockage.
   </para>
  </refsect1>
 

--- a/reference/spl/splobjectstorage/setinfo.xml
+++ b/reference/spl/splobjectstorage/setinfo.xml
@@ -5,7 +5,7 @@
 <refentry xml:id="splobjectstorage.setinfo" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>SplObjectStorage::setInfo</refname>
-  <refpurpose>Modifie les données associée à l'élément courant</refpurpose>
+  <refpurpose>Modifie les données associées à l'élément courant</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/spl/splpriorityqueue/iscorrupted.xml
+++ b/reference/spl/splpriorityqueue/iscorrupted.xml
@@ -5,7 +5,7 @@
 <refentry xml:id="splpriorityqueue.iscorrupted" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>SplPriorityQueue::isCorrupted</refname>
-  <refpurpose>Informe si la file prioritaire est dans un état corrompue</refpurpose>
+  <refpurpose>Informe si la file prioritaire est dans un état corrompu</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/spl/splsubject/attach.xml
+++ b/reference/spl/splsubject/attach.xml
@@ -15,7 +15,7 @@
    <methodparam><type>SplObserver</type><parameter>observer</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Attache un <classname>SplObserver</classname>. Il sera ainsi notifier des mises à jour.
+   Attache un <classname>SplObserver</classname>. Il sera ainsi notifié des mises à jour.
   </para>
 
   &warn.undocumented.func;

--- a/reference/spl/spltempfileobject/construct.xml
+++ b/reference/spl/spltempfileobject/construct.xml
@@ -68,7 +68,7 @@ $temp->fwrite("This is the first line\n");
 $temp->fwrite("And this is the second.\n");
 echo $temp->ftell() . " octets écrits dans le fichier temporaire.\n\n";
 
-// Rewind and read what was written
+// Rembobine et lit ce qui a été écrit
 $temp->rewind();
 foreach ($temp as $line) {
     echo $line;

--- a/reference/sqlite3/sqlite3/escapestring.xml
+++ b/reference/sqlite3/sqlite3/escapestring.xml
@@ -54,7 +54,7 @@
   <warning>
    <simpara>
     La fonction <function>addslashes</function> ne doit <emphasis>PAS</emphasis>
-    être utilisée pour protéger la chaîne dans les requêtes SQL ; il serait possible de
+    être utilisée pour protéger la chaîne dans les requêtes SQL ; il serait possible
      d'observer d'étranges résultats lorsque l'on récupérera les données.
    </simpara>
   </warning>

--- a/reference/sqlite3/sqlite3/lasterrorcode.xml
+++ b/reference/sqlite3/sqlite3/lasterrorcode.xml
@@ -29,7 +29,7 @@
   &reftitle.returnvalues;
   <para>
    Retourne un entier représentant le code erreur de la dernière requête ayant
-   échouée.
+   échoué.
   </para>
  </refsect1>
 

--- a/reference/sqlite3/sqlite3/loadextension.xml
+++ b/reference/sqlite3/sqlite3/loadextension.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="sqlite3.loadextension" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>SQLite3::loadExtension</refname>
-  <refpurpose>Tente de charger une extension de la bibliothèque SQLite</refpurpose>
+  <refpurpose>Tente de charger une bibliothèque d'extension SQLite</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -14,7 +14,7 @@
    <methodparam><type>string</type><parameter>name</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Tente de charger une extension de la bibliothèque SQLite.
+   Tente de charger une bibliothèque d'extension SQLite.
   </para>
  </refsect1>
 
@@ -26,7 +26,7 @@
      <term><parameter>name</parameter></term>
      <listitem>
       <para>
-       Le nom de l'extension à charger. L'extension doit se trouver dans
+       Le nom de la bibliothèque à charger. L'extension doit se trouver dans
        le dossier spécifié par l'option de configuration
        sqlite3.extension_dir.
       </para>

--- a/reference/sqlite3/sqlite3/open.xml
+++ b/reference/sqlite3/sqlite3/open.xml
@@ -16,8 +16,8 @@
    <methodparam choice="opt"><type>string</type><parameter>encryptionKey</parameter><initializer>""</initializer></methodparam>
   </methodsynopsis>
   <para>
-   Ouvre une base de données SQLite 3. Si le chiffrement a été inclus lors de la
-   construction de la base de données, la clé correspondante sera utilisée.
+   Ouvre une base de données SQLite 3. Si la compilation inclut le chiffrement,
+   la clé correspondante sera utilisée.
   </para>
  </refsect1>
 

--- a/reference/sqlite3/sqlite3/openblob.xml
+++ b/reference/sqlite3/sqlite3/openblob.xml
@@ -126,7 +126,7 @@ $conn->exec('CREATE TABLE test (text text)');
 $conn->exec("INSERT INTO test VALUES ('Lorem ipsum')");
 $stream = $conn->openBlob('test', 'text', 1);
 echo stream_get_contents($stream);
-fclose($stream); // mandatory, otherwise the next line would fail
+fclose($stream); // obligatoire, sinon la ligne suivante échouerait
 $conn->close();
 ?>
 ]]>

--- a/reference/sqlite3/sqlite3stmt/getsql.xml
+++ b/reference/sqlite3/sqlite3stmt/getsql.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="sqlite3stmt.getsql" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>SQLite3Stmt::getSQL</refname>
-  <refpurpose>Récupère le SQL d'une déclaration</refpurpose>
+  <refpurpose>Récupère le SQL d'une instruction préparée</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -14,10 +14,10 @@
    <methodparam choice="opt"><type>bool</type><parameter>expand</parameter><initializer>&false;</initializer></methodparam>
   </methodsynopsis>
   <para>
-   Récupère le SQL d'une déclaration préparée. Si <parameter>expand</parameter>
+   Récupère le SQL d'une instruction préparée. Si <parameter>expand</parameter>
    est &false;, le SQL non modifié est récupéré. Si <parameter>expand</parameter>
-   est &true;, tous les paramètres de requête sont remplacés avec leurs valeurs liées,
-   ou avec un <literal>NULL</literal> SQL, si pas encore lié.
+   est &true;, tous les paramètres de requête sont remplacés par leurs valeurs liées,
+   ou par un <literal>NULL</literal> SQL, s'ils ne sont pas encore liés.
   </para>
  </refsect1>
 

--- a/reference/sqlite3/sqlite3stmt/readonly.xml
+++ b/reference/sqlite3/sqlite3stmt/readonly.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="sqlite3stmt.readonly" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>SQLite3Stmt::readOnly</refname>
-  <refpurpose>Détermine si une déclaration est uniquement en lecture seule</refpurpose>
+  <refpurpose>Détermine si une instruction est définitivement en lecture seule</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -14,8 +14,8 @@
    <void/>
   </methodsynopsis>
   <para>
-   Détermine si une déclaration est uniquement en lecture seule. Une déclaration est
-   considérée uniquement en lecture seule, si elle ne fait aucun changement <emphasis>direct</emphasis>
+   Détermine si une instruction est définitivement en lecture seule. Une instruction est
+   considérée comme en lecture seule, si elle ne fait aucun changement <emphasis>direct</emphasis>
    au contenu du fichier de base de données. Il est à noter que les fonctions SQL définies par
    l'utilisateur peuvent <emphasis>indirectement</emphasis> changer la base de données
    en tant qu'effet secondaire.
@@ -30,7 +30,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Retourne &true; si la déclaration est uniquement en lecture seule, &false; sinon.
+   Retourne &true; si l'instruction est définitivement en lecture seule, &false; sinon.
   </para>
  </refsect1>
 

--- a/reference/sqlite3/sqlite3stmt/reset.xml
+++ b/reference/sqlite3/sqlite3stmt/reset.xml
@@ -14,8 +14,8 @@
    <void/>
   </methodsynopsis>
   <para>
-   Réinitialise une requête préparée, de tel sorte à retrouver son état initial,
-   avant exécution. Tous les marqueurs resteront intacts après cette opération.
+   Réinitialise une requête préparée, de manière à retrouver son état initial,
+   avant exécution. Toutes les liaisons resteront intactes après cette opération.
   </para>
  </refsect1>
 
@@ -27,7 +27,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Retourne &true; si la requête préaprée a été correctement réinitialisée,
+   Retourne &true; si la requête préparée a été correctement réinitialisée,
    &return.falseforfailure;.
   </para>
  </refsect1>

--- a/reference/sqlsrv/constants.xml
+++ b/reference/sqlsrv/constants.xml
@@ -568,7 +568,7 @@
   </varlistentry>
   <varlistentry>
    <term>
-    <constant>SQLSRV_SQLTYPE_NVARCHAR('max')</constant>
+    <constant>SQLSRV_SQLTYPE_NVARCHAR</constant>('max')
     (<type>int</type>)
    </term>
    <listitem>
@@ -726,7 +726,7 @@
   </varlistentry>
   <varlistentry>
    <term>
-    <constant>SQLSRV_SQLTYPE_VARBINARY('max')</constant>
+    <constant>SQLSRV_SQLTYPE_VARBINARY</constant>('max')
     (<type>int</type>)
    </term>
    <listitem>
@@ -752,7 +752,7 @@
   </varlistentry>
   <varlistentry>
    <term>
-    <constant>SQLSRV_SQLTYPE_VARCHAR('max')</constant>
+    <constant>SQLSRV_SQLTYPE_VARCHAR</constant>('max')
     (<type>int</type>)
    </term>
    <listitem>

--- a/reference/sqlsrv/functions/sqlsrv-cancel.xml
+++ b/reference/sqlsrv/functions/sqlsrv-cancel.xml
@@ -81,7 +81,7 @@ while( ($row = sqlsrv_fetch_array( $stmt)) && $salesTotal <=100000)
      $count++;
 }
 
-echo "$count sales accounted for the first $$salesTotal in revenue.<br />";
+echo "$count ventes ont représenté les premiers $$salesTotal de revenus.<br />";
 
 // Annule les résultats restants. La requête peut être ré-utilisée.
 sqlsrv_cancel( $stmt);

--- a/reference/sqlsrv/functions/sqlsrv-commit.xml
+++ b/reference/sqlsrv/functions/sqlsrv-commit.xml
@@ -19,7 +19,7 @@
    <function>sqlsrv_commit</function>. La transaction validée inclut toutes les
    requêtes exécutées après un appel à la fonction
    <function>sqlsrv_begin_transaction</function>. Les transactions doivent commencer,
-   être valider ou être annuler en utilisant ces fonctions au lieu d'utiliser des requêtes
+   être validées ou être annulées en utilisant ces fonctions au lieu d'utiliser des requêtes
    déclarant le début ou l'annulation d'une transaction. Pour plus d'informations,
    se reporter aux <link xlink:href="&url.sqlsrv.transaction.handling;">transactions SQLSRV</link>.
   </simpara>

--- a/reference/sqlsrv/functions/sqlsrv-execute.xml
+++ b/reference/sqlsrv/functions/sqlsrv-execute.xml
@@ -80,8 +80,8 @@ $orders = array( 1=>10, 2=>20, 3=>30);
 
 // Exécute la requête pour chaque ordre.
 foreach( $orders as $id => $qty) {
-    // En raison du que $id et $qty sont liés à $stmt1, leurs valeurs
-    // mise à jour sont utilisées lors de chaque exécution de la requête.
+    // En raison du fait que $id et $qty sont liés à $stmt1, leurs valeurs
+    // mises à jour sont utilisées lors de chaque exécution de la requête.
     if( sqlsrv_execute( $stmt ) === false ) {
           die( print_r( sqlsrv_errors(), true));
     }

--- a/reference/sqlsrv/functions/sqlsrv-fetch.xml
+++ b/reference/sqlsrv/functions/sqlsrv-fetch.xml
@@ -17,7 +17,7 @@
   </methodsynopsis>
   <simpara>
    Rend la prochaine ligne d'un jeu de résultats disponible pour lecture.
-   Utiliser la fonction <function>sqlsrv_get_field</function> pour llire les
+   Utiliser la fonction <function>sqlsrv_get_field</function> pour lire les
    champs de la ligne.
   </simpara>
  </refsect1>

--- a/reference/sqlsrv/functions/sqlsrv-free-stmt.xml
+++ b/reference/sqlsrv/functions/sqlsrv-free-stmt.xml
@@ -14,8 +14,8 @@
    <methodparam><type>resource</type><parameter>stmt</parameter></methodparam>
   </methodsynopsis>
   <simpara>
-   Libère toutes les ressources pour la requête spécifié. La requête ne pourra
-   plus être utilisé après le passage à la fonction <function>sqlsrv_free_stmt</function>.
+   Libère toutes les ressources pour la requête spécifiée. La requête ne pourra
+   plus être utilisée après le passage à la fonction <function>sqlsrv_free_stmt</function>.
    Si la requête <function>sqlsrv_free_stmt</function> est appelée alors que la
    requête est en cours d'exécution, l'exécution de la requête est interrompue,
    et la requête est annulée.
@@ -65,7 +65,7 @@ if( $stmt === false ) {
 }
 
 /*-------------------------------
-     Exploitation dde la requête ici.
+     Exploitation de la requête ici.
 -------------------------------*/
 
 /* Libération des ressources associées à la requête. */
@@ -80,7 +80,7 @@ sqlsrv_free_stmt( $stmt);
  <refsect1 role="notes">
   &reftitle.notes;
   <simpara>
-   La principale différentre entre la fonction <function>sqlsrv_free_stmt</function> et
+   La principale différence entre la fonction <function>sqlsrv_free_stmt</function> et
    la fonction <function>sqlsrv_cancel</function> est qu'une ressource de requête
    annulée avec la fonction <function>sqlsrv_cancel</function> peut être ré-exécutée
    si elle a été créée avec la fonction <function>sqlsrv_prepare</function>.

--- a/reference/sqlsrv/functions/sqlsrv-num-rows.xml
+++ b/reference/sqlsrv/functions/sqlsrv-num-rows.xml
@@ -48,7 +48,7 @@
   &reftitle.returnvalues;
   <simpara>
    Retourne le nombre total de lignes récupérées en cas de succès, et
-   &false; si une erreur survient. Si un curseur précédent (par défaut),
+   &false; si une erreur survient. Si un curseur avant (par défaut),
    ou un curseur dynamique est utilisé, &false; sera retourné.
   </simpara>
  </refsect1>
@@ -72,7 +72,7 @@ $stmt = sqlsrv_query( $conn, $sql , $params, $options );
 $row_count = sqlsrv_num_rows( $stmt );
 
 if ($row_count === false)
-   echo "Error in retrieveing row count.";
+   echo "Erreur lors de la récupération du nombre de lignes.";
 else
    echo $row_count;
 ?>

--- a/reference/sqlsrv/functions/sqlsrv-send-stream-data.xml
+++ b/reference/sqlsrv/functions/sqlsrv-send-stream-data.xml
@@ -71,13 +71,13 @@ $stmt = sqlsrv_prepare( $conn, $sql, $params, $options);
 
 sqlsrv_execute( $stmt);
 
-// Envoi jusqu'à 8 Ko de données au serveur
+// Envoie jusqu'à 8 Ko de données au serveur
 // à chaque appel à la fonction sqlsrv_send_stream_data.
 $i = 1;
 while( sqlsrv_send_stream_data( $stmt)) {
       $i++;
 }
-echo "$i calls were made.";
+echo "$i appels ont été effectués.";
 ?>
 ]]>
    </programlisting>

--- a/reference/sqlsrv/setup.xml
+++ b/reference/sqlsrv/setup.xml
@@ -18,7 +18,7 @@
    </simplelist>
   </para>
   <para>
-   L'extension SQLSRV requière que le client natif Microsoft SQL Server 2012
+   L'extension SQLSRV requiert que le client natif Microsoft SQL Server 2012
    soit installé sur la même machine que celle qui exécute PHP. Si le client natif
    Microsoft SQL Server 2012 n'est pas installé, cliquez sur le lien approprié
    ci-dessous pour le télécharger :

--- a/reference/ssh2/book.xml
+++ b/reference/ssh2/book.xml
@@ -4,7 +4,7 @@
 <!-- Reviewed: yes -->
 <book xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="book.ssh2">
  <?phpdoc extension-membership="pecl" ?>
- <title>Shell2 sécurisé</title>
+ <title>SSH2 (Secure Shell version 2)</title>
  <titleabbrev>SSH2</titleabbrev>
 
  <!-- {{{ preface -->

--- a/reference/ssh2/functions/ssh2-auth-hostbased-file.xml
+++ b/reference/ssh2/functions/ssh2-auth-hostbased-file.xml
@@ -108,7 +108,7 @@ if (ssh2_auth_hostbased_file($connection, 'remoteusername', 'myhost.example.com'
                              'localusername')) {
   echo "Identification en utilisant une clé d'hôte publique avec succès\n";
 } else {
-  die('Échec de l\'identification en utilisant une clé d\'hôte publique avec succès');
+  die('Échec de l\'identification en utilisant une clé d\'hôte publique');
 }
 ?>
 ]]>

--- a/reference/ssh2/functions/ssh2-fetch-stream.xml
+++ b/reference/ssh2/functions/ssh2-fetch-stream.xml
@@ -17,7 +17,7 @@
   </methodsynopsis>
   <simpara>
    Parcourt un sous-flux alternatif associé à un flux de canal SSH2.
-   Le protocole SSH2 définie actuellement un seul sous-flux, STDERR, qui a
+   Le protocole SSH2 définit actuellement un seul sous-flux, STDERR, qui a
    un identifiant de sous-flux de <constant>SSH2_STREAM_STDERR</constant> (défini à 1).
   </simpara>
  </refsect1>

--- a/reference/ssh2/functions/ssh2-publickey-remove.xml
+++ b/reference/ssh2/functions/ssh2-publickey-remove.xml
@@ -5,7 +5,7 @@
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.ssh2-publickey-remove">
  <refnamediv>
   <refname>ssh2_publickey_remove</refname>
-  <refpurpose>Supprime un clé publique autorisée</refpurpose>
+  <refpurpose>Supprime une clé publique autorisée</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -17,7 +17,7 @@
    <methodparam><type>string</type><parameter>blob</parameter></methodparam>
   </methodsynopsis>
   <simpara>
-   Supprime un clé publique autorisée.
+   Supprime une clé publique autorisée.
   </simpara>
  </refsect1>
 

--- a/reference/ssh2/functions/ssh2-sftp-lstat.xml
+++ b/reference/ssh2/functions/ssh2-sftp-lstat.xml
@@ -5,7 +5,7 @@
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.ssh2-sftp-lstat">
  <refnamediv>
   <refname>ssh2_sftp_lstat</refname>
-  <refpurpose>Statue un lien symbolique</refpurpose>
+  <refpurpose>Obtient les informations d'un lien symbolique</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -16,7 +16,7 @@
    <methodparam><type>string</type><parameter>path</parameter></methodparam>
   </methodsynopsis>
   <simpara>
-   Statue un lien symbolique sur le système
+   Obtient les informations d'un lien symbolique sur le système
    de fichiers distant <emphasis>sans</emphasis> suivre le lien.
   </simpara>
   <simpara>
@@ -60,7 +60,7 @@
  <refsect1 role="examples">
   &reftitle.examples;
   <example>
-   <title>Statue un lien symbolique via SFTP</title>
+   <title>Obtient les informations d'un lien symbolique via SFTP</title>
    <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/ssh2/functions/ssh2-shell.xml
+++ b/reference/ssh2/functions/ssh2-shell.xml
@@ -93,7 +93,7 @@
  <refsect1 role="examples">
   &reftitle.examples;
   <example>
-   <title>Exécution d'une commande</title>
+   <title>Demande d'un shell interactif</title>
    <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/ssh2/reference.xml
+++ b/reference/ssh2/reference.xml
@@ -4,7 +4,7 @@
 <!-- Reviewed: yes -->
 
 <reference xml:id="ref.ssh2" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
- <title>&Functions; Shell2</title>
+ <title>&Functions; SSH2</title>
 
  &reference.ssh2.entities.functions;
 

--- a/reference/stats/functions/stats-cdf-logistic.xml
+++ b/reference/stats/functions/stats-cdf-logistic.xml
@@ -26,7 +26,7 @@
    CDF, x, mu, et s désignent la fonction de distribution cumulative, la valeur de la variable aléatoire,
    et les paramètres de localisation et d'échelle de la distribution logistique, respectivement.
    <table>
-    <title>Return value and parameters</title>
+    <title>Valeur de retour et paramètres</title>
     <tgroup cols="5">
      <thead>
       <row>

--- a/reference/stats/functions/stats-dens-cauchy.xml
+++ b/reference/stats/functions/stats-dens-cauchy.xml
@@ -36,7 +36,7 @@
      <term><parameter>ave</parameter></term>
      <listitem>
       <para>
-       Le paramètre de location de la distribution
+       Le paramètre de localisation de la distribution
       </para>
      </listitem>
     </varlistentry>

--- a/reference/stats/functions/stats-dens-laplace.xml
+++ b/reference/stats/functions/stats-dens-laplace.xml
@@ -56,7 +56,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Le densité de probabilité à <parameter>x</parameter> ou &false; en cas d'échec.
+   La densité de probabilité à <parameter>x</parameter> ou &false; en cas d'échec.
   </para>
  </refsect1>
 

--- a/reference/stats/functions/stats-rand-gen-chisquare.xml
+++ b/reference/stats/functions/stats-rand-gen-chisquare.xml
@@ -15,7 +15,7 @@
   <para>
    Renvoie une déviation aléatoire de la distribution chi-carré où les degrés de
    liberté sont <parameter>df</parameter>.
-  i</para>
+  </para>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;

--- a/reference/stats/functions/stats-rand-setall.xml
+++ b/reference/stats/functions/stats-rand-setall.xml
@@ -45,7 +45,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Aucune valeurs n'est retournée.
+   Aucune valeur n'est retournée.
   </para>
  </refsect1>
 

--- a/reference/stomp/stomp/ack.xml
+++ b/reference/stomp/stomp/ack.xml
@@ -37,7 +37,7 @@
     <term><parameter>msg</parameter></term>
     <listitem>
      <simpara>
-      Le message où l'identifiant du message à valider.
+      Le message ou l'identifiant du message à valider.
      </simpara>
     </listitem>
    </varlistentry>

--- a/reference/stomp/stomp/construct.xml
+++ b/reference/stomp/stomp/construct.xml
@@ -121,7 +121,7 @@ unset($stomp);
 /* connexion */
 $link = stomp_connect('ssl://localhost:61612');
 
-/* verification de la connexion */
+/* vérification de la connexion */
 if (!$link) {
     die('Connection failed: ' . stomp_connect_error());
 }

--- a/reference/stomp/stomp/error.xml
+++ b/reference/stomp/stomp/error.xml
@@ -84,7 +84,7 @@ string(43) "Invalid transaction id: unknown-transaction"
 /* connexion */
 $link = stomp_connect('ssl://localhost:61612');
 
-/* verification de la connexion */
+/* vérification de la connexion */
 if (!$link) {
     die('Connection failed: ' . stomp_connect_error());
 }

--- a/reference/stomp/stomp/getreadtimeout.xml
+++ b/reference/stomp/stomp/getreadtimeout.xml
@@ -84,7 +84,7 @@ array(2) {
 /* connexion */
 $link = stomp_connect('ssl://localhost:61612');
 
-/* verification de la connexion */
+/* vérification de la connexion */
 if (!$link) {
     die('Connection failed: ' . stomp_connect_error());
 }

--- a/reference/stomp/stomp/getsessionid.xml
+++ b/reference/stomp/stomp/getsessionid.xml
@@ -79,7 +79,7 @@ string(35) "ID:php.net-52873-1257291895530-4:14"
 /* connexion */
 $link = stomp_connect('ssl://localhost:61612');
 
-/* verification de la connexion */
+/* vérification de la connexion */
 if (!$link) {
     die('Connection failed: ' . stomp_connect_error());
 }

--- a/reference/stomp/stomp/readframe.xml
+++ b/reference/stomp/stomp/readframe.xml
@@ -129,7 +129,7 @@ object(StompFrame)#2 (3) {
 /* connexion */
 $link = stomp_connect('ssl://localhost:61612');
 
-/* verification de la connexion */
+/* vérification de la connexion */
 if (!$link) {
     die('Connection failed: ' . stomp_connect_error());
 }

--- a/reference/stomp/stomp/setreadtimeout.xml
+++ b/reference/stomp/stomp/setreadtimeout.xml
@@ -92,7 +92,7 @@ unset($stomp);
 /* connexion */
 $link = stomp_connect('ssl://localhost:61612');
 
-/* verification de la connexion */
+/* vérification de la connexion */
 if (!$link) {
     die('Connection failed: ' . stomp_connect_error());
 }

--- a/reference/stream/book.xml
+++ b/reference/stream/book.xml
@@ -26,7 +26,7 @@
     Il existe de nombreux gestionnaires intégrés à PHP
     par défaut (voir <xref linkend="wrappers"/>),
     et, de plus, des gestionnaires spécifiques peuvent être ajoutés dans
-    les scripts PHP avec la fonction <function>stream_register_wrapper</function>,
+    les scripts PHP avec la fonction <function>stream_wrapper_register</function>,
     ou bien directement par une autre extension.
     Grâce à la souplesse des gestionnaires qui peuvent être ajoutés à PHP,
     il n'y a pas de limites aux possibilités offertes. Pour connaître la liste

--- a/reference/stream/filters.xml
+++ b/reference/stream/filters.xml
@@ -9,7 +9,7 @@
   Un <literal>filtre</literal> est une fonction finale qui effectue des opérations
   sur les données qui sont lues ou écrites dans un flux. Un nombre arbitraire de
   filtres peuvent être ajoutés sur un flux. Des filtres personnalisés peuvent aussi
-  être ajoutés avec la fonction <function>stream_register_filter</function>, ou bien
+  être ajoutés avec la fonction <function>stream_filter_register</function>, ou bien
   dans une extension. Pour
   connaître la liste des filtres actuellement enregistrés, utiliser la fonction
   <function>stream_get_filters</function>.

--- a/reference/stream/functions/stream-context-get-params.xml
+++ b/reference/stream/functions/stream-context-get-params.xml
@@ -16,7 +16,7 @@
   </methodsynopsis>
   <para>
    <function>stream_context_get_params</function> lit les paramètres
-   du contexte ou du flux <parameter>stream_or_context</parameter>.
+   du contexte ou du flux <parameter>context</parameter>.
   </para>
  </refsect1>
 

--- a/reference/stream/functions/stream-filter-append.xml
+++ b/reference/stream/functions/stream-filter-append.xml
@@ -107,7 +107,7 @@ $fp = fopen('test.txt', 'w+');
  * celui de lecture */
 stream_filter_append($fp, "string.rot13", STREAM_FILTER_WRITE);
 
-/* On ajoute un simple chaîne dans le fichier, il sera
+/* On ajoute une simple chaîne dans le fichier, elle sera
  * transformé par ROT13 à l'écriture */
 fwrite($fp, "Ceci est un test\n");
 

--- a/reference/stream/functions/stream-filter-register.xml
+++ b/reference/stream/functions/stream-filter-register.xml
@@ -193,7 +193,7 @@ readfile("foo-bar.txt");
     &example.outputs;
     <screen>
 <![CDATA[
-LINE1
+LIGNE1
 MOT - 2
 FACILE COMME 123
 ]]>

--- a/reference/stream/functions/stream-get-transports.xml
+++ b/reference/stream/functions/stream-get-transports.xml
@@ -53,7 +53,6 @@ Array (
   [2] => unix
   [3] => udg
 )
-?>
 ]]>
     </screen>
    </example>

--- a/reference/stream/functions/stream-is-local.xml
+++ b/reference/stream/functions/stream-is-local.xml
@@ -15,8 +15,8 @@
    <methodparam><type class="union"><type>resource</type><type>string</type></type><parameter>stream</parameter></methodparam>
   </methodsynopsis>
   <para>
-   <function>stream_is_local</function> vérifie si le flux ou 
-   l'URL <parameter>stream_or_url</parameter> est local au système ou non.
+   <function>stream_is_local</function> vérifie si le flux ou
+   l'URL <parameter>stream</parameter> est local au système ou non.
   </para>
  </refsect1>
 

--- a/reference/stream/functions/stream-set-read-buffer.xml
+++ b/reference/stream/functions/stream-set-read-buffer.xml
@@ -38,7 +38,7 @@
        Le nombre d'octets à mettre en buffer. Si <parameter>size</parameter>
        vaut 0 alors les opérations sont sans buffer. Cela garantit que les opérations
        avec <function>fread</function> sont achevées avant que d'autres processus
-       ne soient autorisés à lire dans le flux de sortie.
+       ne soient autorisés à lire dans ce flux d'entrée.
      </para>
     </listitem>
    </varlistentry>

--- a/reference/stream/functions/stream-socket-shutdown.xml
+++ b/reference/stream/functions/stream-socket-shutdown.xml
@@ -45,7 +45,7 @@
        Une des constantes suivantes : <constant>STREAM_SHUT_RD</constant>
        (désactive les réceptions futures), <constant>STREAM_SHUT_WR</constant>
        (désactive les transmissions futures) ou
-       <constant>STREAM_SHUT_RDWR</constant> (désactive les réceptions ou les
+       <constant>STREAM_SHUT_RDWR</constant> (désactive les réceptions et les
        transmissions futures).
       </para>
      </listitem>

--- a/reference/stream/setup.xml
+++ b/reference/stream/setup.xml
@@ -16,7 +16,7 @@
   <simpara>
    La classe <classname>php_user_filter</classname> est prédéfinie. C'est une classe abstraite
    à utiliser avec les filtres personnalisés. Voir le manuel de la fonction
-   <function>stream_register_filter</function> pour plus de détails sur les
+   <function>stream_filter_register</function> pour plus de détails sur les
    implémentations de filtres utilisateurs.
   </simpara>
  </section>

--- a/reference/stream/streamwrapper/construct.xml
+++ b/reference/stream/streamwrapper/construct.xml
@@ -15,7 +15,7 @@
    <void />
   </constructorsynopsis>
   <para>
-   Appelé à la création du gestionnaire de flux, juste avant
+   Appelé à l'ouverture du gestionnaire de flux, juste avant
    <methodname>streamWrapper::stream_open</methodname>.
   </para>
 

--- a/reference/stream/streamwrapper/destruct.xml
+++ b/reference/stream/streamwrapper/destruct.xml
@@ -16,7 +16,7 @@
   </destructorsynopsis>
   <para>
    Appelé lors de la fermeture du gestionnaire de flux,
-   tout de suite après l'appel à la méthode
+   juste avant l'appel à la méthode
    <methodname>streamWrapper::stream_flush</methodname>.
   </para>
 

--- a/reference/stream/streamwrapper/dir-readdir.xml
+++ b/reference/stream/streamwrapper/dir-readdir.xml
@@ -81,11 +81,11 @@ class streamWrapper {
     }
 
     public function dir_readdir() {
-        // Extract the header for this entry
+        // Extrait l'en-tête de cette entrée
         $header      = fread($this->fp, 512);
         $data = unpack("a100filename/a8mode/a8uid/a8gid/a12size/a12mtime/a8checksum/a1filetype/a100link/a100linkedfile", $header);
 
-        // Trim the filename and filesize
+        // Nettoie le nom de fichier et la taille
         $filename    = trim($data["filename"]);
 
         // Pas de fichier, nous sommes à la fin de l'archive
@@ -94,7 +94,7 @@ class streamWrapper {
         }
 
         $octal_bytes = trim($data["size"]);
-        // Filesize is defined in octects
+        // La taille du fichier est définie en octets
         $bytes       = octdec($octal_bytes);
 
         // tar arrondit les tailles de fichiers au multiple de 512 suivant
@@ -157,7 +157,7 @@ string(15) "stream-tell.xml"
 string(16) "stream-write.xml"
 string(10) "unlink.xml"
 string(12) "url-stat.xml"
-Remise à zéro..
+Remise au début..
 string(13) "construct.xml"
 
 ]]>

--- a/reference/stream/streamwrapper/rename.xml
+++ b/reference/stream/streamwrapper/rename.xml
@@ -48,8 +48,8 @@
      <term><parameter>path_to</parameter></term>
      <listitem>
       <para>
-       La nouvelle URL <parameter>path_from</parameter> 
-       avec laquelle le fichier doit être renommé.
+       La nouvelle URL vers laquelle <parameter>path_from</parameter>
+       doit être renommé.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/stream/streamwrapper/stream-lock.xml
+++ b/reference/stream/streamwrapper/stream-lock.xml
@@ -6,7 +6,7 @@
 <refentry xml:id="streamwrapper.stream-lock" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>streamWrapper::stream_lock</refname>
-  <refpurpose>Verrouillage logique de fichiers</refpurpose>
+  <refpurpose>Verrouillage consultatif de fichiers</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/stream/streamwrapper/stream-read.xml
+++ b/reference/stream/streamwrapper/stream-read.xml
@@ -35,7 +35,7 @@
      <term><parameter>count</parameter></term>
      <listitem>
       <para>
-       Le nombre d'octets qui ont pu être lus, à partir de 
+       Le nombre d'octets de données à retourner depuis
        la position courante.
       </para>
      </listitem>

--- a/reference/stream/streamwrapper/stream-seek.xml
+++ b/reference/stream/streamwrapper/stream-seek.xml
@@ -50,9 +50,9 @@
       </para>
       <note>
        <simpara>
-        L'implémentation actuelle ne définie jamais <parameter>whence</parameter> à
+        L'implémentation actuelle ne définit jamais <parameter>whence</parameter> à
         <constant>SEEK_CUR</constant>; en effet ces recherches de position sont
-        convertie en interne à des recherches de type <constant>SEEK_SET</constant>.
+        converties en interne à des recherches de type <constant>SEEK_SET</constant>.
        </simpara>
       </note>
      </listitem>
@@ -90,8 +90,8 @@
    <para>
     Toutes les opérations de déplacement sur un flux ne nécessitent pas
     obligatoirement l'utilisation de cette fonction. Les flux PHP
-    ont la lecture en mémoire tampon d'activé par défaut (voir aussi la
-    fonction <function>stream_set_read_buffer</function>) ainsi que la
+    ont la lecture en mémoire tampon activée par défaut (voir aussi la
+    fonction <function>stream_set_read_buffer</function>) ainsi que le
     déplacement dans ce flux, pouvant être effectué en déplaçant le pointeur
     du buffer.
    </para>

--- a/reference/stream/streamwrapper/stream-tell.xml
+++ b/reference/stream/streamwrapper/stream-tell.xml
@@ -16,7 +16,7 @@
    <void />
   </methodsynopsis>
   <para>
-   Cette méthode est appelée en réponse à <function>ftell</function>
+   Cette méthode est appelée en réponse à <function>fseek</function>
    pour déterminer la position courante.
   </para>
  </refsect1>

--- a/reference/stream/streamwrapper/stream-write.xml
+++ b/reference/stream/streamwrapper/stream-write.xml
@@ -20,8 +20,8 @@
   </para>
   <note>
    <para>
-    N'oubliez pas de mettre à jour la position courante dans le flux,
-    du nombre d'octets qui ont pu être lus.
+    Il est à noter qu'il faut mettre à jour la position courante dans le flux,
+    du nombre d'octets qui ont été écrits avec succès.
    </para>
   </note>
  </refsect1>


### PR DESCRIPTION
Corrections de langue et de traduction dans reference/, de spl to stream (orthographe, grammaire, fidélité à l'anglais).