### PR TITLE
Aligner la structure bloc des pages reference sur doc-en

### DIFF
--- a/reference/datetime/formats.xml
+++ b/reference/datetime/formats.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: lacatoire Status: ready -->
-<!-- Reviewed: yes -->
 <chapter xml:id="datetime.formats" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Formats supportés de temps et de dates</title>
 
@@ -388,72 +387,6 @@ object(DateTimeImmutable)#1 (3) {
   </table>
 
   <table>
-   <title>Formats standards</title>
-   <tgroup cols="2">
-    <thead>
-     <row>
-      <entry>&Description;</entry>
-      <entry>Exemples</entry>
-     </row>
-    </thead>
-    <tbody>
-     <row>
-      <entry>ATOM</entry>
-      <entry>"2022-06-02T16:58:35+00:00"</entry>
-     </row>
-     <row>
-      <entry>COOKIE</entry>
-      <entry>"Thursday, 02-Jun-2022 16:58:35 UTC"</entry>
-     </row>
-     <row>
-      <entry>ISO8601</entry>
-      <entry>"2022-06-02T16:58:35+0000"</entry>
-     </row>
-     <row>
-      <entry><link xlink:href="&url.rfc;822">RFC 822</link></entry>
-      <entry>"Thu, 02 Jun 22 16:58:35 +0000"</entry>
-     </row>
-     <row>
-      <entry><link xlink:href="&url.rfc;850">RFC 850</link></entry>
-      <entry>"Thursday, 02-Jun-22 16:58:35 UTC"</entry>
-     </row>
-     <row>
-      <entry><link xlink:href="&url.rfc;1036">RFC 1036</link></entry>
-      <entry>"Thu, 02 Jun 22 16:58:35 +0000"</entry>
-     </row>
-     <row>
-      <entry><link xlink:href="&url.rfc;1123">RFC 1123</link></entry>
-      <entry>"Thu, 02 Jun 2022 16:58:35 +0000"</entry>
-     </row>
-     <row>
-      <entry><link xlink:href="&url.rfc;2822">RFC 2822</link></entry>
-      <entry>"Thu, 02 Jun 2022 16:58:35 +0000"</entry>
-     </row>
-     <row>
-      <entry><link xlink:href="&url.rfc;3339">RFC 3339</link></entry>
-      <entry>"2022-06-02T16:58:35+00:00"</entry>
-     </row>
-     <row>
-      <entry><link xlink:href="&url.rfc;3339">RFC 3339</link> Extended</entry>
-      <entry>"2022-06-02T16:58:35.698+00:00"</entry>
-     </row>
-     <row>
-      <entry><link xlink:href="&url.rfc;7231">RFC 7231</link></entry>
-      <entry>"Thu, 02 Jun 2022 16:58:35 GMT"</entry>
-     </row>
-     <row>
-      <entry>RSS</entry>
-      <entry>"Thu, 02 Jun 2022 16:58:35 +0000"</entry>
-     </row>
-     <row>
-      <entry>W3C</entry>
-      <entry>"2022-06-02T16:58:35+00:00"</entry>
-     </row>
-    </tbody>
-   </tgroup>
-  </table>
-
-  <table>
    <title>Notations localisées</title>
    <tgroup cols="3">
     <thead>
@@ -771,6 +704,72 @@ object(DateTimeImmutable)#1 (3) {
       <entry><literal>YY</literal></entry>
       <entry>[0-9]{4}</entry>
       <entry>"2000", "2008", "1978"</entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </table>
+
+  <table>
+   <title>Formats standards</title>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Description;</entry>
+      <entry>Exemples</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>ATOM</entry>
+      <entry>"2022-06-02T16:58:35+00:00"</entry>
+     </row>
+     <row>
+      <entry>COOKIE</entry>
+      <entry>"Thursday, 02-Jun-2022 16:58:35 UTC"</entry>
+     </row>
+     <row>
+      <entry>ISO8601</entry>
+      <entry>"2022-06-02T16:58:35+0000"</entry>
+     </row>
+     <row>
+      <entry><link xlink:href="&url.rfc;822">RFC 822</link></entry>
+      <entry>"Thu, 02 Jun 22 16:58:35 +0000"</entry>
+     </row>
+     <row>
+      <entry><link xlink:href="&url.rfc;850">RFC 850</link></entry>
+      <entry>"Thursday, 02-Jun-22 16:58:35 UTC"</entry>
+     </row>
+     <row>
+      <entry><link xlink:href="&url.rfc;1036">RFC 1036</link></entry>
+      <entry>"Thu, 02 Jun 22 16:58:35 +0000"</entry>
+     </row>
+     <row>
+      <entry><link xlink:href="&url.rfc;1123">RFC 1123</link></entry>
+      <entry>"Thu, 02 Jun 2022 16:58:35 +0000"</entry>
+     </row>
+     <row>
+      <entry><link xlink:href="&url.rfc;2822">RFC 2822</link></entry>
+      <entry>"Thu, 02 Jun 2022 16:58:35 +0000"</entry>
+     </row>
+     <row>
+      <entry><link xlink:href="&url.rfc;3339">RFC 3339</link></entry>
+      <entry>"2022-06-02T16:58:35+00:00"</entry>
+     </row>
+     <row>
+      <entry><link xlink:href="&url.rfc;3339">RFC 3339</link> Extended</entry>
+      <entry>"2022-06-02T16:58:35.698+00:00"</entry>
+     </row>
+     <row>
+      <entry><link xlink:href="&url.rfc;7231">RFC 7231</link></entry>
+      <entry>"Thu, 02 Jun 2022 16:58:35 GMT"</entry>
+     </row>
+     <row>
+      <entry>RSS</entry>
+      <entry>"Thu, 02 Jun 2022 16:58:35 +0000"</entry>
+     </row>
+     <row>
+      <entry>W3C</entry>
+      <entry>"2022-06-02T16:58:35+00:00"</entry>
      </row>
     </tbody>
    </tgroup>

--- a/reference/datetime/functions/date-parse.xml
+++ b/reference/datetime/functions/date-parse.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: ee1ce6a0e1875b6851274f8c373ca2bd48630fa0 Maintainer: lacatoire Status: ready -->
-<!-- Reviewed: yes -->
 <refentry xml:id="function.date-parse" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>date_parse</refname>
@@ -71,6 +70,16 @@
    Pour le type <literal>3</literal> (identifiant de fuseau horaire) 
    les champs <literal>tz_abbr</literal> et <literal>tz_id</literal>
    sont ajoutés.
+  </para>
+  <para>
+   Si des éléments de temps relatifs sont présents dans la chaîne
+   <parameter>datetime</parameter>, tels que <literal>+3 days</literal>,
+   le tableau retourné inclut un tableau imbriqué avec la clé
+   <literal>relative</literal>. Ce tableau contient alors les clés
+   <literal>year</literal>, <literal>month</literal>, <literal>day</literal>,
+   <literal>hour</literal>, <literal>minute</literal>,
+   <literal>second</literal>, et si nécessaire <literal>weekday</literal>, et
+   <literal>weekdays</literal>, selon la chaîne qui a été passée.
   </para>
   <para>
    Le tableau inclut les champs <literal>warning_count</literal> et

--- a/reference/dba/dba.connection.xml
+++ b/reference/dba/dba.connection.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: 37d269b8f6d0f8e83a044a2902a7dc92580bbb87 Maintainer: Fan2Shrek Status: ready -->
-<!-- Reviewed: yes -->
 <reference xmlns="http://docbook.org/ns/docbook" xml:id="class.dba-connection" role="class">
  <title>La classe Dba\Connection</title>
  <titleabbrev>Dba\Connection</titleabbrev>
@@ -20,12 +19,16 @@
    &reftitle.classsynopsis;
 
    <!-- {{{ Synopsis -->
-   <classsynopsis class="class">
-    <ooclass>
-     <modifier>final</modifier>
-     <classname>Dba\Connection</classname>
-    </ooclass>
-   </classsynopsis>
+   <packagesynopsis>
+    <package>Dba</package>
+
+    <classsynopsis class="class">
+     <ooclass>
+      <modifier>final</modifier>
+      <classname>Connection</classname>
+     </ooclass>
+    </classsynopsis>
+   </packagesynopsis>
    <!-- }}} -->
 
   </section>

--- a/reference/hash/functions/hash-pbkdf2.xml
+++ b/reference/hash/functions/hash-pbkdf2.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: 539a9823a805ac29cab7fa4baf3ae3a28116a2f5 Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
-<refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+<refentry xml:id="function.hash-pbkdf2" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>hash_pbkdf2</refname>
   <refpurpose>Génère une clé PBKDF2 dérivée du mot de passe fourni</refpurpose>

--- a/reference/image/functions/imagecreate.xml
+++ b/reference/image/functions/imagecreate.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: 9960a09a5705102bf4dd0ce63e03d9ec716d0015 Maintainer: yannick Status: ready -->
-<!-- Reviewed: yes -->
 
 <refentry xml:id="function.imagecreate" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -113,7 +112,6 @@ imagepng($im);
  <refsect1 role="seealso">
   &reftitle.seealso;
   <simplelist>
-   <member><function>imagedestroy</function></member>
    <member><function>imagecreatetruecolor</function></member>
   </simplelist>
  </refsect1>

--- a/reference/info/constants.xml
+++ b/reference/info/constants.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
 <!-- EN-Revision: 3f1dbc451b313fb1ec8058f24c1beccf55fce316 Maintainer: yannick Status: ready -->
-<!-- Reviewed: yes -->
 <appendix xml:id="info.constants" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.constants;
  &extension.constants.core;
@@ -204,7 +202,7 @@
 
  <variablelist xml:id="constant.ini-mode" role="constant_list">
   <title>Constantes mode INI</title>
-  <varlistentry>
+  <varlistentry xml:id="constant.ini-user">
    <term>
     <constant>INI_USER</constant>
     (<type>int</type>)
@@ -217,7 +215,7 @@
     </simpara>
    </listitem>
   </varlistentry>
-  <varlistentry>
+  <varlistentry xml:id="constant.ini-perdir">
    <term>
     <constant>INI_PERDIR</constant>
     (<type>int</type>)
@@ -228,7 +226,7 @@
     </simpara>
    </listitem>
   </varlistentry>
-  <varlistentry>
+  <varlistentry xml:id="constant.ini-system">
    <term>
     <constant>INI_SYSTEM</constant>
     (<type>int</type>)
@@ -239,7 +237,7 @@
     </simpara>
    </listitem>
   </varlistentry>
-  <varlistentry>
+  <varlistentry xml:id="constant.ini-all">
    <term>
     <constant>INI_ALL</constant>
     (<type>int</type>)

--- a/reference/intl/intlchar/charfromname.xml
+++ b/reference/intl/intlchar/charfromname.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: c142be811735a5542c8a2e4c4ed2f81e8cc3acc6 Maintainer: Fan2Shrek Status: ready -->
-<!-- Reviewed: yes -->
 <refentry xml:id="intlchar.charfromname" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>IntlChar::charFromName</refname>
@@ -12,7 +11,7 @@
   <methodsynopsis role="IntlChar">
    <modifier>public</modifier> <modifier>static</modifier> <type class="union"><type>int</type><type>null</type></type><methodname>IntlChar::charFromName</methodname>
    <methodparam><type>string</type><parameter>name</parameter></methodparam>
