### PR TITLE
[Sync EN] Fix example output (screen) inconsistent with code

### DIFF
--- a/language/oop5/inheritance.xml
+++ b/language/oop5/inheritance.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: f94d903985119d3ac00f4528551df947f57b667f Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: df78bd1d232f2cd8df673accf5ba0e280695639b Maintainer: lacatoire Status: ready -->
 <sect1 xml:id="language.oop5.inheritance" xmlns="http://docbook.org/ns/docbook">
  <title>Héritage</title>
  <para>
@@ -88,7 +87,7 @@ class Foo
     
     public function printPHP()
     {
-        echo 'PHP est super' . PHP_EOL;
+        echo 'PHP est super.' . PHP_EOL;
     }
 }
 
@@ -103,9 +102,9 @@ class Bar extends Foo
 $foo = new Foo();
 $bar = new Bar();
 $foo->printItem('baz'); // Affiche : 'Foo: baz'
-$foo->printPHP();       // Affiche : 'PHP est super'
+$foo->printPHP();       // Affiche : 'PHP est super.'
 $bar->printItem('baz'); // Affiche : 'Bar: baz'
-$bar->printPHP();       // Affiche : 'PHP est super'
+$bar->printPHP();       // Affiche : 'PHP est super.'
 
 ?>
 ]]>

--- a/reference/datetime/functions/mktime.xml
+++ b/reference/datetime/functions/mktime.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: Fan2Shrek Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: df78bd1d232f2cd8df673accf5ba0e280695639b Maintainer: lacatoire Status: ready -->
 <refentry xml:id="function.mktime" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>mktime</refname>
@@ -266,12 +265,12 @@ print date('c', $nextyear) . "\n";
   <para>
    <example>
     <title>Dernier jour d'un mois</title>
-    <para>
+    <simpara>
      Le dernier jour d'un mois peut être décrit comme
      le jour "0" du mois suivant, et non pas le jour -1. Les deux
-     exemples suivants vont donner :
-     "Le dernier jour de février 2000 est : 29".
-    </para>
+     exemples suivants vont donner la chaîne
+     "Last day in Feb 2000 is: 29".
+    </simpara>
     <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/dom/domelement/construct.xml
+++ b/reference/dom/domelement/construct.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4f5e2b22575131fa5e9c3004b1c874e1acb06573 Maintainer: yannick Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: df78bd1d232f2cd8df673accf5ba0e280695639b Maintainer: lacatoire Status: ready -->
 <refentry xml:id="domelement.construct" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>DOMElement::__construct</refname>

--- a/reference/ds/ds/map/ksort.xml
+++ b/reference/ds/ds/map/ksort.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 2226ad08fd93e3979efbba47c5ae3545eec97d25 Maintainer: Fan2Shrek Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: df78bd1d232f2cd8df673accf5ba0e280695639b Maintainer: lacatoire Status: ready -->
 <refentry xml:id="ds-map.ksort" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Ds\Map::ksort</refname>
@@ -15,9 +14,9 @@
    <modifier>public</modifier> <type>void</type><methodname>Ds\Map::ksort</methodname>
    <methodparam choice="opt"><type>callable</type><parameter>comparator</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
     Trie la carte en place par clé, en utilisant une fonction <parameter>comparator</parameter> facultative.
-  </para>
+  </simpara>
 
  </refsect1>
 
