### PR TITLE
[Sync EN] Corrige des exemples de code non exécutables

### DIFF
--- a/appendices/migration74/new-features.xml
+++ b/appendices/migration74/new-features.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e150cc645a17588282e5e6b5e43e600a2f345549 Maintainer: girgias Status: ready -->
+<!-- EN-Revision: 8e2cfbdce0cd028a6521c6e073f148e0f7efac7c Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 
 <sect1 xml:id="migration74.new-features" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -98,7 +98,7 @@ class B extends A
 {
     // Erreur fatale : Impossible de vérifier la compatibilité entre B::method():C et
     // A::method(): A, car la classe C n'est pas disponible
-    public function method(): С {}
+    public function method(): C {}
 }
 
 class C extends B {}

--- a/reference/ev/evperiodic/construct.xml
+++ b/reference/ev/evperiodic/construct.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: b4fbf4434abeca44c58575ff3967e5640f7877d5 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 8e2cfbdce0cd028a6521c6e073f148e0f7efac7c Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="evperiodic.construct">
  <refnamediv>
@@ -126,7 +126,7 @@
 // Toutes les 10.5 secondes
 
 function reschedule_cb ($watcher, $now) {
- return $now + (10.5. - fmod($now, 10.5));
+ return $now + (10.5 - fmod($now, 10.5));
 }
 
 $w = new EvPeriodic(0., 0., "reschedule_cb", function ($w, $revents) {

--- a/reference/imagick/imagick/mergeimagelayers.xml
+++ b/reference/imagick/imagick/mergeimagelayers.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 976425d4f6eec32448be3cc22ec063015921b753 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 8e2cfbdce0cd028a6521c6e073f148e0f7efac7c Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="imagick.mergeimagelayers">
@@ -65,7 +65,7 @@
 <?php
 function mergeImageLayers($layerMethodType, $imagePath1, $imagePath2) {
 
-    $imagick = new \Imagick(realpath($imagePath));
+    $imagick = new \Imagick(realpath($imagePath1));
 
     $imagick2 = new \Imagick(realpath($imagePath2));
     $imagick->addImage($imagick2);

--- a/reference/mongodb/mongodb/driver/bulkwritecommand/replaceone.xml
+++ b/reference/mongodb/mongodb/driver/bulkwritecommand/replaceone.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 8e2cfbdce0cd028a6521c6e073f148e0f7efac7c Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 
 <refentry xml:id="mongodb-driver-bulkwritecommand.replaceone" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -122,7 +122,7 @@
 $manager = new MongoDB\Driver\Manager;
 
 $bulk = new MongoDB\Driver\BulkWriteCommand;
-$bulk->replaceOne('db.coll', ['x' => 1], ['x' => 1, 'y' = 2]);
+$bulk->replaceOne('db.coll', ['x' => 1], ['x' => 1, 'y' => 2]);
 
 $result = $manager->executeBulkWriteCommand($bulk);
 

--- a/reference/rar/rarentry/getunpackedsize.xml
+++ b/reference/rar/rarentry/getunpackedsize.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: ee741f54f831af19f135d1d9894a41477ab896c3 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 8e2cfbdce0cd028a6521c6e073f148e0f7efac7c Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="rarentry.getunpackedsize">
  <refnamediv>
@@ -75,7 +75,7 @@ $rar_file = rar_open('example.rar') or die("Échec lors de l'ouverture de l'arch
 
 $entry = rar_entry_get($rar_file, 'Dir/file.txt') or die("Échec lors de la récupération de l'entrée");
 
-echo "Taille décompressée de " . $entry->getName() . " = " . $entry->getPackedSize() . " octets";
+echo "Taille décompressée de " . $entry->getName() . " = " . $entry->getUnpackedSize() . " octets";
 
 ?>
 ]]>

--- a/reference/solr/solrdismaxquery/setqueryalt.xml
+++ b/reference/solr/solrdismaxquery/setqueryalt.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 16b2b1ea9a7261fbb8e38ad85ba183cd13010ae1 Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: 8e2cfbdce0cd028a6521c6e073f148e0f7efac7c Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="solrdismaxquery.setqueryalt" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -51,7 +51,7 @@
 <![CDATA[
 <?php
 
-$dismaxQuery = new DisMaxQuery();
+$dismaxQuery = new SolrDisMaxQuery();
 $dismaxQuery->setQueryAlt('*:*');
 
 ?>

--- a/reference/spl/splfileinfo/getgroup.xml
+++ b/reference/spl/splfileinfo/getgroup.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 84d643420e0a5b43f34238aff8bde6dce168825b Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 8e2cfbdce0cd028a6521c6e073f148e0f7efac7c Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="splfileinfo.getgroup" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -47,7 +47,7 @@
 <![CDATA[
 <?php
 $info = new SplFileInfo('example.jpg');
-echo info->getFilename() . ' appartient au groupe ' . $info->getGroup() . "\n";
+echo $info->getFilename() . ' appartient au groupe ' . $info->getGroup() . "\n";
 print_r(posix_getgrgid($info->getGroup()));
 ?>
 ]]>

--- a/reference/spl/splfileinfo/getowner.xml
+++ b/reference/spl/splfileinfo/getowner.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 84d643420e0a5b43f34238aff8bde6dce168825b Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 8e2cfbdce0cd028a6521c6e073f148e0f7efac7c Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="splfileinfo.getowner" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -47,7 +47,7 @@
 <![CDATA[
 <?php
 $info = new SplFileInfo('example.jpg');
-echo info->getFilename() . ' appartient à l\'utilisateur id ' . $info->getOwner() . "\n";
+echo $info->getFilename() . ' appartient à l\'utilisateur id ' . $info->getOwner() . "\n";
 print_r(posix_getpwuid($info->getOwner()));
 ?>
 ]]>

--- a/reference/spl/splfileinfo/getsize.xml
+++ b/reference/spl/splfileinfo/getsize.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 84d643420e0a5b43f34238aff8bde6dce168825b Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 8e2cfbdce0cd028a6521c6e073f148e0f7efac7c Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="splfileinfo.getsize" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -48,7 +48,7 @@
 <![CDATA[
 <?php
 $info = new SplFileInfo('example.jpg');
-echo $fileinfo->getFilename() . " " . $fileinfo->getSize();
+echo $info->getFilename() . " " . $info->getSize();
 ?>
 ]]>
     </programlisting>

--- a/reference/uri/uri/rfc3986/uri/parse.xml
+++ b/reference/uri/uri/rfc3986/uri/parse.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 8e2cfbdce0cd028a6521c6e073f148e0f7efac7c Maintainer: lacatoire Status: ready -->
 <refentry xml:id="uri-rfc3986-uri.parse" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Uri\Rfc3986\Uri::parse</refname>
@@ -62,7 +62,7 @@ $uri = \Uri\Rfc3986\Uri::parse("https://example.com");
 if ($uri !== null) {
     echo "URI valide : " . $uri->toString();
 } else {
-    echo "URI invalide"
+    echo "URI invalide";
 }
 ?>
 ]]>

--- a/reference/uri/uri/whatwg/url/parse.xml
+++ b/reference/uri/uri/whatwg/url/parse.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 8e2cfbdce0cd028a6521c6e073f148e0f7efac7c Maintainer: lacatoire Status: ready -->
 <refentry xml:id="uri-whatwg-url.parse" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Uri\WhatWg\Url::parse</refname>
@@ -72,7 +72,7 @@ $url = \Uri\WhatWg\Url::parse("https://example.com");
 if ($url !== null) {
     echo "URL valide : " . $url->toAsciiString();
 } else {
-    echo "URL invalide"
+    echo "URL invalide";
 }
 ?>
 ]]>

