### PR TITLE
Sync EN: exit: add changelog and warning about updated exit code behaviour since PHP 8.4.0

### DIFF
--- a/reference/funchand/functions/register-shutdown-function.xml
+++ b/reference/funchand/functions/register-shutdown-function.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: b412bbd26214f7281ac7dd858710e09952a275f2 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 2312f826e5fdedbef87c6288c2c20f9f904b4d0b Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 
 <refentry xml:id="function.register-shutdown-function" xmlns="http://docbook.org/ns/docbook">
@@ -29,6 +29,15 @@
    durant l'une des fonctions d'extinction, le processus sera définitivement
    arrêté, sans que les autres fonctions soient appelées.
   </para>
+  <caution>
+   <simpara>
+    À partir de PHP 8.4.0, un appel à <function>exit</function> sans paramètre
+    depuis une fonction d'arrêt enregistrée réinitialise le code de sortie à
+    <literal>0</literal>. L'appel à <function>exit</function> avec un statut
+    explicite écrase le code de sortie précédent, et ce dans toutes les
+    versions.
+   </simpara>
+  </caution>
   <para>
    Les fonctions d'arrêt peuvent également appeler la fonction
    <function>register_shutdown_function</function> elles-mêmes pour ajouter une

--- a/reference/misc/functions/exit.xml
+++ b/reference/misc/functions/exit.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 2aaaf1967f2510471b694daf8e41a419fc98b751 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 2312f826e5fdedbef87c6288c2c20f9f904b4d0b Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 
 <refentry xml:id="function.exit" xmlns="http://docbook.org/ns/docbook">
@@ -109,6 +109,17 @@
        <link linkend="language.types.declarations.strict"><literal>strict_types</literal></link>,
        peut être appelée avec des arguments nommés et être utilisée
        comme une <link linkend="functions.variable-functions">fonction variable</link>.
+      </entry>
+     </row>
+     <row>
+      <entry>8.4.0</entry>
+      <entry>
+       Un appel à <function>exit</function> sans paramètre depuis une
+       <link linkend="function.register-shutdown-function">fonction d'extinction</link>
+       ou un <link linkend="language.oop5.decon.destructor">destructeur d'objet</link>
+       réinitialise désormais le code de sortie à <literal>0</literal> ;
+       auparavant, le code de sortie défini par un appel antérieur à
+       <function>exit</function> était conservé.
       </entry>
      </row>
     </tbody>


### PR DESCRIPTION
Sync doc-en 2312f826 (PR upstream).

Fixes #2944