@@ -35,9 +34,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
     &return.void;
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">
@@ -100,7 +99,6 @@ print_r($map);
    &example.outputs.similar;
    <screen>
 <![CDATA[
-Ds\Map Object
 Ds\Map Object
 (
     [0] => Ds\Pair Object

--- a/reference/ds/ds/map/ksorted.xml
+++ b/reference/ds/ds/map/ksorted.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 2226ad08fd93e3979efbba47c5ae3545eec97d25 Maintainer: Fan2Shrek Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: df78bd1d232f2cd8df673accf5ba0e280695639b Maintainer: lacatoire Status: ready -->
 <refentry xml:id="ds-map.ksorted" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Ds\Map::ksorted</refname>
@@ -13,9 +12,9 @@
    <modifier>public</modifier> <type>Ds\Map</type><methodname>Ds\Map::ksorted</methodname>
    <methodparam choice="opt"><type>callable</type><parameter>comparator</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
     Renvoie une copie triée par clé, en utilisant une fonction <parameter>comparator</parameter> facultative.
-  </para>
+  </simpara>
 
  </refsect1>
 
@@ -33,9 +32,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
     Renvoie une copie de la carte, triée par clé.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">
@@ -54,7 +53,6 @@ print_r($map->ksorted());
    &example.outputs.similar;
    <screen>
 <![CDATA[
-Ds\Map Object
 Ds\Map Object
 (
     [0] => Ds\Pair Object
@@ -98,7 +96,6 @@ print_r($sorted);
    &example.outputs.similar;
    <screen>
 <![CDATA[
-Ds\Map Object
 Ds\Map Object
 (
     [0] => Ds\Pair Object

--- a/reference/ds/ds/map/pairs.xml
+++ b/reference/ds/ds/map/pairs.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: dd07341fae2c414adc1f700be0890ff32e8daab4 Maintainer: Fan2Shrek Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: df78bd1d232f2cd8df673accf5ba0e280695639b Maintainer: lacatoire Status: ready -->
 <refentry xml:id="ds-map.pairs" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Ds\Map::pairs</refname>
@@ -47,7 +46,7 @@ var_dump($map->pairs());
    &example.outputs.similar;
    <screen>
 <![CDATA[
-object(Ds\Map)#8 (3) {
+object(Ds\Vector)#8 (3) {
   [0]=>
   object(Ds\Pair)#5 (2) {
     ["key"]=>
@@ -70,7 +69,6 @@ object(Ds\Map)#8 (3) {
     int(3)
   }
 }
-p
 ]]>
    </screen>
   </example>

--- a/reference/ds/ds/pair/clear.xml
+++ b/reference/ds/ds/pair/clear.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: dd07341fae2c414adc1f700be0890ff32e8daab4 Maintainer: Fan2Shrek Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: df78bd1d232f2cd8df673accf5ba0e280695639b Maintainer: lacatoire Status: ready -->
 <refentry xml:id="ds-pair.clear" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Ds\Pair::clear</refname>
@@ -50,9 +49,8 @@ print_r($pair);
 <![CDATA[
 Ds\Pair Object
 (
-    [0] => 1
-    [1] => 2
-    [2] => 3
+    [key] => a
+    [value] => 1
 )
 Ds\Pair Object
 (

--- a/reference/ds/ds/vector/join.xml
+++ b/reference/ds/ds/vector/join.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: dd07341fae2c414adc1f700be0890ff32e8daab4 Maintainer: Fan2Shrek Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: df78bd1d232f2cd8df673accf5ba0e280695639b Maintainer: lacatoire Status: ready -->
 <refentry xml:id="ds-vector.join" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Ds\Vector::join</refname>
@@ -73,7 +72,7 @@ var_dump($vector->join());
    &example.outputs.similar;
    <screen>
 <![CDATA[
-string(11) "abc123"
+string(6) "abc123"
 ]]>
    </screen>
   </example>

--- a/reference/memcached/memcached/fetch.xml
+++ b/reference/memcached/memcached/fetch.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 1d8068ecb070fdc360d750e0c1f3f15796e61ec0 Maintainer: jpauli Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: df78bd1d232f2cd8df673accf5ba0e280695639b Maintainer: lacatoire Status: ready -->
 <refentry xml:id="memcached.fetch" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Memcached::fetch</refname>
@@ -62,7 +60,7 @@ while ($result = $m->fetch()) {
 array(3) {
   ["key"]=>
   string(3) "int"
-  "value"]=>
+  ["value"]=>
   int(99)
   ["cas"]=>
   float(2363)

--- a/reference/mongodb/functions/bson/fromphp.xml
+++ b/reference/mongodb/functions/bson/fromphp.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: df78bd1d232f2cd8df673accf5ba0e280695639b Maintainer: lacatoire Status: ready -->
 <refentry xml:id="function.mongodb.bson-fromphp" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>MongoDB\BSON\fromPHP</refname>
@@ -100,7 +99,7 @@ echo bin2hex($bson), "\n";
    &example.outputs;
    <screen>
 <![CDATA[
-0e00000010666f6f000100000000cat
+0e00000010666f6f000100000000
 ]]>
    </screen>
   </example>

--- a/reference/mongodb/mongodb/driver/cursor.xml
+++ b/reference/mongodb/mongodb/driver/cursor.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: df78bd1d232f2cd8df673accf5ba0e280695639b Maintainer: lacatoire Status: ready -->
 
 <reference xml:id="class.mongodb-driver-cursor" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -147,7 +146,7 @@ stdClass Object
     [name] => Vesta
     [size] => 525
     [distance] => 2.362
-}
+)
 ]]>
     </screen>
    </example>

--- a/reference/spl/splobjectstorage/rewind.xml
+++ b/reference/spl/splobjectstorage/rewind.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 6d29533483657c036e49edb5ea88c7103d126681 Maintainer: dams Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: df78bd1d232f2cd8df673accf5ba0e280695639b Maintainer: lacatoire Status: ready -->
 <refentry xml:id="splobjectstorage.rewind" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>SplObjectStorage::rewind</refname>
@@ -63,8 +61,12 @@ while($s->valid()) {
     &example.outputs.similar;
     <screen>
 <![CDATA[
-int(1)
-int(0)
+object(stdClass)#2 (0) {
+}
+string(2) "d1"
+object(stdClass)#3 (0) {
+}
+string(2) "d2"
 ]]>
     </screen>
    </example>

--- a/reference/uri/uri/whatwg/url/getquery.xml
+++ b/reference/uri/uri/whatwg/url/getquery.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: df78bd1d232f2cd8df673accf5ba0e280695639b Maintainer: lacatoire Status: ready -->
 <refentry xml:id="uri-whatwg-url.getquery" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Uri\WhatWg\Url::getQuery</refname>
@@ -45,7 +45,7 @@ echo $url->getQuery();
    &example.outputs;
    <screen>
 <![CDATA[
-foo=bar
+foo/bar
 ]]>
    </screen>
   </example>

--- a/reference/wincache/functions/wincache-ucache-delete.xml
+++ b/reference/wincache/functions/wincache-ucache-delete.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: ed710737ea7ce93f1289809cf89170c6d48b72a6 Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: df78bd1d232f2cd8df673accf5ba0e280695639b Maintainer: lacatoire Status: ready -->
 
 <refentry xml:id="function.wincache-ucache-delete" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -90,7 +88,7 @@ var_dump(wincache_ucache_delete($array2));
     <screen>
 <![CDATA[
 array(4) { [0]=> string(5) "green" 
-           [1]=> string(4) "Blue" 
+           [1]=> string(4) "blue"
            [2]=> string(6) "yellow" 
            [3]=> string(4) "cyan" } 
 ]]>

--- a/reference/yaf/yaf-config-ini.xml
+++ b/reference/yaf/yaf-config-ini.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: df78bd1d232f2cd8df673accf5ba0e280695639b Maintainer: lacatoire Status: ready -->
 <reference xml:id="class.yaf-config-ini" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  
  <title>La classe Yaf_Config_Ini</title>
@@ -156,7 +154,7 @@ var_dump($config->get("database.params.username"));
 <![CDATA[
 string(15) "dev.example.com"
 string(6) "dbname"
-string(7) "devuser
+string(7) "devuser"
 ]]>
    </screen>
   </example>

--- a/reference/yar/examples.xml
+++ b/reference/yar/examples.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 940ea8c1b2b727eb0f3f6412305ab699b9b47cc6 Maintainer: lacatoire Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: df78bd1d232f2cd8df673accf5ba0e280695639b Maintainer: lacatoire Status: ready -->
 
 <chapter xml:id="yar.examples" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.examples;
@@ -80,7 +78,7 @@ var_dump($client->add(1, 2));
 var_dump($client->call("add", array(3, 2)));
 
 
-/* la méthode __add ne peut être appelée */
+/* la méthode _add ne peut être appelée */
 var_dump($client->_add(1, 2));
 ?>
 ]]>


### PR DESCRIPTION
Synchronisation des 16 fichiers FR concernés : correction des blocs <screen> de sortie d'exemple pour qu'ils correspondent au code (doublons retirés, valeurs et types corrigés).

Mise à jour des en-têtes EN-Revision et passage Maintainer: lacatoire.

Fixes #3038