### PR TITLE
Sync new cURL constants (PHP 8.5)

### DIFF
--- a/reference/curl/constants.xml
+++ b/reference/curl/constants.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: dec90c90d3662c5433f7c3972f8557321da7b11d Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: ee972f53e1a95967cd65c6de63ea4b422b987bd3 Maintainer: lacatoire Status: ready -->
 <appendix xml:id="curl.constants" xmlns="http://docbook.org/ns/docbook">
  &reftitle.constants;
  &extension.constants;
@@ -207,6 +205,52 @@
      pour forcer libcurl à vérifier l'authentification non restreinte et si non,
      seulement cet algorithme d'auth est acceptable.
      Disponible à partir de cURL 7.21.3.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlfollow-all">
+   <term>
+    <constant>CURLFOLLOW_ALL</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Valeur pour <constant>CURLOPT_FOLLOWLOCATION</constant> qui active le suivi
+     des redirections et conserve une méthode de requête personnalisée définie avec
+     <constant>CURLOPT_CUSTOMREQUEST</constant> pour toutes les requêtes, même
+     après les redirections.
+     Disponible à partir de PHP 8.5.0 et cURL 8.13.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlfollow-obeycode">
+   <term>
+    <constant>CURLFOLLOW_OBEYCODE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Valeur pour <constant>CURLOPT_FOLLOWLOCATION</constant> qui active le suivi
+     des redirections tout en respectant le code de réponse HTTP : une méthode de requête
+     personnalisée définie avec <constant>CURLOPT_CUSTOMREQUEST</constant> est conservée,
+     sauf qu'elle est changée en <literal>GET</literal> sur les codes de statut de redirection
+     qui l'exigent (tels que 301, 302 et 303).
+     Disponible à partir de PHP 8.5.0 et cURL 8.13.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlfollow-firstonly">
+   <term>
+    <constant>CURLFOLLOW_FIRSTONLY</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Valeur pour <constant>CURLOPT_FOLLOWLOCATION</constant> qui active le suivi
+     des redirections mais utilise une méthode de requête personnalisée définie avec
+     <constant>CURLOPT_CUSTOMREQUEST</constant> pour la première requête uniquement ;
+     les requêtes suivantes suivent la méthode dictée par le code de réponse de redirection.
+     Disponible à partir de PHP 8.5.0 et cURL 8.13.0.
     </simpara>
    </listitem>
   </varlistentry>

--- a/reference/curl/constants_curl_getinfo.xml
+++ b/reference/curl/constants_curl_getinfo.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: f34918d8b2761af5b596b1b762753ee825c19cd8 Maintainer: Fan2Shrek Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: ee972f53e1a95967cd65c6de63ea4b422b987bd3 Maintainer: lacatoire Status: ready -->
 <variablelist xml:id="constant.curl-getinfo.constants" role="constant_list">
  <title><function>curl_getinfo</function></title>
  <varlistentry xml:id="constant.curlinfo-appconnect-time">
@@ -69,6 +68,18 @@
   <listitem>
    <simpara>
     Informations sur la condition temporelle non remplie
+   </simpara>
+  </listitem>
+ </varlistentry>
+ <varlistentry xml:id="constant.curlinfo-conn-id">
+  <term>
+   <constant>CURLINFO_CONN_ID</constant>
+   (<type>int</type>)
+  </term>
+  <listitem>
+   <simpara>
+    L'identifiant de la dernière connexion utilisée par le transfert. L'identifiant de connexion est unique parmi toutes les connexions utilisant le même cache de connexions et permet de distinguer la réutilisation des connexions.
+    Disponible à partir de PHP 8.5.0 et cURL 8.2.0.
    </simpara>
   </listitem>
  </varlistentry>
@@ -250,6 +261,18 @@
   <listitem>
    <simpara>
     Le masque de bits indiquant la méthode d'authentification disponible(s) selon la réponse précédente
+   </simpara>
+  </listitem>
+ </varlistentry>
+ <varlistentry xml:id="constant.curlinfo-httpauth-used">
+  <term>
+   <constant>CURLINFO_HTTPAUTH_USED</constant>
+   (<type>int</type>)
+  </term>
+  <listitem>
+   <simpara>
+    Masque de bits indiquant la ou les méthodes d'authentification HTTP réellement utilisées lors de la requête précédente.
+    Disponible à partir de PHP 8.5.0 et cURL 8.12.0.
    </simpara>
   </listitem>
  </varlistentry>
