### PR TITLE
[Sync EN] Divers : intlchar/digit, pdo_cubrid/reference

### DIFF
--- a/reference/intl/intlchar/digit.xml
+++ b/reference/intl/intlchar/digit.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e166139c786f6fd72a5f856c14027a3c22a8ce7a Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: fe67f9ad47e7f04f50c4ec1366bdbcbd8ab940f2 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="intlchar.digit" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>

--- a/reference/pdo_cubrid/reference.xml
+++ b/reference/pdo_cubrid/reference.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 59ce48edd7eb51e3f9bc19828386ce053dd95690 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: e3654dc683c7a5b73df80549057ddbfceea00266 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <reference xmlns="http://docbook.org/ns/docbook" xml:id="ref.pdo-cubrid"><?phpdoc extension-membership="pecl" ?>
  <title>Fonctions du pilote PDO CUBRID (PDO_CUBRID)</title>


### PR DESCRIPTION
Synchronisation de deux fichiers avec leurs révisions EN respectives. Les modifications EN (réordonnancement d'une sortie d'exemple et correction d'une coquille) étaient déjà correctes côté français : seuls les en-têtes EN-Revision sont mis à jour.