### PR TITLE
Sync EN : changements ext/date de PHP 8.4

### DIFF
--- a/reference/datetime/dateinterval/createfromdatestring.xml
+++ b/reference/datetime/dateinterval/createfromdatestring.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: c0c9d7721b5a8564a4e27671389a456c1be13e6b Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 9eb962113cadccc164d196003062ff5d893de3a5 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="dateinterval.createfromdatestring" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -79,6 +79,13 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.4.0</entry>
+      <entry>
+       A désormais un type de retour provisoire de <type>DateInterval</type>.
+       Auparavant, il était <type class="union"><type>DateInterval</type><type>false</type></type>.
+      </entry>
+     </row>
      <row>
       <entry>8.3.0</entry>
       <entry>

--- a/reference/datetime/dateperiod/construct.xml
+++ b/reference/datetime/dateperiod/construct.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 0cf48a5a4869bd8b42f84e7032076756cde6a474 Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: 9eb962113cadccc164d196003062ff5d893de3a5 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="dateperiod.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -33,8 +33,8 @@
     <methodparam choice="opt"><type>int</type><parameter>options</parameter><initializer>0</initializer></methodparam>
    </constructorsynopsis>
    <simpara>
-    À la place la méthode usine <methodname>DatePeriod::createFromISO8601String</methodname>
-    devrait être utilisée.
+    Cette variante du constructeur est obsolète à partir de PHP 8.4.0, utiliser
+    <methodname>DatePeriod::createFromISO8601String</methodname> à la place.
    </simpara>
   </warning>
   <para>
@@ -164,6 +164,13 @@
       </row>
      </thead>
      <tbody>
+      <row>
+       <entry>8.4.0</entry>
+       <entry>
+        La signature utilisant <parameter>isostr</parameter> a été dépréciée,
+        utiliser <methodname>DatePeriod::createFromISO8601String</methodname> à la place.
+       </entry>
+      </row>
       <row>
        <entry>8.3.0</entry>
        <entry>

--- a/reference/datetime/datetime/modify.xml
+++ b/reference/datetime/datetime/modify.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: 9eb962113cadccc164d196003062ff5d893de3a5 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="datetime.modify" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -69,6 +69,13 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.4.0</entry>
+      <entry>
+       A désormais un type de retour provisoire de <type>DateTime</type>.
+       Auparavant, il était <type class="union"><type>DateTime</type><type>false</type></type>.
+      </entry>
+     </row>
      <row>
       <entry>8.3.0</entry>
       <entry>


### PR DESCRIPTION
Documente les changements PHP 8.4 d'ext/date : types de retour provisoires pour DateInterval::createFromDateString, DateTime::modify, et dépréciation de la variante isostr du constructeur de DatePeriod.

La page DateTimeImmutable::modify de la même PR upstream est déjà couverte par l'autre sync (état final identique).

Fixes #3016