### PR TITLE
Nits translation: reference/ (yaml to zookeeper) + security/

### DIFF
--- a/reference/yaml/callbacks.xml
+++ b/reference/yaml/callbacks.xml
@@ -68,7 +68,7 @@ array(1) {
  </section>
 
  <section xml:id="yaml.callbacks.emit">
-  <title>Emission des fonctions de rappel</title>
+  <title>Émission des fonctions de rappel</title>
   <para>
    L'émission des fonctions de rappel est invoquée lorsqu'une instance
    d'une classe enregistrée est émise via la fonction <function>yaml_emit</function> ou

--- a/reference/yaml/examples.xml
+++ b/reference/yaml/examples.xml
@@ -45,7 +45,7 @@ $invoice = array (
     "comments"=> "Late afternoon is best. Backup contact is Nancy Billsmer @ 338-4338.",
     );
 
-// genère un représentation YAML de invoice
+// génère une représentation YAML de la facture
 $yaml = yaml_emit($invoice);
 var_dump($yaml);
 

--- a/reference/yaml/functions/yaml-parse-file.xml
+++ b/reference/yaml/functions/yaml-parse-file.xml
@@ -90,7 +90,7 @@
    <para>
     Le fait de traiter une entrée utilisateur non sécurisée avec
     <function>yaml_parse_file</function> est dangereux si l'utilisation de
-    <function>unserialize</function> est activé pour les nœuds utilisant
+    <function>unserialize</function> est activée pour les nœuds utilisant
     la balise <literal>!php/object</literal>. Ce comportement peut être
     désactivé en utilisant la configuration ini
     <literal>yaml.decode_php</literal>.

--- a/reference/yaml/functions/yaml-parse-url.xml
+++ b/reference/yaml/functions/yaml-parse-url.xml
@@ -88,7 +88,7 @@
    <para>
     Le fait de traiter une entrée utilisateur non sécurisée avec
     <function>yaml_parse_url</function> est dangereux si l'utilisation de
-    <function>unserialize</function> est activé pour les nœuds utilisant
+    <function>unserialize</function> est activée pour les nœuds utilisant
     la balise <literal>!php/object</literal>. Ce comportement peut être
     désactivé en utilisant la configuration ini
     <literal>yaml.decode_php</literal>.

--- a/reference/yaml/functions/yaml-parse.xml
+++ b/reference/yaml/functions/yaml-parse.xml
@@ -58,8 +58,8 @@
      <term><parameter>callbacks</parameter></term>
      <listitem>
       <para>
-       Analyseurs de contenu pour les nœuds YAML. Tableau associatif tag YAML
-        =&gt; <type>callable</type>. Voir
+       Gestionnaires de contenu pour les nœuds YAML. Tableau associatif tag YAML
+       =&gt; <type>callable</type>. Voir
        <link linkend="yaml.callbacks.parse">l'analyse des fonctions de rappel</link>
        pour plus d'informations.
       </para>

--- a/reference/yaml/functions/yaml-parse.xml
+++ b/reference/yaml/functions/yaml-parse.xml
@@ -58,8 +58,8 @@
      <term><parameter>callbacks</parameter></term>
      <listitem>
       <para>
-       Gestionnaires de contenu pour les nœuds YAML. Tableau associatif tag YAML
-       =&gt; <type>callable</type>. Voir
+       Analyseurs de contenu pour les nœuds YAML. Tableau associatif tag YAML
+        =&gt; <type>callable</type>. Voir
        <link linkend="yaml.callbacks.parse">l'analyse des fonctions de rappel</link>
        pour plus d'informations.
       </para>

--- a/reference/yaml/ini.xml
+++ b/reference/yaml/ini.xml
@@ -98,7 +98,7 @@
       "tag:yaml.org,2002:timestamp" dans le flux du document YAML.
       La valeur par défaut est <literal>0</literal>, elle n'appliquera
       aucun décodage. Mis à <literal>1</literal>, <function>strtotime</function>
-      sera utilisé pour analyser le timestamp comme un timestamp Unix timestamp.
+      sera utilisé pour analyser le timestamp comme un timestamp Unix.
       Mis à <literal>2</literal>, <function>date_create</function> sera utilisée
       pour analyser le timestamp via un objet <type>DateTime</type>.
      </para>
@@ -122,7 +122,7 @@
     </term>
     <listitem>
      <para>
-      Nombres d'espaces pour l'indentation. Un entier entre
+      Nombre d'espaces pour l'indentation. Un entier entre
       <literal>1</literal> et <literal>10</literal> est requis.
      </para>
     </listitem>

--- a/reference/yar/examples.xml
+++ b/reference/yar/examples.xml
@@ -109,7 +109,7 @@ Yar_Concurrent_Client::call("http://example.com/operator.php", "add", array(1, 2
 Yar_Concurrent_Client::call("http://example.com/operator.php", "sub", array(2, 1), "callback");
 Yar_Concurrent_Client::call("http://example.com/operator.php", "mul", array(2, 2), "callback");
 
-/* envoi toutes les requêtes et attend les réponses */
+/* envoie toutes les requêtes et attend les réponses */
 Yar_Concurrent_Client::loop();
 ?>
 ]]>

--- a/reference/yar/yar_client/call.xml
+++ b/reference/yar/yar_client/call.xml
@@ -17,7 +17,7 @@
    <methodparam><type>array</type><parameter>parameters</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Envoi un appel à la méthode RPC distante.
+   Envoie un appel à la méthode RPC distante.
   </para>
  </refsect1>
 

--- a/reference/yar/yar_client/setopt.xml
+++ b/reference/yar/yar_client/setopt.xml
@@ -30,7 +30,7 @@
      <para>
       Peut être :
       <constant>YAR_OPT_PACKAGER</constant>,
-      <constant>YAR_OPT_PERSISTENT</constant> (à besoin du support serveur),
+      <constant>YAR_OPT_PERSISTENT</constant> (a besoin du support serveur),
       <constant>YAR_OPT_TIMEOUT</constant>,
       <constant>YAR_OPT_CONNECT_TIMEOUT</constant>,
       <constant>YAR_OPT_HEADER</constant> (depuis 2.0.4),
@@ -72,13 +72,13 @@ $client->SetOpt(YAR_OPT_CONNECT_TIMEOUT, 1000);
 //Définit le packager à JSON
 $client->SetOpt(YAR_OPT_PACKAGER, "json");
 
-//Définit l'en-tête personnalisée
+//Définit l'en-tête personnalisé
 $client->SetOpt(YAR_OPT_HEADER, array("hr1: val1", "hd2: val2"));
 
 // Définit le proxy HTTP
 $client->SetOpt(YAR_OPT_PROXY, "127.0.0.1:8888");
 
-/* Appel le service distant */
+/* Appelle le service distant */
 $result = $client->some_method("parameter");
 ?>
 ]]>

--- a/reference/yar/yar_concurrent_client/loop.xml
+++ b/reference/yar/yar_concurrent_client/loop.xml
@@ -6,7 +6,7 @@
 <refentry xml:id="yar-concurrent-client.loop" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Yar_Concurrent_Client::loop</refname>
-  <refpurpose>Envoi tous les appels</refpurpose>
+  <refpurpose>Envoie tous les appels</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -17,7 +17,7 @@
    <methodparam choice="opt"><type>callable</type><parameter>error_callback</parameter></methodparam>
   </methodsynopsis>
   <simpara>
-   Envoi tous les appels distants RPC enregistrés.
+   Envoie tous les appels distants RPC enregistrés.
   </simpara>
  </refsect1>
 
@@ -28,9 +28,9 @@
     <term><parameter>callback</parameter></term>
     <listitem>
      <para>
-      Si la fonction de rappel est définie, alors Yar appelera cette fonction
+      Si la fonction de rappel est définie, alors Yar appellera cette fonction
       de rappel après avoir envoyé tous les appels, et avant le retour
-      des réponses, avec $callinfo vallant NULL.
+      des réponses, avec $callinfo valant NULL.
      </para>
      <para>
       Alors, si l'utilisateur ne spécifie pas de fonction de rappel lors de
@@ -44,7 +44,7 @@
     <term><parameter>error_callback</parameter></term>
     <listitem>
      <para>
