### PR TITLE
[Sync EN] nodiscard.xml: comportement sur interfaces, méthodes abstraites et redéfinitions

### DIFF
--- a/language/predefined/attributes/nodiscard.xml
+++ b/language/predefined/attributes/nodiscard.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 30bda33771e1c8fa8fc8a5ee7559fd7fa189caa0 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: e7f89579e2abcecad5a62dd96f11a4926df62e13 Maintainer: lacatoire Status: ready -->
 <reference xml:id="class.nodiscard" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>L'attribut NoDiscard</title>
  <titleabbrev>NoDiscard</titleabbrev>
@@ -30,6 +30,20 @@
      Pour supprimer l'avertissement sans utiliser <code>(void)</code>,
      qui n'est pas supporté avant PHP 8.5,
      il est possible d'utiliser une variable comme <code>$_</code>.
+    </simpara>
+   </note>
+   <note>
+    <simpara>
+     <code>#[\NoDiscard]</code> s'applique à la déclaration de fonction ou de
+     méthode spécifique sur laquelle il est écrit, et l'avertissement est émis
+     en fonction de la déclaration réellement appelée. Par conséquent, ajouter
+     <code>#[\NoDiscard]</code> à une méthode d'interface ou à une méthode
+     abstraite n'émet pas d'avertissement, car la méthode invoquée est la
+     méthode d'implémentation ou de redéfinition. De même, une méthode qui
+     redéfinit une méthode <code>#[\NoDiscard]</code> n'émet pas l'avertissement
+     à moins d'être elle-même marquée avec l'attribut. À l'inverse, une méthode
+     importée depuis un trait conserve l'attribut, car la méthode du trait est
+     copiée dans la classe utilisatrice comme si elle y était déclarée.
     </simpara>
    </note>
   </section>


### PR DESCRIPTION
Sync EN de language/predefined/attributes/nodiscard.xml.

Traduit la note ajoutée en amont : `#[\NoDiscard]` sur une méthode d'interface, abstraite ou redéfinie, et le cas des traits.

Fixes #3052