### PR TITLE
Sync EN: documente l'élément mode de fichier des descripteurs de proc_open

### DIFF
--- a/reference/exec/functions/proc-open.xml
+++ b/reference/exec/functions/proc-open.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 6667724b8a42ba501172bc874dd1644a6744be0f Maintainer: yannick Status: ready -->
+<!-- EN-Revision: f50098447455250c9f92eed119248aaa30920100 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.proc-open" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -82,11 +81,12 @@
        <simplelist>
         <member>
          Un tableau décrivant le pipe à passer au processus. Le premier élément
-         est le type du descripteur et le second est une option pour le type donné.
+         est le type du descripteur et les éléments suivants sont des options pour le type donné.
          Les types valides sont <literal>pipe</literal> (le second élément est soit
          <literal>r</literal> pour passer la fin de lecture du pipe au processus, ou
          <literal>w</literal> pour passer la fin d'écriture) et
-         <literal>file</literal> (le second élément est le nom de fichier).
+         <literal>file</literal> (le second élément est le nom de fichier, et le troisième
+         élément est le mode d'ouverture du fichier, identique à <function>fopen</function>).
          À noter que tout autre élément différent de <literal>w</literal> est traité comme <literal>r</literal>.
         </member>
         <member>


### PR DESCRIPTION
Aligne la description des descripteurs de proc_open sur le wording EN : un descripteur file accepte un troisième élément, le mode d'ouverture du fichier (comme fopen).

Fixes #2999