### PR TITLE
Sync new OpenSSL constants (PHP 8.5)

### DIFF
--- a/reference/openssl/constants.xml
+++ b/reference/openssl/constants.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 5b3a84935252a553528cb81b3dacb88647b57c7b Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 6eadfc4332ac3ba482aef3ebf3eab10e02e007ca Maintainer: lacatoire Status: ready -->
 
 <appendix xml:id="openssl.constants" xmlns="http://docbook.org/ns/docbook">
  &reftitle.constants;
@@ -157,6 +157,18 @@
     <listitem>
      <simpara>
       
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.openssl-pkcs1-pss-padding">
+    <term>
+     <constant>OPENSSL_PKCS1_PSS_PADDING</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Remplissage RSA-PSS.
+      Disponible à partir de PHP 8.5.0.
      </simpara>
     </listitem>
    </varlistentry>
@@ -403,6 +415,46 @@
         Disponible à partir de PHP 8.3.0.
         Définit l'en-tête HTTP Content-Type sur <literal>application/pkcs7-mime</literal> au lieu de
         <literal>application/x-pkcs7-mime</literal> pour chiffrer un message.
+       </entry>
+      </row>
+      <row xml:id="constant.pkcs7-nosmimecap">
+       <entry>
+        <constant>PKCS7_NOSMIMECAP</constant>
+        (<type>int</type>)
+       </entry>
+       <entry>
+        Disponible à partir de PHP 8.5.0.
+        N'inclut pas les capacités S/MIME (SMIMECapabilities) dans la signature.
+       </entry>
+      </row>
+      <row xml:id="constant.pkcs7-crlfeol">
+       <entry>
+        <constant>PKCS7_CRLFEOL</constant>
+        (<type>int</type>)
+       </entry>
+       <entry>
+        Disponible à partir de PHP 8.5.0.
+        Utilise <literal>CRLF</literal> comme fin de ligne dans la sortie.
+       </entry>
+      </row>
+      <row xml:id="constant.pkcs7-nocrl">
+       <entry>
+        <constant>PKCS7_NOCRL</constant>
+        (<type>int</type>)
+       </entry>
+       <entry>
+        Disponible à partir de PHP 8.5.0.
+        N'inclut pas les CRL dans la structure PKCS7.
+       </entry>
+      </row>
+      <row xml:id="constant.pkcs7-no-dual-content">
+       <entry>
+        <constant>PKCS7_NO_DUAL_CONTENT</constant>
+        (<type>int</type>)
+       </entry>
+       <entry>
+        Disponible à partir de PHP 8.5.0.
+        N'inclut pas le contenu en double, évitant la duplication du contenu signé.
        </entry>
       </row>
      </tbody>


### PR DESCRIPTION
Synchronise les nouvelles constantes OpenSSL de PHP 8.5 : OPENSSL_PKCS1_PSS_PADDING et les drapeaux PKCS7 (NOSMIMECAP, CRLFEOL, NOCRL, NO_DUAL_CONTENT).

Fixes #3048