### PR TITLE
[Sync-EN] Remove redundant row from createFromDateString XML

### DIFF
--- a/reference/datetime/dateinterval/createfromdatestring.xml
+++ b/reference/datetime/dateinterval/createfromdatestring.xml
@@ -85,8 +85,6 @@
        A désormais un type de retour provisoire de <type>DateInterval</type>.
        Auparavant, il était <type class="union"><type>DateInterval</type><type>false</type></type>.
       </entry>
-     </row>
-     <row>
       <entry>8.3.0</entry>
       <entry>
        <methodname>DateInterval::createFromDateString</methodname> lance désormais


### PR DESCRIPTION
Removed an unnecessary row from the XML documentation. Fixes https://github.com/php/doc-fr/issues/3025