### PR TITLE
[Sync EN] Add PHP 8.4.0 changelog entries for SPL, Standard, and Filesystem pages

### DIFF
--- a/reference/filesystem/functions/tempnam.xml
+++ b/reference/filesystem/functions/tempnam.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: d1cacac75c04a115ee9b464015ce8e7782bd1517 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 17ebcd2ea14b405b781bd93aea6fa7219b6e29ae Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="function.tempnam" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -72,6 +72,14 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.4.0</entry>
+      <entry>
+       Le nom des fichiers créés par <function>tempnam</function> est
+       désormais plus long de 13 octets. La longueur totale dépend
+       toujours de la plateforme.
+      </entry>
+     </row>
      <row>
       <entry>7.1.0</entry>
       <entry>

--- a/reference/spl/splfixedarray.xml
+++ b/reference/spl/splfixedarray.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: dams Status: ready -->
+<!-- EN-Revision: 17ebcd2ea14b405b781bd93aea6fa7219b6e29ae Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <reference xml:id="class.splfixedarray" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>&class.theclass; <classname>SplFixedArray</classname></title>
@@ -69,6 +69,17 @@
       </row>
      </thead>
      <tbody>
+      <row>
+       <entry>8.4.0</entry>
+       <entry>
+        Les accès hors limites dans <classname>SplFixedArray</classname> lèvent
+        désormais des exceptions de type <exceptionname>OutOfBoundsException</exceptionname>
+        au lieu de <exceptionname>RuntimeException</exceptionname>.
+        Comme <exceptionname>OutOfBoundsException</exceptionname> est une classe
+        fille de <exceptionname>RuntimeException</exceptionname>, aucun changement
+        de comportement n'apparaît lors de la capture de ces exceptions.
+       </entry>
+      </row>
       <row>
        <entry>8.2.0</entry>
        <entry>

--- a/reference/var/functions/debug-zval-dump.xml
+++ b/reference/var/functions/debug-zval-dump.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 2a5223230bf6177c225003ca30c63f48ef266cc0 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 17ebcd2ea14b405b781bd93aea6fa7219b6e29ae Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.debug-zval-dump" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -51,6 +51,30 @@
    &return.void;
   </para>
  </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.4.0</entry>
+      <entry>
+       <function>debug_zval_dump</function> indique désormais si un
+       tableau est compacté (« packed »).
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+
  <refsect1 role="examples">
   &reftitle.examples;
   <para>

--- a/reference/var/functions/unserialize.xml
+++ b/reference/var/functions/unserialize.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: a9e47cecca7d5834de43b7641baf5d86828bb153 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 17ebcd2ea14b405b781bd93aea6fa7219b6e29ae Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.unserialize" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -171,6 +171,14 @@
         Lève désormais des <exceptionname>TypeError</exceptionname> et
         <exceptionname>ValueError</exceptionname> si l'élément <literal>allowed_classes</literal>
         de <parameter>options</parameter> n'est pas un <type>array</type> de noms de classes.
+       </entry>
+      </row>
+      <row>
+       <entry>8.4.0</entry>
+       <entry>
+        La désérialisation de chaînes utilisant le tag majuscule
+        <literal>"S"</literal> est désormais obsolète ; utiliser le tag
+        minuscule <literal>"s"</literal> à la place.
        </entry>
       </row>
       <row>


### PR DESCRIPTION
Synchronise les entrées de changelog 8.4.0 ajoutées en amont pour tempnam, SplFixedArray, debug_zval_dump (nouvelle section changelog) et unserialize.

Fixes #2976