### PR TITLE
[Sync EN] image: Fix examples and description

### DIFF
--- a/reference/image/functions/imagedashedline.xml
+++ b/reference/image/functions/imagedashedline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: fcd9214294f88b05862a538c6dd94c7872420139 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: d56953fc8d508615279a2220f21d7fb6c3298417 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 
 <refentry xml:id="function.imagedashedline" xmlns="http://docbook.org/ns/docbook">
@@ -21,7 +21,8 @@
   <para>
    <function>imagedashedline</function> est obsolète. Il est préférable d'utiliser
    une combinaison des fonctions <function>imagesetstyle</function> et
-   <function>imageline</function>.
+   <function>imageline</function>. Le point 0, 0 est le coin en haut à gauche
+   de l'image.
   </para>
  </refsect1>
  <refsect1 role="parameters">
@@ -33,7 +34,7 @@
      <term><parameter>x1</parameter></term>
      <listitem>
       <para>
-       Coordonnée en X : En haut, à gauche.
+       Coordonnée x du premier point.
       </para>
      </listitem>
     </varlistentry>
@@ -41,8 +42,7 @@
      <term><parameter>y1</parameter></term>
      <listitem>
       <para>
-       Coordonnée en Y : En haut, à gauche. 0 est le coin en haut à gauche
-       de l'image.
+       Coordonnée y du premier point.
       </para>
      </listitem>
     </varlistentry>
@@ -50,7 +50,7 @@
      <term><parameter>x2</parameter></term>
      <listitem>
       <para>
-       Coordonnée en X : En bas, à droite.
+       Coordonnée x du second point.
       </para>
      </listitem>
     </varlistentry>
@@ -58,7 +58,7 @@
      <term><parameter>y2</parameter></term>
      <listitem>
       <para>
-       Coordonnée en Y : En bas, à droite.
+       Coordonnée y du second point.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/image/functions/imagerectangle.xml
+++ b/reference/image/functions/imagerectangle.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: fcd9214294f88b05862a538c6dd94c7872420139 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: d56953fc8d508615279a2220f21d7fb6c3298417 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 
 <refentry xml:id="function.imagerectangle" xmlns="http://docbook.org/ns/docbook">
@@ -20,7 +20,7 @@
   </methodsynopsis>
   <para>
    <function>imagerectangle</function> dessine un rectangle aux coordonnées
-   spécifiées.
+   spécifiées. Le point 0, 0 est le coin en haut à gauche de l'image.
   </para>
  </refsect1>
  <refsect1 role="parameters">
@@ -41,7 +41,6 @@
      <listitem>
       <para>
        Y : coordonnée du coin en haut, à gauche.
-       0, 0 est le coin en haut à gauche de l'image.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/image/functions/imagesetbrush.xml
+++ b/reference/image/functions/imagesetbrush.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: fcd9214294f88b05862a538c6dd94c7872420139 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: d56953fc8d508615279a2220f21d7fb6c3298417 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 
 <refentry xml:id="function.imagesetbrush" xmlns="http://docbook.org/ns/docbook">
@@ -89,6 +89,7 @@
     <programlisting role="php">
 <![CDATA[
 <?php
+
 // Charge un mini-logo PHP
 $php = imagecreatefrompng('./php.png');
 
@@ -97,7 +98,7 @@ $im = imagecreatetruecolor(100, 100);
 
 // Définit l'arrière-plan en blanc
 $white = imagecolorallocate($im, 255, 255, 255);
-imagefilledrectangle($im, 0, 0, 299, 99, $white);
+imagefilledrectangle($im, 0, 0, 99, 99, $white);
 
 // Définit la brosse
 imagesetbrush($im, $php);

--- a/reference/image/functions/imagesetthickness.xml
+++ b/reference/image/functions/imagesetthickness.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: fcd9214294f88b05862a538c6dd94c7872420139 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: d56953fc8d508615279a2220f21d7fb6c3298417 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 
 <refentry xml:id="function.imagesetthickness" xmlns="http://docbook.org/ns/docbook">
@@ -72,13 +72,14 @@
     <programlisting role="php">
 <![CDATA[
 <?php
+
 // Création d'une image en 200x100
 $im = imagecreatetruecolor(200, 100);
 $white = imagecolorallocate($im, 0xFF, 0xFF, 0xFF);
 $black = imagecolorallocate($im, 0x00, 0x00, 0x00);
 
 // Définit l'arrière-plan en blanc
-imagefilledrectangle($im, 0, 0, 299, 99, $white);
+imagefilledrectangle($im, 0, 0, 199, 99, $white);
 
 // Définit l'épaisseur de la ligne à 5
 imagesetthickness($im, 5);


### PR DESCRIPTION
Sync FR sur le commit EN d56953fc : description des paramètres d'`imagedashedline`/`imagerectangle` clarifiée, et correction des coordonnées dans les exemples d'`imagesetbrush` et `imagesetthickness`.

Fixes #2956