### PR TITLE
Sync EN: update array notes for example 10

### DIFF
--- a/language/types/array.xml
+++ b/language/types/array.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 3061900171d4ae84d532571bfd6eda823726dad4 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: bfdd82f3f6cde571a61de3fcea28a03145374dda Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <sect1 xml:id="language.types.array">
  <title>Les tableaux</title>
@@ -545,11 +545,12 @@ var_dump($arr);
    </example>
 
    <note>
-    <para>
-     Comme dit plus haut, si aucune clé n'est spécifiée, l'indice maximal
-     existant est repris, et la nouvelle clé sera ce nombre, plus 1 (mais au moins 0).
-     Si aucun indice entier n'existe, la clé sera <literal>0</literal> (zéro).
-    </para>
+    <simpara>
+     Si aucune clé n'est spécifiée, la clé sera l'indice entier maximal
+     existant + <literal>1</literal>. Si le tableau ne possède aucun indice
+     entier positif, la clé sera <literal>0</literal>.
+     À partir de PHP 8.3.0, elle peut aussi être un entier négatif.
+    </simpara>
 
     <para>
      Il est à noter que la clé entière maximale pour cette opération <emphasis>n'a


### PR DESCRIPTION
Sync of doc-en commit bfdd82f3 into the French translation: reworded the note on the auto-generated key (now mentions the negative integer key since PHP 8.3.0), and switched the para to simpara to mirror EN.

Fixes #2937