--- a/reference/xattr/functions/xattr-list.xml
+++ b/reference/xattr/functions/xattr-list.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14af302c9c0e561fa6f9cdd956268758ba9a89c5 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 8e2cfbdce0cd028a6521c6e073f148e0f7efac7c Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 
 <refentry xml:id="function.xattr-list" xmlns="http://docbook.org/ns/docbook">
@@ -86,7 +86,7 @@ foreach ($root_attributes as $attr_name) {
 }
 
 echo "\n Attributs utilisateur : \n";
-foreach ($attributes as $attr_name) {
+foreach ($user_attributes as $attr_name) {
     printf("%s\n", $attr_name);
 }
 

--- a/reference/xlswriter/xlsx-kernel/auto-filter.xml
+++ b/reference/xlswriter/xlsx-kernel/auto-filter.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 4691215483797da841e61de00eef8adba2960d21 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 8e2cfbdce0cd028a6521c6e073f148e0f7efac7c Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="vtiful-kernel-excel.autoFilter" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -55,7 +55,7 @@ $config = [
 
 $fileObject  = new \Vtiful\Kernel\Excel($config);
 
-$file = $excel->fileName('test.xlsx')
+$file = $fileObject->fileName('test.xlsx')
         ->header(['name', 'age'])
         ->data($data)
         ->autoFilter('A1:B11')  // Filtre automatique

--- a/reference/xlswriter/xlsx-kernel/const-memory.xml
+++ b/reference/xlswriter/xlsx-kernel/const-memory.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 4691215483797da841e61de00eef8adba2960d21 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 8e2cfbdce0cd028a6521c6e073f148e0f7efac7c Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="vtiful-kernel-excel.constMemory" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -64,7 +64,7 @@ $config = [
 
 $fileObject = new \Vtiful\Kernel\Excel($config);
 
-$file = $instance->constMemory('tutorial.xlsx', 'sheet');
+$file = $fileObject->constMemory('tutorial.xlsx', 'sheet');
 ?>
 ]]>
    </programlisting>

--- a/reference/xlswriter/xlsx-kernel/file-name.xml
+++ b/reference/xlswriter/xlsx-kernel/file-name.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 4691215483797da841e61de00eef8adba2960d21 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 8e2cfbdce0cd028a6521c6e073f148e0f7efac7c Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="vtiful-kernel-excel.filename" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -63,7 +63,7 @@ $config = [
 
 $fileObject = new \Vtiful\Kernel\Excel($config);
 
-$file = $instance->fileName('tutorial.xlsx', 'sheet');
+$file = $fileObject->fileName('tutorial.xlsx', 'sheet');
 ?>
 ]]>
    </programlisting>

