### PR TITLE
Sync EN : constantes LDAP et OpenSSL manquantes de PHP 8.4

### DIFF
--- a/reference/ldap/constants.xml
+++ b/reference/ldap/constants.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 26c2246aacfdbf8a40cc2ceccc71c6d878571120 Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 5b3a84935252a553528cb81b3dacb88647b57c7b Maintainer: lacatoire Status: ready -->
 
 <appendix xml:id="ldap.constants" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.constants;
@@ -377,8 +375,21 @@
    </term>
    <listitem>
     <simpara>
-     Spécifie la version minimum du protocole. Cela peut être l'une des valeurs 
-     suivantes : <constant>LDAP_OPT_X_TLS_PROTOCOL_SSL2</constant>,<constant>LDAP_OPT_X_TLS_PROTOCOL_SSL3</constant>, <constant>LDAP_OPT_X_TLS_PROTOCOL_TLS1_0</constant>, <constant>LDAP_OPT_X_TLS_PROTOCOL_TLS1_1</constant>, <constant>LDAP_OPT_X_TLS_PROTOCOL_TLS1_2</constant>
+     Spécifie la version minimum du protocole. Cela peut être l'une des valeurs
+     suivantes : <constant>LDAP_OPT_X_TLS_PROTOCOL_SSL2</constant>,<constant>LDAP_OPT_X_TLS_PROTOCOL_SSL3</constant>, <constant>LDAP_OPT_X_TLS_PROTOCOL_TLS1_0</constant>, <constant>LDAP_OPT_X_TLS_PROTOCOL_TLS1_1</constant>, <constant>LDAP_OPT_X_TLS_PROTOCOL_TLS1_2</constant>, <constant>LDAP_OPT_X_TLS_PROTOCOL_TLS1_3</constant>
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.ldap-opt-x-tls-protocol-max">
+   <term>
+    <constant>LDAP_OPT_X_TLS_PROTOCOL_MAX</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Spécifie la version maximum du protocole. Cela peut être l'une des valeurs
+     suivantes : <constant>LDAP_OPT_X_TLS_PROTOCOL_SSL2</constant>, <constant>LDAP_OPT_X_TLS_PROTOCOL_SSL3</constant>, <constant>LDAP_OPT_X_TLS_PROTOCOL_TLS1_0</constant>, <constant>LDAP_OPT_X_TLS_PROTOCOL_TLS1_1</constant>, <constant>LDAP_OPT_X_TLS_PROTOCOL_TLS1_2</constant>, <constant>LDAP_OPT_X_TLS_PROTOCOL_TLS1_3</constant>.
+     Disponible à partir de PHP 8.4.0.
     </simpara>
    </listitem>
   </varlistentry>
@@ -1158,6 +1169,18 @@
    <listitem>
     <simpara>
      Le protocole TLS 1.2.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.ldap-opt-x-tls-protocol-tls1-3">
+   <term>
+    <constant>LDAP_OPT_X_TLS_PROTOCOL_TLS1_3</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Le protocole TLS 1.3.
+     Disponible à partir de PHP 8.4.0.
     </simpara>
    </listitem>
   </varlistentry>

--- a/reference/ldap/functions/ldap-get-option.xml
+++ b/reference/ldap/functions/ldap-get-option.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: aa120f36c5762e99f9ee121d8caf910e0a67121e Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 5b3a84935252a553528cb81b3dacb88647b57c7b Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="function.ldap-get-option" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -198,6 +198,11 @@
            <entry><constant>LDAP_OPT_X_TLS_PROTOCOL_MIN</constant></entry>
            <entry><type>int</type></entry>
            <entry>7.1</entry>
+          </row>
+          <row>
+           <entry><constant>LDAP_OPT_X_TLS_PROTOCOL_MAX</constant></entry>
+           <entry><type>int</type></entry>
+           <entry>8.4</entry>
           </row>
           <row>
            <entry><constant>LDAP_OPT_X_TLS_RANDOM_FILE</constant></entry>

--- a/reference/ldap/functions/ldap-set-option.xml
+++ b/reference/ldap/functions/ldap-set-option.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 85d9a34e16732043af52954a069a020b8c30ec50 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 5b3a84935252a553528cb81b3dacb88647b57c7b Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="function.ldap-set-option" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -178,6 +178,11 @@
            <entry><constant>LDAP_OPT_X_TLS_PROTOCOL_MIN</constant></entry>
            <entry><type>int</type></entry>
            <entry>PHP 7.1.0</entry>
+          </row>
+          <row>
+           <entry><constant>LDAP_OPT_X_TLS_PROTOCOL_MAX</constant></entry>
+           <entry><type>int</type></entry>
+           <entry>PHP 8.4.0</entry>
           </row>
           <row>
            <entry><constant>LDAP_OPT_X_TLS_RANDOM_FILE</constant></entry>

--- a/reference/openssl/constants.xml
+++ b/reference/openssl/constants.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 5208882ce3910d599e339209f967e183b49ba6ef Maintainer: lacatoire Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 5b3a84935252a553528cb81b3dacb88647b57c7b Maintainer: lacatoire Status: ready -->
 
 <appendix xml:id="openssl.constants" xmlns="http://docbook.org/ns/docbook">
  &reftitle.constants;
@@ -82,7 +80,33 @@
     </term>
     <listitem>
      <simpara>
-      
+
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.x509-purpose-ocsp-helper">
+    <term>
+     <constant>X509_PURPOSE_OCSP_HELPER</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Vérifie le certificat pour une utilisation comme assistant de
+      répondeur OCSP.
+      Disponible à partir de PHP 8.4.0.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.x509-purpose-timestamp-sign">
+    <term>
+     <constant>X509_PURPOSE_TIMESTAMP_SIGN</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Vérifie le certificat pour une utilisation comme signataire
+      d'horodatage de confiance.
+      Disponible à partir de PHP 8.4.0.
      </simpara>
     </listitem>
    </varlistentry>


### PR DESCRIPTION
Documente les constantes ajoutées en PHP 8.4 : LDAP_OPT_X_TLS_PROTOCOL_MAX et LDAP_OPT_X_TLS_PROTOCOL_TLS1_3 côté LDAP, X509_PURPOSE_OCSP_HELPER et X509_PURPOSE_TIMESTAMP_SIGN côté OpenSSL.

Fixes #3010