### PR TITLE
[Sync EN] Add documentation for 6 new pcntl functions (PHP 8.4)

### DIFF
--- a/reference/pcntl/functions/pcntl-forkx.xml
+++ b/reference/pcntl/functions/pcntl-forkx.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: acb474ea92ab6226eaf419a85de05f68c6715a9f Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+<refentry xml:id="function.pcntl-forkx" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>pcntl_forkx</refname>
+  <refpurpose>Crée un processus fils en utilisant forkx(2)</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>int</type><methodname>pcntl_forkx</methodname>
+   <methodparam><type>int</type><parameter>flags</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   La fonction <function>pcntl_forkx</function> crée un processus fils
+   en utilisant l'appel système <literal>forkx(2)</literal>, qui est disponible
+   sur les systèmes illumos et Solaris.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>flags</parameter></term>
+    <listitem>
+     <simpara>
+      Le paramètre <parameter>flags</parameter> contrôle le comportement
+      du fork. Passer <literal>0</literal> pour le comportement par défaut ou
+      <constant>FORK_NOSIGCHLD</constant> pour empêcher l'envoi du signal
+      <constant>SIGCHLD</constant> au processus parent
+      lorsque le processus fils se termine.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   En cas de succès, le PID du processus fils est retourné dans le
+   processus parent, et <literal>0</literal> est retourné
+   dans le processus fils. En cas d'échec, <literal>-1</literal>
+   est retourné dans le contexte du parent, aucun processus fils ne sera
+   créé, et une erreur PHP est levée.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>pcntl_fork</function></member>
+   <member><function>pcntl_rfork</function></member>
+   <member><function>pcntl_waitpid</function></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/pcntl/functions/pcntl-getcpu.xml
+++ b/reference/pcntl/functions/pcntl-getcpu.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: acb474ea92ab6226eaf419a85de05f68c6715a9f Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+<refentry xml:id="function.pcntl-getcpu" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>pcntl_getcpu</refname>
+  <refpurpose>Récupère le numéro du CPU sur lequel le processus appelant s'est exécuté en dernier</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>int</type><methodname>pcntl_getcpu</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   <function>pcntl_getcpu</function> retourne le numéro du CPU sur lequel
+   le processus appelant s'est exécuté en dernier. Cette fonction utilise
+   l'appel système <literal>sched_getcpu(3)</literal> disponible sur Linux.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Retourne le numéro du CPU sous forme d'&integer;.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>pcntl_getcpuaffinity</function></member>
+   <member><function>pcntl_setcpuaffinity</function></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/pcntl/functions/pcntl-getqos-class.xml
+++ b/reference/pcntl/functions/pcntl-getqos-class.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: acb474ea92ab6226eaf419a85de05f68c6715a9f Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+<refentry xml:id="function.pcntl-getqos-class" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>pcntl_getqos_class</refname>
+  <refpurpose>Récupère la classe de qualité de service actuelle du processus</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>Pcntl\QosClass</type><methodname>pcntl_getqos_class</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   Retourne la classe de qualité de service (<acronym>QoS</acronym>) actuelle du processus appelant.
+   Cette fonction n'est disponible que sur macOS, qui utilise les classes <acronym>QoS</acronym> pour
+   gérer l'efficacité énergétique et les performances.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Retourne une valeur de l'énumération <classname>Pcntl\QosClass</classname> représentant
+   la classe <acronym>QoS</acronym> actuelle.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>pcntl_setqos_class</function></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/pcntl/functions/pcntl-setns.xml
+++ b/reference/pcntl/functions/pcntl-setns.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: acb474ea92ab6226eaf419a85de05f68c6715a9f Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+<refentry xml:id="function.pcntl-setns" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>pcntl_setns</refname>
+  <refpurpose>Réassocie le processus appelant à un espace de noms d'un autre processus</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>bool</type><methodname>pcntl_setns</methodname>
+   <methodparam choice="opt"><type class="union"><type>int</type><type>null</type></type><parameter>process_id</parameter><initializer>&null;</initializer></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>nstype</parameter><initializer><constant>CLONE_NEWNET</constant></initializer></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Réassocie le processus appelant à un espace de noms Linux du processus
+   spécifié par <parameter>process_id</parameter>, en utilisant un pidfd obtenu
+   via <literal>pidfd_open(2)</literal> et <literal>setns(2)</literal>.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>process_id</parameter></term>
+    <listitem>
+     <simpara>
+      L'identifiant de processus du processus cible dont l'espace de noms doit être rejoint.
+      Si &null;, le propre PID du processus appelant est utilisé.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>nstype</parameter></term>
+    <listitem>
+     <simpara>
+      Le type d'espace de noms auquel se réassocier. Vaut par défaut
+      <constant>CLONE_NEWNET</constant> (espace de noms réseau).
+      Les valeurs possibles incluent <constant>CLONE_NEWNET</constant>,
+      <constant>CLONE_NEWIPC</constant>,
+      <constant>CLONE_NEWUTS</constant>, et d'autres.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   &return.success;
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>pcntl_unshare</function></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/pcntl/functions/pcntl-setqos-class.xml
+++ b/reference/pcntl/functions/pcntl-setqos-class.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: acb474ea92ab6226eaf419a85de05f68c6715a9f Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+<refentry xml:id="function.pcntl-setqos-class" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>pcntl_setqos_class</refname>
+  <refpurpose>Définit la classe de qualité de service du processus</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>void</type><methodname>pcntl_setqos_class</methodname>
+   <methodparam choice="opt"><type>Pcntl\QosClass</type><parameter>qos_class</parameter><initializer>Pcntl\QosClass::Default</initializer></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Définit la classe de qualité de service (<acronym>QoS</acronym>) du processus appelant.
+   Cette fonction n'est disponible que sur macOS, qui utilise les classes <acronym>QoS</acronym> pour
+   gérer l'efficacité énergétique et les performances.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>qos_class</parameter></term>
+    <listitem>
+     <simpara>
+      La classe <acronym>QoS</acronym> à définir. Doit être l'une des
+      valeurs de l'énumération <classname>Pcntl\QosClass</classname> :
+     </simpara>
+     <simplelist>
+      <member><literal>Pcntl\QosClass::UserInteractive</literal></member>
+      <member><literal>Pcntl\QosClass::UserInitiated</literal></member>
+      <member><literal>Pcntl\QosClass::Default</literal></member>
+      <member><literal>Pcntl\QosClass::Utility</literal></member>
+      <member><literal>Pcntl\QosClass::Background</literal></member>
+     </simplelist>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   &return.void;
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>pcntl_getqos_class</function></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/pcntl/functions/pcntl-wifcontinued.xml
+++ b/reference/pcntl/functions/pcntl-wifcontinued.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: acb474ea92ab6226eaf419a85de05f68c6715a9f Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+<refentry xml:id="function.pcntl-wifcontinued" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>pcntl_wifcontinued</refname>
+  <refpurpose>Vérifie si le processus fils a repris après un arrêt par le contrôle de tâches</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>bool</type><methodname>pcntl_wifcontinued</methodname>
+   <methodparam><type>int</type><parameter>status</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Vérifie si le processus fils qui a provoqué le retour de
+   <function>pcntl_waitpid</function> a repris après un arrêt par le contrôle de tâches.
+   Cette fonction n'est utile que si l'appel à
+   <function>pcntl_waitpid</function> a été effectué en utilisant
+   l'option <constant>WCONTINUED</constant>.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>status</parameter></term>
+    <listitem>
+     &pcntl.parameter.status;
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Retourne &true; si le processus fils qui a provoqué le retour de
+   <function>pcntl_waitpid</function> a repris après un arrêt par le contrôle de tâches,
+   &false; sinon.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>pcntl_waitpid</function></member>
+   <member><function>pcntl_wifstopped</function></member>
+   <member><function>pcntl_wifexited</function></member>
+   <member><function>pcntl_wifsignaled</function></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
Traduction française des 6 nouveaux fichiers pcntl ajoutés en amont (pcntl_forkx, pcntl_getcpu, pcntl_getqos_class, pcntl_setns, pcntl_setqos_class, pcntl_wifcontinued), miroir tag-à-tag de l'EN.

Fixes #2977