### PR TITLE
[Sync EN] Add PHP 8.4.0 changelog entries for Intl and MBString pages

### DIFF
--- a/reference/intl/idn/idn-to-ascii.xml
+++ b/reference/intl/idn/idn-to-ascii.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: e908bfda98eb9fe16fb2c1b5773f312e5c684ee3  Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 1be57c2d7d7306b6167a4305059fe1abe8911699 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <!-- CREDITS: DAnnebicque -->
 
@@ -95,6 +95,21 @@
       </row>
      </thead>
      <tbody>
+      <row>
+       <entry>8.4.0</entry>
+       <entry>
+        Lance désormais une <exceptionname>ValueError</exceptionname>
+        si le paramètre <parameter>domain</parameter> est vide.
+       </entry>
+      </row>
+      <row>
+       <entry>8.4.0</entry>
+       <entry>
+        Lance désormais une <exceptionname>ValueError</exceptionname>
+        si le paramètre <parameter>variant</parameter> n'est pas
+        <constant>INTL_IDNA_VARIANT_UTS46</constant>.
+       </entry>
+      </row>
       <row>
        <entry>7.4.0</entry>
        <entry>

--- a/reference/intl/idn/idn-to-utf8.xml
+++ b/reference/intl/idn/idn-to-utf8.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: d6aee4a5004f7d532f24c06ea2ab2ac0b91b8664 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 1be57c2d7d7306b6167a4305059fe1abe8911699 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <!-- CREDITS: DAnnebicque -->
 
@@ -98,6 +98,21 @@
       </row>
      </thead>
      <tbody>
+      <row>
+       <entry>8.4.0</entry>
+       <entry>
+        Lance désormais une <exceptionname>ValueError</exceptionname>
+        si le paramètre <parameter>domain</parameter> est vide.
+       </entry>
+      </row>
+      <row>
+       <entry>8.4.0</entry>
+       <entry>
+        Lance désormais une <exceptionname>ValueError</exceptionname>
+        si le paramètre <parameter>variant</parameter> n'est pas
+        <constant>INTL_IDNA_VARIANT_UTS46</constant>.
+       </entry>
+      </row>
       <row>
        <entry>7.4.0</entry>
        <entry>

--- a/reference/mbstring/functions/mb-strcut.xml
+++ b/reference/mbstring/functions/mb-strcut.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 92f1b8b177eb5730382abf9f27bae868f1bb636f Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 1be57c2d7d7306b6167a4305059fe1abe8911699 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="function.mb-strcut" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -112,6 +112,12 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.4.0</entry>
+      <entry>
+       Le comportement est désormais plus cohérent sur les chaînes <literal>UTF-8</literal> et <literal>UTF-16</literal> invalides.
+      </entry>
+     </row>
      &mbstring.changelog.encoding-nullable;
     </tbody>
    </tgroup>

--- a/reference/mbstring/functions/mb-substr.xml
+++ b/reference/mbstring/functions/mb-substr.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 92f1b8b177eb5730382abf9f27bae868f1bb636f Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 1be57c2d7d7306b6167a4305059fe1abe8911699 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="function.mb-substr" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -99,6 +99,16 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.4.0</entry>
+      <entry>
+       Sur les chaînes invalides (celles comportant des erreurs d'encodage),
+       les indices de caractères sont désormais interprétés de la même manière
+       que la plupart des autres fonctions mbstring. Cela signifie que les indices
+       de caractères retournés par <function>mb_strpos</function> peuvent être
+       passés directement.
+      </entry>
+     </row>
      &mbstring.changelog.encoding-nullable;
     </tbody>
    </tgroup>


### PR DESCRIPTION
Synchronise les entrées de changelog 8.4.0 ajoutées en amont pour idn_to_ascii, idn_to_utf8, mb_strcut et mb_substr.

Fixes #2975