### PR TITLE
Sync EN: proc_close attend la fin du processus, correction du grammaire des valeurs de retour

### DIFF
--- a/reference/exec/functions/proc-close.xml
+++ b/reference/exec/functions/proc-close.xml
@@ -1,14 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: ef623ccf442df416da4e5bc254b4c5d4f6df9475 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 970d3aa7fdf5c714b584cbe67ebf9e32a1e8b0d3 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id='function.proc-close' xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>proc_close</refname>
   <refpurpose>
-   Ferme un processus ouvert par <function>proc_open</function> et retourne
-   le code de sortie de ce processus
+   Ferme les pipes vers un processus ouvert par <function>proc_open</function>,
+   attend qu'il se termine, et retourne son code de sortie
   </refpurpose>
  </refnamediv>
 
@@ -49,9 +48,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
-   Retourne le code de sortie du processus ou <literal>-1</literal> en cas d'échec.
-  </para>
+  <simpara>
+   Retourne le statut de fin du processus qui a été exécuté. En cas d'erreur,
+   <literal>-1</literal> est retourné.
+  </simpara>
   &note.sigchild;
  </refsect1>
   <refsect1 role="changelog">


### PR DESCRIPTION
Aligne le refpurpose de proc_close sur le wording EN (ferme les pipes et attend la fin du processus, ne le ferme pas) et convertit le bloc des valeurs de retour en simpara.

Fixes #2998