### PR TITLE
Ajouter une vérification CI de l'EN-Revision

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,6 @@
 # https://docs.github.com/en/actions
 
-name: "Build"
+name: "Structure"
 
 on:
   pull_request: null
@@ -10,24 +10,18 @@ on:
 
 jobs:
   build:
-    name: "Build"
+    name: "Check Build"
 
     runs-on: "ubuntu-22.04"
 
-    strategy:
-      matrix:
-        language:
-          - "fr"
-
     steps:
-      - name: "Checkout php/doc-${{ matrix.language }}"
+      - name: "Checkout php/doc-fr"
         uses: "actions/checkout@v4"
         with:
-          path: "${{ matrix.language }}"
-          repository: "php/doc-${{ matrix.language }}"
+          path: "fr"
+          repository: "php/doc-fr"
 
       - name: "Checkout php/doc-en as fallback"
-        if: "matrix.language != 'en'"
         uses: "actions/checkout@v4"
         with:
           path: "en"
@@ -44,5 +38,5 @@ jobs:
           php8.1 doc-base/scripts/qa/extensions.xml.php --check
           php8.1 doc-base/scripts/qa/section-order.php
 
-      - name: "Build documentation for ${{ matrix.language }}"
-        run: "php8.1 doc-base/configure.php --disable-libxml-check --enable-xml-details --redirect-stderr-to-stdout --with-lang=${{ matrix.language }}"
+      - name: "Build documentation for fr"
+        run: "php8.1 doc-base/configure.php --disable-libxml-check --enable-xml-details --redirect-stderr-to-stdout --with-lang=fr"

--- a/.github/workflows/check-en-revision.yml
+++ b/.github/workflows/check-en-revision.yml
@@ -1,0 +1,47 @@
+# https://docs.github.com/en/actions
+# Vérifie que le commentaire EN-Revision des fichiers .xml touchés par une PR
+# pointe le dernier commit doc-en du fichier. Émet une annotation ::error et
+# échoue si le hash est absent, faux, d'un autre fichier, ou en retard.
+
+name: "Structure"
+
+on:
+  pull_request:
+    branches: ["master"]
+    types: [opened, synchronize]
+
+permissions:
+  contents: read
+
+jobs:
+  revision:
+    name: "Check EN-Revision"
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Checkout php/doc-fr"
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: "Checkout php/doc-en"
+        uses: actions/checkout@v4
+        with:
+          path: en
+          repository: php/doc-en
+          fetch-depth: 0
+
+      - name: "Check EN-Revision"
+        run: |
+          BASE="${{ github.event.pull_request.base.sha }}"
+          git fetch --no-tags --depth=1 origin "$BASE"
+          fail=0
+          while IFS= read -r f; do
+            [ -f "$f" ] && [ -f "en/$f" ] || continue
+            declared=$(grep -oiP 'EN-Revision:\s*\K[0-9a-f]+' "$f" | head -1 || true)
+            latest=$(git -C en log -1 --format=%H -- "$f")
+            if [ "$declared" != "$latest" ]; then
+              echo "::error file=$f::EN-Revision ${declared:-absent} != dernier commit doc-en $latest"
+              fail=1
+            fi
+          done < <(git diff --name-only "$BASE"...HEAD -- '*.xml')
+          exit $fail

--- a/.github/workflows/check-style.yml
+++ b/.github/workflows/check-style.yml
@@ -1,4 +1,4 @@
-name: "Check style"
+name: "Style"
 
 on:
   pull_request:
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   check-style:
-    name: "TRADUCTIONS.txt"
+    name: "Check Translations"
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/check-whitespace.yml
+++ b/.github/workflows/check-whitespace.yml
@@ -1,4 +1,4 @@
-name: check-whitespace
+name: "Style"
 
 # Get the repository with all commits to ensure that we can analyze
 # all of the commits contributed via the Pull Request.
@@ -14,6 +14,7 @@ permissions:
 
 jobs:
   check-whitespace:
+    name: "Check Whitespace"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
Ajoute un job CI qui, pour les fichiers `.xml` modifiés par une PR, vérifie que le commentaire `EN-Revision` pointe bien le dernier commit doc-en du fichier. Binaire et bloquant : un hash absent, faux, d'un autre fichier ou en retard fait échouer, avec le bon hash indiqué en annotation (cs2pr).

Mode diff : seuls les fichiers touchés sont analysés. Complète le build et check-whitespace sans les remplacer ; le workflow est repris tel quel par n'importe quelle langue (seul le code langue change).