### PR TITLE
Sync EN: documente la directive INI fatal_error_backtraces

### DIFF
--- a/appendices/migration85/other-changes.xml
+++ b/appendices/migration85/other-changes.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 6b48f364497107ae46f926bfc99a4e3d9d546316 Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: c7b445ec851969e669026cfa483b104ea2de5d95 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <sect1 xml:id="migration85.other-changes">
  <title>Autres changements</title>
@@ -402,8 +402,9 @@
    <title>Core</title>
 
    <simpara>
-    Ajout de fatal_error_backtraces pour contrôler si les erreurs fatales doivent inclure
-    une trace.
+    Ajout de <link
+    linkend="ini.fatal-error-backtraces">fatal_error_backtraces</link> pour
+    contrôler si les erreurs fatales doivent inclure une trace.
     <!-- RFC: https://wiki.php.net/rfc/error_backtraces_v2 -->
    </simpara>
 

--- a/reference/errorfunc/ini.xml
+++ b/reference/errorfunc/ini.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e5ff446c832aded712d45c885609ffdd277e6a49 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: c7b445ec851969e669026cfa483b104ea2de5d95 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <!-- CREDITS: DavidA -->
 
@@ -24,6 +24,14 @@
      <entry>NULL</entry>
      <entry><constant>INI_ALL</constant></entry>
      <entry></entry>
+    </row>
+    <row>
+     <entry><link linkend="ini.fatal-error-backtraces">fatal_error_backtraces</link></entry>
+     <entry>"1"</entry>
+     <entry><constant>INI_ALL</constant></entry>
+     <entry>
+      Disponible à partir de PHP 8.5.0
+     </entry>
     </row>
     <row>
      <entry><link linkend="ini.display-errors">display_errors</link></entry>
@@ -202,6 +210,24 @@
      </note>
     </listitem>
    </varlistentry>
+
+   <varlistentry xml:id="ini.fatal-error-backtraces">
+    <term>
+     <parameter>fatal_error_backtraces</parameter>
+     <type>bool</type>
+    </term>
+    <listitem>
+     <simpara>
+      Contrôle si les erreurs fatales doivent inclure une trace.
+      Les erreurs fatales sont <constant>E_ERROR</constant>,
+      <constant>E_CORE_ERROR</constant>, <constant>E_COMPILE_ERROR</constant>,
+      <constant>E_USER_ERROR</constant>,
+      <constant>E_RECOVERABLE_ERROR</constant>, et
+      <constant>E_PARSE</constant>.
+     </simpara>
+    </listitem>
+   </varlistentry>
+
    <varlistentry xml:id="ini.display-errors">
     <term>
      <parameter>display_errors</parameter>


### PR DESCRIPTION
Documente la directive fatal_error_backtraces (ajoutée en PHP 8.5) dans la liste des directives INI errorfunc, et ajoute le lien dans les changements de migration 8.5.

Fixes #3000