### PR TITLE
Sync EN: ajoute StreamBucket au sommaire stream et corrige l'ancre dataLength

### DIFF
--- a/reference/stream/book.xml
+++ b/reference/stream/book.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 98d4a70aac9e7e3663282507f2f9ce014227e39d Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 564bdc2db8f4c01ba36f64e24356756442b74bc5 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 
 <book xml:id="book.stream" xmlns="http://docbook.org/ns/docbook">
@@ -71,6 +70,7 @@
  &reference.stream.examples;
  &reference.stream.php-user-filter;
  &reference.stream.streamwrapper;
+ &reference.stream.streambucket;
  &reference.stream.reference;
 
 </book>

--- a/reference/stream/streambucket.xml
+++ b/reference/stream/streambucket.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: a7be7e9abb82bfd0c69ea341d74fb9456e93f6f6 Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: 564bdc2db8f4c01ba36f64e24356756442b74bc5 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <reference xml:id="class.streambucket" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>La classe StreamBucket</title>
@@ -75,7 +75,7 @@
       </simpara>
      </listitem>
     </varlistentry>
-    <varlistentry xml:id="streambucket.props.dataLength">
+    <varlistentry xml:id="streambucket.props.datalength">
      <term>int <varname>dataLength</varname></term>
      <listitem>
       <simpara>La longueur de la chaîne dans le sceau.</simpara>
@@ -95,8 +95,6 @@
   </section>
 
  </partintro>
-
- &reference.stream.entities.streambucket;
 
 </reference>
 <!-- Keep this comment at the end of the file


### PR DESCRIPTION
Ajoute la référence StreamBucket manquante dans le book.xml de l'extension stream, et aligne l'ancre de la propriété dataLength sur sa casse EN.

Fixes #3001