### PR TITLE
[Sync EN] unserialization: allowed_classes does not affect enums

### DIFF
--- a/language/enumerations.xml
+++ b/language/enumerations.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4c158f4a34c8f869a43f9f0bd5a4897fb35cec89 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 8af3521cb43f54c652baaf8dbbcb786b79a5d04e Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
  <chapter xml:id="language.enumerations" xmlns="http://docbook.org/ns/docbook" annotations="interactive">
   <title>Les énumérations</title>
@@ -835,6 +835,12 @@ print serialize(Suit::Hearts);
   <para>
    Lors de la désérialisation, si un enum et un cas ne peuvent pas être trouvés pour correspondre à une valeur sérialisée,
    un avertissement sera émis et un &false; sera retourné.</para>
+
+  <simpara>
+   L'option <literal>allowed_classes</literal> de
+   <function>unserialize</function> n'affecte pas les
+   <link linkend="language.enumerations">énumérations</link>.
+  </simpara>
 
   <para>
    Si une Enum pure est sérialisée en JSON, une erreur sera générée. Si une Enum avec valeur de base

--- a/reference/var/functions/unserialize.xml
+++ b/reference/var/functions/unserialize.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 17ebcd2ea14b405b781bd93aea6fa7219b6e29ae Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 8af3521cb43f54c652baaf8dbbcb786b79a5d04e Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.unserialize" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -103,6 +103,9 @@
            <simpara>
             Le fait d'omettre cette option revient à le définir comme &true; :
             PHP va tenter d'instancier les objets de n'importe quelle classe.
+           </simpara>
+           <simpara>
+            Cette option n'affecte pas les <link linkend="language.enumerations">énumérations</link>.
            </simpara>
           </entry>
          </row>


### PR DESCRIPTION
Sync EN (commit 8af3521) : ajoute la précision que l'option allowed_classes de unserialize() n'affecte pas les énumérations, dans language/enumerations.xml et reference/var/functions/unserialize.xml.

Fixes #2986