### PR TITLE
[Sync EN] mysqli: A deprecation notice for mysqli_execute

### DIFF
--- a/reference/mysqli/functions/mysqli-execute.xml
+++ b/reference/mysqli/functions/mysqli-execute.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: bc0556b65588379cb86511d5a0ff8ab4684e1d33 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: d7a97693b4683a8c116ac4ba2e25731f5dcb8890 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 
 <refentry xml:id="function.mysqli-execute" xmlns="http://docbook.org/ns/docbook">
@@ -9,21 +8,15 @@
   <refpurpose>&Alias; <function>mysqli_stmt_execute</function></refpurpose>
  </refnamediv>
 
+ <refsynopsisdiv>
+  &warn.deprecated.function-8-5-0;
+ </refsynopsisdiv>
+
  <refsect1 role="description">
   &reftitle.description;
   <para>
    &info.function.alias; <function>mysqli_stmt_execute</function>.
   </para>
- </refsect1>
-
- <refsect1 role="notes">
-  &reftitle.notes;
-  <note>
-   <para>
-    <function>mysqli_execute</function> est fortement déconseillée et devrait être
-    supprimée prochainement.
-   </para>
-  </note>
  </refsect1>
 
  <refsect1 role="seealso">


### PR DESCRIPTION
Synchronise avec le changement EN : déplace l'avis de dépréciation dans `<refsynopsisdiv>` avec l'entité `&warn.deprecated.function-8-5-0;` et supprime le bloc de notes.

Fixes #2968