### PR TITLE
[Sync EN] sscanf/fscanf: Clarify negative -1 return value (#5580)

### DIFF
--- a/reference/filesystem/functions/fscanf.xml
+++ b/reference/filesystem/functions/fscanf.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 4225e50bc391ddba99e367c231463da0dc04357d Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 9947012f745f0fb6e083bce5a8c920213ff468b7 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.fscanf" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -16,67 +15,69 @@
    <methodparam><type>string</type><parameter>format</parameter></methodparam>
    <methodparam rep="repeat"><type>mixed</type><parameter role="reference">vars</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    La fonction <function>fscanf</function> est similaire à la fonction
    <function>sscanf</function>, sauf qu'elle prend un fichier en entrée,
    représenté par la ressource <parameter>stream</parameter> et interprète
    l'entrée en fonction du format <parameter>format</parameter> spécifié.
-  </para>
-  <para>
-   Tous les caractères blancs de la chaîne de formatage correspondent 
+  </simpara>
+  <simpara>
+   Tous les caractères blancs de la chaîne de formatage correspondent
    à autant d'espaces dans le flux d'entrée. Cela signifie qu'une tabulation
-   (<literal>\t</literal>) dans la chaîne de format peut remplacer 
+   (<literal>\t</literal>) dans la chaîne de format peut remplacer
    un espace simple dans le flux d'entrée.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Chaque appel à la fonction <function>fscanf</function> lit une ligne du fichier.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
   &reftitle.parameters;
-  <para>
-   <variablelist>
-    <varlistentry>
-     <term><parameter>stream</parameter></term>
-     <listitem>
-      &fs.file.pointer;
-     </listitem>
-    </varlistentry>
-    &strings.scanf.parameter.format;
-    <varlistentry>
-     <term><parameter>vars</parameter></term>
-     <listitem>
-      <para>
-       Les valeurs optionnelles à assigner.
-      </para>
-     </listitem>
-    </varlistentry>
-   </variablelist>
-  </para>
+  <variablelist>
+   <varlistentry>
+    <term><parameter>stream</parameter></term>
+    <listitem>
+     &fs.file.pointer;
+    </listitem>
+   </varlistentry>
+   &strings.scanf.parameter.format;
+   <varlistentry>
+    <term><parameter>vars</parameter></term>
+    <listitem>
+     <simpara>
+      Les valeurs optionnelles à assigner.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
  </refsect1>
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Si seulement 2 paramètres sont passés à la fonction, la valeur analysée
-   sera retournée sous la forme d'un tableau. Si des paramètres optionnels
-   sont passés, la fonction retourne le nombre de valeurs assignées.
+   sera retournée sous la forme d'un <type>array</type>. Si des paramètres
+   optionnels sont passés, la fonction retourne le nombre de valeurs assignées.
    Les paramètres optionnels doivent être passés par référence.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    S'il y a plus de sous-chaînes attendues dans le <parameter>format</parameter>
    que disponibles dans <parameter>string</parameter>,
    &null; sera retourné. Pour les autres erreurs, &false; sera retourné.
-  </para>
+  </simpara>
+  <simpara>
+   Lorsque des paramètres optionnels sont utilisés et que la fin de l'entrée
+   lue depuis <parameter>stream</parameter> est atteinte avant qu'aucune
+   valeur n'ait été analysée, <literal>-1</literal> est retourné.
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">
   &reftitle.examples;
-  <para>
-   <example>
-    <title>Exemple avec <function>fscanf</function></title>
-    <programlisting role="php">
+  <example>
+   <title>Exemple avec <function>fscanf</function></title>
+   <programlisting role="php">
 <![CDATA[
 <?php
 $handle = fopen("users.txt", "r");
@@ -87,36 +88,31 @@ while ($userinfo = fscanf($handle, "%s\t%s\t%s\n")) {
 fclose($handle);
 ?>
 ]]>
-    </programlisting>
-   </example>
-  </para>
-  <para>
-   <example>
-    <title>Contenu du fichier users.txt</title>
-    <programlisting role="txt">
+   </programlisting>
+  </example>
+  <example>
+   <title>Contenu du fichier users.txt</title>
+   <programlisting role="txt">
 <![CDATA[
 javier  argonaut        pe
 hiroshi sculptor        jp
 robert  slacker us
 luigi   florist it
 ]]>
-    </programlisting>
-   </example>
-  </para>
+   </programlisting>
+  </example>
  </refsect1>
 
  <refsect1 role="seealso">
   &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><function>fread</function></member>
-    <member><function>fgets</function></member>
-    <member><function>fgetss</function></member>
-    <member><function>sscanf</function></member>
-    <member><function>printf</function></member>
-    <member><function>sprintf</function></member>
-   </simplelist>
-  </para>
+  <simplelist>
+   <member><function>fread</function></member>
+   <member><function>fgets</function></member>
+   <member><function>fgetss</function></member>
+   <member><function>sscanf</function></member>
+   <member><function>printf</function></member>
+   <member><function>sprintf</function></member>
+  </simplelist>
  </refsect1>
 
 </refentry>

--- a/reference/spl/splfileobject/fscanf.xml
+++ b/reference/spl/splfileobject/fscanf.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: d51166ca16fda8e766849505b84f9306ef443f71 Maintainer: jpauli Status: ready -->
+<!-- EN-Revision: 9947012f745f0fb6e083bce5a8c920213ff468b7 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="splfileobject.fscanf" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -15,84 +14,89 @@
    <methodparam><type>string</type><parameter>format</parameter></methodparam>
    <methodparam rep="repeat"><type>mixed</type><parameter role="reference">vars</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Lit une ligne depuis un fichier et l'analyse suivant le format
    <parameter>format</parameter> spécifié.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Les espaces blancs dans la chaîne <parameter>format</parameter> correspondent
    aux espaces blancs dans la ligne du fichier.
    Ceci signifie qu'une tabulation (<literal>\t</literal>) dans le format
    va correspondre à un seul caractère blanc dans le flux d'entrée.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
   &reftitle.parameters;
-  <para>
-   <variablelist>
-    &strings.scanf.parameter.format;
-    <varlistentry>
-     <term><parameter>vars</parameter></term>
-     <listitem>
-      <para>
-       Les valeurs optionnelles assignées.
-      </para>
-     </listitem>
-    </varlistentry>
-   </variablelist>
-  </para>
+  <variablelist>
+   &strings.scanf.parameter.format;
+   <varlistentry>
+    <term><parameter>vars</parameter></term>
+    <listitem>
+     <simpara>
+      Les valeurs optionnelles assignées.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
  </refsect1>
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Si seul 1 paramètre est passé à cette méthode, la valeur analysée
-   sera retournée sous la forme d'un tableau. Sinon, si les paramètres optionnelles
-   sont passés, la fonction retourne le nombre de valeurs assignées.
-   Les paramètres optionnels doivent être passés par référence.
-  </para>
+   sera retournée sous la forme d'un <type>array</type>. Sinon, si des
+   paramètres optionnels sont passés, la méthode retourne le nombre de
+   valeurs assignées. Les paramètres optionnels doivent être passés par
+   référence.
+  </simpara>
+  <simpara>
+   S'il y a plus de sous-chaînes attendues dans le <parameter>format</parameter>
+   que disponibles dans la ligne lue depuis le fichier,
+   &null; sera retourné.
+  </simpara>
+  <simpara>
+   Lorsque des paramètres optionnels sont utilisés et que la fin de la ligne
+   lue depuis le fichier est atteinte avant qu'aucune valeur n'ait été
+   analysée, <literal>-1</literal> est retourné.
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">
   &reftitle.examples;
-  <para>
-   <example>
-    <title>Exemple avec <methodname>SplFileObject::fscanf</methodname></title>
-    <programlisting role="php">
+  <example>
+   <title>Exemple avec <methodname>SplFileObject::fscanf</methodname></title>
+   <programlisting role="php">
 <![CDATA[
 <?php
 $file = new SplFileObject("misc.txt");
 while ($userinfo = $file->fscanf("%s %s %s")) {
-    list ($name, $profession, $countrycode) = $userinfo;
-    // Faire des opérations sur $name $profession $countrycode
+   list ($name, $profession, $countrycode) = $userinfo;
+   // Faire des opérations sur $name $profession $countrycode
 }
 ?>
 ]]>
-    </programlisting>
-    <para>Contenu de users.txt</para>
-    <programlisting role="txt">
+   </programlisting>
+   <simpara>Contenu de users.txt</simpara>
+   <programlisting role="txt">
 <![CDATA[
 javier   argonaut    pe
 hiroshi  sculptor    jp
 robert   slacker     us
 luigi    florist     it
 ]]>
-    </programlisting>
-   </example>
-  </para>
+   </programlisting>
+  </example>
  </refsect1>
 
  <refsect1 role="seealso">
   &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><function>fscanf</function></member>
-    <member><function>sscanf</function></member>
-    <member><function>printf</function></member>
-    <member><function>sprintf</function></member>
-   </simplelist>
-  </para>
+  <simplelist>
+   <member><function>fscanf</function></member>
+   <member><function>sscanf</function></member>
+   <member><function>printf</function></member>
+   <member><function>sprintf</function></member>
+  </simplelist>
  </refsect1>
 
 </refentry>

--- a/reference/strings/functions/sscanf.xml
+++ b/reference/strings/functions/sscanf.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 4225e50bc391ddba99e367c231463da0dc04357d Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 9947012f745f0fb6e083bce5a8c920213ff468b7 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.sscanf" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -16,68 +15,69 @@
    <methodparam><type>string</type><parameter>format</parameter></methodparam>
    <methodparam rep="repeat"><type>mixed</type><parameter role="reference">vars</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    <function>sscanf</function> est l'inverse de la fonction
    <function>printf</function>. <function>sscanf</function> lit
    des données dans la chaîne <parameter>string</parameter>, et
    l'interprète en fonction du format <parameter>format</parameter>.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Tous les caractères blancs dans la chaîne <parameter>format</parameter> correspondent
    à un caractère blanc dans la chaîne <parameter>string</parameter>. Cela signifie que
    même une tabulation (<literal>\t</literal>) dans la chaîne de format peut correspondre à
    un simple espace dans la chaîne <parameter>string</parameter>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
   &reftitle.parameters;
-  <para>
-   <variablelist>
-    <varlistentry>
-     <term><parameter>string</parameter></term>
-     <listitem>
-      <para>
-       La chaîne à analyser.
-      </para>
-     </listitem>
-    </varlistentry>
-    &strings.scanf.parameter.format;
-    <varlistentry>
-     <term><parameter>vars</parameter></term>
-     <listitem>
-      <para>
-       Optionnellement, il est possible de passer des variables dans ce paramètre,
-       par référence qui contiendront les valeurs de l'analyse.
-      </para>
-     </listitem>
-    </varlistentry>
-   </variablelist>
-  </para>
+  <variablelist>
+   <varlistentry>
+    <term><parameter>string</parameter></term>
+    <listitem>
+     <simpara>
+      La chaîne à analyser.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   &strings.scanf.parameter.format;
+   <varlistentry>
+    <term><parameter>vars</parameter></term>
+    <listitem>
+     <simpara>
+      Optionnellement, il est possible de passer des variables dans ce paramètre,
+      par référence qui contiendront les valeurs de l'analyse.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
  </refsect1>
- 
+
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Si seulement deux paramètres sont fournis, les valeurs trouvées
-   seront retournées sous forme de tableau. Sinon, si les paramètres
-   optionnels sont fournis, la fonction retournera le nombre de
-   valeurs assignées. Le paramètre optionnel doit être passé par
-   référence.
-  </para>
-  <para>
+   seront retournées sous la forme d'un <type>array</type>. Sinon, si les
+   paramètres optionnels sont fournis, la fonction retournera le nombre de
+   valeurs assignées. Le paramètre optionnel doit être passé par référence.
+  </simpara>
+  <simpara>
    S'il y a plus de sous-chaînes attendues dans le paramètre
    <parameter>format</parameter>, qu'il y a de disponibles dans
    <parameter>string</parameter>, alors &null; sera retourné.
-  </para>
+  </simpara>
+  <simpara>
+   Lorsque des paramètres optionnels sont utilisés et que la fin de la chaîne
+   <parameter>string</parameter> est atteinte avant qu'aucune valeur n'ait
+   été analysée, <literal>-1</literal> est retourné.
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">
   &reftitle.examples;
-  <para>
-   <example>
-    <title>Exemple avec <function>sscanf</function></title>
-    <programlisting role="php">
+  <example>
+   <title>Exemple avec <function>sscanf</function></title>
+   <programlisting role="php">
 <![CDATA[
 <?php
 // Lecture d'un numéro de série
@@ -88,17 +88,15 @@ list($month, $day, $year) = sscanf($mandate, "%s %d %d");
 echo "Le produit $serial a été fabriqué le : $year-" . substr($month, 0, 3) . "-$day\n";
 ?>
 ]]>
-    </programlisting>
-   </example>
-  </para>
-  <para>
+   </programlisting>
+  </example>
+  <simpara>
    Si des paramètres optionnels sont passés, <function>sscanf</function> retournera
    le nombre de valeurs assignées.
-  </para>
-  <para>
-   <example>
-    <title><function>sscanf</function> - utilisation des paramètres optionnels</title>
-    <programlisting role="php">
+  </simpara>
+  <example>
+   <title><function>sscanf</function> - utilisation des paramètres optionnels</title>
+   <programlisting role="php">
 <![CDATA[
 <?php
 // lit les informations d'auteur, et génère une entrée DocBook
@@ -110,26 +108,23 @@ echo "<author id='$id'>
 </author>\n";
 ?>
 ]]>
-    </programlisting>
-   </example>
-  </para>
+   </programlisting>
+  </example>
  </refsect1>
 
  <refsect1 role="seealso">
   &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><function>printf</function></member>
-    <member><function>sprintf</function></member>
-    <member><function>fprintf</function></member>
-    <member><function>vprintf</function></member>
-    <member><function>vsprintf</function></member>
-    <member><function>vfprintf</function></member>
-    <member><function>fscanf</function></member>
-    <member><function>number_format</function></member>
-    <member><function>date</function></member>
-   </simplelist>
-  </para>
+  <simplelist>
+   <member><function>printf</function></member>
+   <member><function>sprintf</function></member>
+   <member><function>fprintf</function></member>
+   <member><function>vprintf</function></member>
+   <member><function>vsprintf</function></member>
+   <member><function>vfprintf</function></member>
+   <member><function>fscanf</function></member>
+   <member><function>number_format</function></member>
+   <member><function>date</function></member>
+  </simplelist>
  </refsect1>
 
 </refentry>


### PR DESCRIPTION
Sync de la PR doc-en #5580 sur les 3 fichiers listés dans l'issue : ajout du paragraphe sur le retour `-1` quand la fin d'entrée est atteinte avant qu'aucune valeur n'ait été analysée. Au passage, swap `<para>` → `<simpara>` mirroré et `<type>array</type>` markup ajouté.

Closes #2950