### PR TITLE
[Sync EN] PDO : type des constantes int vers bool (PHP 8.4.0)

### DIFF
--- a/reference/pdo/constants.xml
+++ b/reference/pdo/constants.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 7e384b24f7e37c6b4caf735f3601179cc65ef8f9 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 5d8e96f9b174f7471daebce760657eb0f190b0ba Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <appendix xml:id="pdo.constants" xmlns="http://docbook.org/ns/docbook">
  &reftitle.constants;
@@ -226,12 +226,16 @@
    <varlistentry xml:id="pdo.constants.attr-autocommit">
     <term>
      <constant>PDO::ATTR_AUTOCOMMIT</constant>
-     (<type>int</type>)
+     (<type>bool</type>)
     </term>
     <listitem>
      <simpara>
       Si cette valeur est &false;, PDO tente de désactiver l'autocommit afin que la
       connexion commence une transaction.
+     </simpara>
+     <simpara>
+      À partir de PHP 8.4.0, cette constante est de type <type>bool</type> ;
+      elle était auparavant de type <type>int</type>.
      </simpara>
     </listitem>
    </varlistentry>
@@ -483,11 +487,19 @@
    <varlistentry xml:id="pdo.constants.attr-emulate-prepares">
     <term>
      <constant>PDO::ATTR_EMULATE_PREPARES</constant>
-     (<type>int</type>)
+     (<type>bool</type>)
     </term>
     <listitem>
      <simpara>
-
+      Active ou désactive l'émulation des requêtes préparées. Certains pilotes
+      ne supportent pas les requêtes préparées natives ou n'ont qu'un support
+      limité de celles-ci. Lorsqu'elle vaut &true;, PDO émule toujours les
+      requêtes préparées ; lorsqu'elle vaut &false;, il utilise les requêtes
+      préparées natives du pilote.
+     </simpara>
+     <simpara>
+      À partir de PHP 8.4.0, cette constante est de type <type>bool</type> ;
+      elle était auparavant de type <type>int</type>.
      </simpara>
     </listitem>
    </varlistentry>

--- a/reference/pdo_dblib/pdo-dblib.xml
+++ b/reference/pdo_dblib/pdo-dblib.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 608815b2f52cc7dae75eb02e27f457aad1e5e977 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 5d8e96f9b174f7471daebce760657eb0f190b0ba Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <reference xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xml:id="class.pdo-dblib" role="class">
  <title>La classe Pdo\Dblib</title>
@@ -54,7 +54,7 @@
      <fieldsynopsis>
       <modifier>public</modifier>
       <modifier>const</modifier>
-      <type>int</type>
+      <type>bool</type>
       <varname linkend="pdo-dblib.constants.attr-stringify-uniqueidentifier">Pdo\Dblib::ATTR_STRINGIFY_UNIQUEIDENTIFIER</varname>
      </fieldsynopsis>
      <fieldsynopsis>
@@ -78,7 +78,7 @@
      <fieldsynopsis>
       <modifier>public</modifier>
       <modifier>const</modifier>
-      <type>int</type>
+      <type>bool</type>
       <varname linkend="pdo-dblib.constants.attr-datetime-convert">Pdo\Dblib::ATTR_DATETIME_CONVERT</varname>
      </fieldsynopsis>
 
@@ -116,6 +116,8 @@
      <term><constant>Pdo\Dblib::ATTR_STRINGIFY_UNIQUEIDENTIFIER</constant></term>
      <listitem>
       <simpara>
+       À partir de PHP 8.4.0, cette constante est de type <type>bool</type> ;
+       elle était auparavant de type <type>int</type>.
       </simpara>
      </listitem>
     </varlistentry>
@@ -152,6 +154,10 @@
        format défini par l'utilisateur ou par la locale, tel que spécifié dans
        le fichier FreeTDS <filename>locales.conf</filename>. Par défaut, cet
        attribut vaut &false;.
+      </simpara>
+      <simpara>
+       À partir de PHP 8.4.0, cette constante est de type <type>bool</type> ;
+       elle était auparavant de type <type>int</type>.
       </simpara>
      </listitem>
     </varlistentry>

--- a/reference/pdo_mysql/constants.xml
+++ b/reference/pdo_mysql/constants.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: b2a7a5fab7231fa8634096f111ae0fa0dc60bcfe Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 5d8e96f9b174f7471daebce760657eb0f190b0ba Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <section xml:id="ref.pdo-mysql.constants" xmlns="http://docbook.org/ns/docbook">
  &reftitle.constants;
@@ -87,11 +86,15 @@
   <varlistentry xml:id="pdo.constants.mysql-attr-direct-query">
    <term>
     <constant>PDO::MYSQL_ATTR_DIRECT_QUERY</constant>
-    (<type>int</type>)
+    (<type>bool</type>)
    </term>
    <listitem>
     <simpara>
      &Alias; <constant>PDO::ATTR_EMULATE_PREPARES</constant>
+    </simpara>
+    <simpara>
+     À partir de PHP 8.4.0, cette constante est de type <type>bool</type> ;
+     elle était auparavant de type <type>int</type>.
     </simpara>
    </listitem>
   </varlistentry>


### PR DESCRIPTION
Sync EN (commit 5d8e96f) : passe le type de plusieurs constantes PDO de int à bool (ATTR_AUTOCOMMIT, ATTR_EMULATE_PREPARES, MYSQL_ATTR_DIRECT_QUERY, Pdo\Dblib::ATTR_STRINGIFY_UNIQUEIDENTIFIER et ATTR_DATETIME_CONVERT) avec la note 8.4.0, et traduit la description ajoutée de ATTR_EMULATE_PREPARES.

Fixes #2983