### PR TITLE
[Sync EN] SPL : entrées de changelog des dépréciations PHP 8.5.0

### DIFF
--- a/reference/spl/functions/spl-autoload-unregister.xml
+++ b/reference/spl/functions/spl-autoload-unregister.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 60809ebcf7d0c261b2f00e093e4fab70326ffc7b Maintainer: yannick Status: ready -->
+<!-- EN-Revision: e5c8e7add9291c70be2ecd046de6ecfd034545a9 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.spl-autoload-unregister" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>

--- a/reference/spl/splobjectstorage/attach.xml
+++ b/reference/spl/splobjectstorage/attach.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: a0d62151102e4bf83e2bb4068782757d20ba086d Maintainer: yannick Status: ready -->
+<!-- EN-Revision: e5c8e7add9291c70be2ecd046de6ecfd034545a9 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="splobjectstorage.attach" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>

--- a/reference/spl/splobjectstorage/contains.xml
+++ b/reference/spl/splobjectstorage/contains.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: ce98b568f85353c4bf263133f09c4db9294833f9 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: e5c8e7add9291c70be2ecd046de6ecfd034545a9 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="splobjectstorage.contains" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>

--- a/reference/spl/splobjectstorage/detach.xml
+++ b/reference/spl/splobjectstorage/detach.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: ce98b568f85353c4bf263133f09c4db9294833f9 Maintainer: dams Status: ready -->
+<!-- EN-Revision: e5c8e7add9291c70be2ecd046de6ecfd034545a9 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="splobjectstorage.detach" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>


### PR DESCRIPTION
Synchronisation des entrées de changelog signalant les dépréciations PHP 8.5.0 sur quatre pages SPL. Mise à jour des en-têtes EN-Revision.