--- a/reference/xlswriter/xlsx-kernel/insert-text.xml
+++ b/reference/xlswriter/xlsx-kernel/insert-text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 19e8122137a1d42ed60f17fe2c0c2b69b0b2d16b Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 8e2cfbdce0cd028a6521c6e073f148e0f7efac7c Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="vtiful-kernel-excel.insertText" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -89,7 +89,7 @@ for ($index = 0; $index < 10; $index++) {
     $file->insertText($index+1, 1, 10000, '#,##0');
 }
 
-$textFile->output();
+$file->output();
 ]]>
    </programlisting>
   </example>

--- a/reference/yac/yac/add.xml
+++ b/reference/yac/yac/add.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 338bf692d6d24357c4a3b36b098131bc30372378 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 8e2cfbdce0cd028a6521c6e073f148e0f7efac7c Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="yac.add" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -69,7 +69,7 @@
       <title>Permet de s'assurer que l'élément est stocké</title>
       <programlisting role="php">
        <![CDATA[
-       while(!$yac->set("key", "vale));
+       while(!$yac->set("key", "value"));
        ]]>
       </programlisting> 
      </example>

--- a/reference/yaf/yaf_route_rewrite/assemble.xml
+++ b/reference/yaf/yaf_route_rewrite/assemble.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: c9389e4a0e96801fd14d91336ff3f12e45929a73 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 8e2cfbdce0cd028a6521c6e073f148e0f7efac7c Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="yaf-route-rewrite.assemble" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -56,7 +56,7 @@
    <title>Exemple avec <function>Yaf_Route_Rewrite::assemble</function></title>
    <programlisting role="php">
 <![CDATA[
-router = new Yaf_Router();
+$router = new Yaf_Router();
 
 $route  = new Yaf_Route_Rewrite(
                 "/product/:name/:id/*",


### PR DESCRIPTION
Réplique côté FR les corrections d'exemples de code de l'upstream (variables indéfinies, point en trop, opérateurs/points-virgules manquants, noms de classe/méthode erronés) sur les 18 fichiers concernés.

Fixes #2959