-   <methodparam choice="opt"><type>int</type><parameter>type</parameter><initializer>IntlChar::UNICODE_CHAR_NAME</initializer></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>type</parameter><initializer><constant>IntlChar::UNICODE_CHAR_NAME</constant></initializer></methodparam>
   </methodsynopsis>
   <para>
    Trouve un caractère Unicode par son nom et renvoie sa valeur de point de code.

--- a/reference/intl/intlchar/charname.xml
+++ b/reference/intl/intlchar/charname.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: c142be811735a5542c8a2e4c4ed2f81e8cc3acc6 Maintainer: Fan2Shrek Status: ready -->
-<!-- Reviewed: yes -->
 <refentry xml:id="intlchar.charname" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>IntlChar::charName</refname>
@@ -12,7 +11,7 @@
   <methodsynopsis role="IntlChar">
    <modifier>public</modifier> <modifier>static</modifier> <type class="union"><type>string</type><type>null</type></type><methodname>IntlChar::charName</methodname>
    <methodparam><type class="union"><type>int</type><type>string</type></type><parameter>codepoint</parameter></methodparam>
-   <methodparam choice="opt"><type>int</type><parameter>type</parameter><initializer>IntlChar::UNICODE_CHAR_NAME</initializer></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>type</parameter><initializer><constant>IntlChar::UNICODE_CHAR_NAME</constant></initializer></methodparam>
   </methodsynopsis>
   <para>
    Renvoie le nom d'un caractère Unicode.

--- a/reference/intl/intlchar/enumcharnames.xml
+++ b/reference/intl/intlchar/enumcharnames.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: c142be811735a5542c8a2e4c4ed2f81e8cc3acc6 Maintainer: Fan2Shrek Status: ready -->
-<!-- Reviewed: yes -->
 <refentry xml:id="intlchar.enumcharnames" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>IntlChar::enumCharNames</refname>
@@ -14,7 +13,7 @@
    <methodparam><type class="union"><type>int</type><type>string</type></type><parameter>start</parameter></methodparam>
    <methodparam><type class="union"><type>int</type><type>string</type></type><parameter>end</parameter></methodparam>
    <methodparam><type>callable</type><parameter>callback</parameter></methodparam>
-   <methodparam choice="opt"><type>int</type><parameter>type</parameter><initializer>IntlChar::UNICODE_CHAR_NAME</initializer></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>type</parameter><initializer><constant>IntlChar::UNICODE_CHAR_NAME</constant></initializer></methodparam>
   </methodsynopsis>
   <para>
    Enumère tous les caractères Unicode assignés entre les points de code de début et de fin (inclusivement le début, exclusivement la fin)

--- a/reference/intl/intlchar/foldcase.xml
+++ b/reference/intl/intlchar/foldcase.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: c142be811735a5542c8a2e4c4ed2f81e8cc3acc6 Maintainer: Fan2Shrek Status: ready -->
-<!-- Reviewed: yes -->
 <refentry xml:id="intlchar.foldcase" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>IntlChar::foldCase</refname>
@@ -12,7 +11,7 @@
   <methodsynopsis role="IntlChar">
    <modifier>public</modifier> <modifier>static</modifier> <type class="union"><type>int</type><type>string</type><type>null</type></type><methodname>IntlChar::foldCase</methodname>
    <methodparam><type class="union"><type>int</type><type>string</type></type><parameter>codepoint</parameter></methodparam>
-   <methodparam choice="opt"><type>int</type><parameter>options</parameter><initializer>IntlChar::FOLD_CASE_DEFAULT</initializer></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>options</parameter><initializer><constant>IntlChar::FOLD_CASE_DEFAULT</constant></initializer></methodparam>
   </methodsynopsis>
   <para>
    Le caractère donné est mappé à son équivalent de pliage de cas; si le caractère n'a pas d'équivalent de pliage de cas,

--- a/reference/intl/intlchar/getpropertyname.xml
+++ b/reference/intl/intlchar/getpropertyname.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: c142be811735a5542c8a2e4c4ed2f81e8cc3acc6 Maintainer: Fan2Shrek Status: ready -->
-<!-- Reviewed: yes -->
 <refentry xml:id="intlchar.getpropertyname" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>IntlChar::getPropertyName</refname>
@@ -12,7 +11,7 @@
   <methodsynopsis role="IntlChar">
    <modifier>public</modifier> <modifier>static</modifier> <type class="union"><type>string</type><type>false</type></type><methodname>IntlChar::getPropertyName</methodname>
    <methodparam><type>int</type><parameter>property</parameter></methodparam>
-   <methodparam choice="opt"><type>int</type><parameter>type</parameter><initializer>IntlChar::LONG_PROPERTY_NAME</initializer></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>type</parameter><initializer><constant>IntlChar::LONG_PROPERTY_NAME</constant></initializer></methodparam>
   </methodsynopsis>
   <para>
    Renvoie le nom Unicode d'une propriété donnée, tel qu'il est donné dans le fichier de base de données Unicode PropertyAliases.txt.

--- a/reference/intl/intlchar/getpropertyvaluename.xml
+++ b/reference/intl/intlchar/getpropertyvaluename.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: c142be811735a5542c8a2e4c4ed2f81e8cc3acc6 Maintainer: Fan2Shrek Status: ready -->
-<!-- Reviewed: yes -->
 <refentry xml:id="intlchar.getpropertyvaluename" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>IntlChar::getPropertyValueName</refname>
@@ -13,7 +12,7 @@
    <modifier>public</modifier> <modifier>static</modifier> <type class="union"><type>string</type><type>false</type></type><methodname>IntlChar::getPropertyValueName</methodname>
    <methodparam><type>int</type><parameter>property</parameter></methodparam>
    <methodparam><type>int</type><parameter>value</parameter></methodparam>
-   <methodparam choice="opt"><type>int</type><parameter>type</parameter><initializer>IntlChar::LONG_PROPERTY_NAME</initializer></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>type</parameter><initializer><constant>IntlChar::LONG_PROPERTY_NAME</constant></initializer></methodparam>
   </methodsynopsis>
   <para>
    Renvoie le nom Unicode pour une valeur de propriété donnée, tel que donné dans le fichier de base de données Unicode PropertyValueAliases.txt.

--- a/reference/mhash/constants.xml
+++ b/reference/mhash/constants.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
 <!-- EN-Revision: c929e6755af18f6854bfbcb659fb2c4fa3f01592 Maintainer: yannick Status: ready -->
-<!-- Reviewed: yes -->
 
 <appendix xml:id="mhash.constants" xmlns="http://docbook.org/ns/docbook">
  &reftitle.constants;
@@ -12,8 +10,7 @@
   Si un mode n'est pas listé ici, mais listé dans la documentation
   mhash comme étant supporté, il est possible de considérer que cette liste
   n'est plus à jour.
- </para>
- <variablelist>
+  <variablelist>
   <varlistentry xml:id="constant.mhash-adler32">
    <term>
     <constant>MHASH_ADLER32</constant>
@@ -366,6 +363,7 @@
       </listitem>
    </varlistentry>
   </variablelist>
+ </para>
 </appendix>
 
 <!-- Keep this comment at the end of the file

--- a/reference/mongodb/mongodb/driver/manager/construct.xml
+++ b/reference/mongodb/mongodb/driver/manager/construct.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: 36c32a2a930308443ad7fcbbc373c31cc02b9a4e Maintainer: lacatoire Status: ready -->
-<!-- Reviewed: yes -->
 <refentry xml:id="mongodb-driver-manager.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>MongoDB\Driver\Manager::__construct</refname>
@@ -42,23 +41,21 @@
    <varlistentry xml:id="mongodb-driver-manager.construct-uri">
     <term><parameter>uri</parameter></term>
     <listitem>
-     <para>
-      Une URI de connexion <link xlink:href="&url.mongodb.docs;reference/connection-string/">mongodb://</link>:
-      <programlisting role="txt">
+     <simpara>Une URI de connexion <link xlink:href="&url.mongodb.docs;reference/connection-string/">mongodb://</link>:</simpara>
+     <programlisting role="txt">
 <![CDATA[
 mongodb://[username:password@]host1[:port1][,host2[:port2],...[,hostN[:portN]]][/[defaultAuthDb][?options]]
 ]]>
-      </programlisting>
-     </para>
+     </programlisting>
+     <simpara>
+      Par défaut, <literal>"mongodb://127.0.0.1:27017"</literal> si non spécifié.
+     </simpara>
      <simpara>
       Pour les détails sur les options d'URI prises en charge, voir
       <link xlink:href="&url.mongodb.docs;reference/connection-string/#connections-connection-options">Options de chaîne de connexion</link>
       dans le manuel MongoDB.
       <link xlink:href="&url.mongodb.docs;reference/connection-string/#connection-pool-options">Options de pool de connexions</link>
       ne sont pas prises en charge, car l'extension n'implémente pas de pools de connexions.
-     </simpara>
-     <simpara>
-      Par défaut, <literal>"mongodb://127.0.0.1:27017"</literal> si non spécifié.
      </simpara>
      <simpara>
       L'<parameter>uri</parameter> est une URL, donc tous les caractères spéciaux dans
@@ -864,19 +861,18 @@ mongodb://[username:password@]host1[:port1][,host2[:port2],...[,hostN[:portN]]][
         </tbody>
        </tgroup>
       </table>
+      <note>
+       <simpara>
+        Le chiffrement automatique est une fonctionnalité d'entreprise qui
+        ne s'applique qu'aux opérations sur une collection. Le chiffrement automatique n'est pas
+        pris en charge pour les opérations sur une base de données ou une vue, et les opérations qui
+        ne sont pas contournées entraîneront une erreur. Pour contourner le chiffrement automatique
+        pour toutes les opérations, définissez <literal>bypassAutoEncryption=true</literal>
+        dans <literal>autoEncryption</literal>. Pour plus d'informations sur les opérations autorisées,
+        voir la <link xlink:href="&url.mongodb.specs;/blob/master/source/client-side-encryption/client-side-encryption.rst#libmongocrypt-auto-encryption-whitelist">Spécification de chiffrement côté client</link>.
+       </simpara>
+      </note>
      </para>
-
-     <note>
-      <simpara>
-       Le chiffrement automatique est une fonctionnalité d'entreprise qui
-       ne s'applique qu'aux opérations sur une collection. Le chiffrement automatique n'est pas
-       pris en charge pour les opérations sur une base de données ou une vue, et les opérations qui
-       ne sont pas contournées entraîneront une erreur. Pour contourner le chiffrement automatique
-       pour toutes les opérations, définissez <literal>bypassAutoEncryption=true</literal>
-       dans <literal>autoEncryption</literal>. Pour plus d'informations sur les opérations autorisées,
-       voir la <link xlink:href="&url.mongodb.specs;/blob/master/source/client-side-encryption/client-side-encryption.rst#libmongocrypt-auto-encryption-whitelist">Spécification de chiffrement côté client</link>.
-      </simpara>
-     </note>
     </listitem>
    </varlistentry>
   </variablelist>

