### PR TITLE
[Sync EN] appendix 8.4 property hooks: improve terminology

### DIFF
--- a/appendices/migration84/new-features.xml
+++ b/appendices/migration84/new-features.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 525aa5f198d482c0d03be54ddee5af13b376ab99 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: d7efc67559999c1dda0f65c90617b60c6872a61b Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <sect1 xml:id="migration84.new-features">
  <title>Nouvelles fonctionnalités</title>
@@ -54,6 +54,8 @@ $p->firstName = 'peter';
 print $p->firstName; // Affiche "Peter"
 $p->lastName = 'Peterson';
 print $p->fullName; // Affiche "Peter Peterson"
+
+$p->fullName = "Peter 'Pete' Peterson"; // Lève une Error : "Property Person::$fullName is read-only"
 ]]>
     </programlisting>
    </informalexample>


### PR DESCRIPTION
Synchronise l'exemple de property hooks avec le changement EN : ajoute la ligne qui montre l'Error levée lors de l'écriture dans une propriété virtuelle en lecture seule.

Fixes #2965