-      Si la fonction de rappel est définie, alors Yar l'appelera
+      Si la fonction de rappel est définie, alors Yar l'appellera
       lorsqu'une erreur surviendra.
      </para>
     </listitem>
@@ -88,7 +88,7 @@ Yar_Concurrent_Client::call("http://host/api/", "some_method", array("parameters
 Yar_Concurrent_Client::call("http://host/api/", "some_method", array("parameters"), "callback", NULL, array(YAR_OPT_TIMEOUT=>1));
                                                                                //Délai d'attente maximal personnalisé
 
-Yar_Concurrent_Client::loop("callback", "error_callback"); //Envoi les requêtes,
+Yar_Concurrent_Client::loop("callback", "error_callback"); //Envoie les requêtes,
                                                            //error_callback est optionnel
 ?>
 ]]>

--- a/reference/yar/yar_concurrent_client/reset.xml
+++ b/reference/yar/yar_concurrent_client/reset.xml
@@ -5,7 +5,7 @@
 <refentry xml:id="yar-concurrent-client.reset" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Yar_Concurrent_Client::reset</refname>
-  <refpurpose>Nettoie tous les appels enregistré</refpurpose>
+  <refpurpose>Nettoie tous les appels enregistrés</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -15,7 +15,7 @@
    <void />
   </methodsynopsis>
   <para>
-   Nettoie tous les appels enregistré.
+   Nettoie tous les appels enregistrés.
   </para>
  </refsect1>
 

--- a/reference/yar/yar_server/handle.xml
+++ b/reference/yar/yar_server/handle.xml
@@ -20,7 +20,7 @@
    <note>
     <para>
      Les appels RPC sont envoyés par des requêtes HTTP POST.
-     Si une requête HTTP GET est envoyé à l'URI, les informations du service
+     Si une requête HTTP GET est envoyée à l'URI, les informations du service
      (commenté dans la section ci-dessous) seront affichées sur la page.
     </para>
    </note>

--- a/reference/yaz/configure.xml
+++ b/reference/yaz/configure.xml
@@ -22,7 +22,7 @@
    <link xlink:href="&url.yaz.ftp.win32;">espace YAZ WIN32</link>.
   </para>
   <para>
-   Sous Windows, n'oubliez pas d'ajouter le dossier PHP au <envar>PATH</envar>
+   Sous Windows, il ne faut pas oublier d'ajouter le dossier PHP au <envar>PATH</envar>
    pour que le fichier <filename>yaz.dll</filename> soit trouvé par
    le système.
   </para>

--- a/reference/yaz/functions/yaz-ccl-conf.xml
+++ b/reference/yaz/functions/yaz-ccl-conf.xml
@@ -77,7 +77,7 @@
    Dans l'exemple ci-dessous, l'analyseur CCL est configuré pour supporter
    trois champs CCL : <literal>ti</literal>, <literal>au</literal> et
    <literal>isbn</literal>. Chaque champ correspond à leur équivalent BIB-1.
-   On assume que la variable <literal>$id</literal> est l'ID de la connexion.
+   On suppose que la variable <literal>$id</literal> est l'ID de la connexion.
   </para>
   <example>
    <title>Configuration CCL</title>
@@ -89,7 +89,7 @@ $fields = array(
   "au"   => "1=1",
   "isbn" => "1=7"
 );
-yaz_ccl_conf($id, $field);
+yaz_ccl_conf($id, $fields);
 ?>
 ]]>
    </programlisting>

--- a/reference/yaz/functions/yaz-ccl-parse.xml
+++ b/reference/yaz/functions/yaz-ccl-parse.xml
@@ -72,7 +72,7 @@
         </listitem>
         <listitem>
          <para>
