### PR TITLE
Sync EN: eio/constants.xml: add dots at the ends of sentences

### DIFF
--- a/reference/eio/constants.xml
+++ b/reference/eio/constants.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 940ea8c1b2b727eb0f3f6412305ab699b9b47cc6 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 2132501990f8e139a75021165634830f1f6a90e1 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <appendix xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="eio.constants">
  &reftitle.constants;
@@ -17,7 +17,7 @@
     </term>
     <listitem>
      <simpara>
-      Demande une priorité minimale
+      Demande une priorité minimale.
      </simpara>
     </listitem>
    </varlistentry>
@@ -28,7 +28,7 @@
     </term>
     <listitem>
      <simpara>
-      Demande une priorité par défaut
+      Demande une priorité par défaut.
      </simpara>
     </listitem>
    </varlistentry>
@@ -39,7 +39,7 @@
     </term>
     <listitem>
      <simpara>
-      Demande une priorité maximale
+      Demande une priorité maximale.
      </simpara>
     </listitem>
    </varlistentry>
@@ -110,7 +110,7 @@
       contenant les clés suivantes :
       <literal>'name'</literal> - le nom du dossier ;
       <literal>'type'</literal> - une constante <emphasis>EIO_DT_*</emphasis> ;
-      <literal>'inode'</literal> - le nombre d'inodes, si disponible, sinon, non spécifié ;
+      <literal>'inode'</literal> - le nombre d'inodes, si disponible, sinon, non spécifié.
      </simpara>
     </listitem>
    </varlistentry>
@@ -149,7 +149,6 @@
     </term>
     <listitem>
      <simpara>
-
      </simpara>
     </listitem>
    </varlistentry>
@@ -175,7 +174,7 @@
     </term>
     <listitem>
      <simpara>
-      Noeud de type FIFO
+      Noeud de type FIFO.
      </simpara>
     </listitem>
    </varlistentry>
@@ -186,7 +185,7 @@
     </term>
     <listitem>
      <simpara>
-      Type de nœud
+      Type de nœud.
      </simpara>
     </listitem>
    </varlistentry>
@@ -197,7 +196,7 @@
     </term>
     <listitem>
      <simpara>
-      Noeud de type périphérique à caractères multiplexés (v7+coherent)
+      Noeud de type périphérique à caractères multiplexés (v7+coherent).
      </simpara>
     </listitem>
    </varlistentry>
@@ -208,7 +207,7 @@
     </term>
     <listitem>
      <simpara>
-      Noeud de type dossier
+      Noeud de type dossier.
      </simpara>
     </listitem>
    </varlistentry>
@@ -219,7 +218,7 @@
     </term>
     <listitem>
      <simpara>
-      Noeud de type fichier nommé Xenix
+      Noeud de type fichier nommé Xenix.
      </simpara>
     </listitem>
    </varlistentry>
@@ -230,7 +229,7 @@
     </term>
     <listitem>
      <simpara>
-      Type de nœud
+      Type de nœud.
      </simpara>
     </listitem>
    </varlistentry>
@@ -240,7 +239,8 @@
      (<type>int</type>)
     </term>
     <listitem>
-     <simpara>Périphérique de bloc multiplexé (v7+coherent)
+     <simpara>
+      Périphérique de bloc multiplexé (v7+coherent).
      </simpara>
     </listitem>
    </varlistentry>
@@ -251,7 +251,7 @@
     </term>
     <listitem>
      <simpara>
-      Type de nœud
+      Type de nœud.
      </simpara>
     </listitem>
    </varlistentry>
@@ -272,7 +272,7 @@
     </term>
     <listitem>
      <simpara>
-      Noeud de type réseau HP-UX
+      Noeud de type réseau HP-UX.
      </simpara>
     </listitem>
    </varlistentry>
@@ -283,7 +283,7 @@
     </term>
     <listitem>
      <simpara>
-      Noeud de type lien
+      Noeud de type lien.
      </simpara>
     </listitem>
    </varlistentry>
@@ -294,7 +294,7 @@
     </term>
     <listitem>
      <simpara>
-      Noeud de type socket
+      Noeud de type socket.
      </simpara>
     </listitem>
    </varlistentry>
@@ -305,7 +305,7 @@
     </term>
     <listitem>
      <simpara>
-      Noeud de type Solaris door
+      Noeud de type Solaris door.
      </simpara>
     </listitem>
    </varlistentry>
@@ -316,7 +316,7 @@
     </term>
     <listitem>
      <simpara>
-      Noeud de type
+      Noeud de type.
      </simpara>
     </listitem>
    </varlistentry>
@@ -327,7 +327,7 @@
     </term>
     <listitem>
      <simpara>
-      Valeur maximale du type de nœud
+      Valeur maximale du type de nœud.
      </simpara>
     </listitem>
    </varlistentry>


### PR DESCRIPTION
Sync de `reference/eio/constants.xml` sur le commit upstream `2132501` (ajout des points en fin de phrases, miroir tag-à-tag).

Fixes #2941