### PR TITLE
Sync EN : entrées de changelog PHP 8.4.0 (ldap_connect, session_set_save_handler)

### DIFF
--- a/reference/ldap/functions/ldap-connect.xml
+++ b/reference/ldap/functions/ldap-connect.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 57c38af2b053068ad0f1dfdead8128b957ccf4f0 Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: ca23605a1c0e46b9ec85975c6387528c32a7087f Maintainer: lacatoire Status: ready -->
 <refentry xml:id="function.ldap-connect" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>ldap_connect</refname>
@@ -107,6 +106,13 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.4.0</entry>
+      <entry>
+       Appeler <function>ldap_connect</function> avec plus de
+       deux arguments est désormais obsolète.
+      </entry>
+     </row>
      <row>
       <entry>8.3.0</entry>
       <entry>

--- a/reference/session/functions/session-set-save-handler.xml
+++ b/reference/session/functions/session-set-save-handler.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 184f3f7bd45643cb80f828d0bb001991ec3a5fad Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: ca23605a1c0e46b9ec85975c6387528c32a7087f Maintainer: lacatoire Status: ready -->
 
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.session-set-save-handler" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -299,6 +297,30 @@
   <para>
    &return.success;
   </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.4.0</entry>
+      <entry>
+       Appeler <function>session_set_save_handler</function> avec plus
+       de deux arguments est désormais obsolète.
+       Il faut utiliser plutôt la signature à deux arguments.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">


### PR DESCRIPTION
Ajoute les entrées de changelog PHP 8.4.0 : la dépréciation de l'appel à ldap_connect avec plus de deux arguments, et celle de session_set_save_handler avec plus de deux arguments.

Fixes #3012