### PR TITLE
[Sync EN] Document FILTER_THROW_ON_FAILURE and the Filter exception classes (PHP 8.5)

### DIFF
--- a/reference/filter/book.xml
+++ b/reference/filter/book.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 53054bf8decc8648cf2e90a493692a161e2371af Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 3d4ee5f40afbfe44db4f1b13a22a6a38d4b40c7b Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <book xml:id="book.filter" xmlns="http://docbook.org/ns/docbook">
  <?phpdoc extension-membership="bundled" ?>
@@ -52,6 +52,9 @@
  &reference.filter.constants;
  &reference.filter.examples;
  &reference.filter.reference;
+
+ &reference.filter.filter.filterexception;
+ &reference.filter.filter.filterfailedexception;
 
 </book>
 <!-- Keep this comment at the end of the file

--- a/reference/filter/constants.xml
+++ b/reference/filter/constants.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 525aa5f198d482c0d03be54ddee5af13b376ab99 Maintainer: lacatoire Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 3d4ee5f40afbfe44db4f1b13a22a6a38d4b40c7b Maintainer: lacatoire Status: ready -->
 <appendix xml:id="filter.constants" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.constants;
  &extension.constants;
@@ -151,6 +150,25 @@
     <simpara>
      Utilisable avec tout filtre de validation
      <constant>FILTER_VALIDATE_<replaceable>*</replaceable></constant>.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.filter-throw-on-failure">
+   <term>
+    <constant>FILTER_THROW_ON_FAILURE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Lance une <exceptionname>Filter\FilterFailedException</exceptionname>
+     lorsqu'un filtre de validation échoue, au lieu de retourner &false;.
+    </simpara>
+    <simpara>
+     Utilisable avec tout filtre de validation
+     <constant>FILTER_VALIDATE_<replaceable>*</replaceable></constant>.
+    </simpara>
+    <simpara>
+     Disponible à partir de PHP 8.5.0.
     </simpara>
    </listitem>
   </varlistentry>

--- a/reference/filter/filter.filterexception.xml
+++ b/reference/filter/filter.filterexception.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 3d4ee5f40afbfe44db4f1b13a22a6a38d4b40c7b Maintainer: lacatoire Status: ready -->
+<reference xml:id="class.filter-filterexception" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+ <title>La classe Filter\FilterException</title>
+ <titleabbrev>Filter\FilterException</titleabbrev>
+
+ <partintro>
+  <section xml:id="filter-filterexception.intro">
+   &reftitle.intro;
+   <simpara>
+    La classe de base pour les <type>Exception</type>s lancées par l'extension Filter.
+   </simpara>
+  </section>
+
+  <section xml:id="filter-filterexception.synopsis">
+   &reftitle.classsynopsis;
+
+   <packagesynopsis>
+    <package>Filter</package>
+
+    <classsynopsis class="class">
+     <ooexception>
+      <exceptionname>FilterException</exceptionname>
+     </ooexception>
+
+     <ooclass>
+      <modifier>extends</modifier>
+      <classname>Exception</classname>
+     </ooclass>
+
+     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
+      <xi:fallback/>
+     </xi:include>
+
+     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])">
+      <xi:fallback/>
+     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])">
+      <xi:fallback/>
+     </xi:include>
+    </classsynopsis>
+   </packagesynopsis>
+  </section>
+ </partintro>
+</reference>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/filter/filter.filterfailedexception.xml
+++ b/reference/filter/filter.filterfailedexception.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 3d4ee5f40afbfe44db4f1b13a22a6a38d4b40c7b Maintainer: lacatoire Status: ready -->
+<reference xml:id="class.filter-filterfailedexception" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+ <title>La classe Filter\FilterFailedException</title>
+ <titleabbrev>Filter\FilterFailedException</titleabbrev>
+
+ <partintro>
+  <section xml:id="filter-filterfailedexception.intro">
+   &reftitle.intro;
+   <simpara>
+    Lancée lorsqu'un filtre de validation échoue et que le drapeau
+    <constant>FILTER_THROW_ON_FAILURE</constant> est défini.
+   </simpara>
+  </section>
+
+  <section xml:id="filter-filterfailedexception.synopsis">
+   &reftitle.classsynopsis;
+
+   <packagesynopsis>
+    <package>Filter</package>
+
+    <classsynopsis class="class">
+     <ooexception>
+      <exceptionname>FilterFailedException</exceptionname>
+     </ooexception>
+
+     <ooclass>
+      <modifier>extends</modifier>
+      <classname>Filter\FilterException</classname>
+     </ooclass>
+
+     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
+      <xi:fallback/>
+     </xi:include>
+
+     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])">
+      <xi:fallback/>
+     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])">
+      <xi:fallback/>
+     </xi:include>
+    </classsynopsis>
+   </packagesynopsis>
+  </section>
+ </partintro>
+</reference>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
Synchronisation avec l'anglais : documente la constante FILTER_THROW_ON_FAILURE (PHP 8.5) ainsi que les classes d'exception Filter\FilterException et Filter\FilterFailedException.

Mise à jour de book.xml et constants.xml, et traduction des deux nouvelles pages de classe.

Fixes #3037