### PR TITLE
[Sync EN] reflection: supprime le paragraphe obsolète dans hasreturntype.xml

### DIFF
--- a/reference/reflection/reflectionfunctionabstract/hasreturntype.xml
+++ b/reference/reflection/reflectionfunctionabstract/hasreturntype.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: ec2fe9a592f794978114ef5021db9f1d00c2e05d Maintainer: girgias Status: ready -->
+<!-- EN-Revision: c3485c8f1c57caa8ea0fc2924050a175bbc7686d Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="reflectionfunctionabstract.hasreturntype" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -39,7 +39,8 @@
 <![CDATA[
 <?php
 
-function to_int($param) : int {
+function to_int($param): int
+{
     return (int) $param;
 }
 
@@ -73,11 +74,6 @@ bool(false)
 ]]>
     </screen>
    </example>
-  </para>
-  <para>
-   Ceci est le cas car beaucoup de fonctions internes ne définissent pas un type pour
-   leurs paramètres ou leur valeur de retour. Il est donc conseillé d'éviter l'usage
-   de cette méthode sur les fonctions intégrées.
   </para>
  </refsect1>
 


### PR DESCRIPTION
Synchronise la traduction sur le commit EN qui retire le paragraphe désormais obsolète et reformate l'exemple.

Fixes #3031