--- a/reference/mongodb/mongodb/driver/monitoring/serverchangedevent.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/serverchangedevent.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: 36c32a2a930308443ad7fcbbc373c31cc02b9a4e Maintainer: lacatoire Status: ready -->
-<!-- Reviewed: yes --> 
 <reference xml:id="class.mongodb-driver-monitoring-serverchangedevent" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>La classe MongoDB\Driver\Monitoring\ServerChangedEvent</title>
  <titleabbrev>MongoDB\Driver\Monitoring\ServerChangedEvent</titleabbrev>
@@ -10,12 +9,12 @@
 <!-- {{{ MongoDB\Driver\Monitoring\ServerChangedEvent intro -->
   <section xml:id="mongodb-driver-monitoring-serverchangedevent.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     La classe <classname>MongoDB\Driver\Monitoring\ServerChangedEvent</classname>
     encapsule des informations sur une description de serveur modifiée. Par
     exemple, le type d'un serveur passant de secondaire à primaire entraînerait
     un changement de la description de ce serveur.
-   </para>
+   </simpara>
   </section>
 <!-- }}} -->
 

--- a/reference/mongodb/mongodb/driver/monitoring/serverclosedevent.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/serverclosedevent.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: 36c32a2a930308443ad7fcbbc373c31cc02b9a4e Maintainer: lacatoire Status: ready -->
-<!-- Reviewed: yes --> 
 <reference xml:id="class.mongodb-driver-monitoring-serverclosedevent" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>La classe MongoDB\Driver\Monitoring\ServerClosedEvent</title>
  <titleabbrev>MongoDB\Driver\Monitoring\ServerClosedEvent</titleabbrev>
@@ -10,11 +9,11 @@
 <!-- {{{ MongoDB\Driver\Monitoring\ServerClosedEvent intro -->
   <section xml:id="mongodb-driver-monitoring-serverclosedevent.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     La classe <classname>MongoDB\Driver\Monitoring\ServerClosedEvent</classname>
     encapsule des informations sur un serveur fermé. Cela correspond à un
     serveur existant étant retiré de la topologie.
-   </para>
+   </simpara>
   </section>
 <!-- }}} -->
 

--- a/reference/mongodb/mongodb/driver/monitoring/serverheartbeatfailedevent.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/serverheartbeatfailedevent.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: 36c32a2a930308443ad7fcbbc373c31cc02b9a4e Maintainer: lacatoire Status: ready -->
-<!-- Reviewed: yes --> 
 <reference xml:id="class.mongodb-driver-monitoring-serverheartbeatfailedevent" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>La classe MongoDB\Driver\Monitoring\ServerHeartbeatFailedEvent</title>
  <titleabbrev>MongoDB\Driver\Monitoring\ServerHeartbeatFailedEvent</titleabbrev>
@@ -10,13 +9,13 @@
 <!-- {{{ MongoDB\Driver\Monitoring\ServerHeartbeatFailedEvent intro -->
   <section xml:id="mongodb-driver-monitoring-serverheartbeatfailedevent.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     La classe <classname>MongoDB\Driver\Monitoring\ServerHeartbeatFailedEvent</classname>
     encapsule des informations sur un échec de battement de cœur de serveur (c'est-à-dire
    <link xlink:href="&url.mongodb.docs;reference/command/hello/">hello</link>
    commande émise par le biais de
    <link xlink:href="&url.mongodb.sdam;">surveillance du serveur</link>).
-   </para>
+   </simpara>
   </section>
 <!-- }}} -->
 

--- a/reference/mongodb/mongodb/driver/monitoring/serverheartbeatstartedevent.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/serverheartbeatstartedevent.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: 36c32a2a930308443ad7fcbbc373c31cc02b9a4e Maintainer: lacatoire Status: ready -->
-<!-- Reviewed: yes --> 
 <reference xml:id="class.mongodb-driver-monitoring-serverheartbeatstartedevent" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>La classe MongoDB\Driver\Monitoring\ServerHeartbeatStartedEvent</title>
  <titleabbrev>MongoDB\Driver\Monitoring\ServerHeartbeatStartedEvent</titleabbrev>
@@ -10,13 +9,13 @@
 <!-- {{{ MongoDB\Driver\Monitoring\ServerHeartbeatStartedEvent intro -->
   <section xml:id="mongodb-driver-monitoring-serverheartbeatstartedevent.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     La classe <classname>MongoDB\Driver\Monitoring\ServerHeartbeatStartedEvent</classname>
     encapsule des informations sur un battement de cœur de serveur démarré (c'est-à-dire
    <link xlink:href="&url.mongodb.docs;reference/command/hello/">commande hello</link>
    émise par le biais de
    <link xlink:href="&url.mongodb.sdam;">la surveillance du serveur</link>).
-   </para>
+   </simpara>
   </section>
 <!-- }}} -->
 

--- a/reference/mongodb/mongodb/driver/monitoring/serverheartbeatsucceededevent.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/serverheartbeatsucceededevent.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: 36c32a2a930308443ad7fcbbc373c31cc02b9a4e Maintainer: lacatoire Status: ready -->
-<!-- Reviewed: yes --> 
 <reference xml:id="class.mongodb-driver-monitoring-serverheartbeatsucceededevent" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>La classe MongoDB\Driver\Monitoring\ServerHeartbeatSucceededEvent</title>
  <titleabbrev>MongoDB\Driver\Monitoring\ServerHeartbeatSucceededEvent</titleabbrev>
@@ -10,13 +9,13 @@
 <!-- {{{ MongoDB\Driver\Monitoring\ServerHeartbeatSucceededEvent intro -->
   <section xml:id="mongodb-driver-monitoring-serverheartbeatsucceededevent.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     La classe <classname>MongoDB\Driver\Monitoring\ServerHeartbeatSucceededEvent</classname>
     encapsule des informations sur un battement de cœur de serveur réussi (c'est-à-dire
    <link xlink:href="&url.mongodb.docs;reference/command/hello/">commande hello</link>
    émise via
    <link xlink:href="&url.mongodb.sdam;">la surveillance du serveur</link>).
-   </para>
+   </simpara>
   </section>
 <!-- }}} -->
 

--- a/reference/mongodb/mongodb/driver/monitoring/serveropeningevent.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/serveropeningevent.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: 36c32a2a930308443ad7fcbbc373c31cc02b9a4e Maintainer: lacatoire Status: ready -->
-<!-- Reviewed: yes --> 
 <reference xml:id="class.mongodb-driver-monitoring-serveropeningevent" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>La classe MongoDB\Driver\Monitoring\ServerOpeningEvent</title>
  <titleabbrev>MongoDB\Driver\Monitoring\ServerOpeningEvent</titleabbrev>
@@ -10,11 +9,11 @@
 <!-- {{{ MongoDB\Driver\Monitoring\ServerOpeningEvent intro -->
   <section xml:id="mongodb-driver-monitoring-serveropeningevent.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     La classe <classname>MongoDB\Driver\Monitoring\ServerOpeningEvent</classname>
     encapsule des informations sur un serveur ouvert. Cela correspond à un
     nouveau serveur étant ajouté à la topologie.
-   </para>
+   </simpara>
   </section>
 <!-- }}} -->
 

--- a/reference/mongodb/mongodb/driver/monitoring/topologychangedevent.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/topologychangedevent.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: 36c32a2a930308443ad7fcbbc373c31cc02b9a4e Maintainer: lacatoire Status: ready -->
-<!-- Reviewed: yes --> 
 <reference xml:id="class.mongodb-driver-monitoring-topologychangedevent" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>La classe MongoDB\Driver\Monitoring\TopologyChangedEvent</title>
  <titleabbrev>MongoDB\Driver\Monitoring\TopologyChangedEvent</titleabbrev>
@@ -10,12 +9,12 @@
 <!-- {{{ MongoDB\Driver\Monitoring\TopologyChangedEvent intro -->
   <section xml:id="mongodb-driver-monitoring-topologychangedevent.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     La classe <classname>MongoDB\Driver\Monitoring\TopologyChangedEvent</classname>
     encapsule des informations sur une description de topologie modifiée. Par
     exemple, la découverte d'un nouveau primaire dans un ensemble de répliques
     entraînerait un changement de la description de la topologie.
-   </para>
+   </simpara>
   </section>
 <!-- }}} -->
 

--- a/reference/mongodb/mongodb/driver/monitoring/topologyclosedevent.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/topologyclosedevent.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: 36c32a2a930308443ad7fcbbc373c31cc02b9a4e Maintainer: lacatoire Status: ready -->
-<!-- Reviewed: yes -->
 <reference xml:id="class.mongodb-driver-monitoring-topologyclosedevent" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>La classe MongoDB\Driver\Monitoring\TopologyClosedEvent</title>
  <titleabbrev>MongoDB\Driver\Monitoring\TopologyClosedEvent</titleabbrev>
