### PR TITLE
[Sync EN] filter/constants: notation scientifique pour le float booléen

### DIFF
--- a/reference/filter/constants.xml
+++ b/reference/filter/constants.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 3d4ee5f40afbfe44db4f1b13a22a6a38d4b40c7b Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 1c5ff30e9ae64bd4fd7ebbd0cccfb1e642e1b02c Maintainer: lacatoire Status: ready -->
 <appendix xml:id="filter.constants" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.constants;
  &extension.constants;
@@ -279,14 +279,14 @@
    <listitem>
     <simpara>
      Retourne &true; pour <literal>"1"</literal>,
-     <literal>1</literal>, y compris les notations binaire, octale et hexadécimale, <literal>1.0</literal>,
+     <literal>1</literal>, y compris les notations binaire, octale et hexadécimale, <literal>1.0</literal>, y compris la notation scientifique,
      <literal>"true"</literal>, <literal>true</literal>,
      <literal>"on"</literal>,
      et <literal>"yes"</literal>.
     </simpara>
     <simpara>
      Retourne &false; pour <literal>"0"</literal>,
-     <literal>0</literal>, y compris les notations binaire, octale et hexadécimale, <literal>0.0</literal>,
+     <literal>0</literal>, y compris les notations binaire, octale et hexadécimale, <literal>0.0</literal>, y compris la notation scientifique,
      <literal>"false"</literal>, <literal>false</literal>,
      <literal>"off"</literal>,
      <literal>"no"</literal>, et


### PR DESCRIPTION
Synchronisation avec l'EN: mentionne que la notation scientifique est aussi prise en charge pour les valeurs float `1.0`/`0.0` avec `FILTER_VALIDATE_BOOLEAN`.

Fixes #3043