### PR TITLE
Aligner trois pages sur la structure bloc de doc-en

### DIFF
--- a/features/commandline.xml
+++ b/features/commandline.xml
@@ -1482,13 +1482,13 @@ php >
    </programlisting>
   </example>
   
-  <simpara>
+  <para>
    Le shell interactif fournit également une autocomplétion des fonctions,
    des constantes, des noms de classes, des variables, des appels aux méthodes
    statiques et des constantes de classes en utilisant la touche de tabulation.
    À partir de PHP 8.4.0, le chemin vers le fichier d'historique peut être défini en utilisant la
    variable d'environnement <envar>PHP_HISTFILE</envar>.
-  </simpara>
+  </para>
   
   <example>
    <title>Auto-complétion en utilisant la touche de tabulation</title>
@@ -1524,10 +1524,10 @@ php > $foo[TAB]ThisIsAReallyLongVariableName
    </programlisting>
   </example>
   
-  <para>
+  <simpara>
    Le shell interactif stocke l'historique et peut y accéder en utilisant les touches
    haut et bas. L'historique est sauvegardé dans le fichier <filename>~/.php_history</filename>.
-  </para>
+  </simpara>
   
   <para>
    Le &cli.sapi; fournit 2 directives du &php.ini; :

--- a/install/fpm/configuration.xml
+++ b/install/fpm/configuration.xml
@@ -396,16 +396,16 @@
      <para>
       <literal>static</literal> - nombre de processus fils fixés (<literal>pm.max_children</literal>).
      </para>
-     <para>
+     <simpara>
       <literal>ondemand</literal> - le processus se réactive à la demande
       (lorsque demandé, c'est l'opposé de dynamique où <literal>pm.start_servers</literal>
       sont démarrés lorsque le service démarre).
-     </para>
-     <para>
+     </simpara>
+     <simpara>
       <literal>dynamic</literal> - nombre de processus fils dynamiques basé sur les directives suivantes:
       <literal>pm.max_children</literal>, <literal>pm.start_servers</literal>,
       <literal>pm.min_spare_servers</literal>, <literal>pm.max_spare_servers</literal>.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry xml:id="pm.max-children">
@@ -414,12 +414,12 @@
      &integer;
     </term>
     <listitem>
-     <para>
+     <simpara>
       Nombre de processus fils à créer lorsque <literal>pm</literal> est réglé sur
       <literal>static</literal>. Nombre maximum de processus fils à créer lorsque
       <literal>pm</literal> est réglé sur <literal>dynamic</literal> ou <literal>ondemand</literal>.
       Option obligatoire.
-     </para>
+     </simpara>
      <para>
       Cette option affecte la limite du nombre de requêtes simultanées qui seront servies. Équivalent à
       ApacheMaxClients avec mpm_prefork et à <varname>PHP_FCGI_CHILDREN</varname> dans l'implémentation originale

--- a/reference/xmlrpc/functions/xmlrpc-get-type.xml
+++ b/reference/xmlrpc/functions/xmlrpc-get-type.xml
@@ -14,8 +14,9 @@
    <type>string</type><methodname>xmlrpc_get_type</methodname>
    <methodparam><type>mixed</type><parameter>value</parameter></methodparam>
   </methodsynopsis>
+  &warn.experimental.func;
   <para>
-   Particulièrement pratique pour les types chaînes de type 
+   Particulièrement pratique pour les types chaînes de type
    <literal>base64</literal> et <literal>datetime</literal>.
   </para>
  </refsect1>


### PR DESCRIPTION
Trois écarts de structure résiduels vs doc-en : `xmlrpc_get_type` ne portait pas l'avertissement `&warn.experimental.func;` (la page ne signalait pas la fonction comme expérimentale), et des `<para>`/`<simpara>` divergeaient dans `install/fpm/configuration` et `features/commandline`. Réalignés tag à tag sur l'EN.