@@ -10,10 +9,10 @@
 <!-- {{{ MongoDB\Driver\Monitoring\TopologyClosedEvent intro -->
   <section xml:id="mongodb-driver-monitoring-topologyclosedevent.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     La classe <classname>MongoDB\Driver\Monitoring\TopologyClosedEvent</classname>
     encapsule des informations sur une topologie fermée.
-   </para>
+   </simpara>
    <note>
     <simpara>
      En raison du comportement

--- a/reference/mongodb/mongodb/driver/monitoring/topologyopeningevent.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/topologyopeningevent.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: 36c32a2a930308443ad7fcbbc373c31cc02b9a4e Maintainer: lacatoire Status: ready -->
-<!-- Reviewed: yes -->
 <reference xml:id="class.mongodb-driver-monitoring-topologyopeningevent" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>La classe MongoDB\Driver\Monitoring\TopologyOpeningEvent</title>
  <titleabbrev>MongoDB\Driver\Monitoring\TopologyOpeningEvent</titleabbrev>
@@ -10,10 +9,10 @@
 <!-- {{{ MongoDB\Driver\Monitoring\TopologyOpeningEvent intro -->
   <section xml:id="mongodb-driver-monitoring-topologyopeningevent.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     La classe <classname>MongoDB\Driver\Monitoring\TopologyOpeningEvent</classname>
     encapsule des informations sur une topologie ouverte.
-   </para>
+   </simpara>
    <note>
     <simpara>
      En raison du comportement

--- a/reference/mongodb/mongodb/driver/readconcern.xml
+++ b/reference/mongodb/mongodb/driver/readconcern.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: 36c32a2a930308443ad7fcbbc373c31cc02b9a4e Maintainer: lacatoire Status: ready -->
-<!-- Reviewed: yes -->
 <reference xml:id="class.mongodb-driver-readconcern" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>La classe MongoDB\Driver\ReadConcern</title>
  <titleabbrev>MongoDB\Driver\ReadConcern</titleabbrev>
@@ -10,11 +9,11 @@
 <!-- {{{ MongoDB\Driver\ReadConcern intro -->
   <section xml:id="mongodb-driver-readconcern.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     <classname>MongoDB\Driver\ReadConcern</classname> contrôle le niveau
     d'isolation pour les opérations de lecture pour les ensembles de réplicas et les fragments d'ensembles de réplicas. Cette
     option nécessite MongoDB 3.2 ou ultérieur.
-   </para>
+   </simpara>
   </section>
 <!-- }}} -->
 
@@ -112,22 +111,22 @@
     <varlistentry xml:id="mongodb-driver-readconcern.constants.available">
      <term><constant>MongoDB\Driver\ReadConcern::AVAILABLE</constant></term>
      <listitem>
-      <para>
+      <simpara>
        Par défaut pour les lectures sur les secondaires lorsque
        <literal>afterClusterTime</literal> et <literal>level</literal> ne sont pas
        spécifiés.
-      </para>
-      <para>
+      </simpara>
+      <simpara>
        La requête renvoie les données les plus récentes de l'instance. Ne garantit
        pas que les données ont été écrites sur la majorité des membres de l'ensemble de réplicas
        (c'est-à-dire qu'elles peuvent être annulées).
-      </para>
-      <para>
+      </simpara>
+      <simpara>
        Pour les collections non fragmentées (y compris les collections dans un
        déploiement autonome ou un déploiement de réplicas), les lectures
        <literal>"local"</literal> et <literal>"available"</literal> se comportent de manière identique.
-      </para>
-      <para>
+      </simpara>
+      <simpara>
        Pour un cluster partagé, la lecture <literal>"available"</literal> fournit
        une plus grande tolérance aux partitions car elle n'attend pas pour
        garantir des garanties de cohérence. Cependant, une requête avec
@@ -136,37 +135,37 @@
        <literal>"available"</literal>, contrairement à la lecture
        <literal>"local"</literal>, ne contacte pas le
        primaire du fragment ni les serveurs de configuration pour obtenir des métadonnées mises à jour.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="mongodb-driver-readconcern.constants.linearizable">
      <term><constant>MongoDB\Driver\ReadConcern::LINEARIZABLE</constant></term>
      <listitem>
-      <para>
+      <simpara>
        La requête renvoie les données qui reflètent toutes les écritures réussies émises avec un 
        niveau d'écriture de <literal>"majority"</literal> <emphasis>et</emphasis>
        reconnu avant le début de l'opération de lecture. Pour les ensembles de réplicas
        qui fonctionnent avec <literal>writeConcernMajorityJournalDefault</literal> défini
        sur &true;, la lecture linéarisable renvoie des données qui ne seront jamais
        annulées.
-      </para>
-      <para>
+      </simpara>
+      <simpara>
        Avec <literal>writeConcernMajorityJournalDefault</literal> défini sur
        &false;, MongoDB n'attendra pas que les écritures <literal>w: "majority"</literal>
        soient durables avant d'accuser réception des écritures. En tant que tel,
        les opérations d'écriture <literal>"majority"</literal> pourraient éventuellement être annulées
        en cas de perte d'un membre de l'ensemble de réplicas.
-      </para>
-      <para>
+      </simpara>
+      <simpara>
        Il est possible de spécifier un niveau de lecture linéarisable pour les opérations de lecture sur le
        primaire uniquement.
-      </para>
-      <para>
+      </simpara>
+      <simpara>
        La lecture linéarisable garantit que les opérations
        de lecture spécifient un filtre de requête qui identifie de manière unique un seul
        document.
-      </para>
+      </simpara>
       <tip>
        <simpara>
         Toujours utiliser <literal>maxTimeMS</literal> avec une lecture linéarisable
@@ -176,71 +175,71 @@
         le niveau de lecture ne peut pas être satisfait.
        </simpara>
       </tip>
-      <para>
+      <simpara>
        La lecture linéarisable nécessite MongoDB 3.4.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="mongodb-driver-readconcern.constants.local">
      <term><constant>MongoDB\Driver\ReadConcern::LOCAL</constant></term>
      <listitem>
-      <para>
+      <simpara>
        Défaut pour les lectures sur le primaire si <literal>level</literal> n'est pas
        spécifié et pour les lectures sur les secondaires si <literal>level</literal>
        n'est pas spécifié mais que <literal>afterClusterTime</literal> est spécifié.
-      </para>
-      <para>
+      </simpara>
+      <simpara>
        La requête renvoie les données les plus récentes de l'instance. Ne garantit
        pas que les données ont été écrites sur la majorité des membres de l'ensemble de réplicas
        (c'est-à-dire qu'elles peuvent être annulées).
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="mongodb-driver-readconcern.constants.majority">
      <term><constant>MongoDB\Driver\ReadConcern::MAJORITY</constant></term>
      <listitem>
-      <para>
+      <simpara>
        La requête renvoie les données les plus récentes reconnues comme ayant été
        écrites sur la majorité des membres de l'ensemble de réplicas.
-      </para>
-      <para>
+      </simpara>
+      <simpara>
        Pour utiliser le niveau de lecture <literal>"majority"</literal>, les ensembles de réplicas
        doivent utiliser le moteur de stockage WiredTiger et le protocole d'élection version 1.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="mongodb-driver-readconcern.constants.snapshot">
      <term><constant>MongoDB\Driver\ReadConcern::SNAPSHOT</constant></term>
      <listitem>
-      <para>
+      <simpara>
        La lecture <literal>"snapshot"</literal> est disponible pour les transactions
        multi-documents, et à partir de MongoDB 5.0, pour certaines opérations de lecture
        en dehors des transactions multi-documents.
-      </para>
-      <para>
+      </simpara>
+      <simpara>
        Si la transaction ne fait pas partie d'une session cohérente, lors de
        la validation de la transaction avec un niveau d'écriture <literal>"majority"</literal>, les
        opérations de transaction sont garanties d'avoir lu à partir d'un instantané des données
        majoritairement engagées.
-      </para>
-      <para>
+      </simpara>
+      <simpara>
        Si la transaction fait partie d'une session cohérente, lors de
        la validation de la transaction avec un niveau d'écriture <literal>"majority"</literal>, les
        opérations de transaction sont garanties d'avoir lu à partir d'un instantané des données
        majoritairement engagées qui assure la cohérence causale avec l'opération immédiatement
        précédent le début de la transaction.
-      </para>
-      <para>
+      </simpara>
+      <simpara>
        En dehors des transactions multi-documents, le niveau de lecture
        <literal>"snapshot"</literal> est disponible sur les primaires et les secondaires
        pour les opérations de lecture suivantes : <literal>find</literal>,
        <literal>aggregate</literal> et <literal>distinct</literal> (sur
        les collections non fragmentées). Toutes les autres commandes de lecture interdisent
        <literal>"snapshot"</literal>.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
 
@@ -250,62 +249,60 @@
 
   <section role="changelog">
    &reftitle.changelog;
-   <para>
-    <informaltable>
-     <tgroup cols="2">
-      <thead>
-       <row>
-        <entry>&Version;</entry>
-        <entry>&Description;</entry>
-       </row>
-      </thead>
-      <tbody>
-       <row>
-        <entry>PECL mongodb 2.3.0</entry>
-        <entry>
-         Ajout des propriétés publiques <modifier>readonly</modifier>.
-        </entry>
-       </row>
-       <row>
-        <entry>PECL mongodb 1.11.0</entry>
-        <entry>
-         <para>
-          Ajout de la constante
-          <constant>MongoDB\Driver\ReadConcern::SNAPSHOT</constant>.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>PECL mongodb 1.7.0</entry>
-        <entry>
-         Implémente <interfacename>Serializable</interfacename>.
-        </entry>
-       </row>
-       <row>
-        <entry>PECL mongodb 1.4.0</entry>
-        <entry>
-         <para>
-          Ajout de la constante
-          <constant>MongoDB\Driver\ReadConcern::MAJORITY</constant>.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>PECL mongodb 1.2.0</entry>
-        <entry>
-         <para>
-          Ajout de la constante
-          <constant>MongoDB\Driver\ReadConcern::LINEARIZABLE</constant>
-         </para>
-         <para>
-          Implémente <interfacename>MongoDB\BSON\Serializable</interfacename>.
-         </para>
-        </entry>
-       </row>
-      </tbody>
-     </tgroup>
-    </informaltable>
-   </para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>PECL mongodb 2.3.0</entry>
+       <entry>
+        Ajout des propriétés publiques <modifier>readonly</modifier>.
+       </entry>
+      </row>
+      <row>
+       <entry>PECL mongodb 1.11.0</entry>
+       <entry>
+        <simpara>
+         Ajout de la constante
+         <constant>MongoDB\Driver\ReadConcern::SNAPSHOT</constant>.
+        </simpara>
+       </entry>
+      </row>
+      <row>
+       <entry>PECL mongodb 1.7.0</entry>
+       <entry>
+        Implémente <interfacename>Serializable</interfacename>.
+       </entry>
+      </row>
+      <row>
+       <entry>PECL mongodb 1.4.0</entry>
+       <entry>
+        <simpara>
+         Ajout de la constante
+         <constant>MongoDB\Driver\ReadConcern::MAJORITY</constant>.
+        </simpara>
+       </entry>
+      </row>
+      <row>
+       <entry>PECL mongodb 1.2.0</entry>
+       <entry>
+        <simpara>
+         Ajout de la constante
+         <constant>MongoDB\Driver\ReadConcern::LINEARIZABLE</constant>
+        </simpara>
+        <simpara>
+         Implémente <interfacename>MongoDB\BSON\Serializable</interfacename>.
+        </simpara>
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
   </section>
 
   <section xml:id="mongodb-driver-readconcern.seealso">

--- a/reference/mongodb/mongodb/driver/readpreference.xml
+++ b/reference/mongodb/mongodb/driver/readpreference.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: 36c32a2a930308443ad7fcbbc373c31cc02b9a4e Maintainer: lacatoire Status: ready -->
-<!-- Reviewed: no -->
 
 <reference xml:id="class.mongodb-driver-readpreference" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -12,9 +11,9 @@
 <!-- {{{ MongoDB\Driver\ReadPreference intro -->
   <section xml:id="mongodb-driver-readpreference.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
 
-   </para>
+   </simpara>
   </section>
 <!-- }}} -->
 
@@ -177,77 +176,77 @@
     <varlistentry xml:id="mongodb-driver-readpreference.constants.primary">
      <term><constant>MongoDB\Driver\ReadPreference::PRIMARY</constant></term>
      <listitem>
-      <para>
+      <simpara>
        Toutes les opérations lues à partir du jeu de réplicas actuel primaire.
        Il s'agit de la préférence de lecture par défaut pour MongoDB.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="mongodb-driver-readpreference.constants.primary-preferred">
      <term><constant>MongoDB\Driver\ReadPreference::PRIMARY_PREFERRED</constant></term>
      <listitem>
-      <para>
+      <simpara>
        Dans la plupart des situations, les opérations sont lues à partir du 
        primaire, mais s'il n'est pas disponible, les opérations sont lues à partir 
        de membres secondaires.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="mongodb-driver-readpreference.constants.secondary">
      <term><constant>MongoDB\Driver\ReadPreference::SECONDARY</constant></term>
      <listitem>
-      <para>
+      <simpara>
        Toutes les opérations sont lues à partir des membres secondaires du jeu de réplicas.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="mongodb-driver-readpreference.constants.secondary-preferred">
      <term><constant>MongoDB\Driver\ReadPreference::SECONDARY_PREFERRED</constant></term>
      <listitem>
-      <para>
+      <simpara>
        Dans la plupart des cas, les opérations sont lues par des membres 
        secondaires, mais si aucun membre secondaire n'est disponible, les 
        opérations sont lues à partir du primaire.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="mongodb-driver-readpreference.constants.nearest">
      <term><constant>MongoDB\Driver\ReadPreference::NEAREST</constant></term>
      <listitem>
-      <para>
+      <simpara>
        Les opérations sont lues à partir du membre du jeu de réplicas avec la 
        latence de réseau la moins élevée, quel que soit le type du membre.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="mongodb-driver-readpreference.constants.no-max-staleness">
      <term><constant>MongoDB\Driver\ReadPreference::NO_MAX_STALENESS</constant></term>
      <listitem>
-      <para>
+      <simpara>
        La valeur par défaut de l'option <literal>"maxStalenessSeconds"</literal> 
        est de ne spécifier aucune limite sur l'obsolescence maximale, ce qui 
        signifie que le pilote ne prendra pas en compte le décalage d'un 
        secondaire lors du choix de l'endroit où diriger une opération de lecture.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="mongodb-driver-readpreference.constants.smallest-max-staleness-seconds">
      <term><constant>MongoDB\Driver\ReadPreference::SMALLEST_MAX_STALENESS_SECONDS</constant></term>
      <listitem>
-      <para>
+      <simpara>
        La valeur minimale de l'option <literal>"maxStalenessSeconds"</literal> 
        est de 90 secondes. Le pilote estime l'obsolescence des secondes en 
        vérifiant périodiquement la dernière date d'écriture de chaque membre du 
        jeu de réplicas. Comme ces contrôles sont peu fréquents, l'estimation de 
        l'obsolescence est grossière. Ainsi, le pilote ne peut pas appliquer une 
        valeur d'obsolescence maximale inférieure à 90 secondes.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
 
@@ -257,84 +256,82 @@
 
   <section role="changelog">
    &reftitle.changelog;
-   <para>
-    <informaltable>
-     <tgroup cols="2">
-      <thead>
-       <row>
-        <entry>&Version;</entry>
-        <entry>&Description;</entry>
-       </row>
-      </thead>
-      <tbody>
-       <row>
-        <entry>PECL mongodb 2.3.0</entry>
-        <entry>
-         Ajout des propriétés publiques <modifier>readonly</modifier>.
-        </entry>
-       </row>
-       <row>
-        <entry>PECL mongodb 2.0.0</entry>
-        <entry>
-         <para>
-          Supprimer les constantes
-          <constant>MongoDB\Driver\ReadPreference::RP_PRIMARY</constant>,
-          <constant>MongoDB\Driver\ReadPreference::RP_PRIMARY_PREFERRED</constant>,
-          <constant>MongoDB\Driver\ReadPreference::RP_SECONDARY</constant>,
-          <constant>MongoDB\Driver\ReadPreference::RP_SECONDARY_PREFERRED</constant>,
-          et <constant>MongoDB\Driver\ReadPreference::RP_NEAREST</constant>.
-          La méthode <methodname>getMode</methodname> a également été supprimée.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>PECL mongodb 1.20.0</entry>
-        <entry>
-         <para>
-          Les constantes
-          <constant>MongoDB\Driver\ReadPreference::RP_PRIMARY</constant>,
-          <constant>MongoDB\Driver\ReadPreference::RP_PRIMARY_PREFERRED</constant>,
-          <constant>MongoDB\Driver\ReadPreference::RP_SECONDARY</constant>,
-          <constant>MongoDB\Driver\ReadPreference::RP_SECONDARY_PREFERRED</constant>,
-          et <constant>MongoDB\Driver\ReadPreference::RP_NEAREST</constant>
-          sont obsolètes.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>PECL mongodb 1.7.0</entry>
-        <entry>
-         <para>
-          Ajout des constantes
-          <constant>MongoDB\Driver\ReadPreference::PRIMARY</constant>,
-          <constant>MongoDB\Driver\ReadPreference::PRIMARY_PREFERRED</constant>,
-          <constant>MongoDB\Driver\ReadPreference::SECONDARY</constant>,
-          <constant>MongoDB\Driver\ReadPreference::SECONDARY_PREFERRED</constant>,
-          <constant>MongoDB\Driver\ReadPreference::NEAREST</constant>.
-         </para>
-         <para>
-          Implémente <interfacename>Serializable</interfacename>.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>PECL mongodb 1.2.0</entry>
-        <entry>
-         <para>
-          Ajout des constantes
-          <constant>MongoDB\Driver\ReadPreference::NO_MAX_STALENESS</constant>
-          et
-          <constant>MongoDB\Driver\ReadPreference::SMALLEST_MAX_STALENESS_SECONDS</constant>.
-         </para>
-         <para>
-          Implémente <interfacename>MongoDB\BSON\Serializable</interfacename>.
-         </para>
-        </entry>
-       </row>
-      </tbody>
-     </tgroup>
-    </informaltable>
-   </para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>PECL mongodb 2.3.0</entry>
+       <entry>
+        Ajout des propriétés publiques <modifier>readonly</modifier>.
+       </entry>
+      </row>
+      <row>
+       <entry>PECL mongodb 2.0.0</entry>
+       <entry>
+        <simpara>
+         Supprimer les constantes
+         <constant>MongoDB\Driver\ReadPreference::RP_PRIMARY</constant>,
+         <constant>MongoDB\Driver\ReadPreference::RP_PRIMARY_PREFERRED</constant>,
+         <constant>MongoDB\Driver\ReadPreference::RP_SECONDARY</constant>,
+         <constant>MongoDB\Driver\ReadPreference::RP_SECONDARY_PREFERRED</constant>,
+         et <constant>MongoDB\Driver\ReadPreference::RP_NEAREST</constant>.
+         La méthode <methodname>getMode</methodname> a également été supprimée.
+        </simpara>
+       </entry>
+      </row>
+      <row>
+       <entry>PECL mongodb 1.20.0</entry>
+       <entry>
+        <simpara>
+         Les constantes
+         <constant>MongoDB\Driver\ReadPreference::RP_PRIMARY</constant>,
+         <constant>MongoDB\Driver\ReadPreference::RP_PRIMARY_PREFERRED</constant>,
+         <constant>MongoDB\Driver\ReadPreference::RP_SECONDARY</constant>,
+         <constant>MongoDB\Driver\ReadPreference::RP_SECONDARY_PREFERRED</constant>,
+         et <constant>MongoDB\Driver\ReadPreference::RP_NEAREST</constant>
+         sont obsolètes.
+        </simpara>
+       </entry>
+      </row>
+      <row>
+       <entry>PECL mongodb 1.7.0</entry>
+       <entry>
+        <simpara>
+         Ajout des constantes
+         <constant>MongoDB\Driver\ReadPreference::PRIMARY</constant>,
+         <constant>MongoDB\Driver\ReadPreference::PRIMARY_PREFERRED</constant>,
+         <constant>MongoDB\Driver\ReadPreference::SECONDARY</constant>,
+         <constant>MongoDB\Driver\ReadPreference::SECONDARY_PREFERRED</constant>,
+         <constant>MongoDB\Driver\ReadPreference::NEAREST</constant>.
+        </simpara>
+        <simpara>
+         Implémente <interfacename>Serializable</interfacename>.
+        </simpara>
+       </entry>
+      </row>
+      <row>
+       <entry>PECL mongodb 1.2.0</entry>
+       <entry>
+        <simpara>
+         Ajout des constantes
+         <constant>MongoDB\Driver\ReadPreference::NO_MAX_STALENESS</constant>
+         et
+         <constant>MongoDB\Driver\ReadPreference::SMALLEST_MAX_STALENESS_SECONDS</constant>.
+        </simpara>
+        <simpara>
+         Implémente <interfacename>MongoDB\BSON\Serializable</interfacename>.
+        </simpara>
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
   </section>
 
  </partintro>

--- a/reference/mongodb/mongodb/driver/writeconcern.xml
+++ b/reference/mongodb/mongodb/driver/writeconcern.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
 <!-- EN-Revision: 36c32a2a930308443ad7fcbbc373c31cc02b9a4e Maintainer: lacatoire Status: ready -->
-<!-- Reviewed: no -->
 
 <reference xml:id="class.mongodb-driver-writeconcern" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -13,14 +11,14 @@
 <!-- {{{ MongoDB\Driver\WriteConcern intro -->
   <section xml:id="mongodb-driver-writeconcern.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     <classname>MongoDB\Driver\WriteConcern</classname> décrit le niveau 
     d'accusé de réception demandé par MongoDB pour les opérations d'écriture
     à un <literal>mongod</literal> autonome ou à des ensembles de réplicas 
     ou à des clusters fragmentés. Dans les clusters fragmentés, les instances
     de <literal>mongos</literal> transmettent le write concern aux
     fragments.
-   </para>
+   </simpara>
   </section>
 <!-- }}} -->
 
@@ -127,11 +125,11 @@
     <varlistentry xml:id="mongodb-driver-writeconcern.constants.majority">
      <term><constant>MongoDB\Driver\WriteConcern::MAJORITY</constant></term>
      <listitem>
-      <para>
+      <simpara>
        La majorité de tous les membres du jeu de répliques ; les arbitres, les membres non-votants,
        les membres passifs, les membres cachés, et les membres en attente sont
        tous inclus dans la définition d'un write concern de la majorité.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
 
@@ -141,38 +139,36 @@
 
   <section role="changelog">
    &reftitle.changelog;
-   <para>
-    <informaltable>
-     <tgroup cols="2">
-      <thead>
-       <row>
-        <entry>&Version;</entry>
-        <entry>&Description;</entry>
-       </row>
-      </thead>
-      <tbody>
-       <row>
-        <entry>PECL mongodb 2.3.0</entry>
-        <entry>
-         Ajout des propriétés publiques <modifier>readonly</modifier>.
-        </entry>
-       </row>
-       <row>
-        <entry>PECL mongodb 1.7.0</entry>
-        <entry>
-         Implémente <interfacename>Serializable</interfacename>.
-        </entry>
-       </row>
-       <row>
-        <entry>PECL mongodb 1.2.0</entry>
-        <entry>
-         Implémente <interfacename>MongoDB\BSON\Serializable</interfacename>.
-        </entry>
-       </row>
-      </tbody>
-     </tgroup>
-    </informaltable>
-   </para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>PECL mongodb 2.3.0</entry>
+       <entry>
+        Ajout des propriétés publiques <modifier>readonly</modifier>.
+       </entry>
+      </row>
+      <row>
+       <entry>PECL mongodb 1.7.0</entry>
+       <entry>
+        Implémente <interfacename>Serializable</interfacename>.
+       </entry>
+      </row>
+      <row>
+       <entry>PECL mongodb 1.2.0</entry>
+       <entry>
+        Implémente <interfacename>MongoDB\BSON\Serializable</interfacename>.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
   </section>
 
  </partintro>

--- a/reference/mongodb/mongodb/driver/writeconcernerror.xml
+++ b/reference/mongodb/mongodb/driver/writeconcernerror.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
 <!-- EN-Revision: 36c32a2a930308443ad7fcbbc373c31cc02b9a4e Maintainer: lacatoire Status: ready -->
-<!-- Reviewed: no -->
 
 <reference xml:id="class.mongodb-driver-writeconcernerror" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -13,11 +11,11 @@
 <!-- {{{ MongoDB\Driver\WriteConcernError intro -->
   <section xml:id="mongodb-driver-writeconcernerror.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     La classe <classname>MongoDB\Driver\WriteConcernError</classname> 
     contient des informations relatives à une erreur de write concern et peut être retournée par
    <methodname>MongoDB\Driver\WriteResult::getWriteConcernError</methodname>.
-   </para>
+   </simpara>
   </section>
 <!-- }}} -->
 

--- a/reference/mongodb/mongodb/driver/writeerror.xml
+++ b/reference/mongodb/mongodb/driver/writeerror.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
 <!-- EN-Revision: 36c32a2a930308443ad7fcbbc373c31cc02b9a4e Maintainer: lacatoire Status: ready -->
-<!-- Reviewed: no -->
 
 <reference xml:id="class.mongodb-driver-writeerror" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -13,11 +11,11 @@
 <!-- {{{ MongoDB\Driver\WriteError intro -->
   <section xml:id="mongodb-driver-writeerror.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     La classe <classname>MongoDB\Driver\WriteError</classname> contient
     des informations sur une erreur d'écriture et peut être retournée en tant 
     qu'élément d'un tableau à partir de    <methodname>MongoDB\Driver\WriteResult::getWriteErrors</methodname>.
-   </para>
+   </simpara>
   </section>
 <!-- }}} -->
 

--- a/reference/mongodb/mongodb/driver/writeresult.xml
+++ b/reference/mongodb/mongodb/driver/writeresult.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
 <!-- EN-Revision: 36c32a2a930308443ad7fcbbc373c31cc02b9a4e Maintainer: lacatoire Status: ready -->
-<!-- Reviewed: no -->
 
 <reference xml:id="class.mongodb-driver-writeresult" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -13,13 +11,13 @@
 <!-- {{{ MongoDB\Driver\WriteResult intro -->
   <section xml:id="mongodb-driver-writeresult.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     La classe <classname>MongoDB\Driver\WriteResult</classname> contient les 
     informations sur une exécution <classname>MongoDB\Driver\BulkWrite</classname> 
     et peut être retournée par
  <methodname>MongoDB\Driver\Manager::executeBulkWrite</methodname>.
 
-   </para>
+   </simpara>
   </section>
 <!-- }}} -->
 

--- a/reference/mongodb/tutorial/library.xml
+++ b/reference/mongodb/tutorial/library.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
-<!-- Reviewed: yes -->
 <section xml:id="mongodb.tutorial.library" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Utiliser la bibliothèque PHP pour MongoDB (PHPLIB)</title>
 
@@ -80,7 +79,7 @@ require 'vendor/autoload.php';
     <link xlink:href="&url.mongodb.library.docs;">documentation de la bibliothèque</link>.
    </simpara>
 
-   <para>
+   <simpara>
     Si on a utilisé des pilotes MongoDB dans d'autres langages, l'API de la
     bibliothèque devrait sembler familière. Elle contient une classe
     <link xlink:href="&url.mongodb.library.apidocs;/class/MongoDBClient/">Client</link>
@@ -91,7 +90,7 @@ require 'vendor/autoload.php';
     <link xlink:href="&url.mongodb.library.apidocs;/class/MongoDBCollection">Collection</link>
     pour les opérations au niveau de la collection (par exemple, les méthodes
     <link xlink:href="&url.mongodb.wiki.crud;">CRUD</link>, la gestion des index).
-   </para>
+   </simpara>
 
    <para>
     En tant qu'exemple, voici comment on insère un document dans la collection
@@ -141,7 +140,7 @@ foreach ($result as $entry) {
     </programlisting>
    </para>
 
-   <para>
+   <simpara>
     Tandis que les exemples ne le montrent pas, les documents BSON et les tableaux
     sont désérialisés en tant que classes spéciales dans la bibliothèque par défaut.
     Ces classes étendent <classname>ArrayObject</classname> pour la facilité d'utilisation
@@ -152,7 +151,7 @@ foreach ($result as $entry) {
     où les tableaux pourraient se transformer en documents, et vice versa. Voir la
     spécification <xref linkend="mongodb.persistence"/> pour plus d'informations sur
     la façon dont les valeurs sont converties entre PHP et BSON.
-   </para>
+   </simpara>
   </section>
 </section>
 <!-- Keep this comment at the end of the file

--- a/reference/mysqli/mysqli/next-result.xml
+++ b/reference/mysqli/mysqli/next-result.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: 63b99082ef83eade08151f8cb528246fded81db9 Maintainer: yannick Status: ready -->
-<!-- Reviewed: yes -->
 <refentry xml:id="mysqli.next-result" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>mysqli::next_result</refname>
@@ -45,16 +44,16 @@
   </para>
  </refsect1>
 
+ <refsect1 role="errors">
+  &reftitle.errors;
+  &mysqli.conditionalexception;
+ </refsect1>
+
  <refsect1 role="examples">
   &reftitle.examples;
   <para>
    Voir <function>mysqli_multi_query</function>.
   </para>
- </refsect1>
-
- <refsect1 role="errors">
-  &reftitle.errors;
-  &mysqli.conditionalexception;
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/mysqlinfo/set.xml
+++ b/reference/mysqlinfo/set.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
 <!-- EN-Revision: 7cff4d34f0324c9de72d15957e1b62e20f37dfaf Maintainer: yannick Status: ready -->
-<!-- Reviewed: no --><set xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="set.mysqlinfo">
+<set xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="set.mysqlinfo">
  <title>Plugins et drivers MySQL</title>
  <titleabbrev>MySQL</titleabbrev>
 
@@ -197,6 +196,28 @@ echo htmlentities($row['_message']);
 ]]>
     </programlisting>
    </example>
+   <example>
+    <title>Comparaison des instructions préparées</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+// mysqli
+$mysqli = new mysqli("example.com", "utilisateur", "motdepasse", "base de données");
+$statement = $mysqli->prepare("SELECT District FROM City WHERE Name=?");
+$statement->execute(["Amersfoort"]);
+$result = $statement->get_result();
+$row = $result->fetch_assoc();
+echo htmlentities($row['District']);
+
+// PDO
+$pdo = new PDO('mysql:host=example.com;dbname=base de données', 'utilisateur', 'motdepasse');
+$statement = $pdo->prepare("SELECT District FROM City WHERE Name=?");
+$statement->execute(["Amersfoort"]);
+$row = $statement->fetch(PDO::FETCH_ASSOC);
+echo htmlentities($row['District']);
+]]>
+    </programlisting>
+   </example>
    <simpara>
     <emphasis role="bold">Comparaison des fonctionnalités</emphasis>
    </simpara>
@@ -334,28 +355,6 @@ $ ./configure --with-mysqli --with-pdo-mysql
 
 // Non recommandé, compilation avec libmysqlclient
 $ ./configure --with-mysqli=/path/to/mysql_config --with-pdo-mysql=/path/to/mysql_config
-]]>
-    </programlisting>
-   </example>
-   <example>
-    <title>Comparaison des instructions préparées</title>
-    <programlisting role="php">
-<![CDATA[
-<?php
-// mysqli
-$mysqli = new mysqli("example.com", "utilisateur", "motdepasse", "base de données");
-$statement = $mysqli->prepare("SELECT District FROM City WHERE Name=?");
-$statement->execute(["Amersfoort"]);
-$result = $statement->get_result();
-$row = $result->fetch_assoc();
-echo htmlentities($row['District']);
-
-// PDO
-$pdo = new PDO('mysql:host=example.com;dbname=base de données', 'utilisateur', 'motdepasse');
-$statement = $pdo->prepare("SELECT District FROM City WHERE Name=?");
-$statement->execute(["Amersfoort"]);
-$row = $statement->fetch(PDO::FETCH_ASSOC);
-echo htmlentities($row['District']);
 ]]>
     </programlisting>
    </example>

--- a/reference/network/functions/setcookie.xml
+++ b/reference/network/functions/setcookie.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: 6122a8317ca0068fc71f6a5167e0a2d99166ec7c Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
 <refentry xml:id="function.setcookie" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>setcookie</refname>
@@ -198,15 +197,21 @@
 
  <refsect1 role="errors">
   &reftitle.errors;
-  <para>
-   Si le tableau <parameter>options</parameter> contient une clé non supportée,
-   une <exceptionname>ValueError</exceptionname> est lancée.
-  </para>
-  <para>
-   Antérieur à PHP 8.0.0, si le tableau <parameter>options</parameter> contenait
-   une clé non supportée, une erreur de niveau <constant>E_WARNING</constant>
-   était émise.
-  </para>
+  <simpara>
+   Si le tableau <parameter>options</parameter> contient une clé non supportée :
+  </simpara>
+  <itemizedlist>
+   <listitem>
+    <simpara>
+     Antérieur à PHP 8.0.0, une erreur de niveau <constant>E_WARNING</constant> était émise.
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     À partir de PHP 8.0.0, une <exceptionname>ValueError</exceptionname> est lancée.
+    </simpara>
+   </listitem>
+  </itemizedlist>
  </refsect1>
 
  <refsect1 role="changelog">

--- a/reference/pcntl/constants.xml
+++ b/reference/pcntl/constants.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
 <!-- EN-Revision: 71fa455c5670ea4a3a3a0c60e34d906d1061a6c8 Maintainer: yannick Status: ready -->
-<!-- Reviewed: yes -->
 <appendix xml:id="pcntl.constants" xmlns="http://docbook.org/ns/docbook">
  &reftitle.constants;
  <para>
@@ -71,30 +69,6 @@
    </term>
    <listitem>
     <simpara>
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry xml:id="constant.sigckpt">
-   <term>
-    <constant>SIGCKPT</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-     Génère/restitue un point de contrôle.
-     Disponible à partir de PHP 8.4.0 (uniquement sur DragonFlyBSD).
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry xml:id="constant.sigckptexit">
-   <term>
-    <constant>SIGCKPTEXIT</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-     Génère/restitue un point de contrôle et quitte.
-     Disponible à partir de PHP 8.4.0 (uniquement sur DragonFlyBSD).
     </simpara>
    </listitem>
   </varlistentry>
@@ -573,7 +547,7 @@
   </varlistentry>
   <varlistentry xml:id="constant.sig-setmask">
    <term>
-    <constant>SIG_SETMASK</constant> 
+    <constant>SIG_SETMASK</constant>
     (<type>int</type>)
    </term>
    <listitem>
@@ -581,8 +555,32 @@
     </simpara>
    </listitem>
   </varlistentry>
+  <varlistentry xml:id="constant.sigckpt">
+   <term>
+    <constant>SIGCKPT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Génère/restitue un point de contrôle.
+     Disponible à partir de PHP 8.4.0 (uniquement sur DragonFlyBSD).
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.sigckptexit">
+   <term>
+    <constant>SIGCKPTEXIT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Génère/restitue un point de contrôle et quitte.
+     Disponible à partir de PHP 8.4.0 (uniquement sur DragonFlyBSD).
+    </simpara>
+   </listitem>
+  </varlistentry>
  </variablelist>
- 
+
  <variablelist xml:id="pcntl.constants.si">
   <title>Les constantes SI_*</title>
   <varlistentry xml:id="constant.si-user">

--- a/reference/pdo_pgsql/pdo_overloaded/pgsqlCopyFromArray.xml
+++ b/reference/pdo_pgsql/pdo_overloaded/pgsqlCopyFromArray.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: 1993c38d254743d8c0a2140ff6f797660997083d Maintainer: girgias Status: ready -->
-<!-- Reviewed: no -->
 <refentry xml:id="pdo.pgsqlcopyfromarray" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>PDO::pgsqlCopyFromArray</refname>
@@ -21,13 +20,6 @@
   <simpara>
    &info.method.alias; <methodname>Pdo\Pgsql::copyFromArray</methodname>.
   </simpara>
- </refsect1>
-
- <refsect1 role="returnvalues">
-  &reftitle.returnvalues;
-  <para>
-   Retourne &true; en cas de succès,&return.falseforfailure;.
-  </para>
  </refsect1>
 </refentry>
 <!-- Keep this comment at the end of the file

--- a/reference/pdo_pgsql/pdo_overloaded/pgsqlCopyFromFile.xml
+++ b/reference/pdo_pgsql/pdo_overloaded/pgsqlCopyFromFile.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: 1993c38d254743d8c0a2140ff6f797660997083d Maintainer: girgias Status: ready -->
-<!-- Reviewed: no -->
 <refentry xml:id="pdo.pgsqlcopyfromfile" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>PDO::pgsqlCopyFromFile</refname>
@@ -21,13 +20,6 @@
   <simpara>
    &info.method.alias; <methodname>Pdo\Pgsql::copyFromFile</methodname>.
   </simpara>
- </refsect1>
-
- <refsect1 role="returnvalues">
-  &reftitle.returnvalues;
-  <para>
-   Retourne &true; en cas de succès,&return.falseforfailure;.
-  </para>
  </refsect1>
 </refentry>
 <!-- Keep this comment at the end of the file

--- a/reference/pdo_pgsql/pdo_overloaded/pgsqlCopyToArray.xml
+++ b/reference/pdo_pgsql/pdo_overloaded/pgsqlCopyToArray.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: 1993c38d254743d8c0a2140ff6f797660997083d Maintainer: girgias Status: ready -->
-<!-- Reviewed: no -->
 <refentry xml:id="pdo.pgsqlcopytoarray" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>PDO::pgsqlCopyToArray</refname>
@@ -20,13 +19,6 @@
   <simpara>
    &info.method.alias; <methodname>Pdo\Pgsql::copyToArray</methodname>.
   </simpara>
- </refsect1>
-
- <refsect1 role="returnvalues">
-  &reftitle.returnvalues;
-  <para>
-   Retourne un &array; de lignes,&return.falseforfailure;.
-  </para>
  </refsect1>
 </refentry>
 <!-- Keep this comment at the end of the file

--- a/reference/pdo_pgsql/pdo_overloaded/pgsqlCopyToFile.xml
+++ b/reference/pdo_pgsql/pdo_overloaded/pgsqlCopyToFile.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: 1993c38d254743d8c0a2140ff6f797660997083d Maintainer: girgias Status: ready -->
-<!-- Reviewed: no -->
 <refentry xml:id="pdo.pgsqlcopytofile" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>PDO::pgsqlCopyToFile</refname>
@@ -21,13 +20,6 @@
   <simpara>
    &info.method.alias; <methodname>Pdo\Pgsql::copyToFile</methodname>.
   </simpara>
- </refsect1>
-
- <refsect1 role="returnvalues">
-  &reftitle.returnvalues;
-  <para>
-   Retourne &true; en cas de succès,&return.falseforfailure;.
-  </para>
  </refsect1>
 </refentry>
 <!-- Keep this comment at the end of the file

--- a/reference/pdo_pgsql/pdo_overloaded/pgsqlGetNotify.xml
+++ b/reference/pdo_pgsql/pdo_overloaded/pgsqlGetNotify.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: 1993c38d254743d8c0a2140ff6f797660997083d Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
 <refentry xml:id="pdo.pgsqlgetnotify" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>PDO::pgsqlGetNotify</refname>
@@ -18,15 +17,6 @@
   <simpara>
    &info.method.alias; <methodname>Pdo\Pgsql::getNotify</methodname>.
   </simpara>
- </refsect1>
-
- <refsect1 role="returnvalues">
-  &reftitle.returnvalues;
-  <para>
-   Si une ou plusieurs notifications sont en attente, retourne une seule ligne
-   avec les champs <literal>message</literal> et <literal>pid</literal>, sinon,
-   retourne &false;.
-  </para>
  </refsect1>
 </refentry>
 <!-- Keep this comment at the end of the file

--- a/reference/pgsql/functions/pg-cancel-query.xml
+++ b/reference/pgsql/functions/pg-cancel-query.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: c2eca73ef79ebe78cebb34053e41b565af504c4f Maintainer: lacatoire Status: ready -->
-<!-- Reviewed: no -->
-<refentry xmlns="http://docbook.org/ns/docbook">
+<refentry xml:id='function.pg-cancel-query' xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>pg_cancel_query</refname>
   <refpurpose>

--- a/reference/radius/constants.xml
+++ b/reference/radius/constants.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
 <!-- EN-Revision: 9ac4d06c0bddbbb1b87ba93d1591ef1707d30420 Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
 <appendix xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="radius.constants">
  &reftitle.constants;
  &extension.constants;
@@ -1638,6 +1636,58 @@ radius_put_attr($radh, RADIUS_CHAP_CHALLENGE, $challenge);
      </simpara>
     </listitem>
    </varlistentry>
+  </variablelist>
+ </section>
+
+ <section xml:id="radius.constants.vendor-specific">
+  <title>Types d'attribut RADIUS spécifique au vendeur</title>
+
+  <variablelist>
+  <varlistentry xml:id="constant.radius-vendor-microsoft">
+   <term>
+    <constant>RADIUS_VENDOR_MICROSOFT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <para>
+     Attributs spécifiques à Microsoft (<link xlink:href="&url.rfc;2548">RFC 2548</link>) :
+      <simplelist>
+      <member><constant>RADIUS_MICROSOFT_MS_CHAP_RESPONSE</constant></member>
+      <member><constant>RADIUS_MICROSOFT_MS_CHAP_ERROR</constant></member>
+      <member><constant>RADIUS_MICROSOFT_MS_CHAP_PW_1</constant></member>
+      <member><constant>RADIUS_MICROSOFT_MS_CHAP_PW_2</constant></member>
+      <member><constant>RADIUS_MICROSOFT_MS_CHAP_LM_ENC_PW</constant></member>
+      <member><constant>RADIUS_MICROSOFT_MS_CHAP_NT_ENC_PW</constant></member>
+      <member><constant>RADIUS_MICROSOFT_MS_MPPE_ENCRYPTION_POLICY</constant></member>
+      <member><constant>RADIUS_MICROSOFT_MS_MPPE_ENCRYPTION_TYPES</constant></member>
+      <member><constant>RADIUS_MICROSOFT_MS_RAS_VENDOR</constant></member>
+      <member><constant>RADIUS_MICROSOFT_MS_CHAP_DOMAIN</constant></member>
+      <member><constant>RADIUS_MICROSOFT_MS_CHAP_CHALLENGE</constant></member>
+      <member><constant>RADIUS_MICROSOFT_MS_CHAP_MPPE_KEYS</constant></member>
+      <member><constant>RADIUS_MICROSOFT_MS_BAP_USAGE</constant></member>
+      <member><constant>RADIUS_MICROSOFT_MS_LINK_UTILIZATION_THRESHOLD</constant></member>
+      <member><constant>RADIUS_MICROSOFT_MS_LINK_DROP_TIME_LIMIT</constant></member>
+      <member><constant>RADIUS_MICROSOFT_MS_MPPE_SEND_KEY</constant></member>
+      <member><constant>RADIUS_MICROSOFT_MS_MPPE_RECV_KEY</constant></member>
+      <member><constant>RADIUS_MICROSOFT_MS_RAS_VERSION</constant></member>
+      <member><constant>RADIUS_MICROSOFT_MS_OLD_ARAP_PASSWORD</constant></member>
+      <member><constant>RADIUS_MICROSOFT_MS_NEW_ARAP_PASSWORD</constant></member>
+      <member><constant>RADIUS_MICROSOFT_MS_ARAP_PASSWORD_CHANGE_REASON</constant></member>
+      <member><constant>RADIUS_MICROSOFT_MS_FILTER</constant></member>
+      <member><constant>RADIUS_MICROSOFT_MS_ACCT_AUTH_TYPE</constant></member>
+      <member><constant>RADIUS_MICROSOFT_MS_ACCT_EAP_TYPE</constant></member>
+      <member><constant>RADIUS_MICROSOFT_MS_CHAP2_RESPONSE</constant></member>
+      <member><constant>RADIUS_MICROSOFT_MS_CHAP2_SUCCESS</constant></member>
+      <member><constant>RADIUS_MICROSOFT_MS_CHAP2_PW</constant></member>
+      <member><constant>RADIUS_MICROSOFT_MS_PRIMARY_DNS_SERVER</constant></member>
+      <member><constant>RADIUS_MICROSOFT_MS_SECONDARY_DNS_SERVER</constant></member>
+      <member><constant>RADIUS_MICROSOFT_MS_PRIMARY_NBNS_SERVER</constant></member>
+      <member><constant>RADIUS_MICROSOFT_MS_SECONDARY_NBNS_SERVER</constant></member>
+      <member><constant>RADIUS_MICROSOFT_MS_ARAP_CHALLENGE</constant></member>
+     </simplelist>
+    </para>
+   </listitem>
+  </varlistentry>
    <varlistentry xml:id="constant.radius-microsoft-ms-chap-response">
      <term>
       <constant>RADIUS_MICROSOFT_MS_CHAP_RESPONSE</constant>
@@ -1927,58 +1977,6 @@ radius_put_attr($radh, RADIUS_CHAP_CHALLENGE, $challenge);
      </listitem>
     </varlistentry>
   </variablelist>
- </section>
-
- <section xml:id="radius.constants.vendor-specific">
-  <title>Types d'attribut RADIUS spécifique au vendeur</title>
-
-  <variablelist>
-  <varlistentry xml:id="constant.radius-vendor-microsoft">
-   <term>
-    <constant>RADIUS_VENDOR_MICROSOFT</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <para>
-     Attributs spécifiques à Microsoft (<link xlink:href="&url.rfc;2548">RFC 2548</link>) :
-      <simplelist>
-      <member><constant>RADIUS_MICROSOFT_MS_CHAP_RESPONSE</constant></member>
-      <member><constant>RADIUS_MICROSOFT_MS_CHAP_ERROR</constant></member>
-      <member><constant>RADIUS_MICROSOFT_MS_CHAP_PW_1</constant></member>
-      <member><constant>RADIUS_MICROSOFT_MS_CHAP_PW_2</constant></member>
-      <member><constant>RADIUS_MICROSOFT_MS_CHAP_LM_ENC_PW</constant></member>
-      <member><constant>RADIUS_MICROSOFT_MS_CHAP_NT_ENC_PW</constant></member>
-      <member><constant>RADIUS_MICROSOFT_MS_MPPE_ENCRYPTION_POLICY</constant></member>
-      <member><constant>RADIUS_MICROSOFT_MS_MPPE_ENCRYPTION_TYPES</constant></member>
-      <member><constant>RADIUS_MICROSOFT_MS_RAS_VENDOR</constant></member>
-      <member><constant>RADIUS_MICROSOFT_MS_CHAP_DOMAIN</constant></member>
-      <member><constant>RADIUS_MICROSOFT_MS_CHAP_CHALLENGE</constant></member>
-      <member><constant>RADIUS_MICROSOFT_MS_CHAP_MPPE_KEYS</constant></member>
-      <member><constant>RADIUS_MICROSOFT_MS_BAP_USAGE</constant></member>
-      <member><constant>RADIUS_MICROSOFT_MS_LINK_UTILIZATION_THRESHOLD</constant></member>
-      <member><constant>RADIUS_MICROSOFT_MS_LINK_DROP_TIME_LIMIT</constant></member>
-      <member><constant>RADIUS_MICROSOFT_MS_MPPE_SEND_KEY</constant></member>
-      <member><constant>RADIUS_MICROSOFT_MS_MPPE_RECV_KEY</constant></member>
-      <member><constant>RADIUS_MICROSOFT_MS_RAS_VERSION</constant></member>
-      <member><constant>RADIUS_MICROSOFT_MS_OLD_ARAP_PASSWORD</constant></member>
-      <member><constant>RADIUS_MICROSOFT_MS_NEW_ARAP_PASSWORD</constant></member>
-      <member><constant>RADIUS_MICROSOFT_MS_ARAP_PASSWORD_CHANGE_REASON</constant></member>
-      <member><constant>RADIUS_MICROSOFT_MS_FILTER</constant></member>
-      <member><constant>RADIUS_MICROSOFT_MS_ACCT_AUTH_TYPE</constant></member>
-      <member><constant>RADIUS_MICROSOFT_MS_ACCT_EAP_TYPE</constant></member>
-      <member><constant>RADIUS_MICROSOFT_MS_CHAP2_RESPONSE</constant></member>
-      <member><constant>RADIUS_MICROSOFT_MS_CHAP2_SUCCESS</constant></member>
-      <member><constant>RADIUS_MICROSOFT_MS_CHAP2_PW</constant></member>
-      <member><constant>RADIUS_MICROSOFT_MS_PRIMARY_DNS_SERVER</constant></member>
-      <member><constant>RADIUS_MICROSOFT_MS_SECONDARY_DNS_SERVER</constant></member>
-      <member><constant>RADIUS_MICROSOFT_MS_PRIMARY_NBNS_SERVER</constant></member>
-      <member><constant>RADIUS_MICROSOFT_MS_SECONDARY_NBNS_SERVER</constant></member>
-      <member><constant>RADIUS_MICROSOFT_MS_ARAP_CHALLENGE</constant></member>
-     </simplelist>
-    </para>
-   </listitem>
-  </varlistentry>
- </variablelist>
  </section>
 </appendix>
 <!-- Keep this comment at the end of the file

--- a/reference/strings/constants.xml
+++ b/reference/strings/constants.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
 <!-- EN-Revision: 5cadfd39ba0d63d982b51402a8089415ecfc52f3 Maintainer: yannick Status: ready -->
-<!-- Reviewed: yes -->
 <appendix xml:id="string.constants" xmlns="http://docbook.org/ns/docbook">
  &reftitle.constants;
  &extension.constants;
@@ -334,17 +332,6 @@
    <listitem>
     <simpara>
 
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry xml:id="constant.alt-digits">
-   <term>
-    <constant>ALT_DIGITS</constant>
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-     Symboles alternatifs pour les chiffres.
     </simpara>
    </listitem>
   </varlistentry>
@@ -887,6 +874,17 @@
    <listitem>
     <simpara>
      Heure au format de l'ère alternative (chaîne pouvant être utilisée dans <function>strftime</function>).
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.alt-digits">
+   <term>
+    <constant>ALT_DIGITS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Symboles alternatifs pour les chiffres.
     </simpara>
    </listitem>
   </varlistentry>

--- a/reference/strings/functions/number-format.xml
+++ b/reference/strings/functions/number-format.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: 45042fef652f1b4e904e809fcbfcf31f6c60670b Maintainer: yannick Status: ready -->
-<!-- Reviewed: yes -->
 <refentry xml:id="function.number-format" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>number_format</refname>
@@ -111,32 +110,6 @@
     </tgroup>
    </informaltable>
   </para>
-  <example>
-   <title>Une valeur négative pour <parameter>decimals</parameter></title>
-   <simpara>
-    À partir de PHP 8.3.0, une valeur négative pour <parameter>decimals</parameter>
-    est utilisée pour arrondir le nombre de chiffres significatifs avant le point
-    décimal.
-   </simpara>
-   <programlisting role="php">
-<![CDATA[
-<?php
-$number = "1234.5678";
-var_dump(number_format($number, -1));
-var_dump(number_format($number, -2));
-var_dump(number_format($number, -3));
-?>
-]]>
-   </programlisting>
-   &example.outputs;
-   <screen>
-<![CDATA[
-string(5) "1,230"
-string(5) "1,200"
-string(5) "1,000"
-]]>
-   </screen>
-  </example>
  </refsect1>
 
  <refsect1 role="examples">
@@ -175,6 +148,32 @@ echo number_format($number, 2, '.', ''), PHP_EOL;
     </programlisting>
    </example>
   </para>
+  <example>
+   <title>Une valeur négative pour <parameter>decimals</parameter></title>
+   <simpara>
+    À partir de PHP 8.3.0, une valeur négative pour <parameter>decimals</parameter>
+    est utilisée pour arrondir le nombre de chiffres significatifs avant le point
+    décimal.
+   </simpara>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$number = "1234.5678";
+var_dump(number_format($number, -1));
+var_dump(number_format($number, -2));
+var_dump(number_format($number, -3));
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+string(5) "1,230"
+string(5) "1,200"
+string(5) "1,000"
+]]>
+   </screen>
+  </example>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/strings/functions/str-getcsv.xml
+++ b/reference/strings/functions/str-getcsv.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: 45042fef652f1b4e904e809fcbfcf31f6c60670b Maintainer: yannick Status: ready -->
-<!-- Reviewed: yes -->
 <refentry xml:id="function.str-getcsv" xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude">
  <refnamediv>
   <refname>str_getcsv</refname>