-          <literal>errorpos</literal> - position approximée dans la requête
+          <literal>errorpos</literal> - position approximative dans la requête
           qui est en échec (&integer; qui est la position d'un caractère)
          </para>
         </listitem>

--- a/reference/yaz/functions/yaz-connect.xml
+++ b/reference/yaz/functions/yaz-connect.xml
@@ -111,8 +111,8 @@
           </para>
           <note>
            <para>
-            Lors de l'ouverture d' une connexion persistante, il ne sera pas
-            capable de la fermer plus tard avec
+            Lors de l'ouverture d'une connexion persistante, il ne sera pas
+            possible de la fermer plus tard avec
             <function>yaz_close</function>.
            </para>
           </note>

--- a/reference/yaz/functions/yaz-errno.xml
+++ b/reference/yaz/functions/yaz-errno.xml
@@ -48,9 +48,9 @@
   &reftitle.returnvalues;
   <para>
    Retourne un code d'erreur. Le code d'erreur est soit un code diagnostique
-   Z39.50 (habituellement un diagnostique Bib-1), soit un code d'erreur côté
-   client qui est généré par PHP/YAZ lui-même, par exemple 
-   <literal>"Connection failed"</literal>, <literal>"Init Rejected"</literal>, etc.
+   Z39.50 (habituellement un diagnostic Bib-1), soit un code d'erreur côté
+   client qui est généré par PHP/YAZ lui-même, par exemple
+   <literal>"Connect failed"</literal>, <literal>"Init Rejected"</literal>, etc.
   </para>
  </refsect1>
 

--- a/reference/yaz/functions/yaz-itemorder.xml
+++ b/reference/yaz/functions/yaz-itemorder.xml
@@ -22,7 +22,7 @@
    Cette fonction prépare une requête de type "Extended Services" en
    utilisant le <literal>"Profile"</literal> avec <literal>
    "Use of Z39.50 Item Order Extended Service to Transport ILL (Profile/1)"</literal>. 
-   Se reporter <link xlink:href="&url.yaz.ill;">ici</link> ou aux
+   Se reporter <link xlink:href="&url.yaz.ill;">ici</link> et aux
    <link xlink:href="&url.yaz.specs;">spécifications</link>.
   </para>
   </refsect1>
@@ -50,7 +50,7 @@
        Item-ID a la clé item-id,ISBN.
       </para>
       <para>
-       Les paramètres de requête IIL sont :
+       Les paramètres de requête ILL sont :
       </para>
       <literallayout>
 protocol-version-num

--- a/reference/yaz/functions/yaz-range.xml
+++ b/reference/yaz/functions/yaz-range.xml
@@ -7,7 +7,7 @@
  <refnamediv>
   <refname>yaz_range</refname>
   <refpurpose>
-   Spécifie le nombre maximal de résultats à lire
+   Spécifie un intervalle d'enregistrements à récupérer
   </refpurpose>
  </refnamediv>
 
@@ -20,7 +20,7 @@
    <methodparam><type>int</type><parameter>number</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Spécifie le nombre maximal de résultat à lire.
+   Spécifie un intervalle d'enregistrements à récupérer.
   </para>
   <para>
    Cette fonction doit être appelée avant la fonction
@@ -46,7 +46,7 @@
      <listitem>
       <para>
        Spécifie la position du premier enregistrement à récupérer. Les numéros
-       des requêtes vont de 1 à <function>yaz_hits</function>.
+       des enregistrements vont de 1 à <function>yaz_hits</function>.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/yaz/functions/yaz-record.xml
+++ b/reference/yaz/functions/yaz-record.xml
@@ -6,7 +6,7 @@
 <refentry xml:id="function.yaz-record" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>yaz_record</refname>
-  <refpurpose>Retourne un résultat</refpurpose>
+  <refpurpose>Retourne un enregistrement</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -70,8 +70,8 @@
        les navigateurs, etc. Pour spécifier une conversion, ajoutez <literal>;
        charset=</literal><replaceable>from</replaceable><literal>,</literal>
        <replaceable>to</replaceable> ou <replaceable>from</replaceable> est le
-       jeu de caractères orignal du résultat et <replaceable>to</replaceable>
-       est le jeu de résultats à obtenir (comme vu par PHP).
+       jeu de caractères original du résultat et <replaceable>to</replaceable>
+       est le jeu de caractères à obtenir (comme vu par PHP).
       </para>
       <variablelist>
        <varlistentry>
@@ -87,7 +87,7 @@
          </para>
          <para>
           Ce format est approprié si les enregistrements seront affichés
-          rapidement (pour déboguage) ou parce que ce n'est pas faisable
+          rapidement (pour débogage) ou parce que ce n'est pas faisable
           d'effectuer un affichage approprié.
          </para>
         </listitem>
@@ -157,7 +157,7 @@
          </para>
          <para>
           Le tableau retourné consiste en une liste correspondant à chaque
-          feuille/nœud interne de GRS-1. Chaque item de la liste consiste à
+          feuille/nœud interne de GRS-1. Chaque item de la liste consiste en
           une sous-liste avec le premier élément <emphasis>path</emphasis> et
           <emphasis>data</emphasis> (si les données sont disponibles).
          </para>
@@ -260,7 +260,7 @@ Array
    <para>
     Le script PHP ci-dessous retourne un enregistrement MARC21/USMARC
     comme MARCXML. L'enregistrement original est retourné dans le jeu de caractères
-    marc-8 (inconnu de beaucoup d'analyseur XML), donc nous le convertissons en UTF-8
+    marc-8 (inconnu de beaucoup d'analyseurs XML), donc nous le convertissons en UTF-8
     (que tous les analyseurs XML supportent).
     <programlisting role="php">
 <![CDATA[

--- a/reference/yaz/functions/yaz-scan-result.xml
+++ b/reference/yaz/functions/yaz-scan-result.xml
@@ -74,7 +74,7 @@
   <para>
    Retourne un tableau (0..n-1) où n est le nombre de termes retournés. Chaque
    valeur est une paire où le premier item est un terme et le second item est
-   un le nombre de résultats.
+   le nombre de résultats.
   </para>
  </refsect1>
 </refentry>

--- a/reference/yaz/functions/yaz-schema.xml
+++ b/reference/yaz/functions/yaz-schema.xml
@@ -20,7 +20,7 @@
    <function>yaz_schema</function> spécifie le schéma de lecture.
   </para>
   <para>
-   cette fonction devrait être appelée avant <function>yaz_search</function>
+   Cette fonction devrait être appelée avant <function>yaz_search</function>
    ou <function>yaz_present</function>.
   </para>
  </refsect1>

--- a/reference/yaz/functions/yaz-set-option.xml
+++ b/reference/yaz/functions/yaz-set-option.xml
@@ -44,7 +44,7 @@
      <term><parameter>name</parameter> ou <parameter>options</parameter></term>
      <listitem>
       <para>
-       Peut être soit une chaîne de caractères ou un tableau.
+       Peut être soit une chaîne de caractères, soit un tableau.
       </para>
       <para>
        Si donné comme chaîne de caractères, cela sera le nom de l'option

--- a/reference/yaz/functions/yaz-sort.xml
+++ b/reference/yaz/functions/yaz-sort.xml
@@ -20,12 +20,12 @@
    Cette fonction configure les critères de tri et active le tri Z39.50.
   </para>
   <para>
-   Appelez cette fonction <emphasis>avant</emphasis>
-   <function>yaz_search</function>. Si elle est utilisée
-   conjointement avec <function>yaz_search</function>, une commande
-   Z39.50 Sort sera envoyée après chaque retour de recherche et avant
-   que les résultats ne soient lus avec Z39.50 Present
-   (<function>yaz_present</function>).
+   Cette fonction doit être appelée <emphasis>avant</emphasis>
+   <function>yaz_search</function>. Utilisée seule, cette fonction n'a aucun
+   effet. Si elle est utilisée conjointement avec
+   <function>yaz_search</function>, une commande Z39.50 Sort sera envoyée
+   après chaque retour de recherche et avant que les résultats ne soient
+   lus avec Z39.50 Present (<function>yaz_present</function>).
   </para>
  </refsect1>
 

--- a/reference/yaz/functions/yaz-syntax.xml
+++ b/reference/yaz/functions/yaz-syntax.xml
@@ -6,7 +6,7 @@
 <refentry xml:id="function.yaz-syntax" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>yaz_syntax</refname>
-  <refpurpose>Spécifie la syntaxe de lecture des lignes</refpurpose>
+  <refpurpose>Spécifie la syntaxe d'enregistrement préférée pour la récupération</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -17,7 +17,7 @@
    <methodparam><type>string</type><parameter>syntax</parameter></methodparam>
   </methodsynopsis>
   <para>
-   <function>yaz_syntax</function> spécifie la syntaxe de lecture des lignes.
+   <function>yaz_syntax</function> spécifie la syntaxe d'enregistrement préférée pour la récupération.
   </para>
   <para>
    Cette fonction devrait être appelée avant <function>yaz_search</function>

--- a/reference/yaz/functions/yaz-wait.xml
+++ b/reference/yaz/functions/yaz-wait.xml
@@ -17,9 +17,9 @@
   </methodsynopsis>
   <para>
    Cette fonction exécute une activité réseau (bloquée) pour les demandes
-   en attente qui ont été préparées par les fonctions <function>yaz_connect</function>
+   en attente qui ont été préparées par les fonctions <function>yaz_connect</function>,
    <function>yaz_search</function>, <function>yaz_present</function>,
-   <function>yaz_scan</function> et <function>yaz_itemorder</function>
+   <function>yaz_scan</function> et <function>yaz_itemorder</function>.
   </para>
   <para>
    <function>yaz_wait</function> se termine lorsque tous les hôtes

--- a/reference/zip/configure.xml
+++ b/reference/zip/configure.xml
@@ -35,7 +35,7 @@
   </simpara>
  </section>
 
- <section xml:id="zip.pecl.installation">
+ <section xml:id="zip.installation.pecl">
   <title>Installation via PECL</title>
   <simpara>
    &pecl.info;

--- a/reference/zip/constants.xml
+++ b/reference/zip/constants.xml
@@ -541,7 +541,7 @@
  </variablelist>
 
  <variablelist xml:id="ziparchive.constants.er">
-  <title>Archiver les erreurs</title>
+  <title>Erreurs</title>
   <varlistentry xml:id="ziparchive.constants.er-ok">
    <term>
     <constant>ZipArchive::ER_OK</constant>
@@ -773,7 +773,7 @@
    </term>
    <listitem>
     <simpara>
-     erreur interne
+     Erreur interne.
     </simpara>
    </listitem>
   </varlistentry>

--- a/reference/zip/functions/zip-entry-open.xml
+++ b/reference/zip/functions/zip-entry-open.xml
@@ -52,7 +52,7 @@
      <term><parameter>mode</parameter></term>
      <listitem>
       <simpara>
-       Toutes les méthodes spécifiées dans la documentation
+       L'un des modes spécifiés dans la documentation
        de la fonction <function>fopen</function>.
       </simpara>
       <note>

--- a/reference/zip/functions/zip-entry-read.xml
+++ b/reference/zip/functions/zip-entry-read.xml
@@ -45,7 +45,7 @@
       </simpara>
       <note>
        <simpara>
-        Ceci doit être la taille non-compressée qu'on souhaite lire.
+        Ceci devrait être la taille non-compressée qu'on souhaite lire.
        </simpara>
       </note>
      </listitem>

--- a/reference/zip/ziparchive.xml
+++ b/reference/zip/ziparchive.xml
@@ -748,7 +748,7 @@
      <term><varname>lastId</varname></term>
      <listitem>
       <simpara>
-       Valeur de l'index de la dernière entrée (fichier ou dossier)
+       Valeur de l'index de la dernière entrée ajoutée (fichier ou dossier).
        Disponible à partir de PHP 8.0.0 et PECL zip 1.18.0.
       </simpara>
      </listitem>

--- a/reference/zip/ziparchive/addfile.xml
+++ b/reference/zip/ziparchive/addfile.xml
@@ -159,7 +159,7 @@ if ($zip->open('test.zip') === TRUE) {
     <methodname>ZipArchive::close</methodname> soit via destruction de l'objet
     <classname>ZipArchive</classname>. Ceci peut empêcher de supprimer le
     fichier en cours d'ajout même après que le verrou soit
-    relâché.       
+    relâché.
    </simpara>
   </note>
  </refsect1>

--- a/reference/zip/ziparchive/addglob.xml
+++ b/reference/zip/ziparchive/addglob.xml
@@ -37,7 +37,7 @@
     <term><parameter>flags</parameter></term>
     <listitem>
      <simpara>
-      Un masque d'octets de drapeaux <literal>glob()</literal>.
+      Un masque de bits de drapeaux <literal>glob()</literal>.
      </simpara>
     </listitem>
    </varlistentry>
@@ -81,7 +81,7 @@
          <literal>"flags"</literal>
         </simpara>
         <simpara>
-         Masque de bit consistant de
+         Masque de bits composé de
          <constant>ZipArchive::FL_OVERWRITE</constant>,
          <constant>ZipArchive::FL_ENC_GUESS</constant>,
          <constant>ZipArchive::FL_ENC_UTF_8</constant>,
@@ -154,7 +154,7 @@
       <row>
        <entry>8.0.0, PECL zip 1.18.0</entry>
        <entry>
-        <parameter>flags</parameter> a été ajouté.
+        <literal>"flags"</literal> dans <parameter>options</parameter> a été ajouté.
        </entry>
       </row>
       <row>

--- a/reference/zip/ziparchive/extractto.xml
+++ b/reference/zip/ziparchive/extractto.xml
@@ -41,7 +41,7 @@
      <term><parameter>pathto</parameter></term>
      <listitem>
       <simpara>
-       Endroit où l'on doit extraire les fichiers
+       Endroit où l'on doit extraire les fichiers.
       </simpara>
      </listitem>
     </varlistentry>
@@ -50,7 +50,7 @@
      <listitem>
       <simpara>
        Les entrées à extraire. Ce peut être soit le nom d'une entrée ou un
-       tableau de noms
+       tableau de noms.
       </simpara>
      </listitem>
     </varlistentry>

--- a/reference/zip/ziparchive/getexternalattributesindex.xml
+++ b/reference/zip/ziparchive/getexternalattributesindex.xml
@@ -17,7 +17,7 @@
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter></methodparam>
   </methodsynopsis>
   <simpara>
-   Récupére les attributs externes d'une entrée définie par son index.
+   Récupère les attributs externes d'une entrée définie par son index.
   </simpara>
  </refsect1>
  <refsect1 role="parameters">
@@ -53,7 +53,7 @@
      <listitem>
       <simpara>
        Si ce drapeau est positionné à <constant>ZipArchive::FL_UNCHANGED</constant>,
-       les attributs originaux inchangé sont retournées.
+       les attributs originaux inchangés sont retournés.
       </simpara>
      </listitem>
     </varlistentry>

--- a/reference/zip/ziparchive/getexternalattributesname.xml
+++ b/reference/zip/ziparchive/getexternalattributesname.xml
@@ -52,7 +52,7 @@
      <listitem>
       <simpara>
        Si ce drapeau est positionné à <constant>ZipArchive::FL_UNCHANGED</constant>,
-       les attributs originaux inchangé sont retournées.
+       les attributs originaux inchangés sont retournés.
       </simpara>
      </listitem>
     </varlistentry>

--- a/reference/zip/ziparchive/getfromindex.xml
+++ b/reference/zip/ziparchive/getfromindex.xml
@@ -43,7 +43,7 @@
      <term><parameter>flags</parameter></term>
      <listitem>
       <para>
-       Le flag à utiliser pour ouvrir l'archive.
+       Les flags à utiliser pour ouvrir l'archive.
        <itemizedlist>
         <listitem>
          <simpara>

--- a/reference/zip/ziparchive/getstatusstring.xml
+++ b/reference/zip/ziparchive/getstatusstring.xml
@@ -50,7 +50,7 @@
       <row>
        <entry>8.0.0, PECL zip 1.18.0</entry>
        <entry>
-        Cette méthode peut être appelé sur une archive fermée.
+        Cette méthode peut être appelée sur une archive fermée.
        </entry>
       </row>
      </tbody>

--- a/reference/zip/ziparchive/getstreamname.xml
+++ b/reference/zip/ziparchive/getstreamname.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="ziparchive.getstreamname" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>ZipArchive::getStreamName</refname>
-  <refpurpose>Récupère un gestionnaire de fichier pour l'entrée définie par son nom (lecture seule))</refpurpose>
+  <refpurpose>Récupère un gestionnaire de fichier pour l'entrée définie par son nom (lecture seule)</refpurpose>
  </refnamediv>
  <refsect1 role="description">
   &reftitle.description;

--- a/reference/zip/ziparchive/iscompressionmethoddupported.xml
+++ b/reference/zip/ziparchive/iscompressionmethoddupported.xml
@@ -57,7 +57,7 @@
   <note>
    <simpara>
     Cette fonction est uniquement disponible si la compilation
-    a été réalisée avec ≥ 1.7.0.
+    a été réalisée avec libzip ≥ 1.7.0.
    </simpara>
   </note>
  </refsect1>

--- a/reference/zip/ziparchive/setcommentname.xml
+++ b/reference/zip/ziparchive/setcommentname.xml
@@ -25,7 +25,7 @@
      <term><parameter>name</parameter></term>
      <listitem>
       <simpara>
-       Nom de l'entrée
+       Nom de l'entrée.
       </simpara>
      </listitem>
     </varlistentry>
@@ -33,7 +33,7 @@
      <term><parameter>comment</parameter></term>
      <listitem>
       <simpara>
-       Le contenu du commentaire
+       Le contenu du commentaire.
       </simpara>
      </listitem>
     </varlistentry>

--- a/reference/zip/ziparchive/setexternalattributesindex.xml
+++ b/reference/zip/ziparchive/setexternalattributesindex.xml
@@ -35,7 +35,7 @@
      <term><parameter>opsys</parameter></term>
      <listitem>
       <simpara>
-       Code du système d'exploitation, définie par une des constantes ZipArchive::OPSYS_.
+       Code du système d'exploitation, défini par une des constantes ZipArchive::OPSYS_.
       </simpara>
      </listitem>
     </varlistentry>

--- a/reference/zip/ziparchive/setexternalattributesname.xml
+++ b/reference/zip/ziparchive/setexternalattributesname.xml
@@ -35,7 +35,7 @@
      <term><parameter>opsys</parameter></term>
      <listitem>
       <simpara>
-       Code du système d'exploitation, définie par une des constantes ZipArchive::OPSYS_.
+       Code du système d'exploitation, défini par une des constantes ZipArchive::OPSYS_.
       </simpara>
      </listitem>
     </varlistentry>

--- a/reference/zip/ziparchive/setmtimeindex.xml
+++ b/reference/zip/ziparchive/setmtimeindex.xml
@@ -42,7 +42,7 @@
      <term><parameter>flags</parameter></term>
      <listitem>
       <simpara>
-       Drapeaux optionnels, non utilisés quant à présent.
+       Drapeaux optionnels, non utilisés pour le moment.
       </simpara>
      </listitem>
     </varlistentry>

--- a/reference/zip/ziparchive/setmtimename.xml
+++ b/reference/zip/ziparchive/setmtimename.xml
@@ -42,7 +42,7 @@
      <term><parameter>flags</parameter></term>
      <listitem>
       <simpara>
-       Drapeaux optionnels, non utilisés quant à présent.
+       Drapeaux optionnels, non utilisés pour le moment.
       </simpara>
      </listitem>
     </varlistentry>

--- a/reference/zip/ziparchive/setpassword.xml
+++ b/reference/zip/ziparchive/setpassword.xml
@@ -47,7 +47,7 @@
     décompresser l'archive, et est également le mot de passe par défaut pour
     <methodname>ZipArchive::setEncryptionName</methodname> et
     <methodname>ZipArchive::setEncryptionIndex</methodname>.
-    Précedemment, cette fonction ne définissait que le mot de passe à utiliser pour
+    Antérieurement, cette fonction ne définissait que le mot de passe à utiliser pour
     décompresser l'archive ; elle ne permettait pas de transformer une
     <classname>ZipArchive</classname> non protégée par mot de passe en une
     <classname>ZipArchive</classname> protégée par un mot de passe.

--- a/reference/zip/ziparchive/unchangeindex.xml
+++ b/reference/zip/ziparchive/unchangeindex.xml
@@ -24,7 +24,7 @@
      <term><parameter>index</parameter></term>
      <listitem>
       <simpara>
-       Index de l'entrée
+       Index de l'entrée.
       </simpara>
      </listitem>
     </varlistentry>

--- a/reference/zlib/examples.xml
+++ b/reference/zlib/examples.xml
@@ -22,7 +22,7 @@ $s = "Seulement un test, test, test, test, test, test, test, test!\n";
 // Ouvre un fichier en écriture, avec une compression maximale
 $zp = gzopen($filename, "w9");
 
-// Ecrit une chaîne dans le fichier
+// Écrit une chaîne dans le fichier
 gzwrite($zp, $s);
 
 // Ferme le fichier

--- a/reference/zlib/functions/deflate_add.xml
+++ b/reference/zlib/functions/deflate_add.xml
@@ -88,7 +88,7 @@
      <row>
       <entry>8.0.0</entry>
       <entry>
-       <parameter>context</parameter> attend désormais une instance de <classname>DeflateContext</classname>
+       <parameter>context</parameter> attend désormais une instance de <classname>DeflateContext</classname> ;
        avant, une <type>resource</type> était attendue.
       </entry>
      </row>

--- a/reference/zlib/functions/gzclose.xml
+++ b/reference/zlib/functions/gzclose.xml
@@ -15,7 +15,7 @@
   </methodsynopsis>
   <para>
    <function>gzclose</function> referme le fichier compressé
-   <parameter>zp</parameter>.
+   <parameter>stream</parameter>.
   </para>
  </refsect1>
  <refsect1 role="parameters">

--- a/reference/zlib/functions/gzdeflate.xml
+++ b/reference/zlib/functions/gzdeflate.xml
@@ -20,8 +20,8 @@
    le format de données <literal>DEFLATE</literal>.
   </para>
   <para>
-   Pour plus de détails sur l'algorithme, consulter le document
-   "<link xlink:href="&url.rfc;1951">ZLIB Compressed Data Format
+   Pour plus de détails sur l'algorithme de compression DEFLATE, consulter le document
+   "<link xlink:href="&url.rfc;1951">DEFLATE Compressed Data Format
    Specification version 1.3</link>" (RFC 1951).
   </para>
  </refsect1>

--- a/reference/zlib/functions/gzinflate.xml
+++ b/reference/zlib/functions/gzinflate.xml
@@ -33,7 +33,7 @@
      <term><parameter>max_length</parameter></term>
      <listitem>
       <para>
-       La longueur maximale de données décodé.
+       La longueur maximale des données décodées.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/zlib/functions/gzpassthru.xml
+++ b/reference/zlib/functions/gzpassthru.xml
@@ -17,7 +17,7 @@
   </methodsynopsis>
   <para>
    <function>gzpassthru</function> lit les données restantes du fichier
-   <parameter>zp</parameter> jusqu'à la fin (position <acronym>EOF</acronym>),
+   <parameter>stream</parameter> jusqu'à la fin (position <acronym>EOF</acronym>),
    puis affiche le résultat (décompressé).
   </para>
   <note>

--- a/reference/zlib/functions/gzread.xml
+++ b/reference/zlib/functions/gzread.xml
@@ -39,7 +39,7 @@
      <term><parameter>length</parameter></term>
      <listitem>
       <para>
-       Le nombre d'octets lus.
+       Le nombre d'octets à lire.
       </para>
      </listitem>
     </varlistentry>
@@ -67,7 +67,7 @@
      <row>
       <entry>7.4.0</entry>
       <entry>
-       Cette fonction retourne désormais &false; en cas d'échec; auparavant
+       Cette fonction retourne désormais &false; en cas d'échec ; auparavant
        <literal>0</literal> était retourné.
       </entry>
      </row>

--- a/reference/zlib/functions/gzrewind.xml
+++ b/reference/zlib/functions/gzrewind.xml
@@ -15,7 +15,7 @@
   </methodsynopsis>
   <para>
    <function>gzrewind</function> replace le pointeur de position du fichier
-   <parameter>zp</parameter> au début de celui-ci.
+   <parameter>stream</parameter> au début de celui-ci.
   </para>
  </refsect1>
  <refsect1 role="parameters">

--- a/reference/zlib/functions/gztell.xml
+++ b/reference/zlib/functions/gztell.xml
@@ -15,7 +15,8 @@
   </methodsynopsis>
   <para>
    <function>gztell</function> retourne la position du pointeur de
-   lecture dans le fichier <parameter>zp</parameter>.
+   fichier donné ; c'est-à-dire son décalage dans le flux de fichier
+   non compressé.
   </para>
  </refsect1>
  <refsect1 role="parameters">

--- a/reference/zlib/functions/gzuncompress.xml
+++ b/reference/zlib/functions/gzuncompress.xml
@@ -48,7 +48,7 @@
   </para>
   <para>
    <function>gzuncompress</function> retourne une erreur
-   si la chaîne décompressée est 32768 fois plus longue que la chaîne compressée
+   si la chaîne décompressée est plus de 32768 fois plus longue que la chaîne compressée
    <parameter>data</parameter> ou plus grande que la taille de
    <parameter>max_length</parameter> octets, passé comme paramètre optionnel.
   </para>

--- a/reference/zlib/functions/gzwrite.xml
+++ b/reference/zlib/functions/gzwrite.xml
@@ -16,9 +16,8 @@
    <methodparam choice="opt"><type class="union"><type>int</type><type>null</type></type><parameter>length</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
   <para>
-   <function>gzwrite</function> écrit le contenu de la chaîne
-   <parameter>data</parameter> dans le fichier compressé
-   <parameter>zp</parameter>.
+   <function>gzwrite</function> écrit le contenu de
+   <parameter>data</parameter> dans le fichier gz donné.
   </para>
  </refsect1>
  <refsect1 role="parameters">

--- a/reference/zlib/functions/inflate-get-read-len.xml
+++ b/reference/zlib/functions/inflate-get-read-len.xml
@@ -56,8 +56,8 @@
      <row>
       <entry>8.0.0</entry>
       <entry>
-       <parameter>context</parameter> attend désormais une instance de <classname>InflateContext</classname>
-       avant une <type>resource</type> était attendue.
+       <parameter>context</parameter> attend désormais une instance de <classname>InflateContext</classname> ;
+       auparavant, une <type>resource</type> était attendue.
       </entry>
      </row>
     </tbody>

--- a/reference/zlib/functions/inflate_add.xml
+++ b/reference/zlib/functions/inflate_add.xml
@@ -94,8 +94,8 @@
      <row>
       <entry>8.0.0</entry>
       <entry>
-       <parameter>context</parameter> attend désormais une instance <classname>InflateContext</classname>
-       avant une <type>resource</type> était attendue.
+       <parameter>context</parameter> attend désormais une instance <classname>InflateContext</classname> ;
+       auparavant, une <type>resource</type> était attendue.
       </entry>
      </row>
     </tbody>

--- a/reference/zlib/functions/zlib-decode.xml
+++ b/reference/zlib/functions/zlib-decode.xml
@@ -48,7 +48,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Retourne les données compressées, &return.falseforfailure;.
+   Retourne les données décompressées, &return.falseforfailure;.
   </para>
  </refsect1>
 

--- a/reference/zlib/functions/zlib-get-coding-type.xml
+++ b/reference/zlib/functions/zlib-get-coding-type.xml
@@ -5,7 +5,7 @@
 <refentry xml:id="function.zlib-get-coding-type" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>zlib_get_coding_type</refname>
-  <refpurpose>Retourne la méthode de compression utilisée avec Gzip</refpurpose>
+  <refpurpose>Retourne la méthode de compression utilisée pour la compression de sortie</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -40,7 +40,6 @@
     <member>
      La directive <link
      linkend="ini.zlib.output-compression">zlib.output_compression</link>
-     directive
     </member>
    </simplelist>
   </para>

--- a/reference/zlib/ini.xml
+++ b/reference/zlib/ini.xml
@@ -67,7 +67,7 @@
      <para>
       Cette option accepte aussi des valeurs entières au lieu des booléens,
       "On"/"Off", ce qui permet de configurer la taille du tampon de sortie
-      (par défaut, il vaut 4ko).
+      (par défaut, il vaut 4 Ko).
      </para>
      <note>
       <para>

--- a/reference/zlib/setup.xml
+++ b/reference/zlib/setup.xml
@@ -32,7 +32,7 @@
    Cette extension définit une ressource de fichier, retournée par la
    fonction <function>gzopen</function>.
    Antérieur à PHP 8.0.0, les ressources <literal>zlib.deflate</literal> et
-   <literal>zlib.inflate</literal> étaient aussi définies
+   <literal>zlib.inflate</literal> étaient aussi définies.
   </para>
  </section>
  <!-- }}} -->

--- a/reference/zmq/zmq.xml
+++ b/reference/zmq/zmq.xml
@@ -448,7 +448,7 @@
         pair avec lequel le socket communique. Le fait de définir
         cette option sur un socket n'affectera que les connexions
         effectuées après que l'option ait été définie. Sur ZeroMQ 3.x,
-        c'est un gestionnaire pour définir à la fois SNDHWM et RCVHWM.
+        c'est une enveloppe pour définir à la fois SNDHWM et RCVHWM.
         (Valeur : &integer;).
        </para>
       </listitem>
@@ -580,7 +580,7 @@
       <listitem>
        <para>
         La valeur linger du socket. Spécifie la durée de blocage du socket
-        lors de sa tentative d'afficher les messages après qu'il n'ait été
+        lors de sa tentative de vider les messages après qu'il a été
         fermé (Valeur : &integer;)</para>
       </listitem>
      </varlistentry>

--- a/reference/zmq/zmqcontext/construct.xml
+++ b/reference/zmq/zmqcontext/construct.xml
@@ -18,7 +18,7 @@
   </methodsynopsis>
   <para>
    Construit un nouveau contexte ZMQ. Le contexte est utilisé pour initialiser
-   les sockets. Un contexte persistent est nécessaire pour initialiser des
+   les sockets. Un contexte persistant est nécessaire pour initialiser des
    sockets persistants.
   </para>
  </refsect1>
@@ -39,9 +39,9 @@
      <term><parameter>is_persistent</parameter></term>
      <listitem>
       <para>
-       Si le contexte est persistent ou non. Un contexte persistent
+       Si le contexte est persistant ou non. Un contexte persistant
        est stocké pour plusieurs requêtes, et est nécessaire pour les
-       sockets persistents.
+       sockets persistants.
       </para>
      </listitem>
     </varlistentry>
@@ -76,7 +76,7 @@ $socket = $context->getSocket(ZMQ::SOCKET_REQ, 'my sock');
 /* Connexion au socket */
 $socket->connect("tcp://example.com:1234");
 
-/* Envoi une requête */
+/* Envoie une requête */
 $socket->send("Hello there");
 
 /* Réception de la réponse */

--- a/reference/zmq/zmqcontext/getsocket.xml
+++ b/reference/zmq/zmqcontext/getsocket.xml
@@ -19,8 +19,8 @@
   </methodsynopsis>
   <para>
    Raccourci pour créer de nouveaux sockets depuis le contexte. Si le contexte
-   n'est pas persistent, le paramètre <parameter>persistent_id</parameter>
-   sera ignoré, et le socket deviendra non persistent. Le paramètre
+   n'est pas persistant, le paramètre <parameter>persistent_id</parameter>
+   sera ignoré, et le socket deviendra non persistant. Le paramètre
    <parameter>on_new_socket</parameter> ne sera appelé que si une nouvelle structure
    sous-jacente de socket est créée.
   </para>
@@ -42,7 +42,7 @@
      <term><parameter>persistent_id</parameter></term>
      <listitem>
       <para>
-       Si <parameter>persistent_id</parameter> est spécifié, le socket sera persistent
+       Si <parameter>persistent_id</parameter> est spécifié, le socket sera persistant
        entre les différentes requêtes.
       </para>
      </listitem>
@@ -92,7 +92,7 @@ $context = new ZMQContext();
 /* Crée un nouveau socket */
 $socket = $context->getSocket(ZMQ::SOCKET_REQ, 'my sock');
 
-/* COnnexion au socket */
+/* Connexion au socket */
 $socket->connect("tcp://example.com:1234");
 
 /* Envoi une requête */

--- a/reference/zmq/zmqcontext/ispersistent.xml
+++ b/reference/zmq/zmqcontext/ispersistent.xml
@@ -6,7 +6,7 @@
 <refentry xml:id="zmqcontext.ispersistent" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>ZMQContext::isPersistent</refname>
-  <refpurpose>Vérifie si le contexte est persistent</refpurpose>
+  <refpurpose>Vérifie si le contexte est persistant</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -16,8 +16,8 @@
    <void />
   </methodsynopsis>
   <para>
-   Vérifie si le contexte est persistent. Un contexte persistent est nécessaire
-   pour les connexions persistentes, sachant que chaque socket est 
+   Vérifie si le contexte est persistant. Un contexte persistant est nécessaire
+   pour les connexions persistantes, sachant que chaque socket est
    alloué à un contexte.
   </para>
  </refsect1>
@@ -30,7 +30,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Retourne &true; si le contexte est persistent, et &false; s'il ne l'est pas.
+   Retourne &true; si le contexte est persistant, et &false; s'il ne l'est pas.
   </para>
  </refsect1>
 

--- a/reference/zmq/zmqdevice/construct.xml
+++ b/reference/zmq/zmqdevice/construct.xml
@@ -49,7 +49,7 @@
     <term><parameter>listener</parameter></term>
     <listitem>
      <para>
-      Socket d'écoute, qui recoit une copie de tous les messages
+      Socket d'écoute, qui reçoit une copie de tous les messages
       entrants et sortants. Le type de ce socket doit être
       SUB, PULL ou DEALER.
      </para>
@@ -63,8 +63,8 @@
   <para>
    L'appel à cette méthode va préparer le périphérique. Habituellement,
    les périphériques sont des processus qui s'exécutent pendant beaucoup
-   de temps, aussi l'exécution de cette méthode depuis un script interactiv
-   n'est pas recommandé. Cette méthode lance une exception ZMQDeviceException
+   de temps, aussi l'exécution de cette méthode depuis un script interactif
+   n'est pas recommandée. Cette méthode lance une exception ZMQDeviceException
    si le périphérique ne peut être lancé.
   </para>
  </refsect1>

--- a/reference/zmq/zmqdevice/run.xml
+++ b/reference/zmq/zmqdevice/run.xml
@@ -28,10 +28,10 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   L'appel à cette méthode est bloquante tant que le périphérique
+   L'appel à cette méthode est bloquant tant que le périphérique
    est en fonctionnement. Il n'est pas recommandé d'utiliser les
    périphériques depuis des scripts interactifs. En cas d'échec,
-   cette méthode a lancé une exception ZMQDeviceException.
+   cette méthode lancera une exception ZMQDeviceException.
   </para>
  </refsect1>
 

--- a/reference/zmq/zmqdevice/setidlecallback.xml
+++ b/reference/zmq/zmqdevice/setidlecallback.xml
@@ -45,7 +45,7 @@
      <para>
       Le délai d'attente maximal avant d'appeler la fonction de rappel, en millisecondes.
       La fonction de rappel est appelée périodiquement lorsqu'il n'y a aucune activité
-      sur le périphérique. La valeur du délai d'attente maximal garantie qu'il y aura
+      sur le périphérique. La valeur du délai d'attente maximal garantit qu'il y aura
       au moins cette durée entre les appels à la fonction de rappel.
      </para>
     </listitem>

--- a/reference/zmq/zmqdevice/settimercallback.xml
+++ b/reference/zmq/zmqdevice/settimercallback.xml
@@ -23,7 +23,7 @@
    entre les fonctions de rappel de l'inactivité et du timer est que
    la fonction de rappel de l'inactivité est appelée uniquement lorsque le
    périphérique est inactif. La signature de la fonction de rappel
-   est : mixed $user_data). Ajouté dans l'extension ZMQ en version 1.1.0.
+   est : callback (mixed $user_data). Ajouté dans l'extension ZMQ en version 1.1.0.
   </para>
  </refsect1>
 
@@ -48,7 +48,7 @@
       doit être appelée, en millisecondes. La fonction de rappel
       d'inactivité est appelée périodiquement lorsqu'il n'y a aucune
       activité sur le périphérique. La valeur du délai d'attente
-      maximal garantie qu'il y aura au moins ce temps là avant l'appel
+      maximal garantit qu'il y aura au moins ce temps-là avant l'appel
       à la fonction de rappel.
      </para>
     </listitem>

--- a/reference/zmq/zmqpoll/poll.xml
+++ b/reference/zmq/zmqpoll/poll.xml
@@ -83,7 +83,7 @@
    <example>
     <title>Exemple avec <function>ZMQPoll</function></title>
     <para>
-     Create a simple poll server
+     Crée un serveur poll simple
     </para>
     <programlisting role="php">
 <![CDATA[
@@ -99,7 +99,7 @@ $server->bind("tcp://127.0.0.1:5555");
 /* Crée un nouveau poll pour les messages entrants/sortants */
 $poll = new ZMQPoll();
 
-/* Ajout l'objet et écoute les entrées/sorties du poll */
+/* Ajoute l'objet et écoute les entrées/sorties du poll */
 $id = $poll->add($server, ZMQ::POLL_IN | ZMQ::POLL_OUT);
 echo "Added object with id " . $id . "\n";
 
@@ -112,7 +112,7 @@ while (true) {
    $events = 0;
 
    try {
-       /* Bloc le Poll tant qu'il y a quelque chose à faire */
+       /* Bloque le Poll tant qu'il y a quelque chose à faire */
        $events = $poll->poll($readable, $writable, -1);
        $errors = $poll->getLastErrors();
 
@@ -126,7 +126,7 @@ while (true) {
    }
 
    if ($events > 0) {
-       /* Boucle sur les objets accessible en lecture et réceptionne les messages */
+       /* Boucle sur les objets accessibles en lecture et réceptionne les messages */
        foreach ($readable as $r) {
            try {
                echo "Received message: " . $r->recv() . "\n";
@@ -135,7 +135,7 @@ while (true) {
            }
        }
 
-       /* Boucle sur les objets accessible en écriture et retourne les messages */
+       /* Boucle sur les objets accessibles en écriture et retourne les messages */
        foreach ($writable as $w) {
            try {
                $w->send("Got it!");

--- a/reference/zmq/zmqsocket/construct.xml
+++ b/reference/zmq/zmqsocket/construct.xml
@@ -20,13 +20,13 @@
   </methodsynopsis>
   <para>
    Construit un objet ZMQSocket. Le paramètre <parameter>persistent_id</parameter>
-   peut être utilisé pour allouer un socket persistent. Un socket
-   persistent doit être alloué depuis un contexte persistent,
+   peut être utilisé pour allouer un socket persistant. Un socket
+   persistant doit être alloué depuis un contexte persistant,
    et il restera connecté pendant plusieurs requêtes. Le paramètre
    <parameter>persistent_id</parameter> peut être utilisé
    pour ré-appeler le même socket lors des prochaines requêtes.
    <parameter>on_new_socket</parameter> est appelé uniquement lorsqu'une
-   nouvelle structure sous-jacente de socket est créé.
+   nouvelle structure sous-jacente de socket est créée.
   </para>
  </refsect1>
 
@@ -55,8 +55,8 @@
      <listitem>
       <para>
        Si <parameter>persistent_id</parameter> est spécifié, le socket sera
-       persistent pendant plusieurs requêtes. Si <parameter>context</parameter>
-       n'est pas persistent, le socket passera automatiquement en mode non-persistent.
+       persistant pendant plusieurs requêtes. Si <parameter>context</parameter>
+       n'est pas persistant, le socket passera automatiquement en mode non-persistant.
       </para>
      </listitem>
     </varlistentry>
@@ -66,7 +66,7 @@
       <para>
        Fonction de rappel, qui sera exécutée lorsqu'une nouvelle structure de socket
        sera créée. Cette fonction ne sera pas appelée si la connexion
-       persistente est ré-appelée.
+       persistante est ré-appelée.
       </para>
       <methodsynopsis>
        <methodname><replaceable>callback</replaceable></methodname>
@@ -99,7 +99,7 @@
 <?php
 
 /*
-  Le socket est persistent, aussi, cette fonction est appelée uniquement
+  Le socket est persistant, aussi, cette fonction est appelée uniquement
   lors de la première requête du script.
 */
 function on_new_socket_cb(ZMQSocket $socket, $persistent_id = null)

--- a/reference/zmq/zmqsocket/disconnect.xml
+++ b/reference/zmq/zmqsocket/disconnect.xml
@@ -16,7 +16,7 @@
    <methodparam><type>string</type><parameter>dsn</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Déconnecte le socket depuis un point final distant précédemment connecté.
+   Déconnecte le socket d'un point final distant précédemment connecté.
    Le point final est défini au format <literal>transport://address</literal>
    où le transport est un des suivants : inproc, ipc, tcp, pgm ou epgm.
   </para>

--- a/reference/zmq/zmqsocket/getpersistentid.xml
+++ b/reference/zmq/zmqsocket/getpersistentid.xml
@@ -6,7 +6,7 @@
 <refentry xml:id="zmqsocket.getpersistentid" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>ZMQSocket::getPersistentId</refname>
-  <refpurpose>Récupère l'ID persistent</refpurpose>
+  <refpurpose>Récupère l'ID persistant</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -28,8 +28,8 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Retourne l'ID persistent assigné à l'objet ou
-   &null; si le socjet n'est pas persistent.
+   Retourne l'ID persistant assigné à l'objet ou
+   &null; si le socket n'est pas persistant.
   </para>
  </refsect1>
 

--- a/reference/zmq/zmqsocket/ispersistent.xml
+++ b/reference/zmq/zmqsocket/ispersistent.xml
@@ -6,7 +6,7 @@
 <refentry xml:id="zmqsocket.ispersistent" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>ZMQSocket::isPersistent</refname>
-  <refpurpose>Vérifie si le socket est persistent</refpurpose>
+  <refpurpose>Vérifie si le socket est persistant</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -16,7 +16,7 @@
    <void />
   </methodsynopsis>
   <para>
-   Vérifie si le socket est persistent.
+   Vérifie si le socket est persistant.
   </para>
  </refsect1>
 
@@ -28,7 +28,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Retourne un &boolean; suivant si le socket est persistent ou non.
+   Retourne un &boolean; suivant si le socket est persistant ou non.
   </para>
  </refsect1>
 

--- a/reference/zmq/zmqsocket/recv.xml
+++ b/reference/zmq/zmqsocket/recv.xml
@@ -6,7 +6,7 @@
 <refentry xml:id="zmqsocket.recv" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>ZMQSocket::recv</refname>
-  <refpurpose>Recoit un message</refpurpose>
+  <refpurpose>Reçoit un message</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/zmq/zmqsocket/recvmulti.xml
+++ b/reference/zmq/zmqsocket/recvmulti.xml
@@ -6,7 +6,7 @@
 <refentry xml:id="zmqsocket.recvmulti" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>ZMQSocket::recvMulti</refname>
-  <refpurpose>Recoit un message multipart</refpurpose>
+  <refpurpose>Reçoit un message multipart</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/zmq/zmqsocket/send.xml
+++ b/reference/zmq/zmqsocket/send.xml
@@ -6,7 +6,7 @@
 <refentry xml:id="zmqsocket.send" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>ZMQSocket::send</refname>
-  <refpurpose>Envoi un message</refpurpose>
+  <refpurpose>Envoie un message</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/zmq/zmqsocket/sendmulti.xml
+++ b/reference/zmq/zmqsocket/sendmulti.xml
@@ -6,7 +6,7 @@
 <refentry xml:id="zmqsocket.sendmulti" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>ZMQSocket::sendmulti</refname>
-  <refpurpose>Envoi un message multipart</refpurpose>
+  <refpurpose>Envoie un message multipart</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/zookeeper/configure.xml
+++ b/reference/zookeeper/configure.xml
@@ -17,7 +17,7 @@
  <para>
   Pour utiliser zookeeper, configurer PHP avec l'option 
   <option role="configure">--with-libzookeeper-dir=DIR</option>.
-  DIR est le prefixe du dossier d'installation du client C, il doit contenir le 
+  DIR est le préfixe du dossier d'installation du client C, il doit contenir le
   fichier <filename>include/zookeeper/zookeeper.h</filename>
  </para>
  <para>

--- a/reference/zookeeper/functions/zookeeper_dispatch.xml
+++ b/reference/zookeeper/functions/zookeeper_dispatch.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="function.zookeeper-dispatch" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>zookeeper_dispatch</refname>
-  <refpurpose>Appelle les fonctions de rappels pour les opérations en attente</refpurpose>
+  <refpurpose>Appelle les fonctions de rappel pour les opérations en attente</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -15,7 +15,7 @@
   </methodsynopsis>
 
   <para>
-   La fonction <function>zookeeper_dispatch</function> appelle les fonctions de rappels passées par les opérations comme <methodname>Zookeeper::get</methodname> ou <methodname>Zookeeper::exists</methodname>.
+   La fonction <function>zookeeper_dispatch</function> appelle les fonctions de rappel passées par les opérations comme <methodname>Zookeeper::get</methodname> ou <methodname>Zookeeper::exists</methodname>.
   </para>
 
   <caution>
@@ -54,7 +54,7 @@
   <example xml:id="function.zookeeper-dispatch.example.1">
    <title>Exemple de <methodname>zookeeper_dispatch</methodname> #1</title>
    <para>
-     Répartir manuellement les fonctions de rappels.
+     Répartir manuellement les fonctions de rappel.
    </para>
    <programlisting role="php">
 <![CDATA[

--- a/reference/zookeeper/ini.xml
+++ b/reference/zookeeper/ini.xml
@@ -70,7 +70,7 @@
     </term>
     <listitem>
      <para>
-      Autorise le verrouillage des sessions PHP
+      Autorise le verrouillage des sessions PHP.
      </para>
     </listitem>
    </varlistentry>
@@ -83,7 +83,7 @@
     <listitem>
      <simpara>
       Temps d'attente en microsecondes pour les tentatives de verrouillage de la session PHP.
-      Soyez prudent lors de la définition de cette valeur. Les valeurs valides sont des entiers,
+      Il faut être prudent lors de la définition de cette valeur. Les valeurs valides sont des entiers,
       où 0 est interprété comme la valeur par défaut.
       Les valeurs négatives entraînent un verrouillage réduit à une tentative de verrouillage.
      </simpara>

--- a/reference/zookeeper/zookeeper.xml
+++ b/reference/zookeeper/zookeeper.xml
@@ -737,7 +737,7 @@
      <varlistentry xml:id="zookeeper.constants.invalidcallback">
       <term><constant>Zookeeper::INVALIDCALLBACK</constant></term>
       <listitem>
-       <para>Callback spécifié invalide.</para>
+       <para>Fonction de rappel spécifiée invalide.</para>
       </listitem>
      </varlistentry>
      <varlistentry xml:id="zookeeper.constants.invalidacl">

--- a/reference/zookeeper/zookeeper/delete.xml
+++ b/reference/zookeeper/zookeeper/delete.xml
@@ -53,7 +53,7 @@
   </para>
   <caution>
     <simpara>
-      À partir de la version 0.3.0, cette méthode émet <classname>ZookeeperException</classname> et ses dérivés.
+      Depuis la version 0.3.0, cette méthode émet <classname>ZookeeperException</classname> et ses dérivés.
     </simpara>
   </caution>
  </refsect1>

--- a/reference/zookeeper/zookeeper/delete.xml
+++ b/reference/zookeeper/zookeeper/delete.xml
@@ -53,7 +53,7 @@
   </para>
   <caution>
     <simpara>
-      Depuis la version 0.3.0, cette méthode émet <classname>ZookeeperException</classname> et ses dérivés.
+      À partir de la version 0.3.0, cette méthode émet <classname>ZookeeperException</classname> et ses dérivés.
     </simpara>
   </caution>
  </refsect1>

--- a/reference/zookeeper/zookeeper/isrecoverable.xml
+++ b/reference/zookeeper/zookeeper/isrecoverable.xml
@@ -27,7 +27,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Renvoie true/faux en cas de succès, et faux en cas d'échec.
+   Renvoie true/false en cas de succès, et false en cas d'échec.
   </para>
  </refsect1>
 

--- a/reference/zookeeper/zookeeper/setdebuglevel.xml
+++ b/reference/zookeeper/zookeeper/setdebuglevel.xml
@@ -81,7 +81,7 @@ SUCCESS
  <refsect1 role="seealso">
   &reftitle.seealso;
   <simplelist>
-   <member><link linkend="zookeeper.constants.log-levels">Niveau de journalisation ZooKeeper</link></member>
+   <member><link linkend="zookeeper.constants.log-levels">Niveaux de journalisation ZooKeeper</link></member>
    <member><classname>ZookeeperException</classname></member>
   </simplelist>
  </refsect1>

--- a/reference/zookeeper/zookeeper/setwatcher.xml
+++ b/reference/zookeeper/zookeeper/setwatcher.xml
@@ -44,7 +44,7 @@
   </para>
   <caution>
     <simpara>
-      Depuis la version 0.3.0, cette méthode émet <classname>ZookeeperException</classname> et ses dérivés.
+      À partir de la version 0.3.0, cette méthode émet <classname>ZookeeperException</classname> et ses dérivés.
     </simpara>
   </caution>
  </refsect1>

--- a/security/database.xml
+++ b/security/database.xml
@@ -253,7 +253,7 @@ union select '1', concat(uname||'-'||passwd) as name, '1971-01-01', '0' from use
    </para>
    <para>
     Les instructions <literal>UPDATE</literal> et <literal>INSERT</literal> sont également
-    susceptibles à de telles attaques
+    susceptibles de telles attaques.
     <example>
      <title>Modifier un mot de passe ... et gain de droits ! (n'importe quel serveur de bases de données)</title>
      <programlisting role="php">

--- a/security/errors.xml
+++ b/security/errors.xml
@@ -108,7 +108,7 @@
   soit de désactiver l'affichage des erreurs en utilisant l'option de configuration
   <literal>display_errors</literal> de &php.ini;. En choisissant la
   seconde solution, il est également recommandé de définir le chemin vers le fichier
-  de log en utilisant la directive de configuration <literal>error_log</literal>,
+  de journal d'événements en utilisant la directive de configuration <literal>error_log</literal>,
   et d'activer la directive <literal>log_errors</literal>.
   <example>
    <title>Détecter des variables non protégées avec E_ALL</title>

--- a/security/filesystem.xml
+++ b/security/filesystem.xml
@@ -54,10 +54,10 @@ echo "Ce fichier a été effacé !";
   documents dans les comptes des autres utilisateurs.
   Dans ce cas, il est préférable d'utiliser une autre forme d'identification.
   Il faut considérer ce qui pourrait se passer si les utilisateurs passent
-  <literal>../etc/</literal> et <literal>passwd</literal> comme arguments!
+  <literal>../etc/</literal> et <literal>passwd</literal> comme arguments !
   Le code serait exécuté tel que :
   <example>
-   <title>Une attaque du système de fichiers!</title>
+   <title>Une attaque du système de fichiers !</title>
    <programlisting role="php">
 <![CDATA[
 <?php

--- a/security/general.xml
+++ b/security/general.xml
@@ -31,7 +31,7 @@
   bien notées, avec l'heure à laquelle elles ont été exécutées, depuis
   quel emplacement géographique, leur type, etc. mais que l'utilisateur
   est identifié uniquement par un cookie, la robustesse du lien entre
-  l'utilisateur et les logs de transactions est sévèrement réduite.
+  l'utilisateur et le journal des transactions est sévèrement réduite.
  </simpara>
  <simpara>
   Lors des tests d'un site, il faut garder à l'esprit qu'il est impossible


### PR DESCRIPTION
Corrections de langue et de traduction dans reference/, de yaml to zookeeper + security/ (orthographe, grammaire, fidélité à l'anglais).