### PR TITLE
[Sync EN] chr/ord : entrées de changelog des dépréciations PHP 8.5.0

### DIFF
--- a/reference/strings/functions/chr.xml
+++ b/reference/strings/functions/chr.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 45042fef652f1b4e904e809fcbfcf31f6c60670b Maintainer: yannick Status: ready -->
+<!-- EN-Revision: e5c8e7add9291c70be2ecd046de6ecfd034545a9 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://docbook.org/ns/docbook" xml:id="function.chr">
  <refnamediv>

--- a/reference/strings/functions/ord.xml
+++ b/reference/strings/functions/ord.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 45042fef652f1b4e904e809fcbfcf31f6c60670b Maintainer: yannick Status: ready -->
+<!-- EN-Revision: e5c8e7add9291c70be2ecd046de6ecfd034545a9 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://docbook.org/ns/docbook" xml:id="function.ord">
  <refnamediv>


### PR DESCRIPTION
Synchronisation des pages chr et ord avec la doc EN : ajout des entrées de changelog signalant la dépréciation en PHP 8.5.0. Bump de l'EN-Revision.