### PR TITLE
[Sync EN] reflection : entrées de changelog des dépréciations PHP 8.5.0

### DIFF
--- a/reference/reflection/reflectionclass/getconstant.xml
+++ b/reference/reflection/reflectionclass/getconstant.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: ec2fe9a592f794978114ef5021db9f1d00c2e05d Maintainer: yannick Status: ready -->
+<!-- EN-Revision: e5c8e7add9291c70be2ecd046de6ecfd034545a9 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="reflectionclass.getconstant" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>

--- a/reference/reflection/reflectionmethod/setaccessible.xml
+++ b/reference/reflection/reflectionmethod/setaccessible.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: ce98b568f85353c4bf263133f09c4db9294833f9 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: e5c8e7add9291c70be2ecd046de6ecfd034545a9 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="reflectionmethod.setaccessible" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>

--- a/reference/reflection/reflectionproperty/setaccessible.xml
+++ b/reference/reflection/reflectionproperty/setaccessible.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: ce98b568f85353c4bf263133f09c4db9294833f9 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: e5c8e7add9291c70be2ecd046de6ecfd034545a9 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="reflectionproperty.setaccessible" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>


### PR DESCRIPTION
Synchronisation EN des entrées de changelog signalant les dépréciations PHP 8.5.0 pour trois pages reflection. Bump de l'EN-Revision (le contenu traduit était déjà présent mais le hash n'avait pas été mis à jour).