### PR TITLE
Sync EN : dépréciations PHP 8.4 (constantes SID et SOAP_FUNCTIONS_ALL)

### DIFF
--- a/reference/session/constants.xml
+++ b/reference/session/constants.xml
@@ -21,7 +21,7 @@
     </simpara>
     <warning>
      <simpara>
-      Cette constante est obsolète depuis PHP 8.4.0.
+      Cette constante est obsolète à partir de PHP 8.4.0.
      </simpara>
     </warning>
    </listitem>

--- a/reference/session/constants.xml
+++ b/reference/session/constants.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: a0ae28d3bc85f927c22649ebd9a590b921534b7d Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 7c4e8d8219e9a65553cfc378bb46405bf6b2ed53 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 
 <appendix xml:id="session.constants" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -20,6 +19,11 @@
      C'est la même valeur que celle retournée par la fonction
      <function>session_id</function>.
     </simpara>
+    <warning>
+     <simpara>
+      Cette constante est obsolète depuis PHP 8.4.0.
+     </simpara>
+    </warning>
    </listitem>
   </varlistentry>
   <varlistentry xml:id="constant.php-session-disabled">

--- a/reference/soap/constants.xml
+++ b/reference/soap/constants.xml
@@ -62,7 +62,7 @@
      </entry>
      <entry>999</entry>
      <entry>
-      Obsolète depuis PHP 8.4.0.
+      Obsolète à partir de PHP 8.4.0.
      </entry>
     </row>
     <row xml:id="constant.soap-encoded">

--- a/reference/soap/constants.xml
+++ b/reference/soap/constants.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: f309e78f9439ae5d063a284cefb4b375233aa785 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 7c4e8d8219e9a65553cfc378bb46405bf6b2ed53 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 
 <appendix xml:id="soap.constants" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -61,7 +61,9 @@
       (<type>int</type>)
      </entry>
      <entry>999</entry>
-     <entry/>
+     <entry>
+      Obsolète depuis PHP 8.4.0.
+     </entry>
     </row>
     <row xml:id="constant.soap-encoded">
      <entry>


### PR DESCRIPTION
Documente les dépréciations introduites en PHP 8.4 : la constante SID (session) et SOAP_FUNCTIONS_ALL (soap).

Les constantes LDAP et OpenSSL de la même PR upstream sont déjà couvertes par l'autre sync (état final identique).

Fixes #3011