### PR TITLE
Sync EN: fix bpftrace note about environment variable

### DIFF
--- a/features/dtrace.xml
+++ b/features/dtrace.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 939350f9b52be4b91e04ec1a5d41995e63aa5150 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 7c966c94fde8a9bb4e52975b559dc0bb0cb2ef72 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <chapter xml:id="features.dtrace" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>DTrace Traçage dynamique</title>
@@ -593,7 +593,7 @@ probe process("sapi/cli/php").provider("php").mark("request__startup") {
     par PID avec <literal>-p</literal> si nécessaire.
    </simpara>
    <simpara>
-    Il faut s'assurer que le binaire cible est compilé avec DTrace et que l'environnement est correctement configuré.
+    Il faut s'assurer que le binaire cible est compilé avec DTrace et que la variable d'environnement est correctement configurée.
     Voir <link linkend="features.dtrace.install">Configurer PHP pour les sondes statiques DTrace</link> pour les détails.
    </simpara>
    <para>


### PR DESCRIPTION
Aligne la note bpftrace sur le wording EN : la variable d'environnement (et non l'environnement) doit être correctement configurée.

Fixes #3002