### PR TITLE
[Sync EN] radius_get_vendor_attr: type de retour array|false

### DIFF
--- a/reference/radius/functions/radius-get-vendor-attr.xml
+++ b/reference/radius/functions/radius-get-vendor-attr.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 9ac4d06c0bddbbb1b87ba93d1591ef1707d30420 Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
-<refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.radius-get-vendor-attr">
+<!-- EN-Revision: 4047ef2a8b552d69909e1cee259fcad65d2510c7 Maintainer: lacatoire Status: ready -->
+<refentry xml:id="function.radius-get-vendor-attr" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>radius_get_vendor_attr</refname>
   <refpurpose>Extrait un attribut spécifique au vendeur</refpurpose>
@@ -11,7 +9,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>array</type><methodname>radius_get_vendor_attr</methodname>
+   <type class="union"><type>array</type><type>false</type></type><methodname>radius_get_vendor_attr</methodname>
    <methodparam><type>string</type><parameter>data</parameter></methodparam>
   </methodsynopsis>
   <simpara>


### PR DESCRIPTION
Synchronisation avec l'EN: le type de retour de `radius_get_vendor_attr` devient `array|false` (la fonction peut retourner &false; en cas d'erreur).

Fixes #3042