### PR TITLE
[Sync EN] ReturnTypeWillChange: ajoute l'avertissement sur le futur type de retour strict

### DIFF
--- a/language/predefined/attributes/returntypewillchange.xml
+++ b/language/predefined/attributes/returntypewillchange.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 77325b622f91355b118e8f3bc9ff940e8201f55d Maintainer: pierrick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 0019a7e201442447fd746c2852d28ba839ed15ae Maintainer: lacatoire Status: ready -->
 <reference xml:id="class.returntypewillchange" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>La classe ReturnTypeWillChange</title>
  <titleabbrev>ReturnTypeWillChange</titleabbrev>
@@ -9,14 +8,28 @@
 
   <section xml:id="returntypewillchange.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     La plupart des méthodes internes non finales exigent désormais que les méthodes de surcharge déclarent
     un type de retour compatible, sinon un avis d'obsolescence est émis lors de la validation de l'héritage.
-    Dans le cas où le type de retour ne peut pas être déclaré pour une méthode de surcharge en raison de 
+    Cela introduit une phase de type de retour provisoire : le moteur émet un avis d'obsolescence
+    plutôt qu'une erreur fatale lorsque les types de retour sont incompatibles, avant qu'ils ne soient
+    imposés dans une version future.
+    Dans le cas où le type de retour ne peut pas être déclaré pour une méthode de surcharge en raison de
     problèmes de compatibilité entre les versions de PHP,
     un attribut <code>#[\ReturnTypeWillChange]</code> peut être ajouté pour taire
     l'avis d'obsolescence.
-   </para>
+   </simpara>
+
+   <warning>
+    <simpara>
+     L'attribut <classname>ReturnTypeWillChange</classname> supprime les avis d'obsolescence
+     durant la phase de type de retour provisoire <emphasis>uniquement</emphasis>.
+     Il n'a aucun effet lors de la surcharge de méthodes définies dans des classes définies par l'utilisateur.
+     Une fois que les méthodes internes adopteront des types stricts, les incompatibilités dans les
+     signatures des méthodes de surcharge provoqueront une erreur fatale et cet attribut n'aura plus aucun effet.
+    </simpara>
+   </warning>
+
   </section>
 
   <section xml:id="returntypewillchange.synopsis">


### PR DESCRIPTION
Synchronise la traduction sur le commit EN qui détaille la phase de type de retour provisoire et ajoute un avertissement sur la portée de l'attribut.

Fixes #3029