### PR TITLE
[Sync EN] reflection: ReflectionFunction::__construct() example expects bool param

### DIFF
--- a/reference/reflection/reflectionfunction/construct.xml
+++ b/reference/reflection/reflectionfunction/construct.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 525aa5f198d482c0d03be54ddee5af13b376ab99 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 629dfc9ec496d66c49b626dfc72a4981e74d6250 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="reflectionfunction.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -89,12 +89,12 @@ function dumpReflectionFunction($func)
     );
 
     // Affiche les commentaires de documentation
-    printf("---> Documentation:\n %s\n", var_export($func->getDocComment(), 1));
+    printf("---> Documentation:\n %s\n", var_export($func->getDocComment(), true));
 
     // Affiche les variables statiques existantes
     if ($statics = $func->getStaticVariables())
     {
-        printf("---> Static variables: %s\n", var_export($statics, 1));
+        printf("---> Static variables: %s\n", var_export($statics, true));
     }
 }
 


### PR DESCRIPTION
Synchronise l'exemple avec le changement EN : utilise `true` au lieu de `1` comme second argument de `var_export()`.

Fixes #2966