### PR TITLE
[Sync EN] Cubrid: Fix the broken cubrid_prepare description

### DIFF
--- a/reference/cubrid/functions/cubrid-prepare.xml
+++ b/reference/cubrid/functions/cubrid-prepare.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 22492de2eede0a31a4ac486489d5475e1536354d Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 5acad2fc911ee95b2293ece98dfb45a64b91ae14 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.cubrid-prepare">
  <refnamediv>
@@ -17,16 +16,18 @@
    <methodparam choice="opt"><type>int</type><parameter>option</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
   <simpara>
-   La fonction <function>cubrid_prepare</function> prépare une requête SQL pour un
-   gestionnaire de connexion fourni. Cette requête SQL pré-compilée sera incluse dans
-   la fonction <function>cubrid_prepare</function>.
+   La fonction <function>cubrid_prepare</function> compile une requête SQL pour un
+   gestionnaire de connexion donné et retourne un gestionnaire qui représente la requête
+   pré-compilée.
   </simpara>
   <simpara>
-   De plus, il est possible d'utiliser cette requête à plusieurs reprises ou pour traiter
-   de gros volumes de données. Une seule requête peut être utilisée et il est possible d'y
-   placer des variables. L'ajout d'une variable se fait lorsque l'on veut
-   lier une valeur dans la clause VALUES ou WHERE d'une requête. Il est à noter qu'il est
-   autorisé de lier une valeur à une variable (?) uniquement en utilisant la fonction
+   Une requête préparée peut être exécutée plusieurs fois, ce qui est efficace pour une
+   exécution répétée ou pour traiter de gros volumes de données. Une seule requête peut
+   être utilisée, et un paramètre peut être marqué par un point d'interrogation
+   (<literal>?</literal>) à l'emplacement approprié dans la requête SQL. Un paramètre est
+   ajouté lors de la liaison d'une valeur dans la clause <literal>VALUES</literal> d'une
+   instruction <literal>INSERT</literal> ou dans la clause <literal>WHERE</literal>. Il
+   est à noter qu'une valeur ne peut être liée à un paramètre qu'en utilisant la fonction
    <function>cubrid_bind</function>.
   </simpara>
  </refsect1>


### PR DESCRIPTION
Synchronise avec le changement EN : réécrit la description de <function>cubrid_prepare</function> pour la clarifier et ajoute le balisage <literal> sur les termes SQL.

Fixes #2969