### PR TITLE
Traduction de IntlDateFormatter::parseToCalendar et Spoofchecker::setAllowedChars (PHP 8.4)

### DIFF
--- a/reference/intl/dateformatter/parsetocalendar.xml
+++ b/reference/intl/dateformatter/parsetocalendar.xml
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 20687bf9c58232244e41272d118b98ef4af16a69 Maintainer: lacatoire Status: ready -->
+<refentry xml:id="intldateformatter.parsetocalendar" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>IntlDateFormatter::parseToCalendar</refname>
+  <refpurpose>Analyse une chaîne en timestamp, en mettant à jour un calendrier ouvert</refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="IntlDateFormatter">
+   <modifier>public</modifier> <type class="union"><type>int</type><type>float</type><type>false</type></type><methodname>IntlDateFormatter::parseToCalendar</methodname>
+   <methodparam><type>string</type><parameter>string</parameter></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter role="reference">offset</parameter><initializer>&null;</initializer></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Convertit <parameter>string</parameter> en une valeur temporelle incrémentale, en
+   commençant à <parameter>offset</parameter> et en consommant autant que possible de
+   la valeur d'entrée.
+  </simpara>
+  <simpara>
+   Cette méthode se comporte comme <methodname>IntlDateFormatter::parse</methodname>, à
+   ceci près que le fuseau horaire du formateur est mis à jour selon les informations de
+   fuseau horaire contenues dans la chaîne <parameter>string</parameter> analysée.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>string</parameter></term>
+    <listitem>
+     <simpara>
+      La chaîne à convertir en temps.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>offset</parameter></term>
+    <listitem>
+     <simpara>
+      Position à laquelle commencer l'analyse dans <parameter>string</parameter> (à base zéro).
+      Si aucune erreur ne survient avant que <parameter>string</parameter> ne soit consommée,
+      <parameter>offset</parameter> contiendra -1, sinon il contiendra la position à laquelle
+      l'analyse s'est terminée (et où l'erreur est survenue).
+      Cette variable contiendra la position de fin si l'analyse échoue.
+      Si <parameter>offset</parameter> &gt; <code>strlen($string)</code>, l'analyse échoue immédiatement.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Le timestamp de la valeur analysée, ou &false; si la valeur ne peut être analysée.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Exemple avec <methodname>IntlDateFormatter::parseToCalendar</methodname></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$fmt = new IntlDateFormatter(
+    'en_US',
+    IntlDateFormatter::FULL,
+    IntlDateFormatter::FULL,
+    'America/Los_Angeles',
+    IntlDateFormatter::GREGORIAN
+);
+echo $fmt->parseToCalendar('Wednesday, December 20, 1989 at 4:00:00 PM Pacific Standard Time');
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+630201600
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>IntlDateFormatter::parse</methodname></member>
+   <member><methodname>IntlDateFormatter::format</methodname></member>
+   <member><methodname>IntlDateFormatter::getErrorCode</methodname></member>
+   <member><methodname>IntlDateFormatter::getErrorMessage</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/intl/spoofchecker/setallowedchars.xml
+++ b/reference/intl/spoofchecker/setallowedchars.xml
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 20687bf9c58232244e41272d118b98ef4af16a69 Maintainer: lacatoire Status: ready -->
+<refentry xml:id="spoofchecker.setallowedchars" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Spoofchecker::setAllowedChars</refname>
+  <refpurpose>Définit l'ensemble des caractères autorisés lors de l'exécution des vérifications</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Spoofchecker">
+   <modifier>public</modifier> <type>void</type><methodname>Spoofchecker::setAllowedChars</methodname>
+   <methodparam><type>string</type><parameter>pattern</parameter></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>patternOptions</parameter><initializer>0</initializer></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Restreint les caractères considérés comme acceptables par les vérifications suivantes
+   à l'ensemble décrit par <parameter>pattern</parameter>. Tout caractère en dehors de cet
+   ensemble fait que <methodname>Spoofchecker::isSuspicious</methodname> signale un résultat.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>pattern</parameter></term>
+    <listitem>
+     <simpara>
+      Un ensemble de caractères décrit sous forme de motif <literal>UnicodeSet</literal>,
+      c'est-à-dire une classe de caractères de style expression régulière. Il doit commencer
+      par <literal>[</literal> et se terminer par <literal>]</literal>, par exemple
+      <literal>[a-z0-9]</literal>.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>patternOptions</parameter></term>
+    <listitem>
+     <simpara>
+      Un masque de bits contrôlant la façon dont <parameter>pattern</parameter> est interprété.
+      Il doit valoir <literal>0</literal>, ou <constant>Spoofchecker::IGNORE_SPACE</constant>
+      seul ou combiné avec exactement l'une des constantes
+      <constant>Spoofchecker::CASE_INSENSITIVE</constant>,
+      <constant>Spoofchecker::ADD_CASE_MAPPINGS</constant>, ou
+      <constant>Spoofchecker::SIMPLE_CASE_INSENSITIVE</constant>.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Aucune valeur n'est retournée.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simpara>
+   Lance une <exceptionname>ValueError</exceptionname> si <parameter>pattern</parameter>
+   n'est pas un motif d'ensemble de caractères valide, ou si
+   <parameter>patternOptions</parameter> n'est pas une combinaison d'options valide.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Exemple avec <methodname>Spoofchecker::setAllowedChars</methodname></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$checker = new Spoofchecker();
+$checker->setAllowedChars('[a-z0-9]');
+
+var_dump($checker->isSuspicious('hello'));
+var_dump($checker->isSuspicious('héllo'));
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+bool(false)
+bool(true)
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Spoofchecker::setAllowedLocales</methodname></member>
+   <member><methodname>Spoofchecker::isSuspicious</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
Traduit les deux nouvelles méthodes intl de PHP 8.4 : IntlDateFormatter::parseToCalendar et Spoofchecker::setAllowedChars.

Fixes #3013