### PR TITLE
Sync EN: make the boolean example executable

### DIFF
--- a/language/types/boolean.xml
+++ b/language/types/boolean.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4657c1173e6b3852cdc8db4fc64f380d10ebae0c Maintainer: yannick Status: ready -->
+<!-- EN-Revision: ee66d210fb1dd5799fbca9881c6ac2560a19579d Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes Maintainer: mikaelkael -->
 
 <sect1 xml:id="language.types.boolean">
@@ -21,7 +21,10 @@
    <programlisting role="php">
 <![CDATA[
 <?php
+
 $foo = true; // assigne la valeur TRUE à $foo
+
+var_dump($foo); // bool(true)
 ?>
 ]]>
    </programlisting>
@@ -37,6 +40,7 @@ $foo = true; // assigne la valeur TRUE à $foo
    <programlisting role="php">
 <![CDATA[
 <?php
+
 $action = "show_version";
 $show_separators = true;
 


### PR DESCRIPTION
Rend le premier exemple de la page booléen exécutable en ajoutant un var_dump, en miroir du wording EN.

Fixes #2997