### PR TITLE
Sync EN: fiber/throw.xml: add an example

### DIFF
--- a/language/predefined/fiber/throw.xml
+++ b/language/predefined/fiber/throw.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 8fee3ae9715ffa15922469eb7d98f4878917a6ee Maintainer: pierrick Status: ready -->
+<!-- EN-Revision: b3a0b9924ba577a3abf246c1bd1a6cf5c4bf14dc Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="fiber.throw" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -41,6 +41,40 @@
    La valeur fournie au prochain appel à <methodname>Fiber::suspend</methodname> ou &null; si la fibre retourne.
    Si la fibre lance une exception avant de se suspendre, elle sera émise lors de l'appel à cette méthode.
   </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <informalexample>
+   <programlisting role="php">
+<![CDATA[
+<?php
+
+$fiber = new Fiber(function () {
+   try {
+       // Suspend l'exécution de la fibre en déclarant un point d'interruption
+       Fiber::suspend();
+   } catch (Throwable $e) {
+       echo $e->getMessage();
+   }
+});
+
+$fiber->start();
+
+// Reprend l'exécution de la fibre en
+// passant l'Exception à lancer au point d'interruption
+$fiber->throw(new Exception('Message d\'une exception lancée au point d\'interruption courant'));
+
+?>
+]]>
+   </programlisting>
+   &example.outputs.similar;
+   <screen>
+<![CDATA[
+Message d'une exception lancée au point d'interruption courant
+]]>
+   </screen>
+  </informalexample>
  </refsect1>
 
 </refentry>


### PR DESCRIPTION
Sync de `language/predefined/fiber/throw.xml` sur le commit upstream `b3a0b99` : ajout de l'exemple `Fiber::throw()`, commentaires PHP et message d'exception traduits.

Fixes #2940