### PR TITLE
Sync EN: fix copy-pasted descriptions referencing the wrong function

### DIFF
--- a/reference/apcu/functions/apcu-cache-info.xml
+++ b/reference/apcu/functions/apcu-cache-info.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 804d8a05451c13328eb1192553dcb2374706cabb Maintainer: moradZahid Status: ready -->
+<!-- EN-Revision: 184764a63e01525315f54897f3bd38eaa1242b42 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.apcu-cache-info">
  <refnamediv>
@@ -43,8 +43,8 @@
   <note>
    <simpara>
     <function>apcu_cache_info</function> émettra un avertissement s'il est
-    incapable de retrouver les données du cache APC. Cela se produit
-    typiquement lorsqu'APC n'est pas activé.
+    incapable de retrouver les données du cache APCu. Cela se produit
+    typiquement lorsqu'APCu n'est pas activé.
    </simpara>
   </note>
  </refsect1>

--- a/reference/apcu/functions/apcu-key-info.xml
+++ b/reference/apcu/functions/apcu-key-info.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 804d8a05451c13328eb1192553dcb2374706cabb Maintainer: moradZahid Status: ready -->
+<!-- EN-Revision: 184764a63e01525315f54897f3bd38eaa1242b42 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.apcu-key-info">
  <refnamediv>

--- a/reference/cubrid/functions/cubrid-lob2-import.xml
+++ b/reference/cubrid/functions/cubrid-lob2-import.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 22492de2eede0a31a4ac486489d5475e1536354d Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 184764a63e01525315f54897f3bd38eaa1242b42 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.cubrid-lob2-import">
  <refnamediv>

--- a/reference/cubrid/functions/cubrid-pconnect.xml
+++ b/reference/cubrid/functions/cubrid-pconnect.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 22492de2eede0a31a4ac486489d5475e1536354d Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 184764a63e01525315f54897f3bd38eaa1242b42 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.cubrid-pconnect">
  <refnamediv>
@@ -100,7 +100,7 @@
  <refsect1 role="examples">
   &reftitle.examples;
   <example>
-   <title>Exemple avec <function>cubrid_connect</function></title>
+   <title>Exemple avec <function>cubrid_pconnect</function></title>
    <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/cubrid/functions/cubrid-seq-insert.xml
+++ b/reference/cubrid/functions/cubrid-seq-insert.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 22492de2eede0a31a4ac486489d5475e1536354d Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 184764a63e01525315f54897f3bd38eaa1242b42 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.cubrid-seq-insert">
  <refnamediv>
@@ -19,7 +19,7 @@
    <methodparam><type>string</type><parameter>seq_element</parameter></methodparam>
   </methodsynopsis>
   <simpara>
-   La fonction <function>cubrid_col_insert</function> est utilisée pour
+   La fonction <function>cubrid_seq_insert</function> est utilisée pour
    insérer un élément dans une séquence de types d'attributs.
   </simpara>
  </refsect1>

--- a/reference/eio/functions/eio-chown.xml
+++ b/reference/eio/functions/eio-chown.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4e53894013ec0d223e2723ece46447ba00d5baf5 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 184764a63e01525315f54897f3bd38eaa1242b42 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.eio-chown">
  <refnamediv>
   <refname>eio_chown</refname>
-  <refpurpose>Modifie les permissions d'un fichier/dossier</refpurpose>
+  <refpurpose>Modifie le propriétaire d'un fichier/dossier</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -19,7 +19,9 @@
    <methodparam choice="opt"><type>mixed</type><parameter>data</parameter><initializer>NULL</initializer></methodparam>
   </methodsynopsis>
   <simpara>
-   Modifie les permissions d'un fichier ou d'un dossier.
+   <function>eio_chown</function> modifie le propriétaire d'un fichier ou d'un
+   dossier. Le nouveau propriétaire est spécifié par <parameter>uid</parameter>,
+   et le groupe par <parameter>gid</parameter>.
   </simpara>
  </refsect1>
 

