### PR TITLE
[Sync EN] zookeeper/connect: bump EN-Revision

### DIFF
--- a/reference/zookeeper/zookeeper/connect.xml
+++ b/reference/zookeeper/zookeeper/connect.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: dfd68fd22aef25658bc9348176b55b504d26ab11 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 999d171f3e2972aa42c860916761d0bcb9ce6b70 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="zookeeper.connect" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>


### PR DESCRIPTION
La correction EN ne concernait qu'une faute d'anglais (« connections is » : « connection is »). La traduction FR « la connexion est actuellement connectée » était déjà correcte, donc seul l'EN-Revision est mis à jour.

Fixes #2961