@@ -175,8 +174,7 @@ array(1) {
 
  <refsect1 role="seealso">
   &reftitle.seealso;
-  <para>
-   <simplelist>
+  <simplelist>
    <member><function>fputcsv</function></member>
    <member><function>fgetcsv</function></member>
    <member><methodname>SplFileObject::fgetcsv</methodname></member>
@@ -184,7 +182,6 @@ array(1) {
    <member><methodname>SplFileObject::setCsvControl</methodname></member>
    <member><methodname>SplFileObject::getCsvControl</methodname></member>
   </simplelist>
-  </para>
  </refsect1>
 </refentry>
 <!-- Keep this comment at the end of the file

--- a/reference/strings/functions/substr.xml
+++ b/reference/strings/functions/substr.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: 71166b721ba6bb7dd3110da86efa3b723e1f7651 Maintainer: yannick Status: ready -->
-<!-- Reviewed: yes -->
 <refentry xml:id="function.substr" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>substr</refname>
@@ -212,8 +211,6 @@ echo "7) ", var_export(substr(1.2e3, 0, 4), true), PHP_EOL;
 ]]>
     </screen>
    </example>
-  </para>
-
   <example>
    <title>Intervalle de Caractères Invalide</title>
    <para>
@@ -241,6 +238,7 @@ bool(false)
 ]]>
    </screen>
   </example>
