### PR TITLE
Nits translation: reference/ (uodbc to yaf)

### DIFF
--- a/reference/uodbc/configure.xml
+++ b/reference/uodbc/configure.xml
@@ -97,8 +97,8 @@
       Par défaut, c'est <filename>/usr/local</filename>.
       Il faut s'assurer que la variable CUSTOM_ODBC_LIBS est
       définie, et que le fichier <filename>odbc.h</filename> est dans
-      le chemin d'inclusion, c'est-à-dire que
-      il est recommandé de définir les lignes suivantes pour 
+      le chemin d'inclusion, c'est-à-dire qu'il est recommandé
+      de définir les lignes suivantes pour
       <literal>Sybase SQL Anywhere 5.5.00</literal> sous QNX,
       avant d'utiliser le script de configuration :
 <![CDATA[

--- a/reference/uodbc/functions/odbc-autocommit.xml
+++ b/reference/uodbc/functions/odbc-autocommit.xml
@@ -42,7 +42,7 @@
        Si <parameter>enable</parameter> vaut &true;, l'autovalidation
        est activée. S'il est &false;, l'autovalidation
        est désactivée.
-       Si &null; est passé, cette fonction renvoie le statut d'auto-engagement pour
+       Si &null; est passé, cette fonction renvoie le statut d'autovalidation pour
        <parameter>odbc</parameter>.
       </para>
      </listitem>
@@ -61,7 +61,7 @@
   </para>
   <para>
    Si <parameter>enable</parameter> est non null, cette fonction retourne &true;
-   en cas de succès,et &false; si une erreur survient.
+   en cas de succès, et &false; si une erreur survient.
   </para>
  </refsect1>
  <refsect1 role="changelog">

--- a/reference/uodbc/functions/odbc-binmode.xml
+++ b/reference/uodbc/functions/odbc-binmode.xml
@@ -20,7 +20,7 @@
    colonnes de données binaires. Les types ODBC SQL affectés sont
    <literal>BINARY</literal>, <literal>VARBINARY</literal> et
    <literal>LONGVARBINARY</literal>.
-   Le mode par défaut peut être définie en utilisant la directive &php.ini;
+   Le mode par défaut peut être défini en utilisant la directive &php.ini;
    <link linkend="ini.uodbc.defaultbinmode">uodbc.defaultbinmode</link>
   </para>
   <para>
@@ -88,7 +88,7 @@
    Si <function>odbc_fetch_into</function> est utilisé, passthru
    signifie qu'une chaîne vide sera retournée pour ces colonnes.
    Si la fonction <function>odbc_result</function> est utilisée, passthru
-   signifie que les données sont envoyés directement au client (i.e. imprimé).
+   signifie que les données sont envoyées directement au client (i.e. imprimées).
   </para>
  </refsect1>
  <refsect1 role="parameters">

--- a/reference/uodbc/functions/odbc-columnprivileges.xml
+++ b/reference/uodbc/functions/odbc-columnprivileges.xml
@@ -117,7 +117,7 @@
  <refsect1 role="examples">
   &reftitle.examples;
   <example xml:id="odbc-columnprivileges.example.basic">
-   <title>Lister les Priviléges pour une Colonne</title>
+   <title>Lister les Privilèges pour une Colonne</title>
    <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/uodbc/functions/odbc-connection-string-quote.xml
+++ b/reference/uodbc/functions/odbc-connection-string-quote.xml
@@ -36,7 +36,7 @@
     <term><parameter>str</parameter></term>
     <listitem>
      <para>
-      La chaîne de caractères à sans guillemets.
+      La chaîne de caractères sans guillemets.
      </para>
     </listitem>
    </varlistentry>

--- a/reference/uodbc/functions/odbc-field-len.xml
+++ b/reference/uodbc/functions/odbc-field-len.xml
@@ -71,7 +71,7 @@
   &reftitle.seealso;
   <para>
    <simplelist>
-    <member><function>odbc_field_scale</function>pour connaître
+    <member><function>odbc_field_scale</function> pour connaître
     l'échelle d'un nombre à virgule flottante</member>
    </simplelist>
   </para>

--- a/reference/uodbc/functions/odbc-field-precision.xml
+++ b/reference/uodbc/functions/odbc-field-precision.xml
@@ -19,7 +19,7 @@
   &reftitle.seealso;
   <para>
    <simplelist>
-    <member><function>odbc_field_scale</function>pour connaître
+    <member><function>odbc_field_scale</function> pour connaître
     l'échelle d'un nombre à virgule flottante.</member>
    </simplelist>
   </para>

--- a/reference/uodbc/functions/odbc-foreignkeys.xml
+++ b/reference/uodbc/functions/odbc-foreignkeys.xml
@@ -37,10 +37,10 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>fk_catalog</parameter></term>
+     <term><parameter>pk_catalog</parameter></term>
      <listitem>
       <para>
-       Le catalogue (&apos;qualifier&apos; en terminology ODBC 2) de la clé
+       Le catalogue (&apos;qualifier&apos; en terminologie ODBC 2) de la clé
        primaire de table.
       </para>
      </listitem>
@@ -49,7 +49,7 @@
      <term><parameter>pk_schema</parameter></term>
      <listitem>
       <para>
-       Le schèma (&apos;qualifier&apos; en terminology ODBC 2) de la clé
+       Le schéma (&apos;qualifier&apos; en terminologie ODBC 2) de la clé
        primaire de table.
       </para>
      </listitem>
@@ -63,10 +63,10 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>pk_catalog</parameter></term>
+     <term><parameter>fk_catalog</parameter></term>
      <listitem>
       <para>
-       Le catalogue (&apos;qualifier&apos; en terminology ODBC 2) de la clé
+       Le catalogue (&apos;qualifier&apos; en terminologie ODBC 2) de la clé
        étrangère de table.
       </para>
      </listitem>
@@ -75,7 +75,7 @@
      <term><parameter>fk_schema</parameter></term>
      <listitem>
       <para>
-       Le schèma (&apos;qualifier&apos; en terminology ODBC 2) de la clé
+       Le schéma (&apos;qualifier&apos; en terminologie ODBC 2) de la clé
        étrangère de table.
       </para>
      </listitem>
@@ -118,10 +118,10 @@
    &odbc.result.driver-specific;
   </para>
   <simpara>
-   Si les clés étrangères associé avec une clé primaire sont demandées, le jeu
+   Si les clés étrangères associées avec une clé primaire sont demandées, le jeu
    de résultat est ordonné par <literal>FKTABLE_CAT</literal>, <literal>FKTABLE_SCHEM</literal>,
    <literal>FKTABLE_NAME</literal> et <literal>KEY_SEQ</literal>.
-   Si les clés primaire associé avec une clé étrangère sont demandées, le jeu
+   Si les clés primaires associées avec une clé étrangère sont demandées, le jeu
    de résultat est ordonné par <literal>PKTABLE_CAT</literal>, <literal>PKTABLE_SCHEM</literal>,
    <literal>PKTABLE_NAME</literal> et <literal>KEY_SEQ</literal>.
   </simpara>

--- a/reference/uodbc/functions/odbc-longreadlen.xml
+++ b/reference/uodbc/functions/odbc-longreadlen.xml
@@ -40,7 +40,7 @@
       <para>
        Le nombre d'octets retourné à PHP.
        S'il est défini à <literal>0</literal>, les données des colonnes
-       de type LONG sont passé au client (i.e. imprimé) lorsqu'elles sont
+       de type LONG sont passées au client (i.e. imprimées) lorsqu'elles sont
        récupérées avec la fonction <function>odbc_result</function>.
       </para>
      </listitem>

--- a/reference/uodbc/functions/odbc-next-result.xml
+++ b/reference/uodbc/functions/odbc-next-result.xml
@@ -37,7 +37,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Retourne &true; s'il n'y a plus de jeux de résultats, &false; sinon.
+   Retourne &true; s'il y a plus de jeux de résultats, &false; sinon.
   </para>
  </refsect1>
 
@@ -81,7 +81,7 @@ $a_Row2 = odbc_fetch_array($r_Results);
 echo "Affiche le premier jeu de résultats : ";
 var_dump($a_Row1, $a_Row2);
 
-echo "Récupération du deuxième jeu de résultats : ";
+echo "Récupération du second jeu de résultats : ";
 var_dump(odbc_next_result($r_Results));
 
 $a_Row1 = odbc_fetch_array($r_Results);

--- a/reference/uodbc/functions/odbc-primarykeys.xml
+++ b/reference/uodbc/functions/odbc-primarykeys.xml
@@ -104,7 +104,7 @@
  <refsect1 role="examples">
   &reftitle.examples;
   <example xml:id="odbc-primarykeys.example.basic">
-   <title>Lister les Clés primaire d'une Colonne</title>
+   <title>Lister les Clés primaires d'une Colonne</title>
    <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/uodbc/functions/odbc-procedurecolumns.xml
+++ b/reference/uodbc/functions/odbc-procedurecolumns.xml
@@ -55,7 +55,7 @@
      <term><parameter>procedure</parameter></term>
      <listitem>
       <para>
-       Le procédure.
+       La procédure.
        &odbc.parameter.search;
       </para>
      </listitem>
@@ -139,7 +139,7 @@
  <refsect1 role="examples">
   &reftitle.examples;
   <example xml:id="odbc-procedurecolumns.example.basic">
-   <title>Liste les Colonnes d'une Procédure Stocké</title>
+   <title>Liste les Colonnes d'une Procédure Stockée</title>
    <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/uodbc/functions/odbc-procedures.xml
+++ b/reference/uodbc/functions/odbc-procedures.xml
@@ -116,7 +116,7 @@
  <refsect1 role="examples">
   &reftitle.examples;
   <example xml:id="odbc-procedures.example.basic">
-   <title>Liste les Procédures stocké d'une Base de Donnée</title>
+   <title>Liste les Procédures stockées d'une Base de Données</title>
    <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/uodbc/functions/odbc-result.xml
+++ b/reference/uodbc/functions/odbc-result.xml
@@ -82,7 +82,7 @@
    la valeur du troisième champ de la ligne courante du
    résultat <parameter>result_id</parameter>. Le deuxième
    appel à <function>odbc_result</function> retourne la valeur du
-   troisième champ dont le nom est "val" de la ligne courante du
+   champ dont le nom est "val" de la ligne courante du
    résultat <parameter>result_id</parameter>. Une erreur survient si
    le paramètre de colonne est inférieur à 1, ou
    dépasse le nombre de colonnes du résultat. De la même

--- a/reference/uodbc/functions/odbc-specialcolumns.xml
+++ b/reference/uodbc/functions/odbc-specialcolumns.xml
@@ -24,7 +24,7 @@
   <para>
    Retourne soit l'ensemble optimal de colonnes qui identifie de façon unique
    une ligne d'une table, ou les colonnes qui sont automatiquement mises à
-   jour lorsqu'un des valeurs de la ligne est mise à jour par une transaction.
+   jour lorsqu'une des valeurs de la ligne est mise à jour par une transaction.
   </para>
  </refsect1>
 
@@ -95,7 +95,7 @@
      <listitem>
       <para>
        Détermine si les colonnes spéciales qui peuvent avoir une valeur NULL
-       doivent être retourné ou non.
+       doivent être retournées ou non.
        Un de <constant>SQL_NO_NULLS</constant> ou <constant>SQL_NULLABLE</constant>.
       </para>
      </listitem>

--- a/reference/uodbc/functions/odbc-tableprivileges.xml
+++ b/reference/uodbc/functions/odbc-tableprivileges.xml
@@ -108,7 +108,7 @@
  <refsect1 role="examples">
   &reftitle.examples;
   <example xml:id="odbc-tableprivileges.example.basic">
-   <title>Liste les Priviléges d'une Table</title>
+   <title>Liste les Privilèges d'une Table</title>
    <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/uodbc/functions/odbc-tables.xml
+++ b/reference/uodbc/functions/odbc-tables.xml
@@ -34,7 +34,7 @@
       Si <parameter>catalog</parameter> est un signe de pourcentage (%),
       et <parameter>schema</parameter> et <parameter>table</parameter> sont
       des chaînes vides, alors le résultat contient la liste des
-      qualifiés valides pour la source (toutes les colonnes hormis
+      qualificateurs valides pour la source (toutes les colonnes hormis
       TABLE_QUALIFIER contiennent NULL).
      </simpara>
     </listitem>

--- a/reference/uopz/book.xml
+++ b/reference/uopz/book.xml
@@ -15,7 +15,7 @@
    expose les fonctionnalités du moteur Zend, normalement utilisées au moment de
    la compilation et de l'exécution, afin de permettre la modification des
    structures internes que représentent le code PHP, et pour le code utilisateur
-   d'inter-agir avec la VM.
+   d'interagir avec la VM.
   </para>
   <para>
    uopz supporte les activités suivantes :

--- a/reference/uopz/constants.xml
+++ b/reference/uopz/constants.xml
@@ -96,7 +96,7 @@
   </variablelist>
  </para>
  <para>
-  Les constantes suivantes contrôlent le comportement du VM après qu'un gestionnaire utilisateur ne
+  Les constantes suivantes contrôlent le comportement de la VM après qu'un gestionnaire utilisateur ne
   soit appelé ; soyez extrêmement prudent !
   Ces constantes sont supprimées à partir de uopz 5.0.0.
  </para>

--- a/reference/uopz/functions/uopz-flags.xml
+++ b/reference/uopz/functions/uopz-flags.xml
@@ -56,7 +56,7 @@
     <listitem>
      <para>
       Un jeu valide de drapeaux ZEND_ACC_ flags.
-      Si omit, <function>uopz_flags</function> agit commt un récupérateur.
+      Si omis, <function>uopz_flags</function> agit comme un récupérateur.
      </para>
     </listitem>
    </varlistentry>
@@ -75,7 +75,7 @@
   &reftitle.errors;
   <simpara>
    À partir de PHP 7.4.0, si le paramètre <parameter>flags</parameter> est
-   fournie <function>uopz_flags</function> émet une
+   fourni <function>uopz_flags</function> émet une
    <classname>RuntimeException</classname>, si
    <link linkend="book.opcache">OPcache</link> est activé, et l'entrée de classe
    de <parameter>class</parameter> ou l'entrée de fonction
@@ -97,7 +97,7 @@
      <row>
       <entry>PECL uopz 5.0.0</entry>
       <entry>
-       Le paramètre <parameter>flags</parameter> est désormait optionnel. Auparavant,
+       Le paramètre <parameter>flags</parameter> est désormais optionnel. Auparavant,
        <constant>ZEND_ACC_FETCH</constant> devait être passé pour utiliser
        <function>uopz_flags</function> en tant que récupérateur.
       </entry>

--- a/reference/uopz/functions/uopz-function.xml
+++ b/reference/uopz/functions/uopz-function.xml
@@ -65,7 +65,7 @@
     <term><parameter>modifiers</parameter></term>
     <listitem>
      <para>
-      Les modificateurs de la fonction ; par défaut, copé ou
+      Les modificateurs de la fonction ; par défaut, copié ou
       ZEND_ACC_PUBLIC
      </para>
     </listitem>

--- a/reference/url/functions/get-meta-tags.xml
+++ b/reference/url/functions/get-meta-tags.xml
@@ -73,10 +73,10 @@
   </para>
   <para>
    La valeur de la propriété sera utilisée comme clé du tableau,
-   et sa valeur comme valeur correspondante de la clé. Il sera possible de
-   ainsi passer en revue facilement ce tableau avec les fonctions
+   et sa valeur comme valeur correspondante de la clé. Il sera ainsi possible de
+   passer en revue facilement ce tableau avec les fonctions
    de tableau standard. Les caractères spéciaux présents dans la
-   valeur seront replacés par un souligné (<literal>"_"</literal>),
+   valeur seront remplacés par un souligné (<literal>"_"</literal>),
    et le reste est converti en minuscules. Si deux balises méta possèdent
    le même nom, seule la dernière sera retournée.
   </para>

--- a/reference/url/functions/parse-url.xml
+++ b/reference/url/functions/parse-url.xml
@@ -17,7 +17,7 @@
   <para>
    Cette fonction analyse une URL et retourne un tableau associatif contenant
    tous les éléments qui y sont présents.
-   Les valeurs des éléments du tableau <emphasis>NE sont PAS</emphasis> URL décodés
+   Les valeurs des éléments du tableau <emphasis>NE sont PAS</emphasis> URL décodées.
   </para>
   <para>
    Cette fonction n'est <emphasis role="strong">pas</emphasis>

--- a/reference/var/functions/debug-zval-dump.xml
+++ b/reference/var/functions/debug-zval-dump.xml
@@ -99,14 +99,14 @@ string(11) "Hello World" refcount(3)
       <link linkend="language.references">Références Expliquées</link>). Ce
       refcount est stocké dans un zval de référence séparé, pointant à la zval
       pour la valeur actuelle. Cette zval additionnelle n'est actuellement pas
-      montré par <function>debug_zval_dump</function>.
+      montrée par <function>debug_zval_dump</function>.
      </member>
     </simplelist>
    </para>
    <para>
     Car <function>debug_zval_dump</function> prend son entrée comme un
     paramètre normal, passé par valeur, la technique de copy on write sera
-    utilisé pour la passé: au lieu de copier les données, le refcount sera
+    utilisée pour la passer : au lieu de copier les données, le refcount sera
     incrémenté de 1 pour la durée de vie de l'appel de la fonction. Si la
     fonction modifie le paramètre après l'avoir reçu, alors une copie sera
     faite ; comme elle n'en fait pas, elle affichera un refcount de 1 plus
@@ -140,8 +140,8 @@ string(11) "Hello World" refcount(2)
    </para>
    <para>
     Bien que <varname>$var1</varname>, <varname>$var2</varname>, et
-    <varname>$var3</varname> sont liés en tant que référence, seule la
-    <emphasis>valeur</emphasis> est passé à <function>debug_zval_dump</function>.
+    <varname>$var3</varname> soient liés en tant que référence, seule la
+    <emphasis>valeur</emphasis> est passée à <function>debug_zval_dump</function>.
     Cette valeur est utilisée une seule fois par le jeu de références, et une
     fois à l'intérieur de <function>debug_zval_dump</function>, ainsi
     il affiche un refcount de 2.
@@ -152,7 +152,7 @@ string(11) "Hello World" refcount(2)
     que les entiers n'utilisent pas "copy on write", et donc n'affichent aucun
     refcount. Dans d'autres cas, le refcount montre d'autres copies utilisées
     en interne, tels que quand une chaîne littérale ou tableau est stocké comme
-    une partie d'une instruction de code
+    une partie d'une instruction de code.
    </para>
   </note>
  </refsect1>

--- a/reference/var/functions/get-debug-type.xml
+++ b/reference/var/functions/get-debug-type.xml
@@ -126,7 +126,7 @@
           implémente une interface, par exemple <literal>"Foo\Bar@anonymous"</literal>
          </entry>
          <entry>
-          Les classes anonymes sont créer via la syntaxe <code>$x = new class { ... }</code>
+          Les classes anonymes sont créées via la syntaxe <code>$x = new class { ... }</code>
          </entry>
         </row>
        </tbody>
@@ -160,7 +160,7 @@ echo get_debug_type($fp), PHP_EOL;
 fclose($fp);
 echo get_debug_type($fp), PHP_EOL;
 
-echo get_debug_type(new stdClass), PHP_EOL;
+echo get_debug_type(new \stdClass), PHP_EOL;
 echo get_debug_type(new class {}), PHP_EOL;
 
 

--- a/reference/var/functions/gettype.xml
+++ b/reference/var/functions/gettype.xml
@@ -16,8 +16,8 @@
   </methodsynopsis>
   <para>
    Retourne le type de la variable <parameter>value</parameter>.
-   Pour vérifier le type de la variable, il est possible de
-   utiliser les fonctions <literal>is_*</literal>.
+   Pour vérifier le type de la variable, il est possible
+   d'utiliser les fonctions <literal>is_*</literal>.
   </para>
  </refsect1>
 

--- a/reference/var/functions/intval.xml
+++ b/reference/var/functions/intval.xml
@@ -18,7 +18,7 @@
   </methodsynopsis>
   <para>
    Retourne la valeur &integer; de <parameter>value</parameter> en utilisant
-   la <parameter>base</parameter> fourni pour la conversion (par défaut en
+   la <parameter>base</parameter> fournie pour la conversion (par défaut en
    base 10). <function>intval</function> ne devrait pas être utilisée
    sur des objets, dans ces cas, une erreur de niveau <constant>E_WARNING</constant>
    sera émise et la fonction retournera 1.
@@ -208,7 +208,7 @@ echo intval(true), PHP_EOL;                    // 1
     <member><function>strval</function></member>
     <member><function>settype</function></member>
     <member><function>is_numeric</function></member>
-    <member><link linkend="language.types.type-juggling">Définition du type</link></member>
+    <member><link linkend="language.types.type-juggling">Transtypage</link></member>
     <member><link linkend="ref.bc">Nombres de grande taille BCMath</link></member>
    </simplelist>
   </para>

--- a/reference/var/functions/is-callable.xml
+++ b/reference/var/functions/is-callable.xml
@@ -6,7 +6,7 @@
  <refnamediv>
   <refname>is_callable</refname>
   <refpurpose>
-   Détermine si une valeur peut être appelé comme une fonction
+   Détermine si une valeur peut être appelée comme une fonction
    dans la portée courante
   </refpurpose>
  </refnamediv>
@@ -44,7 +44,7 @@
       <para>
        Si l'argument <parameter>syntax_only</parameter> vaut &true;, la
        fonction ne va vérifier que si <parameter>value</parameter> peut être
-       une fonction ou une méthode. Il rejettera toutes les valeurs
+       une fonction ou une méthode. Elle rejettera toutes les valeurs
        qui ne sont pas des objets <link linkend="object.invoke">invocables</link>,
        des <classname>Closure</classname>, des &string;s, ou des &array;s qui n'ont pas
        une structure valide pour être utilisées comme un callback. Un tableau appelable valide
@@ -71,7 +71,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Retourne &true; si <parameter>value</parameter> peut être appelé comme
+   Retourne &true; si <parameter>value</parameter> peut être appelée comme
    une fonction, &false; sinon.
   </para>
  </refsect1>
@@ -194,7 +194,7 @@ bool(true)
     la méthode n'est pas définie.
    </member>
    <member>
-    Cette fonction peut déclencher l'autochargement si appelé avec le nom
+    Cette fonction peut déclencher l'autochargement si appelée avec le nom
     d'une classe.
    </member>
   </simplelist>

--- a/reference/var/functions/is-numeric.xml
+++ b/reference/var/functions/is-numeric.xml
@@ -137,15 +137,15 @@ NULL N'est PAS numérique
 $tests = [
     " 42",
     "42 ",
-    "\u{A0}9001", // non-breaking space
-    "9001\u{A0}", // non-breaking space
+    "\u{A0}9001", // espace insécable
+    "9001\u{A0}", // espace insécable
 ];
 
 foreach ($tests as $element) {
     if (is_numeric($element)) {
-        echo var_export($element, true) . " is numeric", PHP_EOL;
+        echo var_export($element, true) . " est numérique", PHP_EOL;
     } else {
-        echo var_export($element, true) . " is NOT numeric", PHP_EOL;
+        echo var_export($element, true) . " N'est PAS numérique", PHP_EOL;
     }
 }
 ?>
@@ -154,19 +154,19 @@ foreach ($tests as $element) {
     &example.outputs.8;
     <screen>
 <![CDATA[
-' 42' is numeric
-'42 ' is numeric
-' 9001' is NOT numeric
-'9001 ' is NOT numeric
+' 42' est numérique
+'42 ' est numérique
+' 9001' N'est PAS numérique
+'9001 ' N'est PAS numérique
 ]]>
     </screen>
     &example.outputs.7;
     <screen>
 <![CDATA[
-' 42' is numeric
-'42 ' is NOT numeric
-' 9001' is NOT numeric
-'9001 ' is NOT numeric
+' 42' est numérique
+'42 ' N'est PAS numérique
+' 9001' N'est PAS numérique
+'9001 ' N'est PAS numérique
 ]]>
    </screen>
    </example>

--- a/reference/var/functions/is-object.xml
+++ b/reference/var/functions/is-object.xml
@@ -56,9 +56,9 @@
        <entry>7.2.0</entry>
        <entry>
         <function>is_object</function> retourne maintenant &true; pour un objet
-        désérialise sans une définition de classe
+        désérialisé sans une définition de classe
         (classe de <classname>__PHP_Incomplete_Class</classname>).
-        Précédement &false; était retourné.
+        Précédemment &false; était retourné.
        </entry>
       </row>
      </tbody>
@@ -92,7 +92,7 @@ $obj = new stdClass();
 $obj->students = array('Kalle', 'Ross', 'Felipe');
 
 var_dump(get_students(null));
-var_dump(get_students($obj));;
+var_dump(get_students($obj));
 ?>
 ]]>
     </programlisting>

--- a/reference/var/functions/isset.xml
+++ b/reference/var/functions/isset.xml
@@ -121,8 +121,8 @@ var_dump(isset($a['test']));            // TRUE
 var_dump(isset($a['foo']));             // FALSE
 var_dump(isset($a['bonjour']));           // FALSE
 
-// La clé 'bonjour' vaut NULL et est considérée comme non existante
-// Si vous voulez vérifier l'existence de cette clé, utiliser cette fonction
+// La clé 'bonjour' vaut NULL et est considérée comme inexistante
+// S'il faut vérifier les clés ayant des valeurs NULL, essayer cette fonction
 var_dump(array_key_exists('bonjour', $a) ); // TRUE
 
 // Vérification des valeurs en profondeur

--- a/reference/var/functions/print-r.xml
+++ b/reference/var/functions/print-r.xml
@@ -21,7 +21,7 @@
   </para>
   <para>
    <function>print_r</function>, <function>var_dump</function> et
-   <function>var_export</function> affiche
+   <function>var_export</function> affichent
    également les propriétés protégées et privées d'un objet.
    Les membres des classes statiques ne seront pas affichés.
   </para>

--- a/reference/var/functions/unserialize.xml
+++ b/reference/var/functions/unserialize.xml
@@ -54,7 +54,7 @@
        Si la variable désérialisée est un objet, après avoir réussi à le
        reconstruire, PHP tentera automatiquement d'appeler les méthodes
        <link linkend="object.unserialize">__unserialize()</link> ou
-       <link linkend="object.wakeup">__wakeup</link> (si l'une d'elles existe).
+       <link linkend="object.wakeup">__wakeup()</link> (si l'une d'elles existe).
       </para>
       <para>
        <note>

--- a/reference/var/functions/unset.xml
+++ b/reference/var/functions/unset.xml
@@ -206,7 +206,7 @@ unset($foo1, $foo2, $foo3);
    <para>
     Lors de l'utilisation de <function>unset</function> sur des propriétés d'objet
     inaccessibles, la méthode magique 
-    <link linkend="object.unset">__unset</link>
+    <link linkend="object.unset">__unset()</link>
     sera appelée, si elle existe.
    </para>
   </note>

--- a/reference/varnish/varnishadmin/auth.xml
+++ b/reference/varnish/varnishadmin/auth.xml
@@ -6,7 +6,7 @@
 <refentry xml:id="varnishadmin.auth" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>VarnishAdmin::auth</refname>
-  <refpurpose>S'Authentifie sur une instance Varnish</refpurpose>
+  <refpurpose>S'authentifie sur une instance Varnish</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/wddx/book.xml
+++ b/reference/wddx/book.xml
@@ -23,10 +23,10 @@
   </para>
   <warning>
    <para>
-    Ne passez pas de données utilisateurs qui ne sont pas de confiance à la fonction
+    Ne pas passer de données utilisateur non fiables à la fonction
     <function>wddx_deserialize</function>. La désérialisation peut conduire au chargement
-    et à l'exécution des données lors de l'instanciation de l'objet et de son autochargement,
-    aussi, un utilisateur malicieux peut être capable d'exploiter ce comportement.
+    et à l'exécution du code lors de l'instanciation de l'objet et de son autochargement,
+    ainsi, un utilisateur malveillant pourrait être en mesure d'exploiter cette faille.
     Utiliser donc un format sécurisé et standardisé d'échange de données tel que JSON
     (via la fonction <function>json_decode</function> et la fonction
     <function>json_encode</function>) s'il faut passer les données sérialisées à l'utilisateur.

--- a/reference/wddx/configure.xml
+++ b/reference/wddx/configure.xml
@@ -20,7 +20,7 @@
  <section xml:id="wddx.installation.phplt74">
   <title>PHP &lt; 7.4</title>
   <para>
-   Après avoir installé Expat, compilez PHP avec
+   Après avoir installé Expat, compiler PHP avec
    <option role="configure">--enable-wddx</option> et utiliser
    <option role="configure">--with-libexpat-dir</option> pour Expat.
   </para>

--- a/reference/wddx/functions/wddx-add-vars.xml
+++ b/reference/wddx/functions/wddx-add-vars.xml
@@ -46,7 +46,7 @@
      <listitem>
       <para>
        Peut être une &string; nommant une variable ou un tableau
-       contenant des noms de variables ou d'autres tableaux, etc..
+       contenant des noms de variables ou d'autres tableaux, etc.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/wddx/functions/wddx-deserialize.xml
+++ b/reference/wddx/functions/wddx-deserialize.xml
@@ -24,10 +24,10 @@
   </para>
   <warning>
    <para>
-    Ne passez pas d'entrée utilisateur non vérifiée à <function>wddx_deserialize</function>.
-    La désérialisation peut faire que le code soit chargé, et exécuté lors
+    Ne pas passer d'entrée utilisateur non vérifiée à <function>wddx_deserialize</function>.
+    La désérialisation peut faire que le code soit chargé et exécuté lors
     de l'instanciation et l'autochargement de l'objet, et un utilisateur mal
-    intentionné peut être capable d'y loger un exploit.
+    intentionné pourrait être en mesure d'exploiter cette faille.
     Utiliser un format, sûr, d'échange de données standardisé comme JSON (à l'aide de
     <function>json_decode</function> et <function>json_encode</function>) s'il faut
     passer des données sérialisées à l'utilisateur.

--- a/reference/wddx/functions/wddx-serialize-vars.xml
+++ b/reference/wddx/functions/wddx-serialize-vars.xml
@@ -35,8 +35,8 @@
      <term><parameter>var_name</parameter></term>
      <listitem>
       <para>
-       Peut être soit une &string; nommant une variable ou un tableau
-       contenant des noms de variables ou d'autres tableaux, etc..
+       Peut être une &string; nommant une variable ou un tableau
+       contenant des noms de variables ou d'autres tableaux, etc.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/wddx/reference.xml
+++ b/reference/wddx/reference.xml
@@ -4,7 +4,7 @@
 <!-- Reviewed: yes -->
 
 <reference xml:id="ref.wddx" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
- <title>WDDX &Functions;</title>
+ <title>&Functions; WDDX</title>
 
  &reference.wddx.entities.functions;
 

--- a/reference/win32service/constants.xml
+++ b/reference/win32service/constants.xml
@@ -499,7 +499,7 @@
       <entry><constant>WIN32_ERROR_ACCESS_DENIED</constant></entry>
       <entry><literal>0x00000005</literal></entry>
       <entry>
-       Le gestionnaire de la base de données SMC ne dispose pas des droits d'accès appropriés.
+       Le gestionnaire de la base de données SCM ne dispose pas des droits d'accès appropriés.
       </entry>
      </row>
      <row xml:id="constant.win32-error-circular-dependency">
@@ -746,7 +746,7 @@
       <entry><constant>WIN32_ABOVE_NORMAL_PRIORITY_CLASS</constant></entry>
       <entry><literal>0x00008000</literal></entry>
       <entry>
-       Processus ayant une priorité supérieure WIN32_NORMAL_PRIORITY_CLASS
+       Processus ayant une priorité supérieure à WIN32_NORMAL_PRIORITY_CLASS
        mais inférieure à WIN32_HIGH_PRIORITY_CLASS.
       </entry>
      </row>

--- a/reference/win32service/functions/win32-create-service.xml
+++ b/reference/win32service/functions/win32-create-service.xml
@@ -174,7 +174,7 @@
           <para>
            Le paramètre <parameter>base_priority</parameter> peut être défini à
            une des constantes définies dans les
-           <link linkend="win32service.constants.basepriorities">classes de basse priorité Win32</link>.
+           <link linkend="win32service.constants.basepriorities">classes de priorité de base Win32</link>.
           </para>
          </listitem>
         </varlistentry>        <varlistentry>
@@ -428,7 +428,7 @@
 <?php
 $x = win32_create_service(array(
     'service'     => 'dummyphp',                                        // le nom de votre service
-    'display'     => 'service PHP simple PHP',                            // la description courte
+    'display'     => 'service PHP simple',                            // la description courte
     'description' => 'Ceci est un service Windows créé en utilisant PHP', // la description longue
     'params'      => '"' . __FILE__ . '"  run',                           // chemin vers le script ainsi que les paramètres
 ));
@@ -449,7 +449,7 @@ debug_zval_dump($x);
 <?php
 $x = win32_create_service(array(
     'service'      => 'dummyphp',                                       // Le nom du service
-    'display'               => 'service PHP simple PHP',                             // Une courte description
+    'display'               => 'service PHP simple',                             // Une courte description
     'description'           => 'Ceci est un service Windows créé en utilisant PHP.', // Une longue description
     'params'                => '"' . __FILE__ . '"  run',                            // chemin vers le script ainsi que les paramètres
     'dependencies' => array("Netman"),                                      // La liste des dépendances
@@ -471,14 +471,14 @@ debug_zval_dump($x);
 <?php
 $x = win32_create_service(array(
     'service'               => 'dummyphp',                                           // Le nom du service
-    'display'               => 'service PHP simple PHP',                             // Une courte description
+    'display'               => 'service PHP simple',                             // Une courte description
     'description'           => 'Ceci est un service Windows créé en utilisant PHP.', // Une longue description
     'params'                => '"' . __FILE__ . '"  run',                            // chemin vers le script ainsi que les paramètres
     'recovery_delay'        => 120000,                                               // Les actions de récupération seront exécutées après 2 minutes
     'recovery_action_1'     => WIN32_SC_ACTION_RESTART,                              // Première défaillance, redémarrage du service
     'recovery_action_2'     => WIN32_SC_ACTION_RUN_COMMAND,                          // Deuxième défaillance, exécution d'une commande
     'recovery_action_3'     => WIN32_SC_ACTION_NONE,                                 // Défaillance suivante, ne rien faire
-    'recovery_reset_period' => 86400,                                                // Réinitialiser le compteur des défaillances après 1 jour (86400 minutes)
+    'recovery_reset_period' => 86400,                                                // Réinitialiser le compteur des défaillances après 1 jour (86400 secondes)
     'recovery_enabled'      => true,                                                 // Activer les options de récupération
     'recovery_reboot_msg'   => null,                                                 // Ne pas définir de message de redémarrage, il n'est pas utile.
     'recovery_command'      => "c:\clean-service.bat",                               // Lorsque l'action est WIN32_SC_ACTION_RUN_COMMAND, exécuter cette commande.
@@ -496,7 +496,7 @@ debug_zval_dump($x);
   <para>
    <simplelist>
     <member><function>win32_delete_service</function></member>
-    <member><link linkend="win32service.constants.basepriorities">Les classes de basse priorité Win32</link></member>
+    <member><link linkend="win32service.constants.basepriorities">Les classes de priorité de base Win32</link></member>
     <member><link linkend="win32service.constants.recovery-action">Les actions de récupération Win32</link></member>
     <member><link linkend="win32service.constants.errors">Les codes erreurs Win32</link></member>
    </simplelist>

--- a/reference/win32service/functions/win32-delete-service.xml
+++ b/reference/win32service/functions/win32-delete-service.xml
@@ -19,7 +19,7 @@
    d'administrateur sont requis pour que cette fonction réussisse.
   </para>
   <para>
-   Cette fonction ne fait que marquer le service pour suppression. Si d'autre
+   Cette fonction ne fait que marquer le service pour suppression. Si d'autres
    processus (comme l'Applet Services) sont ouverts, alors la suppression sera
    reportée jusqu'à ce que ces applications soient fermées. Si un service est
    marqué pour suppression, d'autres tentatives de suppression échoueront et les

--- a/reference/win32service/functions/win32-get-last-control-message.xml
+++ b/reference/win32service/functions/win32-get-last-control-message.xml
@@ -63,7 +63,7 @@
  <refsect1 role="errors">
   &reftitle.errors;
   <para>
-   Avant la version 1.0.0, si cette fonction est utilisée en dehors du SAPI <literal>"cli"</literal>, une 
+   Avant la version 1.0.0, si cette fonction est utilisée en dehors du SAPI <literal>"cli"</literal>, une
    erreur <constant>E_ERROR</constant> sera émise.
   </para>
   <para>

--- a/reference/win32service/functions/win32-get-last-control-message.xml
+++ b/reference/win32service/functions/win32-get-last-control-message.xml
@@ -22,7 +22,7 @@
   <caution>
    <para>
     Depuis la version 0.2.0, cette fonction fonctionne uniquement en ligne de 
-    commande. Elle est désactivé dans les autres cas.
+    commande. Elle est désactivée dans les autres cas.
    </para>
   </caution>
   
@@ -63,7 +63,7 @@
  <refsect1 role="errors">
   &reftitle.errors;
   <para>
-   Avant la version 1.0.0, si cette fonction est utilisé en dehors du SAPI <literal>"cli"</literal>, une 
+   Avant la version 1.0.0, si cette fonction est utilisée en dehors du SAPI <literal>"cli"</literal>, une 
    erreur <constant>E_ERROR</constant> sera émise.
   </para>
   <para>

--- a/reference/win32service/functions/win32-query-service-status.xml
+++ b/reference/win32service/functions/win32-query-service-status.xml
@@ -135,7 +135,7 @@
      <term><parameter>ProcessId</parameter></term>
      <listitem>
       <para>
-       L'identifiant de processus de fenêtre. Si 0, le processus ne fonctionne
+       L'identifiant de processus Windows. Si 0, le processus ne fonctionne
        pas.
       </para>
      </listitem>

--- a/reference/win32service/functions/win32-send-custom-control.xml
+++ b/reference/win32service/functions/win32-send-custom-control.xml
@@ -76,7 +76,7 @@
     <parameter>servicename</parameter> est vide.
   </para>
   <para>
-    Une <classname>ValueError</classname> est levé si la valeur du paramètre 
+    Une <classname>ValueError</classname> est levée si la valeur du paramètre
    <parameter>control</parameter> n'est pas entre 128 et 255.
   </para>
    <para>

--- a/reference/win32service/functions/win32-set-service-exit-code.xml
+++ b/reference/win32service/functions/win32-set-service-exit-code.xml
@@ -55,7 +55,7 @@
  <refsect1 role="errors"><!-- {{{ -->
   &reftitle.errors;
    <para>
-   Avant la version 1.0.0, si cette fonction est utilisé en dehors du SAPI <literal>"cli"</literal>, une 
+   Avant la version 1.0.0, si cette fonction est utilisée en dehors du SAPI <literal>"cli"</literal>, une
    erreur <constant>E_ERROR</constant> sera émise.
   </para>
   <para>

--- a/reference/win32service/functions/win32-set-service-exit-mode.xml
+++ b/reference/win32service/functions/win32-set-service-exit-mode.xml
@@ -17,7 +17,7 @@
   </methodsynopsis>
   <para>
    Si le paramètre <parameter>gracefulMode</parameter> est fourni, le mode de 
-   sortie est modifié. Lorsque le mode de sortie n'est pas gracefuly, le code de 
+   sortie est modifié. Lorsque le mode de sortie n'est pas gracieux, le code de
    sortie utilisé peut être défini avec la fonction 
    <function>win32_set_service_exit_code</function>.
   </para>
@@ -54,7 +54,7 @@
  <refsect1 role="errors"><!-- {{{ -->
   &reftitle.errors;
   <para>
-   Avant la version 1.0.0, si cette fonction est utilisé en dehors du SAPI <literal>"cli"</literal>, une 
+   Avant la version 1.0.0, si cette fonction est utilisée en dehors du SAPI <literal>"cli"</literal>, une
    erreur <constant>E_ERROR</constant> sera émise.
   </para>
   <para>

--- a/reference/win32service/functions/win32-set-service-pause-resume-state.xml
+++ b/reference/win32service/functions/win32-set-service-pause-resume-state.xml
@@ -49,7 +49,7 @@
  <refsect1 role="errors"><!-- {{{ -->
   &reftitle.errors;
   <para>
-   À partir de la version 1.0.0, si le SAPI n'est pas <literal>"cli"</literal>, cette fonction émet une erreur de niveau
+   Avant la version 1.0.0, si le SAPI n'est pas <literal>"cli"</literal>, cette fonction émet une erreur de niveau
    <constant>E_ERROR</constant>.
   </para>
 

--- a/reference/win32service/functions/win32-set-service-status.xml
+++ b/reference/win32service/functions/win32-set-service-status.xml
@@ -85,7 +85,7 @@
  <refsect1 role="errors"><!-- {{{ -->
   &reftitle.errors;
     <para>
-   Avant la version 1.0.0, si cette fonction est utilisé en dehors du SAPI <literal>"cli"</literal>, une 
+   Avant la version 1.0.0, si cette fonction est utilisée en dehors du SAPI <literal>"cli"</literal>, une
    erreur <constant>E_ERROR</constant> sera émise.
   </para>
   <para>

--- a/reference/win32service/functions/win32-start-service-ctrl-dispatcher.xml
+++ b/reference/win32service/functions/win32-start-service-ctrl-dispatcher.xml
@@ -16,7 +16,7 @@
    <methodparam choice="opt"><type>bool</type><parameter>gracefulMode</parameter><initializer>true</initializer></methodparam>
   </methodsynopsis>
   <para>
-   Lorsque exécuté via le Gestionnaire de Contrôle de Service, un processus de
+   Lorsqu'exécuté via le Gestionnaire de Contrôle de Service, un processus de
    service est requis pour "archiver" avec lui pour établir un service de
    surveillance et de communication ergonomique. Cette fonction effectue un
    archivage en démarrant un thread pour gérer les communications de bas
@@ -25,7 +25,7 @@
   <para>
    Une fois démarré, le processus du service doit faire 2 choses. La première
    est d'indiquer au Service Control Manager que le service est en cours
-   d'exécution. La seconde est d'appeler la fonction
+   d'exécution. Ceci est réalisé en appelant la fonction
    <function>win32_set_service_status</function> avec la constante
    <constant>WIN32_SERVICE_RUNNING</constant>. Si l'on a besoin de
    lancer des processus longs avant que le service ne soit lancé, alors
@@ -83,7 +83,7 @@
  <refsect1 role="errors">
   &reftitle.errors;
   <para>
-   Avant la version 1.0.0, si cette fonction est utilisé en dehors du SAPI <literal>"cli"</literal>, une 
+   Avant la version 1.0.0, si cette fonction est utilisée en dehors du SAPI <literal>"cli"</literal>, une
    erreur <constant>E_ERROR</constant> sera émise.
   </para>
   <para>

--- a/reference/win32service/rightinfo/construct.xml
+++ b/reference/win32service/rightinfo/construct.xml
@@ -14,7 +14,7 @@
    <void />
   </methodsynopsis>
   <para>
-   Les objets <classname>Win32Service\RightInfo</classname> sont retournes en tant que
+   Les objets <classname>Win32Service\RightInfo</classname> sont retournés en tant que
    résultat de <function>win32_read_right_access_service</function>.
   </para>
  </refsect1>

--- a/reference/win32service/rightinfo/get-rights.xml
+++ b/reference/win32service/rightinfo/get-rights.xml
@@ -29,7 +29,7 @@
    Renvoie la liste des droits de l'utilisateur.
   </para>
   <para>
-   Le tableau indexé est le masque de bits du droit représenté par les <link linkend="win32service.constants.rights">constants de permissions</link>.
+   Le tableau indexé est le masque de bits du droit représenté par les <link linkend="win32service.constants.rights">constantes de permissions</link>.
   </para>
   <para>
    La valeur est une chaîne avec le nom de la constante Windows (sans le préfixe <literal>WIN32_</literal>).

--- a/reference/win32service/win32servicerightinfo.xml
+++ b/reference/win32service/win32servicerightinfo.xml
@@ -15,7 +15,7 @@
   <section xml:id="win32service-rightinfo.intro">
    &reftitle.intro;
    <para>
-    La classe inter <classname>Win32Service\RightInfo</classname> encapsule le résultat de <function>win32_read_right_access_service</function>.
+    La classe interne <classname>Win32Service\RightInfo</classname> encapsule le résultat de <function>win32_read_right_access_service</function>.
    </para>
   </section>
 <!-- }}} -->

--- a/reference/wincache/functions/wincache-scache-info.xml
+++ b/reference/wincache/functions/wincache-scache-info.xml
@@ -61,13 +61,13 @@
     </listitem>
     <listitem>
      <simpara>
-      <literal>total_hit_count</literal> - nombre total de fois que les données ont été servis
+      <literal>total_hit_count</literal> - nombre total de fois que les données ont été servies
       depuis le cache
      </simpara>
     </listitem>
     <listitem>
      <simpara>
-      <literal>total_miss_count</literal> - nombre total de fois que les données ont été trouvées dans
+      <literal>total_miss_count</literal> - nombre total de fois que les données n'ont pas été trouvées dans
       le cache
      </simpara>
     </listitem>

--- a/reference/wincache/functions/wincache-ucache-dec.xml
+++ b/reference/wincache/functions/wincache-ucache-dec.xml
@@ -29,7 +29,7 @@
      <term><parameter>key</parameter></term>
      <listitem>
       <para>
-       La clé <parameter>key</parameter> utilisée pour stoker la variable
+       La clé <parameter>key</parameter> utilisée pour stocker la variable
        dans le cache. Le paramètre <parameter>key</parameter> est sensible
        à la casse.
       </para>

--- a/reference/wincache/functions/wincache-ucache-delete.xml
+++ b/reference/wincache/functions/wincache-ucache-delete.xml
@@ -27,7 +27,7 @@
      <term><parameter>key</parameter></term>
      <listitem>
       <para>
-       La clé <parameter>key</parameter> utilisée pour stoker la variable dans
+       La clé <parameter>key</parameter> utilisée pour stocker la variable dans
        le cache. Le paramètre <parameter>key</parameter> est sensible à la casse.
        <parameter>key</parameter> peut être un tableau de clés.
       </para>

--- a/reference/wincache/functions/wincache-ucache-exists.xml
+++ b/reference/wincache/functions/wincache-ucache-exists.xml
@@ -27,7 +27,7 @@
      <term><parameter>key</parameter></term>
      <listitem>
       <para>
-       La clé <parameter>key</parameter> utilisée pour stoker
+       La clé <parameter>key</parameter> utilisée pour stocker
        la variable dans le cache. Le paramètre <parameter>key</parameter>
        est sensible à la casse.
       </para>

--- a/reference/wincache/functions/wincache-ucache-get.xml
+++ b/reference/wincache/functions/wincache-ucache-get.xml
@@ -30,11 +30,11 @@
        La clé <parameter>key</parameter> utilisée pour stocker la variable
        dans le cache. Le paramètre <parameter>key</parameter> est sensible à la casse.
        <parameter>key</parameter> peut être un tableau de clés. Dans ce cas, la valeur
-       retournée sera un tableau de valeurs de chaque éléments du tableau <parameter>key</parameter>.
+       retournée sera un tableau de valeurs de chaque élément du tableau <parameter>key</parameter>.
        Si un objet ou un tableau contenant des objets est retourné, alors les objets
        seront désérialisés. Se reporter à la fonction
        <link linkend="object.wakeup">__wakeup()</link> pour plus
-       de détails sur les désérialisation des objets.
+       de détails sur la désérialisation des objets.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/wincache/functions/wincache-ucache-inc.xml
+++ b/reference/wincache/functions/wincache-ucache-inc.xml
@@ -29,7 +29,7 @@
      <term><parameter>key</parameter></term>
      <listitem>
       <para>
-       La clé <parameter>key</parameter> utilisée pour stoker la variable
+       La clé <parameter>key</parameter> utilisée pour stocker la variable
        dans le cache. Le paramètre <parameter>key</parameter> est sensible à la casse.
       </para>
      </listitem>

--- a/reference/wincache/functions/wincache-ucache-info.xml
+++ b/reference/wincache/functions/wincache-ucache-info.xml
@@ -6,7 +6,7 @@
 <refentry xml:id="function.wincache-ucache-info" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>wincache_ucache_info</refname>
-  <refpurpose>Récupère des informations sur des données stokées dans le cache utilisateur</refpurpose>
+  <refpurpose>Récupère des informations sur des données stockées dans le cache utilisateur</refpurpose>
  </refnamediv>
  <refsect1 role="description">
   &reftitle.description;
@@ -16,7 +16,7 @@
    <methodparam choice="opt"><type>string</type><parameter>key</parameter><initializer>NULL</initializer></methodparam>
   </methodsynopsis>
   <para>
-   Récupère des informations sur des données stokées dans le cache utilisateur.
+   Récupère des informations sur des données stockées dans le cache utilisateur.
   </para>
  </refsect1>
  <refsect1 role="parameters">
@@ -74,12 +74,12 @@
     </listitem>
     <listitem>
      <simpara>
-      <literal>total_hit_count</literal> - durée depuis laquelle les données ont été servies depuis le cache
+      <literal>total_hit_count</literal> - nombre de fois que les données ont été servies depuis le cache
      </simpara>
     </listitem>
     <listitem>
      <simpara>
-      <literal>total_miss_count</literal> - durée depuis laquelle les données n'ont pu être trouvée dans le cache
+      <literal>total_miss_count</literal> - nombre de fois que les données n'ont pu être trouvées dans le cache
      </simpara>
     </listitem>
     <listitem>
@@ -88,12 +88,12 @@
       <itemizedlist spacing="compact">
        <listitem>
         <simpara>
-         <literal>key_name</literal> - nom de la clé utilisée pour stoker les données
+         <literal>key_name</literal> - nom de la clé utilisée pour stocker les données
         </simpara>
        </listitem>
        <listitem>
         <simpara>
-         <literal>value_type</literal> - type de valeur stokée pour cette clé
+         <literal>value_type</literal> - type de valeur stockée pour cette clé
         </simpara>
        </listitem>
        <listitem>

--- a/reference/wincache/win32build.xml
+++ b/reference/wincache/win32build.xml
@@ -92,7 +92,7 @@ nmake
    </procedure>
   </section>
   <section xml:id="wincache.win32build.verify">
-   <title>Verifying the build</title>
+   <title>Vérifier la construction</title>
    <para>
     Les étapes suivantes décrivent comment vérifier que WinCache a été construit correctement :
    </para>

--- a/reference/wkhtmltox/reference.xml
+++ b/reference/wkhtmltox/reference.xml
@@ -4,7 +4,7 @@
 <!-- Reviewed: yes -->
 
 <reference xml:id="ref.wkhtmltox" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
- <title>wkhtmltox &Functions;</title>
+ <title>&Functions; wkhtmltox</title>
 
  &reference.wkhtmltox.entities.functions;
 

--- a/reference/wkhtmltox/wkhtmltox.image.converter.xml
+++ b/reference/wkhtmltox/wkhtmltox.image.converter.xml
@@ -14,7 +14,7 @@
   <section xml:id="wkhtmltox-image-converter.intro">
    &reftitle.intro;
    <para>
-    Convertie un HTML en une image en plusieurs formats
+    Convertit un HTML en une image en plusieurs formats
    </para>
   </section>
 <!-- }}} -->

--- a/reference/xdiff/book.xml
+++ b/reference/xdiff/book.xml
@@ -25,7 +25,7 @@
   <para>
    Depuis la version 1.5.0, il y a deux jeux de fonctions pour générer les fichiers
    binaires. Les nouvelles fonctions, <function>xdiff_string_rabdiff</function> et 
-   <function>xdiff_file_rabdiff</function> génère un résultat compatible avec les anciennes
+   <function>xdiff_file_rabdiff</function> génèrent un résultat compatible avec les anciennes
    fonctions, mais généralement plus rapidement, et avec des résultats plus compacts. Pour plus
    de détails sur la génération de patchs binaires, et leur différence, voir le site Web de
    <link xlink:href="&url.xdiff;">libxdiff</link>.

--- a/reference/xdiff/functions/xdiff-file-merge3.xml
+++ b/reference/xdiff/functions/xdiff-file-merge3.xml
@@ -19,8 +19,7 @@
    <methodparam><type>string</type><parameter>dest</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Fusionne les fichiers <parameter>file1</parameter>, <parameter>file2</parameter>
-   et <parameter>file3</parameter> en un seul et le stocke dans
+   Fusionne trois fichiers en un seul et le stocke dans
    <parameter>dest</parameter>. Le fichier <parameter>old_file</parameter>
    est la version originale, tandis que les fichiers <parameter>new_file1</parameter>
    et <parameter>new_file2</parameter> sont les versions modifiées de l'original.

--- a/reference/xlswriter/reference.xml
+++ b/reference/xlswriter/reference.xml
@@ -4,7 +4,7 @@
 <!-- Reviewed: yes Maintainer: girgias -->
 
 <reference xml:id="ref.xlswriter" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
- <title>XlsWriter &Functions;</title>
+ <title>&Functions; XlsWriter</title>
  &reference.xlswriter.entities.functions;
 </reference>
 

--- a/reference/xlswriter/xlsx-format/bold.xml
+++ b/reference/xlswriter/xlsx-format/bold.xml
@@ -37,7 +37,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Une ressource de formattage.
+   Une ressource de formatage.
   </para>
  </refsect1>
 

--- a/reference/xlswriter/xlsx-format/underline.xml
+++ b/reference/xlswriter/xlsx-format/underline.xml
@@ -67,7 +67,7 @@ $excel->fileName('tutorial01.xlsx');
 $format = new \Vtiful\Kernel\Format($excel->getHandle());
 $underlineStyle = $format->underline(\Vtiful\Kernel\Format::UNDERLINE_SINGLE)->toResource();
 
-$execl->header(['name', 'age'])
+$excel->header(['name', 'age'])
     ->data([['viest', 21]])
     ->setColumn('A:A', 200, $underlineStyle)
     ->output();

--- a/reference/xml/eventhandlers.xml
+++ b/reference/xml/eventhandlers.xml
@@ -32,8 +32,8 @@
       </entry>
       <entry>
        <literal>"Character data"</literal> correspond grosso modo à tout ce qui n'est
-       pas une balise XML, y compris les espaces entre les balises. Notez
-       bien que l'analyseur XML n'ajoute ou n'efface aucun espace, et que
+       pas une balise XML, y compris les espaces entre les balises. Il
+       est à noter que l'analyseur XML n'ajoute ou n'efface aucun espace, et que
        c'est à l'application de
        décider de la signification de ces espaces.
       </entry>
@@ -47,8 +47,8 @@
        exécutables (<literal>processing instructions</literal> ou PIs).
        &lt;?php ?&gt; est une instruction exécutable où
        <replaceable>php</replaceable> est appelé programme cible.
-       Ces instructions sont gérées de manière spécifique,
-       (sauf le programme cible <literal>"XML"</literal> qui est réservé).
+       Ces instructions sont gérées de manière spécifique
+       (toutes les cibles d'instructions commençant par <literal>"XML"</literal> sont réservées).
       </entry>
      </row>
      <row>
@@ -65,7 +65,7 @@
       </entry>
       <entry>
        Ce gestionnaire est appelé pour gérer les
-       déclaration des entités non analysées (NDATA).
+       déclarations des entités non analysées (NDATA).
       </entry>
      </row>
      <row>

--- a/reference/xml/examples.xml
+++ b/reference/xml/examples.xml
@@ -55,10 +55,10 @@ while ($data = fread($fp, 4096)) {
  </section>
 
  <section xml:id="example.xml-map-tags">
-  <title>Transtypage XML -> HTML</title>
+  <title>Mappage XML -> HTML</title>
   <para>
    <example>
-    <title>Transtypage XML -> HTML</title>
+    <title>Mappage XML -> HTML</title>
     <para>
      Cet exemple remplace les balises XML d'un document par des balises
      HTML. Les éléments inconnus seront ignorés.

--- a/reference/xml/functions/xml-set-character-data-handler.xml
+++ b/reference/xml/functions/xml-set-character-data-handler.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="function.xml-set-character-data-handler" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>xml_set_character_data_handler</refname>
-  <refpurpose>Affecte les gestionnaires de texte littéral</refpurpose>
+  <refpurpose>Affecte le gestionnaire de données de caractères</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/xml/functions/xml-set-end-namespace-decl-handler.xml
+++ b/reference/xml/functions/xml-set-end-namespace-decl-handler.xml
@@ -52,7 +52,7 @@
           <simpara>
            Le préfixe est une &string; utilisée pour référencer
            le namespace dans un objet.
-           &false; si aucun préfixe existe.
+           &false; si aucun préfixe n'existe.
           </simpara>
          </listitem>
         </varlistentry>

--- a/reference/xml/functions/xml-set-notation-decl-handler.xml
+++ b/reference/xml/functions/xml-set-notation-decl-handler.xml
@@ -69,7 +69,7 @@
          <listitem>
           <simpara>
            La racine pour la résolution de l'identifiant système
-           (<literal>system_id</literal>) de l'entité externe.
+           (<literal>system_id</literal>) de la déclaration de notation.
           </simpara>
          </listitem>
         </varlistentry>
@@ -77,7 +77,7 @@
          <term><parameter>system_id</parameter></term>
          <listitem>
           <simpara>
-           Identifiant système pour cette entité externe.
+           Identifiant système de la déclaration de notation externe.
           </simpara>
          </listitem>
         </varlistentry>
@@ -87,7 +87,7 @@
          </term>
          <listitem>
           <simpara>
-           Identifiant public pour cette entité externe.
+           Identifiant public de la déclaration de notation externe.
           </simpara>
          </listitem>
         </varlistentry>

--- a/reference/xml/functions/xml-set-unparsed-entity-decl-handler.xml
+++ b/reference/xml/functions/xml-set-unparsed-entity-decl-handler.xml
@@ -19,7 +19,7 @@
    l'analyseur XML <parameter>parser</parameter>.
   </para>
   <para>
-   Le gestionnaire <parameter>parser</parameter> sera appelé si l'analyseur XML rencontre une
+   Le <parameter>handler</parameter> sera appelé si l'analyseur XML rencontre une
    déclaration d'entité externe avec une déclaration
    de NDATA, comme suit :
    <programlisting role="xml">

--- a/reference/xmlreader/xmlreader.xml
+++ b/reference/xmlreader/xmlreader.xml
@@ -286,7 +286,7 @@
     <varlistentry xml:id="xmlreader.props.isdefault">
      <term><varname>isDefault</varname></term>
      <listitem>
-      <para>Indique si l'attribut est par défaut à partir du DTD</para>
+      <para>Indique si l'attribut tire sa valeur par défaut de la DTD</para>
      </listitem>
     </varlistentry>
 

--- a/reference/xmlreader/xmlreader/lookupnamespace.xml
+++ b/reference/xmlreader/xmlreader/lookupnamespace.xml
@@ -24,7 +24,7 @@
      <term><parameter>prefix</parameter></term>
      <listitem>
       <para>
-       Chaînes de caractères contenant le préfixe.
+       Chaîne de caractères contenant le préfixe.
       </para>
      </listitem>
     </varlistentry>
@@ -34,7 +34,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   La valeur de l'espace de noms, ou &null; si aucun espace de noms existe.
+   La valeur de l'espace de noms, ou &null; si aucun espace de noms n'existe.
   </para>
  </refsect1>
 

--- a/reference/xmlreader/xmlreader/movetoattributens.xml
+++ b/reference/xmlreader/xmlreader/movetoattributens.xml
@@ -14,7 +14,7 @@
    <methodparam><type>string</type><parameter>namespace</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Positionne le curseur sur le nom de l'attribut dans l'espace de noms
+   Positionne le curseur sur l'attribut nommé dans l'espace de noms
    spécifié.
   </para>
  </refsect1>

--- a/reference/xmlreader/xmlreader/next.xml
+++ b/reference/xmlreader/xmlreader/next.xml
@@ -13,8 +13,8 @@
    <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>name</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
   <para>
-   Positionne le curseur sur le prochain nœud en sautant tous les sous arbres.
-   Si aucun nœud existe, le curseur est déplacé à la fin du document.
+   Positionne le curseur sur le prochain nœud en sautant tous les sous-arbres.
+   Si aucun nœud n'existe, le curseur est déplacé à la fin du document.
   </para>
  </refsect1>
  <refsect1 role="parameters">

--- a/reference/xmlreader/xmlreader/open.xml
+++ b/reference/xmlreader/xmlreader/open.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="xmlreader.open" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>XMLReader::open</refname>
-  <refpurpose>Fixe le URI contenant le XML à analyser</refpurpose>
+  <refpurpose>Fixe l'URI contenant le XML à analyser</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -22,7 +22,7 @@
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
   <para>
-   Fixe le URI contenant le document XML à être analysé.
+   Fixe l'URI contenant le document XML à être analysé.
   </para>
  </refsect1>
 
@@ -78,7 +78,7 @@
    <listitem>
     <simpara>
      Cette méthode peut être appelée statiquement, mais, avant PHP 8.0.0,
-     cela génèrera une erreur <constant>E_DEPRECATED</constant> dans ce cas.
+     cela générera une erreur <constant>E_DEPRECATED</constant> dans ce cas.
     </simpara>
    </listitem>
   </itemizedlist>

--- a/reference/xmlreader/xmlreader/read.xml
+++ b/reference/xmlreader/xmlreader/read.xml
@@ -13,7 +13,7 @@
    <void/>
   </methodsynopsis>
   <para>
-   Déplace le curseur au prochain nœud texte du document.
+   Déplace le curseur sur le prochain nœud du document.
   </para>
  </refsect1>
  <refsect1 role="parameters">

--- a/reference/xmlreader/xmlreader/xml.xml
+++ b/reference/xmlreader/xmlreader/xml.xml
@@ -105,7 +105,7 @@
      <row>
       <entry>8.0.0</entry>
       <entry>
-       <methodname>XMLReader::xml</methodname> est désormais déclaré comme méthode statique,
+       <methodname>XMLReader::XML</methodname> est désormais déclaré comme méthode statique,
        mais peut toujours être appelé sur une instance de <classname>XMLReader</classname>.
       </entry>
      </row>

--- a/reference/xmlrpc/functions/xmlrpc-decode-request.xml
+++ b/reference/xmlrpc/functions/xmlrpc-decode-request.xml
@@ -6,7 +6,7 @@
 <refentry xml:id="function.xmlrpc-decode-request" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>xmlrpc_decode_request</refname>
-  <refpurpose>Décode le code XML en variables PHP natives</refpurpose>
+  <refpurpose>Décode le XML en types PHP natifs</refpurpose>
  </refnamediv>
  <refsect1 role="description">
   &reftitle.description;

--- a/reference/xmlrpc/functions/xmlrpc-encode-request.xml
+++ b/reference/xmlrpc/functions/xmlrpc-encode-request.xml
@@ -5,7 +5,7 @@
 <refentry xml:id="function.xmlrpc-encode-request" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>xmlrpc_encode_request</refname>
-  <refpurpose>Génère le XML pour une méthode</refpurpose>
+  <refpurpose>Génère le XML pour une requête de méthode</refpurpose>
  </refnamediv>
  <refsect1 role="description">
   &reftitle.description;

--- a/reference/xmlrpc/functions/xmlrpc-is-fault.xml
+++ b/reference/xmlrpc/functions/xmlrpc-is-fault.xml
@@ -6,7 +6,7 @@
 <refentry xml:id="function.xmlrpc-is-fault" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>xmlrpc_is_fault</refname>
-  <refpurpose>Détermine si un tableau de valeurs représente un XMLRPC</refpurpose>
+  <refpurpose>Détermine si la valeur d'un tableau représente une erreur XMLRPC</refpurpose>
  </refnamediv>
  <refsect1 role="description">
   &reftitle.description;

--- a/reference/xmlrpc/functions/xmlrpc-server-add-introspection-data.xml
+++ b/reference/xmlrpc/functions/xmlrpc-server-add-introspection-data.xml
@@ -6,7 +6,7 @@
 <refentry xml:id="function.xmlrpc-server-add-introspection-data" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>xmlrpc_server_add_introspection_data</refname>
-  <refpurpose>Ajoute des données d'introspection</refpurpose>
+  <refpurpose>Ajoute de la documentation d'introspection</refpurpose>
  </refnamediv>
  <refsect1 role="description">
   &reftitle.description;

--- a/reference/xmlrpc/functions/xmlrpc-server-destroy.xml
+++ b/reference/xmlrpc/functions/xmlrpc-server-destroy.xml
@@ -6,7 +6,7 @@
 <refentry xml:id="function.xmlrpc-server-destroy" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>xmlrpc_server_destroy</refname>
-  <refpurpose>Détruit un serveur XMLRPC</refpurpose>
+  <refpurpose>Détruit les ressources du serveur</refpurpose>
  </refnamediv>
  <refsect1 role="description">
   &reftitle.description;

--- a/reference/xmlrpc/functions/xmlrpc-server-register-method.xml
+++ b/reference/xmlrpc/functions/xmlrpc-server-register-method.xml
@@ -6,7 +6,7 @@
 <refentry xml:id="function.xmlrpc-server-register-method" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>xmlrpc_server_register_method</refname>
-  <refpurpose>Enregistre une fonction PHP avec une méthode</refpurpose>
+  <refpurpose>Associe une fonction PHP à la méthode XMLRPC correspondant à method_name</refpurpose>
  </refnamediv>
  <refsect1 role="description">
   &reftitle.description;

--- a/reference/xmlwriter/xmlwriter/openmemory.xml
+++ b/reference/xmlwriter/xmlwriter/openmemory.xml
@@ -5,7 +5,7 @@
  <refnamediv>
   <refname>XMLWriter::openMemory</refname>
   <refname>xmlwriter_open_memory</refname>
-  <refpurpose>Crée un nouveau xmlwriter en utilisant la mémoire pour l'affichage des chaînes</refpurpose>
+  <refpurpose>Crée un nouveau xmlwriter en utilisant la mémoire pour la sortie sous forme de chaîne</refpurpose>
  </refnamediv>
  <refsect1 role="description">
   &reftitle.description;
@@ -21,7 +21,7 @@
   </methodsynopsis>
   <para>
    Crée un nouvel objet <classname>XMLWriter</classname>, 
-   en utilisant la mémoire pour l'affichage des chaînes.
+   en utilisant la mémoire pour la sortie sous forme de chaîne.
   </para>
  </refsect1>
  <refsect1 role="parameters">

--- a/reference/xmlwriter/xmlwriter/openuri.xml
+++ b/reference/xmlwriter/xmlwriter/openuri.xml
@@ -5,7 +5,7 @@
  <refnamediv>
   <refname>XMLWriter::openUri</refname>
   <refname>xmlwriter_open_uri</refname>
-  <refpurpose>Crée un nouveau xmlwriter, en utilisant l'URI source pour l'affichage</refpurpose>
+  <refpurpose>Crée un nouveau xmlwriter, en utilisant l'URI source pour la sortie</refpurpose>
  </refnamediv>
  <refsect1 role="description">
   &reftitle.description;
@@ -20,7 +20,7 @@
    <methodparam><type>string</type><parameter>uri</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Crée un nouveau XMLWriter, en utilisant l'<parameter>uri</parameter> pour l'affichage.
+   Crée un nouveau XMLWriter, en utilisant l'<parameter>uri</parameter> pour la sortie.
   </para>
  </refsect1>
  <refsect1 role="parameters">
@@ -31,7 +31,7 @@
      <term><parameter>uri</parameter></term>
      <listitem>
       <para>
-       L'URI de la &resource; pour l'affichage.
+       L'URI de la &resource; pour la sortie.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/xpass/constants.xml
+++ b/reference/xpass/constants.xml
@@ -16,7 +16,7 @@
  </simpara>
 
  <variablelist xml:id="xpass.constants.algo">
-  <title>Méthodes de hashage</title>
+  <title>Méthodes de hachage</title>
   <varlistentry xml:id="constant.crypt-prefix-std-des">
    <term>
     <constant>CRYPT_PREFIX_STD_DES</constant>
@@ -73,7 +73,7 @@
    <listitem>
     <simpara>
      Un hachage basé sur le chiffrement par bloc Blowfish, modifié pour avoir un calendrier de clés extra-coûteux.
-     Développé à l'origine par Niels Proles et David Mazieres pour OpenBSD et également supporté sur les versions récentes
+     Développé à l'origine par Niels Provos et David Mazieres pour OpenBSD et également supporté sur les versions récentes
      de FreeBSD et NetBSD, sur Solaris 10 et plus récent, et sur plusieurs distributions GNU/*/Linux.
     </simpara>
    </listitem>

--- a/reference/xsl/xsltprocessor/setparameter.xml
+++ b/reference/xsl/xsltprocessor/setparameter.xml
@@ -20,8 +20,8 @@
    <methodparam><type>array</type><parameter>options</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Spécifie la valeur d'un ou plusieurs paramètres pour être utilisés dans une
-   sous-séquence de transformation avec <classname>XSLTProcessor</classname>.
+   Spécifie la valeur d'un ou plusieurs paramètres pour être utilisés dans des
+   transformations ultérieures avec <classname>XSLTProcessor</classname>.
    Si le paramètre n'existe pas dans la feuille de style, il sera ignoré.
   </para>
  </refsect1>

--- a/reference/yac/book.xml
+++ b/reference/yac/book.xml
@@ -11,8 +11,8 @@
  <preface xml:id="intro.yac">
   &reftitle.intro;
   <para>
-   Yac (Yet Another cache), est un verrou libre, un cache de données utilisateur
-   en mémoire partagée, pouvant être utilisé pour remplacer APC.
+   Yac (Yet Another cache), est un cache de données utilisateur
+   en mémoire partagée, sans verrou, pouvant être utilisé pour remplacer APC.
   </para>
  </preface>
 

--- a/reference/yac/yac/dump.xml
+++ b/reference/yac/yac/dump.xml
@@ -6,7 +6,7 @@
 <refentry xml:id="yac.dump" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Yac::dump</refname>
-  <refpurpose>Extraie les valeurs du cache</refpurpose>
+  <refpurpose>Extrait les valeurs du cache</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -16,7 +16,7 @@
    <methodparam><type>int</type><parameter>$num</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Extraie les valeurs stockées dans le cache
+   Extrait les valeurs stockées dans le cache
   </para>
  </refsect1>
 
@@ -37,7 +37,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Les éléments extrais.
+   Les éléments extraits.
   </para>
  </refsect1>
 

--- a/reference/yac/yac/flush.xml
+++ b/reference/yac/yac/flush.xml
@@ -28,7 +28,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Une valeur booléen, toujours &true;.
+   Une valeur booléenne, toujours &true;.
   </para>
  </refsect1>
 

--- a/reference/yac/yac/set.xml
+++ b/reference/yac/yac/set.xml
@@ -6,7 +6,7 @@
 <refentry xml:id="yac.set" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Yac::set</refname>
-  <refpurpose>Stock une valeur dans le cache</refpurpose>
+  <refpurpose>Stocke une valeur dans le cache</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/yac/yac/setter.xml
+++ b/reference/yac/yac/setter.xml
@@ -6,7 +6,7 @@
 <refentry xml:id="yac.setter" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Yac::__set</refname>
-  <refpurpose>Stock un élément dans le cache</refpurpose>
+  <refpurpose>Stocke un élément dans le cache</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -17,7 +17,7 @@
    <methodparam><type>mixed</type><parameter>value</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Stock un élément dans le cache
+   Stocke un élément dans le cache
   </para>
  </refsect1>
 

--- a/reference/yaconf/ini.xml
+++ b/reference/yaconf/ini.xml
@@ -47,8 +47,8 @@
      </term>
      <listitem>
       <para>
-       Intervalle dans laquelle Yaconf détectera les modifications de fichier
-       INI (grâce au mtime du dossier), si ceci est définie à zéro, il faut
+       Intervalle dans lequel Yaconf détectera les modifications de fichier
+       INI (grâce au mtime du dossier), si ceci est défini à zéro, il faut
        redémarrer PHP pour recharger les configurations.
       </para>
      </listitem>

--- a/reference/yaconf/reference.xml
+++ b/reference/yaconf/reference.xml
@@ -4,7 +4,7 @@
 <!-- Reviewed: yes -->
 
 <reference xml:id="ref.yaconf" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
- <title>Yaconf &Functions;</title>
+ <title>&Functions; Yaconf</title>
  &reference.yaconf.entities.functions;
 </reference>
 

--- a/reference/yaf/ini.xml
+++ b/reference/yaf/ini.xml
@@ -228,7 +228,7 @@
       <warning>
        <para>
         Yaf utilise le chemin vers le fichier ini comme clé de l'entrée du cache,
-        aussi, n'utiliser pas un chemin absolu pour le chemin vers le fichier ini,
+        aussi, utiliser un chemin absolu pour le chemin vers le fichier ini,
         sinon, il se pourrait qu'il y ait des conflits si deux applications
         utilisent le même chemin relatif pour le chemin vers le fichier de configuration ini.
        </para>

--- a/reference/yaf/yaf-config-ini.xml
+++ b/reference/yaf/yaf-config-ini.xml
@@ -20,7 +20,7 @@
     configuration hiérarchique des clés des données, ainsi qu'un
     héritage entre les sections des données de configuration.
     La hiérarchie des données de configuration est supportée en séparant
-    les clés avec un point ou une virgule. Une section peut étendre ou
+    les clés avec un point. Une section peut étendre ou
     hériter d'une autre section en faisant suivre le nom de la section
     avec le caractère ":", suivi du nom de la section depuis laquelle
     les données sont héritées.

--- a/reference/yaf/yaf-controller-abstract.xml
+++ b/reference/yaf/yaf-controller-abstract.xml
@@ -4,7 +4,7 @@
 <!-- Reviewed: no -->
 <reference xml:id="class.yaf-controller-abstract" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
- <title>la classe Yaf_Controller_Abstract</title>
+ <title>La classe Yaf_Controller_Abstract</title>
  <titleabbrev>Yaf_Controller_Abstract</titleabbrev>
 
  <partintro>
@@ -126,7 +126,7 @@ class IndexController extends Yaf_Controller_Abstract {
 
     /* la méthode de l'action peut avoir des arguments */
     public function indexAction($name, $id) {
-       /* $name et $id sont des données brûtes non sécurisées */
+       /* $name et $id sont des données brutes non sécurisées */
        assert($name == $this->getRequest()->getParam("name"));
        assert($id   == $this->_request->getParam("id"));
     }

--- a/reference/yaf/yaf-dispatcher.xml
+++ b/reference/yaf/yaf-dispatcher.xml
@@ -16,13 +16,13 @@
     Le but de <classname>Yaf_Dispatcher</classname>
     est d'initialiser l'environnement de la requête,
     router la requête entrante, et distribuer les actions découvertes ;
-    il aggrège toutes les réponses et les retourne une fois le processus
+    il agrège toutes les réponses et les retourne une fois le processus
     terminé.
    </para>
    <para>
     <classname>Yaf_Dispatcher</classname> implémente également le patron
     singleton, ce qui signifie qu'une seule instance de cette classe
-    ne peut être disponible à la fois. Ceci lui permet aussi d'agir comme
+    peut être disponible à la fois. Ceci lui permet aussi d'agir comme
     un registre dans lequel les autres objets du processus de distribution
     peuvent s'inscrire.
    </para>

--- a/reference/yaf/yaf-loader.xml
+++ b/reference/yaf/yaf-loader.xml
@@ -13,7 +13,7 @@
    &reftitle.intro;
    <para>
     <classname>Yaf_Loader</classname> introduit une solution
-    d'autochargement compréhensive pour Yaf.
+    d'autochargement complète pour Yaf.
    </para>
    <para>
     La première fois qu'une instance de la classe
@@ -35,7 +35,7 @@
     <note>
      <para>
       Il convient de conserver yaf.use_spl_autoload à Off à moins qu'il y ait d'autres
-      bibliothèques qui possèdent son propre système de chargement
+      bibliothèques qui possèdent leur propre système de chargement
       et puissent ré-écrire ce comportement.
      </para>
     </note>

--- a/reference/yaf/yaf-request-http.xml
+++ b/reference/yaf/yaf-request-http.xml
@@ -22,7 +22,7 @@
       Pour des raisons de sécurité, $_GET/$_POST sont accessibles
       en lecture seule dans Yaf, ce qui signifie que si on définit une
       valeur à ces variables globales, il ne sera pas possible de les
-      récupérer via les méthodes <methodname>Yaf_Request_Http::getQurey</methodname> ou
+      récupérer via les méthodes <methodname>Yaf_Request_Http::getQuery</methodname> ou
       <methodname>Yaf_Request_Http::getPost</methodname>.
      </para>
      <para>

--- a/reference/yaf/yaf-route-regex.xml
+++ b/reference/yaf/yaf-route-regex.xml
@@ -14,7 +14,7 @@
    &reftitle.intro;
    <para>
     <classname>Yaf_Route_Regex</classname> est la route la plus
-    fexible de toutes les routes internes de Yaf.
+    flexible de toutes les routes internes de Yaf.
    </para>
   </section>
 <!-- }}} -->

--- a/reference/yaf/yaf-route-simple.xml
+++ b/reference/yaf/yaf-route-simple.xml
@@ -24,7 +24,7 @@
    <para>
     <methodname>Yaf_Route_Simple::route</methodname> retourne toujours &true;,
     aussi, il est important de mettre <classname>Yaf_Route_Simple</classname>
-    au début de la pilte de routes, sinon, toutes les autres routes ne seront
+    au début de la pile de routes, sinon, toutes les autres routes ne seront
     pas appelées.
    </para>
   </section>

--- a/reference/yaf/yaf-view-interface.xml
+++ b/reference/yaf/yaf-view-interface.xml
@@ -15,7 +15,7 @@
    &reftitle.intro;
    <para>
     Yaf fournit la possibilité aux développeurs d'utiliser
-    des moteurs de viasualisation personnalisés au lieu
+    des moteurs de visualisation personnalisés au lieu
     de celui fourni par défaut (<classname>Yaf_View_Simple</classname>).
     Pour voir un exemple d'utilisation, se reporter à la documentation
     sur la méthode <methodname>Yaf_Dispatcher::setView</methodname>.

--- a/reference/yaf/yaf_action_abstract/execute.xml
+++ b/reference/yaf/yaf_action_abstract/execute.xml
@@ -22,8 +22,8 @@
    peut avoir des arguments.
    <note>
     <para>
-     La valeur récupérée depuis la requête n'est pas sécurisée. Il est recommandé de
-     effectuer quelques filtres avant de l'utiliser.
+     La valeur récupérée depuis la requête n'est pas sécurisée. Il est recommandé
+     d'effectuer quelques filtres avant de l'utiliser.
     </para>
    </note>
   </para>

--- a/reference/yaf/yaf_application/bootstrap.xml
+++ b/reference/yaf/yaf_application/bootstrap.xml
@@ -84,8 +84,8 @@ $application->bootstrap();
    &example.outputs.similar;
    <screen>
 <![CDATA[
-1st called
-2nd called
+1er appel
+2ème appel
 ]]>
    </screen>
   </example>

--- a/reference/yaf/yaf_application/environ.xml
+++ b/reference/yaf/yaf_application/environ.xml
@@ -16,7 +16,7 @@
    <void />
   </methodsynopsis>
   <para>
-   Récupère la propriété <literal>yaf.environ</literal> qui a été défini dans
+   Récupère la propriété <literal>yaf.environ</literal> qui a été définie dans
    yaf.environ, qui a comme valeur par défaut "product".
   </para>
  </refsect1>

--- a/reference/yaf/yaf_controller_abstract/getmodulename.xml
+++ b/reference/yaf/yaf_controller_abstract/getmodulename.xml
@@ -16,7 +16,7 @@
    <void />
   </methodsynopsis>
   <para>
-   Récupère le nom du contrôleur du module.
+   Récupère le nom du module du contrôleur.
   </para>
  </refsect1>
 

--- a/reference/yaf/yaf_dispatcher/disableview.xml
+++ b/reference/yaf/yaf_dispatcher/disableview.xml
@@ -17,7 +17,7 @@
   </methodsynopsis>
   <para>
    Désactive le moteur de visualisation, utilisé par les applications pour lesquelles
-   l'utilisation s'occupe lui même de l'affichage.
+   l'utilisateur s'occupe lui-même de l'affichage.
    <note>
     <para>
      Il est possible de simplement retourner &false; dans une action pour éviter

--- a/reference/yaf/yaf_dispatcher/getdefaultaction.xml
+++ b/reference/yaf/yaf_dispatcher/getdefaultaction.xml
@@ -29,7 +29,7 @@
   &reftitle.returnvalues;
   <para>
    Une &string; représentant le nom de l'action par défaut ;
-   par défaut, veut "index".
+   par défaut, vaut "index".
   </para>
  </refsect1>
 

--- a/reference/yaf/yaf_dispatcher/getrequest.xml
+++ b/reference/yaf/yaf_dispatcher/getrequest.xml
@@ -6,7 +6,7 @@
 <refentry xml:id="yaf-dispatcher.getrequest" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Yaf_Dispatcher::getRequest</refname>
-  <refpurpose>Récupère l'instance demandée</refpurpose>
+  <refpurpose>Récupère l'instance de la requête</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/yaf/yaf_dispatcher/registerplugin.xml
+++ b/reference/yaf/yaf_dispatcher/registerplugin.xml
@@ -16,7 +16,7 @@
    <methodparam><type>Yaf_Plugin_Abstract</type><parameter>plugin</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Enregistre une plugin (voir <classname>Yaf_Plugin_Abstract</classname>).
+   Enregistre un plugin (voir <classname>Yaf_Plugin_Abstract</classname>).
    Généralement, l'enregistrement d'un plugin se situe dans le
    bootstrap (voir <classname>Yaf_Bootstrap_Abstract</classname>).
   </para>

--- a/reference/yaf/yaf_dispatcher/setview.xml
+++ b/reference/yaf/yaf_dispatcher/setview.xml
@@ -119,7 +119,7 @@ class Smarty_Adapter implements Yaf_View_Interface
     }
  
     /**
-     * Autorise unset() sur des proporiétés d'objet
+     * Autorise unset() sur des propriétés d'objet
      *
      * @param string $key
      * @return void
@@ -136,7 +136,7 @@ class Smarty_Adapter implements Yaf_View_Interface
      * OU le passage d'un tableau de clé=> valeur pour une définition en masse.
      *
      * @see __set()
-     * @param string|array $spec La stratégie d'assignement à utiliser (clé our
+     * @param string|array $spec La stratégie d'assignement à utiliser (clé ou
      * tableau de clé=>valeur)
      * @param mixed $value (Optionnel) Si on assigne une variable nommée, utilise ce paramètre comme valeur.
      * @return void

--- a/reference/yaf/yaf_loader/registerlocalnamespace.xml
+++ b/reference/yaf/yaf_loader/registerlocalnamespace.xml
@@ -27,7 +27,7 @@
   </para>
   <para>
    Lorsque l'autochargement est appelé, <classname>Yaf_Loader</classname>
-   va déterminer quel dossier de bibliothèques la recherche doit s'effectuer
+   va déterminer dans quel dossier de bibliothèques la recherche doit s'effectuer
    en examinant le préfixe du nom de la classe demandée. Si le préfixe est
    enregistré comme local, alors la recherche se fera dans le dossier
    local de bibliothèques, sinon, la recherche se fera dans le dossier

--- a/reference/yaf/yaf_plugin_abstract/dispatchloopstartup.xml
+++ b/reference/yaf/yaf_plugin_abstract/dispatchloopstartup.xml
@@ -6,7 +6,7 @@
 <refentry xml:id="yaf-plugin-abstract.dispatchloopstartup" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Yaf_Plugin_Abstract::dispatchLoopStartup</refname>
-  <refpurpose>Crochet avant une boucle de répétition</refpurpose>
+  <refpurpose>Crochet avant une boucle de répartition</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/yaf/yaf_request_abstract/setactionname.xml
+++ b/reference/yaf/yaf_request_abstract/setactionname.xml
@@ -17,8 +17,8 @@
    <methodparam choice="opt"><type>bool</type><parameter>format_name</parameter><initializer>true</initializer></methodparam>
   </methodsynopsis>
   <para>
-   Définit le nom de l'action à requérir ; habituellement utilisé pour
-   personnalisé le routeur pour définir le nom du contrôleur de la route
+   Définit le nom de l'action à requérir ; habituellement utilisé par un
+   routeur personnalisé pour définir le nom du contrôleur de la route
    résultante.
   </para>
   

--- a/reference/yaf/yaf_request_abstract/setcontrollername.xml
+++ b/reference/yaf/yaf_request_abstract/setcontrollername.xml
@@ -18,7 +18,7 @@
   </methodsynopsis>
   <para>
    Définit le nom du contrôleur dans la requête ; habituellement utilisé par les routeurs
-   personnalisées pour définir le nom du contrôleur de la route résultante.
+   personnalisés pour définir le nom du contrôleur de la route résultante.
   </para>
  </refsect1>
 

--- a/reference/yaf/yaf_request_abstract/setparam.xml
+++ b/reference/yaf/yaf_request_abstract/setparam.xml
@@ -6,7 +6,7 @@
 <refentry xml:id="yaf-request-abstract.setparam" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Yaf_Request_Abstract::setParam</refname>
-  <refpurpose>Définie un paramètre dans une requête</refpurpose>
+  <refpurpose>Définit un paramètre dans une requête</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -17,7 +17,7 @@
    <methodparam choice="opt"><type>string</type><parameter>value</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Définie un paramètre dans une requête, qui pourra être récupéré
+   Définit un paramètre dans une requête, qui pourra être récupéré
    via la méthode <methodname>Yaf_Request_Abstract::getParam</methodname>.
   </para>
  </refsect1>

--- a/reference/yaf/yaf_request_http/construct.xml
+++ b/reference/yaf/yaf_request_http/construct.xml
@@ -5,7 +5,7 @@
 <refentry xml:id="yaf-request-http.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Yaf_Request_Http::__construct</refname>
-  <refpurpose>Constructeur de __construct</refpurpose>
+  <refpurpose>Constructeur de Yaf_Request_Http</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/yaf/yaf_request_simple/construct.xml
+++ b/reference/yaf/yaf_request_simple/construct.xml
@@ -5,7 +5,7 @@
 <refentry xml:id="yaf-request-simple.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Yaf_Request_Simple::__construct</refname>
-  <refpurpose>Constructeur de __construct</refpurpose>
+  <refpurpose>Constructeur de Yaf_Request_Simple</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/yaf/yaf_response_abstract/clearheaders.xml
+++ b/reference/yaf/yaf_response_abstract/clearheaders.xml
@@ -6,7 +6,7 @@
 <refentry xml:id="yaf-response-abstract.clearheaders" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Yaf_Response_Abstract::clearHeaders</refname>
-  <refpurpose>Supprime toutes les en-têtes définies</refpurpose>
+  <refpurpose>Supprime tous les en-têtes définis</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/yaf/yaf_response_abstract/prependbody.xml
+++ b/reference/yaf/yaf_response_abstract/prependbody.xml
@@ -17,7 +17,7 @@
    <methodparam choice="opt"><type>string</type><parameter>key</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Ajout un contenu à un bloc de contenu existant.
+   Ajoute un contenu à un bloc de contenu existant.
   </para>
  </refsect1>
 

--- a/reference/yaf/yaf_response_abstract/setbody.xml
+++ b/reference/yaf/yaf_response_abstract/setbody.xml
@@ -37,11 +37,11 @@
     <listitem>
      <para>
       La clé du contenu ; il est possible de définir un contenu avec une clé ;
-      pour ne pas la spécifiez pas, alors
+      si l'on n'en spécifie pas, alors
       Yaf_Response_Abstract::DEFAULT_BODY sera utilisé.
       <note>
        <para>
-        Ce paramètre a été introduit en 2.2.0..
+        Ce paramètre a été introduit en 2.2.0.
       </para>
       </note>
      </para>

--- a/reference/yaf/yaf_route_map/route.xml
+++ b/reference/yaf/yaf_route_map/route.xml
@@ -6,7 +6,7 @@
 <refentry xml:id="yaf-route-map.route" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Yaf_Route_Map::route</refname>
-  <refpurpose>Le but route</refpurpose>
+  <refpurpose>Le but de route</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/yaf/yaf_route_regex/route.xml
+++ b/reference/yaf/yaf_route_regex/route.xml
@@ -40,7 +40,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Si le masque fourni par le troisième paramètre de la méthode
+   Si le masque fourni par le premier paramètre de la méthode
    <methodname>Yaf_Route_Regex::_construct</methodname>
    correspond avec la requête URI, &true; sera retourné, sinon &false;.
   </para>

--- a/reference/yaf/yaf_route_rewrite/construct.xml
+++ b/reference/yaf/yaf_route_rewrite/construct.xml
@@ -48,8 +48,8 @@
       pour savoir quel module/controller/action doit être routé.
      </para>
      <para>
-      Les éléments du tableau module/controller/action sont optionnels, pour ne pas les
-      assignez pas en une valeur spécifique, ils seront routés vers la
+      Les éléments du tableau module/controller/action sont optionnels, si on ne
+      leur assigne pas de valeur spécifique, ils seront routés vers la
       cible par défaut.
      </para>
     </listitem>

--- a/reference/yaf/yaf_route_simple/assemble.xml
+++ b/reference/yaf/yaf_route_simple/assemble.xml
@@ -55,7 +55,7 @@
   <para>
    Lance une <classname>Yaf_Exception_TypeError</classname> si les clés de
    <parameter>info</parameter> <literal>':c'</literal> ou
-   <literal>':a'</literal> ne sont pas définie.
+   <literal>':a'</literal> ne sont pas définies.
   </para>
  </refsect1>
 

--- a/reference/yaf/yaf_route_static/assemble.xml
+++ b/reference/yaf/yaf_route_static/assemble.xml
@@ -55,7 +55,7 @@
   <para>
    Lance une <classname>Yaf_Exception_TypeError</classname> si les clés de
    <parameter>info</parameter> <literal>':c'</literal> et
-   <literal>':a'</literal> ne sont pas définie.
+   <literal>':a'</literal> ne sont pas définies.
   </para>
  </refsect1>
 

--- a/reference/yaf/yaf_route_supervar/assemble.xml
+++ b/reference/yaf/yaf_route_supervar/assemble.xml
@@ -55,7 +55,7 @@
   <para>
    Lance une <classname>Yaf_Exception_TypeError</classname> si les clés de
    <parameter>info</parameter> <literal>':c'</literal> et
-   <literal>':a'</literal> ne sont pas définie.
+   <literal>':a'</literal> ne sont pas définies.
   </para>
  </refsect1>
 

--- a/reference/yaf/yaf_router/addroute.xml
+++ b/reference/yaf/yaf_router/addroute.xml
@@ -17,8 +17,8 @@
   </methodsynopsis>
   <para>
    Par défaut, Yaf_Router utilise une instance de la classe
-   <classname>Yaf_Route_Static</classname> comme route par défaut. Il est possible de
-   ajouter de nouvelles routes dans la pile des routes du routeur en appelant
+   <classname>Yaf_Route_Static</classname> comme route par défaut. Il est possible
+   d'ajouter de nouvelles routes dans la pile des routes du routeur en appelant
    cette méthode.
   </para>
   <para>

--- a/reference/yaf/yaf_session/construct.xml
+++ b/reference/yaf/yaf_session/construct.xml
@@ -5,7 +5,7 @@
 <refentry xml:id="yaf-session.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Yaf_Session::__construct</refname>
-  <refpurpose>Le constructeur de __construct</refpurpose>
+  <refpurpose>Le constructeur de Yaf_Session</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/yaf/yaf_view_simple/construct.xml
+++ b/reference/yaf/yaf_view_simple/construct.xml
@@ -37,10 +37,10 @@
     <listitem>
      <para>
       <![CDATA[
-      Options pour le moteur, depuis Yaf 2.1.13, vous pouvez utiliser
-      la balise courte "<?=$var?>" dans votre template (suivant "short_open_tag"),
-      ainsi devient disponible une option nommée "short_tag", que vous pouvez
-      désactiver pour ne pas utiliser short_tag dans vos templates.
+      Options pour le moteur, à partir de Yaf 2.1.13, il est possible d'utiliser
+      la balise courte "<?=$var?>" dans le template (suivant "short_open_tag"),
+      ainsi devient disponible une option nommée "short_tag", qu'il est possible de
+      désactiver pour ne pas utiliser short_tag dans les templates.
       ]]>
      </para>
     </listitem>
@@ -62,7 +62,7 @@
  <refsect1 role="examples">
   &reftitle.examples;
   <example>
-   <title>Exemple avec <classname>Yaf_View_Simple::__constructor</classname></title>
+   <title>Exemple avec <methodname>Yaf_View_Simple::__construct</methodname></title>
    <programlisting role="php">
 <![CDATA[
 <?php


### PR DESCRIPTION
Corrections de langue et de traduction dans reference/, de uodbc to yaf (orthographe, grammaire, fidélité à l'anglais).