@@ -446,6 +469,18 @@
    </simpara>
   </listitem>
  </varlistentry>
+ <varlistentry xml:id="constant.curlinfo-proxyauth-used">
+  <term>
+   <constant>CURLINFO_PROXYAUTH_USED</constant>
+   (<type>int</type>)
+  </term>
+  <listitem>
+   <simpara>
+    Masque de bits indiquant la ou les méthodes d'authentification du proxy réellement utilisées lors de la requête précédente.
+    Disponible à partir de PHP 8.5.0 et cURL 8.12.0.
+   </simpara>
+  </listitem>
+ </varlistentry>
  <varlistentry xml:id="constant.curlinfo-proxy-error">
   <term>
    <constant>CURLINFO_PROXY_ERROR</constant>
@@ -467,6 +502,18 @@
    <simpara>
     Le résultat de la vérification du certificat qui a été demandée (en utilisant l'option <constant>CURLOPT_PROXY_SSL_VERIFYPEER</constant>). Utilisé uniquement pour les proxies HTTPS.
     Disponible à partir de PHP 7.3.0 et cURL 7.52.0
+   </simpara>
+  </listitem>
+ </varlistentry>
+ <varlistentry xml:id="constant.curlinfo-queue-time-t">
+  <term>
+   <constant>CURLINFO_QUEUE_TIME_T</constant>
+   (<type>int</type>)
+  </term>
+  <listitem>
+   <simpara>
+    Le temps, en microsecondes, durant lequel le transfert a été maintenu dans une file d'attente avant de démarrer, en raison des limites fixées par <constant>CURLMOPT_MAX_TOTAL_CONNECTIONS</constant> ou des options similaires.
+    Disponible à partir de PHP 8.5.0 et cURL 8.6.0.
    </simpara>
   </listitem>
  </varlistentry>
@@ -775,6 +822,18 @@
    <simpara>
     Le temps total en microsecondes pour le dernier transfert, y compris la résolution du nom, la connexion TCP, etc.
     Disponible à partir de PHP 7.3.0 et cURL 7.61.0
+   </simpara>
+  </listitem>
+ </varlistentry>
+ <varlistentry xml:id="constant.curlinfo-used-proxy">
+  <term>
+   <constant>CURLINFO_USED_PROXY</constant>
+   (<type>int</type>)
+  </term>
+  <listitem>
+   <simpara>
+    Indique si le transfert précédent a utilisé un proxy ; retourne <literal>1</literal> si un proxy a été utilisé et <literal>0</literal> sinon.
+    Disponible à partir de PHP 8.5.0 et cURL 8.7.0.
    </simpara>
   </listitem>
  </varlistentry>

--- a/reference/curl/constants_curl_setopt.xml
+++ b/reference/curl/constants_curl_setopt.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 525aa5f198d482c0d03be54ddee5af13b376ab99 Maintainer: lacatoire Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: e7e81a179eabc75e1b37947c7696afd557cef656 Maintainer: lacatoire Status: ready -->
  <variablelist role="constant_list">
   <title><function>curl_setopt</function></title>
   <varlistentry xml:id="constant.curlopt-abstract-unix-socket">
@@ -1381,6 +1380,21 @@
      Cette option accepte toute valeur pouvant être convertie en un <type>int</type> valide.
      Disponible à partir de cURL 7.1.0.
     </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.curlopt-infilesize-large">
+   <term>
+    <constant>CURLOPT_INFILESIZE_LARGE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     La taille attendue, en octets, du fichier lors de l'envoi d'un fichier
+     à un site distant. Il s'agit de la variante 64 bits de
+     <constant>CURLOPT_INFILESIZE</constant>, permettant de spécifier des tailles
+     supérieures à 2 Go.
+     Disponible à partir de PHP 8.5.0.
+    </simpara>
    </listitem>
   </varlistentry>
   <varlistentry xml:id="constant.curlopt-interface">


### PR DESCRIPTION
Synchronise les nouvelles constantes cURL de PHP 8.5 : CURLFOLLOW_*, plusieurs CURLINFO_* et CURLOPT_INFILESIZE_LARGE. Le fichier constants_curl_setopt.xml est aligné sur l'état final EN (simpara).

Fixes #3047
Fixes #3046