+  </para>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/uodbc/functions/odbc-num-rows.xml
+++ b/reference/uodbc/functions/odbc-num-rows.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
 <!-- EN-Revision: ed1aff13602c94f86344bdd7c4fbc31f5a71bf84 Maintainer: yannick Status: ready -->
-<!-- Reviewed: yes -->
 
 <refentry xml:id="function.odbc-num-rows" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -45,17 +43,6 @@
    Cette fonction retournera -1 si une erreur survient.
   </para>
  </refsect1>
- <refsect1 role="notes">
-  &reftitle.notes;
-  <note>
-   <para>
-    L'utilisation de la fonction <function>odbc_num_rows</function> pour
-    déterminer le nombre de lignes disponible après un SELECT retournera
-    -1 avec la plupart des pilotes.
-   </para>
-  </note>
- </refsect1>
-
  <refsect1 role="changelog">
   &reftitle.changelog;
   <informaltable>
@@ -71,6 +58,17 @@
     </tbody>
    </tgroup>
   </informaltable>
+ </refsect1>
+
+ <refsect1 role="notes">
+  &reftitle.notes;
+  <note>
+   <para>
+    L'utilisation de la fonction <function>odbc_num_rows</function> pour
+    déterminer le nombre de lignes disponible après un SELECT retournera
+    -1 avec la plupart des pilotes.
+   </para>
+  </note>
  </refsect1>
 </refentry>
 <!-- Keep this comment at the end of the file

