### PR TITLE
[Sync EN] precedence.xml: priorité unaire/instanceof et affectation dans les opérateurs préfixes

### DIFF
--- a/language/operators/precedence.xml
+++ b/language/operators/precedence.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: a7428462fea1c0387cf5e8473b4c48c3c8ac8c2c Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 80dfa568e602649eb13585bf59a7b6239eddaac3 Maintainer: lacatoire Status: ready -->
 <sect1 xml:id="language.operators.precedence">
  <title>La priorité des opérateurs</title>
  <titleabbrev>Priorité des opérateurs</titleabbrev>
@@ -308,6 +307,18 @@
    </tgroup>
   </table>
  </para>
+ <note>
+  <simpara>
+   Les opérateurs unaires partageant la même ligne que les opérateurs de
+   transtypage (<literal>~</literal>, <literal>@</literal>, et les
+   <literal>+</literal>/<literal>-</literal> unaires) sont prioritaires sur
+   <literal>instanceof</literal>, tandis que <literal>!</literal> l'est moins.
+   Par conséquent, <literal>(int) $x instanceof Foo</literal> est interprété
+   comme <literal>((int) $x) instanceof Foo</literal>, alors que
+   <literal>!$x instanceof Foo</literal> est interprété comme
+   <literal>!($x instanceof Foo)</literal>.
+  </simpara>
+ </note>
  <para>
   <example>
    <title>Associativité</title>
@@ -431,6 +442,16 @@ x moins un est égal à 3, en tout cas j'espère
    Dans cette situation, le résultat de <literal>foo()</literal>
    sera placé dans la variable <varname>$a</varname>.
   </para>
+  <simpara>
+   Cela est possible parce que le membre de gauche d'une affectation doit être
+   une variable : l'affectation est donc regroupée avec cette variable plutôt
+   qu'avec l'opérateur préfixe environnant, pourtant plus prioritaire. Il en va
+   de même pour les autres opérateurs préfixes prenant une expression comme
+   opérande, tels que <literal>clone</literal>, les opérateurs de transtypage,
+   <literal>@</literal> et <literal>~</literal> : par exemple,
+   <literal>clone $a = $b</literal> est interprété comme
+   <literal>clone ($a = $b)</literal>, et non <literal>(clone $a) = $b</literal>.
+  </simpara>
  </note>
  <sect2 role="changelog">
   &reftitle.changelog;


### PR DESCRIPTION
Sync EN de language/operators/precedence.xml.

Traduit les deux notes ajoutées en amont : priorité des opérateurs unaires vis-à-vis de `instanceof`, et regroupement de l'affectation dans les opérateurs préfixes.

Fixes #3051