--- a/reference/eio/functions/eio-fchown.xml
+++ b/reference/eio/functions/eio-fchown.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 4e53894013ec0d223e2723ece46447ba00d5baf5 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 184764a63e01525315f54897f3bd38eaa1242b42 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.eio-fchown">
  <refnamediv>
@@ -82,7 +82,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   <function>eio_chmod</function> retourne la ressource demandée
+   <function>eio_fchown</function> retourne la ressource demandée
    en cas de succès,&return.falseforfailure;.
   </simpara>
  </refsect1>

--- a/reference/eio/functions/eio-fstat.xml
+++ b/reference/eio/functions/eio-fstat.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 4e53894013ec0d223e2723ece46447ba00d5baf5 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 184764a63e01525315f54897f3bd38eaa1242b42 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.eio-fstat">
  <refnamediv>
@@ -64,7 +64,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   <function>eio_busy</function> retourne la ressource
+   <function>eio_fstat</function> retourne la ressource
    demandée en cas de succès,&return.falseforfailure;.
   </simpara>
  </refsect1>
@@ -72,7 +72,7 @@
  <refsect1 role="examples">
   &reftitle.examples;
   <example>
-   <title><function>eio_lstat</function> example</title>
+   <title><function>eio_fstat</function> example</title>
    <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/eio/functions/eio-nready.xml
+++ b/reference/eio/functions/eio-nready.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 4e53894013ec0d223e2723ece46447ba00d5baf5 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 184764a63e01525315f54897f3bd38eaa1242b42 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.eio-nready">
  <refnamediv>
@@ -37,7 +37,6 @@
   &reftitle.seealso;
   <simplelist>
    <member><function>eio_nreqs</function></member>
-   <member><function>eio_nready</function></member>
    <member><function>eio_nthreads</function></member>
   </simplelist>
  </refsect1>

--- a/reference/eio/functions/eio-truncate.xml
+++ b/reference/eio/functions/eio-truncate.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 4e53894013ec0d223e2723ece46447ba00d5baf5 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 184764a63e01525315f54897f3bd38eaa1242b42 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.eio-truncate">
  <refnamediv>
@@ -72,7 +72,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   <function>eio_busy</function> retourne la ressource demandée
+   <function>eio_truncate</function> retourne la ressource demandée
    en cas de succès,&return.falseforfailure;.
   </simpara>
  </refsect1>

--- a/reference/enchant/functions/enchant-dict-suggest.xml
+++ b/reference/enchant/functions/enchant-dict-suggest.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: a6b55f8de61955b35c83fec32651201cce4aa383 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 184764a63e01525315f54897f3bd38eaa1242b42 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.enchant-dict-suggest">
  <refnamediv>
   <refname>enchant_dict_suggest</refname>
-  <refpurpose>Retourne une liste de valeurs si aucune des conditions n'est réunie</refpurpose>
+  <refpurpose>Suggère des orthographes pour un mot</refpurpose>
  </refnamediv>
  <refsect1 role="description">
   &reftitle.description;

--- a/reference/ev/evchild/createstopped.xml
+++ b/reference/ev/evchild/createstopped.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: b4fbf4434abeca44c58575ff3967e5640f7877d5 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 184764a63e01525315f54897f3bd38eaa1242b42 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="evchild.createstopped">
  <refnamediv>
   <refname>EvChild::createStopped</refname>
-  <refpurpose>Crée une instance de l'observateur stoppé EvCheck</refpurpose>
+  <refpurpose>Crée une instance de l'observateur stoppé EvChild</refpurpose>
  </refnamediv>
  <refsect1 role="description">
   &reftitle.description;

--- a/reference/ev/evsignal/construct.xml
+++ b/reference/ev/evsignal/construct.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: b4fbf4434abeca44c58575ff3967e5640f7877d5 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 184764a63e01525315f54897f3bd38eaa1242b42 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="evsignal.construct">
  <refnamediv>
@@ -32,7 +32,7 @@
   </constructorsynopsis>
   <simpara>
    Construit un objet watcher EvSignal et le démarre automatiquement.
-   Pour un watcher périodique stoppé, utiliser plutôt la méthode
+   Pour un watcher de signal stoppé, utiliser plutôt la méthode
    <methodname>EvSignal::createStopped</methodname>.
   </simpara>
  </refsect1>

