### PR TITLE
Traduction de HashContext::__debugInfo (PHP 8.4)

### DIFF
--- a/reference/hash/hashcontext/debuginfo.xml
+++ b/reference/hash/hashcontext/debuginfo.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: ed4d79beef8c9abd379088eefc8901a6fece7a3b Maintainer: lacatoire Status: ready -->
+<refentry xml:id="hashcontext.debuginfo" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>HashContext::__debugInfo</refname>
+  <refpurpose>Retourne des informations de débogage sur le contexte de hachage</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="HashContext">
+   <modifier>public</modifier> <type>array</type><methodname>HashContext::__debugInfo</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   Cette méthode n'est pas destinée à être appelée directement ; elle est invoquée par
+   <function>var_dump</function> et les fonctions associées lors de l'inspection d'une
+   instance de <classname>HashContext</classname>.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Retourne un tableau associatif d'informations de débogage. Il contient une clé
+   <literal>algo</literal> contenant le nom de l'algorithme de hachage utilisé par
+   le contexte.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Exemple avec <methodname>HashContext::__debugInfo</methodname></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$ctx = hash_init('sha256');
+var_dump($ctx);
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+object(HashContext)#1 (1) {
+  ["algo"]=>
+  string(6) "sha256"
+}
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>hash_init</function></member>
+   <member><function>var_dump</function></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
Traduit la nouvelle méthode HashContext::__debugInfo introduite en PHP 8.4.

Fixes #3014