### PR TITLE
[Sync EN] Changelog PHP 8.5 pour les fonctions readline

### DIFF
--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 525aa5f198d482c0d03be54ddee5af13b376ab99 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: be246a268d0d5ab0b215c429cb031e70c98327ef Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <!-- Relecture des Notes, Précautions, Avertissements, Astuces, Divers et Retour le 2018-12-29 par girgias -->
 
@@ -906,6 +906,13 @@ de ce manuel pour une description des <literal xmlns="http://docbook.org/ns/docb
 
 <!ENTITY return.type.true.84 '<row xmlns="http://docbook.org/ns/docbook">
  <entry>8.4.0</entry>
+ <entry>
+  Le type de retour est maintenant &true;, auparavant il était <type>bool</type>.
+ </entry>
+</row>'>
+
+<!ENTITY return.type.true.85 '<row xmlns="http://docbook.org/ns/docbook">
+ <entry>8.5.0</entry>
  <entry>
   Le type de retour est maintenant &true;, auparavant il était <type>bool</type>.
  </entry>

--- a/reference/readline/functions/readline-add-history.xml
+++ b/reference/readline/functions/readline-add-history.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 53208f9bd0a035a4e1409ba700106540474c9ef1 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: be246a268d0d5ab0b215c429cb031e70c98327ef Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.readline-add-history">
  <refnamediv>
@@ -39,6 +38,24 @@
    &return.true.always;
   </simpara>
  </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     &return.type.true.85;
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+
 </refentry>
 <!-- Keep this comment at the end of the file
 Local variables:

--- a/reference/readline/functions/readline-callback-handler-install.xml
+++ b/reference/readline/functions/readline-callback-handler-install.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 53208f9bd0a035a4e1409ba700106540474c9ef1 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: be246a268d0d5ab0b215c429cb031e70c98327ef Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.readline-callback-handler-install">
  <refnamediv>
@@ -58,6 +57,23 @@
   <simpara>
    &return.true.always;
   </simpara>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     &return.type.true.85;
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/readline/functions/readline-clear-history.xml
+++ b/reference/readline/functions/readline-clear-history.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 53208f9bd0a035a4e1409ba700106540474c9ef1 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: be246a268d0d5ab0b215c429cb031e70c98327ef Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.readline-clear-history">
  <refnamediv>
@@ -30,6 +29,24 @@
    &return.true.always;
   </simpara>
  </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     &return.type.true.85;
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+
 </refentry>
 <!-- Keep this comment at the end of the file
 Local variables:


### PR DESCRIPTION
Sync EN (commit be246a2) : ajoute l'entité return.type.true.85 (language-snippets.ent) et la section changelog 8.5.0 dans readline_add_history, readline_callback_handler_install et readline_clear_history.

Fixes #2984