--- a/reference/event/event.xml
+++ b/reference/event/event.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 23ea6be076881a34e1d454e9680968ece085f7f6 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 184764a63e01525315f54897f3bd38eaa1242b42 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 
 <reference xml:id="class.event" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
@@ -161,11 +161,11 @@
       <constant>Event::WRITE</constant>
      </term>
      <listitem>
-      <para>
+      <simpara>
        Ce drapeau indique qu'un événement devient actif lorsque le descripteur
        de fichier fourni (habituellement, une ressource de flux ou un socket)
        est prêt pour une écriture.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry xml:id="event.constants.signal">

--- a/reference/event/eventhttprequest/getbufferevent.xml
+++ b/reference/event/eventhttprequest/getbufferevent.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: e5d7cfa894ddb7d30f5b63ef272f33e80e1c63f3 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 184764a63e01525315f54897f3bd38eaa1242b42 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="eventhttprequest.getbufferevent" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -13,7 +13,7 @@
   <methodsynopsis>
    <modifier>public</modifier>
    <type>EventBufferEvent</type>
-   <methodname>EventHttpRequest::closeConnection</methodname>
+   <methodname>EventHttpRequest::getBufferEvent</methodname>
    <void />
   </methodsynopsis>
   <para>

--- a/reference/fann/functions/fann-get-activation-function.xml
+++ b/reference/fann/functions/fann-get-activation-function.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e41806c30bf6975e452c0d4ce35ab0984c2fa68c Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: 184764a63e01525315f54897f3bd38eaa1242b42 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="function.fann-get-activation-function" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -57,10 +57,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Une constante <link linkend="constants.fann-activation-funcs">de fonctions d'activation</link> ou -1
    si le neurone n'est pas défini dans le réseau de neurones, ou &false; en cas d'erreur.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/fann/functions/fann-get-rprop-decrease-factor.xml
+++ b/reference/fann/functions/fann-get-rprop-decrease-factor.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: e41806c30bf6975e452c0d4ce35ab0984c2fa68c Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 184764a63e01525315f54897f3bd38eaa1242b42 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="function.fann-get-rprop-decrease-factor" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>fann_get_rprop_decrease_factor</refname>
-  <refpurpose>Retourne le facteur d'accroissement utilisé pendant l'entraînement RPROP</refpurpose>
+  <refpurpose>Retourne le facteur de décroissement utilisé pendant l'entraînement RPROP</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/zmq/zmqdevice/settimercallback.xml
+++ b/reference/zmq/zmqdevice/settimercallback.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: be295015d068095fc92880baef4e47038646adbd Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 184764a63e01525315f54897f3bd38eaa1242b42 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="zmqdevice.settimercallback" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -33,24 +33,23 @@
    <varlistentry>
     <term><parameter>cb_func</parameter></term>
     <listitem>
-     <para>
-      Fonction de rappel à appeler lorsque le périphérique est inactif.
+     <simpara>
+      Fonction de rappel à appeler lorsque le timer se déclenche.
       Elle doit retourner &false; ou une valeur évaluée à &false;
       pour stopper le périphérique.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>timeout</parameter></term>
     <listitem>
-     <para>
-      Indique à partir de combien de temps la fonction de rappel d'inactivité
+     <simpara>
+      Indique à partir de combien de temps la fonction de rappel du timer
       doit être appelée, en millisecondes. La fonction de rappel
-      d'inactivité est appelée périodiquement lorsqu'il n'y a aucune
-      activité sur le périphérique. La valeur du délai d'attente
+      du timer est appelée périodiquement. La valeur du délai d'attente
       maximal garantit qu'il y aura au moins ce temps-là avant l'appel
       à la fonction de rappel.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>


### PR DESCRIPTION
Sync of doc-en commit 184764a6 into the French translation.

EN-Revision bumped and Maintainer set to lacatoire on the 18 files. The wrong-function references, refpurposes and para/simpara changes are mirrored, and the matching French wording is corrected where the translation carried the same mistake.

Fixes #2936