### PR TITLE
[Sync EN] reflection : correction des types de retour (getTraits, canBePassedByValue)

### DIFF
--- a/reference/reflection/reflectionclass/gettraits.xml
+++ b/reference/reflection/reflectionclass/gettraits.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: ca840c9a6d665e60a7de48b57a5b6440c0d3b0c1 Maintainer: jpauli Status: ready -->
+<!-- EN-Revision: 93906cd3b6cf8f7217503dba4d994a1ebd32d4ac Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="reflectionclass.gettraits" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,9 +13,9 @@
    <modifier>public</modifier> <type>array</type><methodname>ReflectionClass::getTraits</methodname>
    <void/>
   </methodsynopsis>
-  <para>
+  <simpara>
    Retourne un tableau des traits utilisés par cette classe.
-  </para>
+  </simpara>
 
  </refsect1>
 
@@ -26,11 +26,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retourne un tableau avec le nom du trait en clé et des instances
    <classname>ReflectionClass</classname> des traits en question en valeurs.
-   Retourne &null; en cas d'erreur.
-  </para>
+  </simpara>
  </refsect1>
 
 </refentry>

--- a/reference/reflection/reflectionparameter/canbepassedbyvalue.xml
+++ b/reference/reflection/reflectionparameter/canbepassedbyvalue.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: ec2fe9a592f794978114ef5021db9f1d00c2e05d Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 93906cd3b6cf8f7217503dba4d994a1ebd32d4ac Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="reflectionparameter.canbepassedbyvalue" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -22,11 +22,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retourne &true; si le paramètre peut être passé par valeur,
    &false; sinon.
-   Retourne &null; si une erreur survient.
-  </para>
+  </simpara>
  </refsect1>
 
 </refentry>


### PR DESCRIPTION
Synchronisation EN : retrait du `null` inexact dans les valeurs de retour de `ReflectionClass::getTraits()` et `ReflectionParameter::canBePassedByValue()`. Conversion des paragraphes concernés en `<simpara>` pour suivre l'amont.