--- a/reference/yaz/functions/yaz-record.xml
+++ b/reference/yaz/functions/yaz-record.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
 <!-- EN-Revision: f9c4a68ef4f89e51e6d9b905ad3ddb6492386dd3 Maintainer: yannick Status: ready -->
-<!-- Reviewed: yes -->
 
 <refentry xml:id="function.yaz-record" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -227,9 +225,7 @@ print_r($ar);
 ?>
 ]]>
     </programlisting>
-   </para>
-   &example.outputs;
-   <screen>
+    <screen>
 <![CDATA[
 Array
 (
@@ -253,7 +249,8 @@ Array
         )
 )
 ]]>
-   </screen>
+    </screen>
+   </para>
   </example>
   <example>
    <title>Travail avec MARCXML</title>

--- a/reference/zip/ziparchive/getexternalattributesindex.xml
+++ b/reference/zip/ziparchive/getexternalattributesindex.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
-<!-- Reviewed: yes -->
 <refentry xml:id="ziparchive.getexternalattributesindex" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>ZipArchive::getExternalAttributesIndex</refname>
@@ -14,7 +13,7 @@
    <methodparam><type>int</type><parameter>index</parameter></methodparam>
    <methodparam><type>int</type><parameter role="reference">opsys</parameter></methodparam>
    <methodparam><type>int</type><parameter role="reference">attr</parameter></methodparam>
-   <methodparam choice="opt"><type>int</type><parameter>flags</parameter></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
   <simpara>
    Récupère les attributs externes d'une entrée définie par son index.


### PR DESCRIPTION
Sur 48 pages de `reference/`, la structure de balises bloc avait dérivé de doc-en : `<para>` restés là où l'EN a `<simpara>`, sections/tables/exemples mal placés, blocs ou `xml:id` manquants, doublons. Cette PR réaligne tout sur l'EN, tag à tag.

Aucun changement de contenu traduit au-delà de ce qu'impose l'alignement structurel. Divergences trouvées par comparaison de squelette XML EN/FR sur les fichiers à jour.