### PR TITLE
[Sync EN] Phar::setStub : ajout de la description du paramètre length

### DIFF
--- a/reference/phar/Phar/setStub.xml
+++ b/reference/phar/Phar/setStub.xml
@@ -72,7 +72,7 @@ include 'phar://monphar.phar/unfichier.php';
       <warning>
        <simpara>
         Passer l'argument <parameter>length</parameter> avec une &resource; dans
-        le premier argument est <emphasis>OBSOLÈTE</emphasis> depuis PHP 8.3.0.
+        le premier argument est <emphasis>OBSOLÈTE</emphasis> à partir de PHP 8.3.0.
         Il faut utiliser <literal>$phar->setStub(stream_get_contents($resource))</literal> à la place.
        </simpara>
       </warning>

--- a/reference/phar/Phar/setStub.xml
+++ b/reference/phar/Phar/setStub.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 8a910daad2efdfd29acf6766be8bca7c32c3dd2a Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: d7056bd0948e3dd9316708247933026bd3d560b1 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="phar.setstub">
  <refnamediv>
@@ -15,7 +15,6 @@
   </methodsynopsis>
   &phar.write;
 
-
   <para>
    Cette méthode est utilisée pour ajouter un chargeur PHP à une nouvelle archive Phar, ou
    pour remplacer le conteneur de chargement d'une archive Phar existante.
@@ -23,14 +22,20 @@
   <para>
    Le conteneur de chargement d'une archive Phar est utilisé quand une archive est incluse directement
    comme dans cet exemple :
-  </para>
-  <programlisting role="php">
+   <programlisting role="php">
 <![CDATA[
 <?php
 include 'monphar.phar';
 ?>
-   ]]>
-  </programlisting>
+]]>
+   </programlisting>
+   ou par simple exécution :
+   <screen>
+<![CDATA[
+php monphar.phar
+]]>
+   </screen>
+  </para>
   <para>
    Le chargeur n'est pas utilisé quand un fichier est inclus via le flux <literal>phar</literal>
    comme ceci :
@@ -61,9 +66,16 @@ include 'phar://monphar.phar/unfichier.php';
     <varlistentry>
      <term><parameter>length</parameter></term>
      <listitem>
-      <para>
-       
-      </para>
+      <simpara>
+       Longueur de <parameter>stub</parameter> en octets.
+      </simpara>
+      <warning>
+       <simpara>
+        Passer l'argument <parameter>length</parameter> avec une &resource; dans
+        le premier argument est <emphasis>OBSOLÈTE</emphasis> depuis PHP 8.3.0.
+        Il faut utiliser <literal>$phar->setStub(stream_get_contents($resource))</literal> à la place.
+       </simpara>
+      </warning>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -124,12 +136,14 @@ include 'phar://monphar.phar/unfichier.php';
     <programlisting role="php">
 <![CDATA[
 <?php
+
 try {
     $p = new Phar(dirname(__FILE__) . '/nouveau.phar', 0, 'nouveau.phar');
     $p['a.php'] = '<?php var_dump("Salut");';
     $p->setStub('<?php var_dump("Premier"); Phar::mapPhar("nouveau.phar"); __HALT_COMPILER(); ?>');
     include 'phar://nouveau.phar/a.php';
     var_dump($p->getStub());
+
     $p['b.php'] = '<?php var_dump("Tout le monde");';
     $p->setStub('<?php var_dump("Second"); Phar::mapPhar("nouveau.phar"); __HALT_COMPILER(); ?>');
     include 'phar://nouveau.phar/b.php';

--- a/reference/phar/PharData/setStub.xml
+++ b/reference/phar/PharData/setStub.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4c394e560dac163a0be9098de27153a9f98ef490 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: d7056bd0948e3dd9316708247933026bd3d560b1 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="phardata.setstub">
  <refnamediv>
@@ -27,18 +27,18 @@
     <varlistentry>
      <term><parameter>stub</parameter></term>
      <listitem>
-      <para>
-    Une chaîne de caractères ou un gestionnaire de flux ouvert à utiliser en tant que conteneur de 
-    chargement exécutable pour l'archive phar. Ce paramètre est ignoré.
-      </para>
+      <simpara>
+       Formellement, une chaîne de caractères ou un gestionnaire de flux ouvert à utiliser en tant que
+       conteneur de chargement exécutable pour l'archive phar. Ce paramètre est ignoré.
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>length</parameter></term>
      <listitem>
-      <para>
-       
-      </para>
+      <simpara>
+       <parameter>stub</parameter> en octets. Ce paramètre est ignoré.
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>


### PR DESCRIPTION
Synchronise avec l'amont la description du paramètre `length` de `Phar::setStub` et `PharData::setStub`, l'avertissement d'obsolescence (PHP 8.3.0) et l'exemple d'inclusion (ajout du cas `php monphar.phar`).

Fixes #2981