### PR TITLE
[Sync EN] CLI : changements SAPI 8.5 (cli_get/set_process_title)

### DIFF
--- a/reference/info/functions/cli-get-process-title.xml
+++ b/reference/info/functions/cli-get-process-title.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: a331ac8a86bb5929b79be9a369fac1e3af516241 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: b08b472de7041be8dbae153556b714efa93f20c0 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.cli-get-process-title" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>

--- a/reference/info/functions/cli-set-process-title.xml
+++ b/reference/info/functions/cli-set-process-title.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 2df224f44552cfc88fad705cca33c4cdb01d62ed Maintainer: yannick Status: ready -->
+<!-- EN-Revision: b08b472de7041be8dbae153556b714efa93f20c0 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="function.cli-set-process-title" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -16,12 +15,12 @@
    <methodparam><type>string</type><parameter>title</parameter></methodparam>
   </methodsynopsis>
 
-  <para>
+  <simpara>
    Définit le titre du processus visible avec des outils comme
    <command>top</command> et <command>ps</command>. Cette fonction
    n'est disponible qu'en mode
    <link linkend="features.commandline">CLI</link>.
-  </para>
+  </simpara>
 
  </refsect1>
 
@@ -31,9 +30,9 @@
    <varlistentry>
     <term><parameter>title</parameter></term>
     <listitem>
-     <para>
-      Le nouveau titre
-     </para>
+     <simpara>
+      Le nouveau titre.
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -41,18 +40,18 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="errors">
   &reftitle.errors;
 
-  <para>
+  <simpara>
    Une alerte de niveau <constant>E_WARNING</constant> sera générée si le système
    sous-jacent n'est pas supporté.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">
@@ -81,10 +80,8 @@
 
  <refsect1 role="examples">
   &reftitle.examples;
-  <para>
-   <example>
-    <title>Exemple avec <function>cli_set_process_title</function></title>
-    <programlisting role="php">
+  <informalexample>
+   <programlisting role="php">
 <![CDATA[
 <?php
 $title = "Mon super script PHP";
@@ -99,18 +96,15 @@ if (!cli_set_process_title($title)) {
 }
 ?>
 ]]>
-    </programlisting>
-   </example>
-  </para>
+   </programlisting>
+  </informalexample>
  </refsect1>
 
  <refsect1 role="seealso">
   &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><function>cli_get_process_title</function></member>
-   </simplelist>
-  </para>
+  <simplelist>
+   <member><function>cli_get_process_title</function></member>
+  </simplelist>
  </refsect1>
 
 </refentry>


### PR DESCRIPTION
Synchronisation des pages cli_get_process_title et cli_set_process_title avec l'anglais (changements SAPI 8.5). Ajout de l'entrée de changelog 8.5.0 et passage des paragraphes inline en simpara.