### PR TITLE
[Sync EN] pdo_pgsql : dépréciations 8.5, exemples, corrections

### DIFF
--- a/appendices/migration84/other-changes.xml
+++ b/appendices/migration84/other-changes.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 0f1d7fba407bd1385616508a1e42e31fe009bff2 Maintainer: Fan2Shrek Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 858400b07586b88dcb1e17a95e7a178b54b89d86 Maintainer: lacatoire Status: ready -->
 <sect1 xml:id="migration84.other-changes">
  <title>Autres changements</title>
 
@@ -249,7 +248,7 @@
    </simpara>
 
    <simpara>
-    Une nouvelle constante <constant>PDO::PGSQL_ATTR_RESULT_MEMORY_SIZE</constant>
+    Une nouvelle constante <constant>Pdo\Pgsql::ATTR_RESULT_MEMORY_SIZE</constant>
     a été ajoutée pour récupérer l'utilisation de la mémoire des résultats de requête avec
     <methodname>PDO::getAttribute</methodname> pour les pilotes qui le prennent en charge.
    </simpara>
@@ -326,7 +325,7 @@
 
    <simpara>
     Support de la récupération de l'utilisation de la mémoire des requêtes pour
-    <constant>PDO::PGSQL_ATTR_RESULT_MEMORY_SIZE</constant>.
+    <constant>Pdo\Pgsql::ATTR_RESULT_MEMORY_SIZE</constant>.
    </simpara>
 
    <simpara>

--- a/reference/pdo_pgsql/constants.xml
+++ b/reference/pdo_pgsql/constants.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9b69a8dcce47d6619d6459914e784627cbb02a5f Maintainer: Fan2Shrek Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 858400b07586b88dcb1e17a95e7a178b54b89d86 Maintainer: lacatoire Status: ready -->
 <section xml:id="ref.pdo-pgsql.constants" xmlns="http://docbook.org/ns/docbook">
  &reftitle.constants;
  &pdo.driver-constants;
@@ -14,6 +13,67 @@
    <listitem>
     <simpara>
      &Alias; <constant>Pdo\Pgsql::ATTR_DISABLE_PREPARES</constant>.
+     À partir de PHP 8.5.0, cette constante est obsolète.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="pdo.constants.pgsql-transaction-idle">
+   <term>
+    <constant>PDO::PGSQL_TRANSACTION_IDLE</constant>
+     (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Équivalent à <constant>Pdo\Pgsql::TRANSACTION_IDLE</constant>.
+     À partir de PHP 8.5.0, cette constante est obsolète, car elle n'a aucun effet.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="pdo.constants.pgsql-transaction-active">
+   <term>
+    <constant>PDO::PGSQL_TRANSACTION_ACTIVE</constant>
+     (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Équivalent à <constant>Pdo\Pgsql::TRANSACTION_ACTIVE</constant>.
+     À partir de PHP 8.5.0, cette constante est obsolète, car elle n'a aucun effet.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="pdo.constants.pgsql-transaction-intrans">
+   <term>
+    <constant>PDO::PGSQL_TRANSACTION_INTRANS</constant>
+     (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Équivalent à <constant>Pdo\Pgsql::TRANSACTION_INTRANS</constant>.
+     À partir de PHP 8.5.0, cette constante est obsolète, car elle n'a aucun effet.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="pdo.constants.pgsql-transaction-inerror">
+   <term>
+    <constant>PDO::PGSQL_TRANSACTION_INERROR</constant>
+     (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Équivalent à <constant>Pdo\Pgsql::TRANSACTION_INERROR</constant>.
+     À partir de PHP 8.5.0, cette constante est obsolète, car elle n'a aucun effet.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="pdo.constants.pgsql-transaction-unknown">
+   <term>
+    <constant>PDO::PGSQL_TRANSACTION_UNKNOWN</constant>
+     (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Équivalent à <constant>Pdo\Pgsql::TRANSACTION_UNKNOWN</constant>.
+     À partir de PHP 8.5.0, cette constante est obsolète, car elle n'a aucun effet.
     </simpara>
    </listitem>
   </varlistentry>

--- a/reference/pdo_pgsql/pdo-pgsql.xml
+++ b/reference/pdo_pgsql/pdo-pgsql.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 3f82c54505bbf99a7dfdee2ae7f674b1e2719bd3 Maintainer: lacatoire Status: ready -->
-<!-- Reviewed: yes -->
-<reference xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xml:id="class.pdo-pgsql" role="class">
+<!-- EN-Revision: 858400b07586b88dcb1e17a95e7a178b54b89d86 Maintainer: lacatoire Status: ready -->
+<reference xml:id="class.pdo-pgsql" xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" role="class">
  <title>La classe Pdo\Pgsql</title>
  <titleabbrev>Pdo\Pgsql</titleabbrev>
 
@@ -160,36 +159,51 @@
     <varlistentry xml:id="pdo-pgsql.constants.transaction-idle">
      <term><constant>Pdo\Pgsql::TRANSACTION_IDLE</constant></term>
      <listitem>
-      <simpara>
-      </simpara>
+      <warning>
+       <simpara>
+        Cette constante n'a aucun effet, et est obsolète à partir de PHP 8.5.0.
+       </simpara>
+      </warning>
      </listitem>
     </varlistentry>
     <varlistentry xml:id="pdo-pgsql.constants.transaction-active">
      <term><constant>Pdo\Pgsql::TRANSACTION_ACTIVE</constant></term>
      <listitem>
-      <simpara>
-      </simpara>
+      <warning>
+       <simpara>
+        Cette constante n'a aucun effet, et est obsolète à partir de PHP 8.5.0.
+       </simpara>
+      </warning>
      </listitem>
     </varlistentry>
     <varlistentry xml:id="pdo-pgsql.constants.transaction-intrans">
      <term><constant>Pdo\Pgsql::TRANSACTION_INTRANS</constant></term>
      <listitem>
-      <simpara>
-      </simpara>
+      <warning>
+       <simpara>
+        Cette constante n'a aucun effet, et est obsolète à partir de PHP 8.5.0.
+       </simpara>
+      </warning>
      </listitem>
     </varlistentry>
     <varlistentry xml:id="pdo-pgsql.constants.transaction-inerror">
      <term><constant>Pdo\Pgsql::TRANSACTION_INERROR</constant></term>
      <listitem>
-      <simpara>
-      </simpara>
+      <warning>
+       <simpara>
+        Cette constante n'a aucun effet, et est obsolète à partir de PHP 8.5.0.
+       </simpara>
+      </warning>
      </listitem>
     </varlistentry>
     <varlistentry xml:id="pdo-pgsql.constants.transaction-unknown">
      <term><constant>Pdo\Pgsql::TRANSACTION_UNKNOWN</constant></term>
      <listitem>
-      <simpara>
-      </simpara>
+      <warning>
+       <simpara>
+        Cette constante n'a aucun effet, et est obsolète à partir de PHP 8.5.0.
+       </simpara>
+      </warning>
      </listitem>
     </varlistentry>
    </variablelist>

--- a/reference/pdo_pgsql/pdo/pgsql/copyfromarray.xml
+++ b/reference/pdo_pgsql/pdo/pgsql/copyfromarray.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9b69a8dcce47d6619d6459914e784627cbb02a5f Maintainer: Fan2Shrek Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 858400b07586b88dcb1e17a95e7a178b54b89d86 Maintainer: lacatoire Status: ready -->
 <refentry xml:id="pdo-pgsql.copyfromarray" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>Pdo\Pgsql::copyFromArray</refname>
@@ -79,40 +78,69 @@
   </simpara>
  </refsect1>
 
- <!-- TODO?
- <refsect1 role="errors">
-  &reftitle.errors;
-  <simpara>
-   When does this function issue <constant>E_*</constant> level errors,
-   and/or throw <exceptionname>Exception</exceptionname>s.
-  </simpara>
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       <parameter>rows</parameter> accepte désormais également un
+       <classname>Traversable</classname> ; antérieur à cela, seul un
+       <type>array</type> était accepté.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
- -->
 
- <!-- TODO?
  <refsect1 role="examples">
   &reftitle.examples;
   <example xml:id="pdo-pgsql.copyfromarray.example.basic">
-   <title><methodname>Pdo\Pgsql::copyFromArray</methodname> example</title>
+   <title>Exemple avec <methodname>Pdo\Pgsql::copyFromArray</methodname></title>
    <simpara>
-    Description.
+    Chaque élément de <parameter>rows</parameter> est un enregistrement dont les
+    champs sont joints par <parameter>separator</parameter> (une tabulation par
+    défaut).
    </simpara>
    <programlisting role="php">
 <![CDATA[
 <?php
-echo "Code example";
+$db = new Pdo\Pgsql('pgsql:dbname=test host=localhost', $user, $pass);
+$db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+$db->exec('CREATE TABLE fruits (id int, name text, qty int)');
+
+$rows = [
+    "1\tapple\t10",
+    "2\tbanana\t20",
+    "3\tcherry\t30",
+];
+$db->copyFromArray('fruits', $rows);
+
+foreach ($db->query('SELECT * FROM fruits ORDER BY id') as $row) {
+    echo "{$row['id']} {$row['name']} {$row['qty']}\n";
+}
 ?>
 ]]>
    </programlisting>
    &example.outputs;
    <screen>
 <![CDATA[
-Code example
+1 apple 10
+2 banana 20
+3 cherry 30
 ]]>
    </screen>
   </example>
  </refsect1>
- -->
 
  <refsect1 role="seealso">
   &reftitle.seealso;

--- a/reference/pdo_pgsql/pdo/pgsql/copyfromfile.xml
+++ b/reference/pdo_pgsql/pdo/pgsql/copyfromfile.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9b69a8dcce47d6619d6459914e784627cbb02a5f Maintainer: Fan2Shrek Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 858400b07586b88dcb1e17a95e7a178b54b89d86 Maintainer: lacatoire Status: ready -->
 <refentry xml:id="pdo-pgsql.copyfromfile" xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude">
  <refnamediv>
   <refname>Pdo\Pgsql::copyFromFile</refname>
@@ -57,40 +56,47 @@
   </simpara>
  </refsect1>
 
- <!-- TODO?
  <refsect1 role="errors">
   &reftitle.errors;
   <simpara>
-   When does this function issue <constant>E_*</constant> level errors,
-   and/or throw <exceptionname>Exception</exceptionname>s.
+   Si <parameter>filename</parameter> ne peut pas être ouvert en lecture, l'échec
+   est signalé via la gestion des erreurs de la connexion
+   (voir <constant>PDO::ATTR_ERRMODE</constant>) ; avec
+   <constant>PDO::ERRMODE_EXCEPTION</constant>, une
+   <exceptionname>PDOException</exceptionname> est levée.
   </simpara>
  </refsect1>
- -->
 
- <!-- TODO?
  <refsect1 role="examples">
   &reftitle.examples;
   <example xml:id="pdo-pgsql.copyfromfile.example.basic">
-   <title><methodname>Pdo\Pgsql::copyFromFile</methodname> example</title>
+   <title>Exemple avec <methodname>Pdo\Pgsql::copyFromFile</methodname></title>
    <simpara>
-    Description.
+    Le fichier contient un enregistrement par ligne, les champs étant joints par
+    <parameter>separator</parameter> (une tabulation par défaut).
    </simpara>
    <programlisting role="php">
 <![CDATA[
 <?php
-echo "Code example";
+$db = new Pdo\Pgsql('pgsql:dbname=test host=localhost', $user, $pass);
+$db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+$db->exec('CREATE TABLE fruits (id int, name text, qty int)');
+
+file_put_contents('/tmp/fruits.tsv', "1\tapple\t10\n2\tbanana\t20\n");
+$db->copyFromFile('fruits', '/tmp/fruits.tsv');
+
+echo $db->query('SELECT count(*) FROM fruits')->fetchColumn(), "\n";
 ?>
 ]]>
    </programlisting>
    &example.outputs;
    <screen>
 <![CDATA[
-Code example
+2
 ]]>
    </screen>
   </example>
  </refsect1>
- -->
 
  <refsect1 role="seealso">
   &reftitle.seealso;

--- a/reference/pdo_pgsql/pdo/pgsql/copytoarray.xml
+++ b/reference/pdo_pgsql/pdo/pgsql/copytoarray.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9ec2c28f9400490fe1b70fb88e50e23de97905f1 Maintainer: Fan2Shrek Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 858400b07586b88dcb1e17a95e7a178b54b89d86 Maintainer: lacatoire Status: ready -->
 <refentry xml:id="pdo-pgsql.copytoarray" xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude">
  <refnamediv>
   <refname>Pdo\Pgsql::copyToArray</refname>
@@ -51,40 +50,40 @@
   </simpara>
  </refsect1>
 
- <!-- TODO?
- <refsect1 role="errors">
-  &reftitle.errors;
-  <simpara>
-   When does this function issue <constant>E_*</constant> level errors,
-   and/or throw <exceptionname>Exception</exceptionname>s.
-  </simpara>
- </refsect1>
- -->
-
- <!-- TODO?
  <refsect1 role="examples">
   &reftitle.examples;
   <example xml:id="pdo-pgsql.copytoarray.example.basic">
-   <title><methodname>Pdo\Pgsql::copyToArray</methodname> example</title>
+   <title>Exemple avec <methodname>Pdo\Pgsql::copyToArray</methodname></title>
    <simpara>
-    Description.
+    Chaque élément retourné est un enregistrement, les champs étant joints par
+    <parameter>separator</parameter> et suivis d'un saut de ligne final.
    </simpara>
    <programlisting role="php">
 <![CDATA[
 <?php
-echo "Code example";
+$db = new Pdo\Pgsql('pgsql:dbname=test host=localhost', $user, $pass);
+$db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+$db->exec('CREATE TABLE fruits (id int, name text, qty int)');
+$db->exec("INSERT INTO fruits VALUES (1, 'apple', 10), (2, 'banana', 20)");
+
+$rows = $db->copyToArray('fruits');
+var_export($rows);
 ?>
 ]]>
    </programlisting>
    &example.outputs;
    <screen>
 <![CDATA[
-Code example
+array (
+  0 => '1	apple	10
+',
+  1 => '2	banana	20
+',
+)
 ]]>
    </screen>
   </example>
  </refsect1>
- -->
 
  <refsect1 role="seealso">
   &reftitle.seealso;

--- a/reference/pdo_pgsql/pdo/pgsql/copytofile.xml
+++ b/reference/pdo_pgsql/pdo/pgsql/copytofile.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9b69a8dcce47d6619d6459914e784627cbb02a5f Maintainer: Fan2Shrek Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 858400b07586b88dcb1e17a95e7a178b54b89d86 Maintainer: lacatoire Status: ready -->
 <refentry xml:id="pdo-pgsql.copytofile" xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude">
  <refnamediv>
   <refname>Pdo\Pgsql::copyToFile</refname>
@@ -62,49 +61,47 @@
   </simpara>
  </refsect1>
 
- <!-- TODO?
  <refsect1 role="errors">
   &reftitle.errors;
   <simpara>
-   When does this function issue <constant>E_*</constant> level errors,
-   and/or throw <exceptionname>Exception</exceptionname>s.
+   Si <parameter>filename</parameter> ne peut pas être ouvert en écriture, ou ne
+   peut pas être écrit, l'échec est signalé via la gestion des erreurs de la
+   connexion (voir <constant>PDO::ATTR_ERRMODE</constant>) ; avec
+   <constant>PDO::ERRMODE_EXCEPTION</constant>, une
+   <exceptionname>PDOException</exceptionname> est levée.
   </simpara>
  </refsect1>
- -->
 
- <!-- TODO?
  <refsect1 role="examples">
   &reftitle.examples;
   <example xml:id="pdo-pgsql.copytofile.example.basic">
-   <title><methodname>Pdo\Pgsql::copyToFile</methodname> example</title>
+   <title>Exemple avec <methodname>Pdo\Pgsql::copyToFile</methodname></title>
    <simpara>
-    Description.
+    La table est écrite dans <parameter>filename</parameter>, un enregistrement
+    par ligne, les champs étant joints par <parameter>separator</parameter>.
    </simpara>
    <programlisting role="php">
 <![CDATA[
 <?php
-echo "Code example";
+$db = new Pdo\Pgsql('pgsql:dbname=test host=localhost', $user, $pass);
+$db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+$db->exec('CREATE TABLE fruits (id int, name text, qty int)');
+$db->exec("INSERT INTO fruits VALUES (1, 'apple', 10), (2, 'banana', 20)");
+
+$db->copyToFile('fruits', '/tmp/fruits.tsv');
+echo file_get_contents('/tmp/fruits.tsv');
 ?>
 ]]>
    </programlisting>
    &example.outputs;
    <screen>
 <![CDATA[
-Code example
+1	apple	10
+2	banana	20
 ]]>
    </screen>
   </example>
  </refsect1>
-
- <refsect1 role="notes">
-  &reftitle.notes;
-  <note>
-   <simpara>
-    Any notes that don't fit anywhere else should go here.
-   </simpara>
-  </note>
- </refsect1>
- -->
 
  <refsect1 role="seealso">
   &reftitle.seealso;

--- a/reference/pdo_pgsql/pdo/pgsql/getnotify.xml
+++ b/reference/pdo_pgsql/pdo/pgsql/getnotify.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: c142be811735a5542c8a2e4c4ed2f81e8cc3acc6 Maintainer: Fan2Shrek Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 858400b07586b88dcb1e17a95e7a178b54b89d86 Maintainer: lacatoire Status: ready -->
 <refentry xml:id="pdo-pgsql.getnotify" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>Pdo\Pgsql::getNotify</refname>
@@ -51,9 +50,13 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   Si une ou plusieurs notifications sont en attente, retourne une seule ligne,
-   avec les champs <literal>message</literal> et <literal>pid</literal>,
-   sinon retourne &false;.
+   Si une notification est en attente, retourne une seule ligne, sinon retourne
+   &false;. La ligne possède un champ <literal>message</literal> (le nom du canal)
+   et un champ <literal>pid</literal> (l'identifiant du processus du backend
+   émetteur). Si la notification transporte une charge utile non vide, la ligne
+   possède également un champ <literal>payload</literal>. Avec
+   <constant>PDO::FETCH_NUM</constant>, ces champs se trouvent aux indices
+   <literal>0</literal>, <literal>1</literal> et <literal>2</literal>.
   </simpara>
  </refsect1>
 
@@ -77,30 +80,40 @@
   </simpara>
  </refsect1>
 
- <!-- TODO?
  <refsect1 role="examples">
   &reftitle.examples;
   <example xml:id="pdo-pgsql.getnotify.example.basic">
-   <title><methodname>Pdo\Pgsql::getNotify</methodname> example</title>
+   <title>Exemple avec <methodname>Pdo\Pgsql::getNotify</methodname></title>
    <simpara>
-    Description.
+    S'abonner à un canal avec <literal>LISTEN</literal>, puis lire la prochaine
+    notification en attente avec un délai d'attente d'une seconde.
    </simpara>
    <programlisting role="php">
 <![CDATA[
 <?php
-echo "Code example";
+$db = new Pdo\Pgsql('pgsql:dbname=test host=localhost', $user, $pass);
+$db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+
+$db->exec('LISTEN messages');
+$db->exec("NOTIFY messages, 'hello'");
+
+$notification = $db->getNotify(PDO::FETCH_ASSOC, 1000);
+var_export($notification);
 ?>
 ]]>
    </programlisting>
-   &example.outputs;
+   &example.outputs.similar;
    <screen>
 <![CDATA[
-Code example
+array (
+  'message' => 'messages',
+  'pid' => 1928,
+  'payload' => 'hello',
+)
 ]]>
    </screen>
   </example>
  </refsect1>
- -->
 
  <refsect1 role="seealso">
   &reftitle.seealso;

--- a/reference/pdo_pgsql/pdo/pgsql/getpid.xml
+++ b/reference/pdo_pgsql/pdo/pgsql/getpid.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 02b075821852f44e97742ba6f586cc2fa3272806 Maintainer: Fan2Shrek Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 858400b07586b88dcb1e17a95e7a178b54b89d86 Maintainer: lacatoire Status: ready -->
 <refentry xml:id="pdo-pgsql.getpid" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>Pdo\Pgsql::getPid</refname>
@@ -30,6 +29,34 @@
   <simpara>
    Renvoie le PID sous forme d'un <type>int</type>.
   </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="pdo-pgsql.getpid.example.basic">
+   <title>Exemple avec <methodname>Pdo\Pgsql::getPid</methodname></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$db = new Pdo\Pgsql('pgsql:dbname=test host=localhost', $user, $pass);
+echo $db->getPid();
+?>
+]]>
+   </programlisting>
+   &example.outputs.similar;
+   <screen>
+<![CDATA[
+12345
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>pg_get_pid</function></member>
+  </simplelist>
  </refsect1>
 </refentry>
 <!-- Keep this comment at the end of the file

--- a/reference/pdo_pgsql/pdo/pgsql/lobopen.xml
+++ b/reference/pdo_pgsql/pdo/pgsql/lobopen.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4bf27edcd6c317ea311e68117bb2fa20dacb8e57 Maintainer: Fan2Shrek Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 858400b07586b88dcb1e17a95e7a178b54b89d86 Maintainer: lacatoire Status: ready -->
 <refentry xml:id="pdo-pgsql.lobopen" xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude">
  <refnamediv>
   <refname>Pdo\Pgsql::lobOpen</refname>
@@ -41,8 +40,11 @@
     <term><parameter>mode</parameter></term>
     <listitem>
      <simpara>
-      Si le mode est <literal>r</literal>, ouvre le flux en lecture.
-      Si le mode est <literal>w</literal>, ouvre le flux en écriture.
+      Le mode d'accès. Si <parameter>mode</parameter> contient
+      <literal>w</literal> ou <literal>+</literal>, le flux est ouvert en
+      lecture et en écriture ; sinon, il est ouvert en lecture seule. Un
+      indicateur <literal>b</literal> (binaire) n'a aucun effet. La valeur par
+      défaut <literal>"rb"</literal> ouvre le flux en lecture.
      </simpara>
     </listitem>
    </varlistentry>
@@ -72,10 +74,10 @@ $db = new Pdo\Pgsql('pgsql:dbname=test host=localhost', $user, $pass);
 $db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 $db->beginTransaction();
 $stmt = $db->prepare("SELECT oid FROM BLOBS WHERE ident = ?");
-$stmt->execute(array($some_id));
+$stmt->execute([$some_id]);
 $stmt->bindColumn('oid', $oid, PDO::PARAM_STR);
 $stmt->fetch(PDO::FETCH_BOUND);
-$stream = $db->pgsqlLOBOpen($oid, 'r');
+$stream = $db->lobOpen($oid, 'r');
 header("Content-type: application/octet-stream");
 fpassthru($stream);
 ?>

--- a/reference/pdo_pgsql/pdo/pgsql/lobunlink.xml
+++ b/reference/pdo_pgsql/pdo/pgsql/lobunlink.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 02b075821852f44e97742ba6f586cc2fa3272806 Maintainer: Fan2Shrek Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 858400b07586b88dcb1e17a95e7a178b54b89d86 Maintainer: lacatoire Status: ready -->
 <refentry xml:id="pdo-pgsql.lobunlink" xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude">
  <refnamediv>
   <refname>Pdo\Pgsql::lobUnlink</refname>
@@ -48,19 +47,19 @@
    <title><methodname>Pdo\Pgsql::lobUnlink</methodname> example</title>
    <simpara>
     Cet exemple supprime un objet large de la base de données avant de supprimer
-    la ligne qui le référence dans la table blobs. Il est utilisé dans les exemples de
+    la ligne qui le référence. Il utilise la table blobs des exemples de
     <methodname>Pdo\Pgsql::lobCreate</methodname> et
     <methodname>Pdo\Pgsql::lobOpen</methodname>.
    </simpara>
    <programlisting role="php">
 <![CDATA[
 <?php
-$db = new PDO('pgsql:dbname=test host=localhost', $user, $pass);
+$db = new Pdo\Pgsql('pgsql:dbname=test host=localhost', $user, $pass);
 $db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 $db->beginTransaction();
-$db->pgsqlLOBUnlink($oid);
+$db->lobUnlink($oid);
 $stmt = $db->prepare("DELETE FROM BLOBS where ident = ?");
-$stmt->execute(array($some_id));
+$stmt->execute([$some_id]);
 $db->commit();
 ?>
 ]]>

--- a/reference/pdo_pgsql/pdo_overloaded/pgsqlCopyFromArray.xml
+++ b/reference/pdo_pgsql/pdo_overloaded/pgsqlCopyFromArray.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 1993c38d254743d8c0a2140ff6f797660997083d Maintainer: girgias Status: ready -->
+<!-- EN-Revision: 858400b07586b88dcb1e17a95e7a178b54b89d86 Maintainer: lacatoire Status: ready -->
 <refentry xml:id="pdo.pgsqlcopyfromarray" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>PDO::pgsqlCopyFromArray</refname>
@@ -7,12 +7,17 @@
    &Alias; <methodname>Pdo\Pgsql::copyFromArray</methodname>
   </refpurpose>
  </refnamediv>
+
+ <refsynopsisdiv>
+  &warn.deprecated.function-8-5-0;
+ </refsynopsisdiv>
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
+   <modifier role="attribute">#[\Deprecated]</modifier>
    <modifier>public</modifier> <type>bool</type><methodname>PDO::pgsqlCopyFromArray</methodname>
    <methodparam><type>string</type><parameter>tableName</parameter></methodparam>
-   <methodparam><type>array</type><parameter>rows</parameter></methodparam>
+   <methodparam><type class="union"><type>array</type><type>Traversable</type></type><parameter>rows</parameter></methodparam>
    <methodparam choice="opt"><type>string</type><parameter>separator</parameter><initializer>"\t"</initializer></methodparam>
    <methodparam choice="opt"><type>string</type><parameter>nullAs</parameter><initializer>"\\\\N"</initializer></methodparam>
    <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>fields</parameter><initializer>&null;</initializer></methodparam>
@@ -20,6 +25,30 @@
   <simpara>
    &info.method.alias; <methodname>Pdo\Pgsql::copyFromArray</methodname>.
   </simpara>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Le paramètre <parameter>rows</parameter> accepte désormais aussi un
+       <classname>Traversable</classname> ; antérieur à cela, seul un
+       <type>array</type> était accepté.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 </refentry>
 <!-- Keep this comment at the end of the file

--- a/reference/pdo_pgsql/pdo_overloaded/pgsqlCopyFromFile.xml
+++ b/reference/pdo_pgsql/pdo_overloaded/pgsqlCopyFromFile.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 1993c38d254743d8c0a2140ff6f797660997083d Maintainer: girgias Status: ready -->
+<!-- EN-Revision: 858400b07586b88dcb1e17a95e7a178b54b89d86 Maintainer: lacatoire Status: ready -->
 <refentry xml:id="pdo.pgsqlcopyfromfile" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>PDO::pgsqlCopyFromFile</refname>
@@ -7,9 +7,14 @@
    &Alias; <methodname>Pdo\Pgsql::copyFromFile</methodname>
   </refpurpose>
  </refnamediv>
+
+ <refsynopsisdiv>
+  &warn.deprecated.function-8-5-0;
+ </refsynopsisdiv>
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
+   <modifier role="attribute">#[\Deprecated]</modifier>
    <modifier>public</modifier> <type>bool</type><methodname>PDO::pgsqlCopyFromFile</methodname>
    <methodparam><type>string</type><parameter>tableName</parameter></methodparam>
    <methodparam><type>string</type><parameter>filename</parameter></methodparam>

--- a/reference/pdo_pgsql/pdo_overloaded/pgsqlCopyToArray.xml
+++ b/reference/pdo_pgsql/pdo_overloaded/pgsqlCopyToArray.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 1993c38d254743d8c0a2140ff6f797660997083d Maintainer: girgias Status: ready -->
+<!-- EN-Revision: 858400b07586b88dcb1e17a95e7a178b54b89d86 Maintainer: lacatoire Status: ready -->
 <refentry xml:id="pdo.pgsqlcopytoarray" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>PDO::pgsqlCopyToArray</refname>
@@ -7,9 +7,14 @@
    &Alias; <methodname>Pdo\Pgsql::copyToArray</methodname>
   </refpurpose>
  </refnamediv>
+
+ <refsynopsisdiv>
+  &warn.deprecated.function-8-5-0;
+ </refsynopsisdiv>
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
+   <modifier role="attribute">#[\Deprecated]</modifier>
    <modifier>public</modifier> <type class="union"><type>array</type><type>false</type></type><methodname>PDO::pgsqlCopyToArray</methodname>
    <methodparam><type>string</type><parameter>tableName</parameter></methodparam>
    <methodparam choice="opt"><type>string</type><parameter>separator</parameter><initializer>"\t"</initializer></methodparam>

--- a/reference/pdo_pgsql/pdo_overloaded/pgsqlCopyToFile.xml
+++ b/reference/pdo_pgsql/pdo_overloaded/pgsqlCopyToFile.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 1993c38d254743d8c0a2140ff6f797660997083d Maintainer: girgias Status: ready -->
+<!-- EN-Revision: 858400b07586b88dcb1e17a95e7a178b54b89d86 Maintainer: lacatoire Status: ready -->
 <refentry xml:id="pdo.pgsqlcopytofile" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>PDO::pgsqlCopyToFile</refname>
@@ -7,9 +7,14 @@
    &Alias; <methodname>Pdo\Pgsql::copyToFile</methodname>
   </refpurpose>
  </refnamediv>
+
+ <refsynopsisdiv>
+  &warn.deprecated.function-8-5-0;
+ </refsynopsisdiv>
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
+   <modifier role="attribute">#[\Deprecated]</modifier>
    <modifier>public</modifier> <type>bool</type><methodname>PDO::pgsqlCopyToFile</methodname>
    <methodparam><type>string</type><parameter>tableName</parameter></methodparam>
    <methodparam><type>string</type><parameter>filename</parameter></methodparam>

--- a/reference/pdo_pgsql/pdo_overloaded/pgsqlGetNotify.xml
+++ b/reference/pdo_pgsql/pdo_overloaded/pgsqlGetNotify.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 1993c38d254743d8c0a2140ff6f797660997083d Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 858400b07586b88dcb1e17a95e7a178b54b89d86 Maintainer: lacatoire Status: ready -->
 <refentry xml:id="pdo.pgsqlgetnotify" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>PDO::pgsqlGetNotify</refname>
@@ -7,9 +7,14 @@
    &Alias; <methodname>Pdo\Pgsql::getNotify</methodname>
   </refpurpose>
  </refnamediv>
+
+ <refsynopsisdiv>
+  &warn.deprecated.function-8-5-0;
+ </refsynopsisdiv>
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
+   <modifier role="attribute">#[\Deprecated]</modifier>
    <modifier>public</modifier> <type class="union"><type>array</type><type>false</type></type><methodname>PDO::pgsqlGetNotify</methodname>
    <methodparam choice="opt"><type>int</type><parameter>fetchMode</parameter><initializer>PDO::FETCH_DEFAULT</initializer></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>timeoutMilliseconds</parameter><initializer>0</initializer></methodparam>

--- a/reference/pdo_pgsql/pdo_overloaded/pgsqlGetPid.xml
+++ b/reference/pdo_pgsql/pdo_overloaded/pgsqlGetPid.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 1993c38d254743d8c0a2140ff6f797660997083d Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 858400b07586b88dcb1e17a95e7a178b54b89d86 Maintainer: lacatoire Status: ready -->
 <refentry xml:id="pdo.pgsqlgetpid" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>PDO::pgsqlGetPid</refname>
@@ -8,9 +7,14 @@
    &Alias; <methodname>Pdo\Pgsql::getPid</methodname>
   </refpurpose>
  </refnamediv>
+
+ <refsynopsisdiv>
+  &warn.deprecated.function-8-5-0;
+ </refsynopsisdiv>
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
+   <modifier role="attribute">#[\Deprecated]</modifier>
    <modifier>public</modifier> <type>int</type><methodname>PDO::pgsqlGetPid</methodname>
    <void/>
   </methodsynopsis>

--- a/reference/pdo_pgsql/pdo_overloaded/pgsqlLOBCreate.xml
+++ b/reference/pdo_pgsql/pdo_overloaded/pgsqlLOBCreate.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 1993c38d254743d8c0a2140ff6f797660997083d Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 858400b07586b88dcb1e17a95e7a178b54b89d86 Maintainer: lacatoire Status: ready -->
 <refentry xml:id="pdo.pgsqllobcreate" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>PDO::pgsqlLOBCreate</refname>
@@ -8,9 +7,14 @@
    &Alias; <methodname>Pdo\Pgsql::lobCreate</methodname>
   </refpurpose>
  </refnamediv>
+
+ <refsynopsisdiv>
+  &warn.deprecated.function-8-5-0;
+ </refsynopsisdiv>
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
+   <modifier role="attribute">#[\Deprecated]</modifier>
    <modifier>public</modifier> <type>string</type><methodname>PDO::pgsqlLOBCreate</methodname>
    <void/>
   </methodsynopsis>

--- a/reference/pdo_pgsql/pdo_overloaded/pgsqlLOBOpen.xml
+++ b/reference/pdo_pgsql/pdo_overloaded/pgsqlLOBOpen.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 1993c38d254743d8c0a2140ff6f797660997083d Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 858400b07586b88dcb1e17a95e7a178b54b89d86 Maintainer: lacatoire Status: ready -->
 <refentry xml:id="pdo.pgsqllobopen" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>PDO::pgsqlLOBOpen</refname>
@@ -8,9 +7,14 @@
    &Alias; <methodname>Pdo\Pgsql::lobOpen</methodname>
   </refpurpose>
  </refnamediv>
+
+ <refsynopsisdiv>
+  &warn.deprecated.function-8-5-0;
+ </refsynopsisdiv>
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
+   <modifier role="attribute">#[\Deprecated]</modifier>
    <modifier>public</modifier> <type class="union"><type>resource</type><type>false</type></type><methodname>PDO::pgsqlLOBOpen</methodname>
    <methodparam><type>string</type><parameter>oid</parameter></methodparam>
    <methodparam choice="opt"><type>string</type><parameter>mode</parameter><initializer>"rb"</initializer></methodparam>

--- a/reference/pdo_pgsql/pdo_overloaded/pgsqlLOBUnlink.xml
+++ b/reference/pdo_pgsql/pdo_overloaded/pgsqlLOBUnlink.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 1993c38d254743d8c0a2140ff6f797660997083d Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 858400b07586b88dcb1e17a95e7a178b54b89d86 Maintainer: lacatoire Status: ready -->
 <refentry xml:id="pdo.pgsqllobunlink" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>PDO::pgsqlLOBUnlink</refname>
@@ -8,9 +7,14 @@
    &Alias; <methodname>Pdo\Pgsql::lobUnlink</methodname>
   </refpurpose>
  </refnamediv>
+
+ <refsynopsisdiv>
+  &warn.deprecated.function-8-5-0;
+ </refsynopsisdiv>
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
+   <modifier role="attribute">#[\Deprecated]</modifier>
    <modifier>public</modifier> <type>bool</type><methodname>PDO::pgsqlLOBUnlink</methodname>
    <methodparam><type>string</type><parameter>oid</parameter></methodparam>
   </methodsynopsis>

--- a/reference/pdo_pgsql/reference.xml
+++ b/reference/pdo_pgsql/reference.xml
@@ -146,6 +146,15 @@ pgsql:host=localhost;port=5432;dbname=testdb;user=bruce;password=mypass
 ]]>
        </programlisting>
       </para>
+      <para>
+       L'exemple suivant montre PDO_PGSQL DSN pour se connecter à une base
+       de données PostgreSQL via une socket unix <filename>/tmp/.s.PGSQL.5432</filename> :
+       <programlisting>
+<![CDATA[
+pgsql:host=/tmp;port=5432;dbname=testdb;user=bruce;password=mypass
+]]>
+       </programlisting>
+      </para>
      </example>
     </para>
    </refsect1>

--- a/reference/pdo_pgsql/reference.xml
+++ b/reference/pdo_pgsql/reference.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 3c1bec9d700807df36994cf368ba291214cd424d Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 858400b07586b88dcb1e17a95e7a178b54b89d86 Maintainer: lacatoire Status: ready -->
 <reference xml:id="ref.pdo-pgsql" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
   <?phpdoc extension-membership="bundledexternal" ?>
   <title>Fonctions du pilote PDO PostgreSQL (PDO_PGSQL)</title>
@@ -19,10 +17,10 @@
 
    <section xml:id="ref.pdo-pgsql.resources">
     &reftitle.resources;
-    <para>
+    <simpara>
      Cette extension définit une ressource de flux, retournée
-     par la fonction <function>PDO::pgsqlLOBOpen</function>.
-    </para>
+     par <methodname>Pdo\Pgsql::lobOpen</methodname>.
+    </simpara>
    </section>
 
    &reference.pdo-pgsql.configure;
@@ -31,9 +29,11 @@
    <section xml:id="ref.pdo-pgsql.general-notes">
     <title>Notes générales</title>
     <note>
-     <para>
-      Les champs <literal>bytea</literal> sont retournés sous forme de flux.
-     </para>
+     <simpara>
+      Les colonnes <literal>bytea</literal> sont retournées sous forme de ressources de flux. Voir
+      <link linkend="pdo.lobs">Objets larges (LOBs)</link> pour savoir comment lire ces
+      valeurs et comment lier des données avec <constant>PDO::PARAM_LOB</constant>.
+     </simpara>
     </note>
    </section>
 
@@ -106,10 +106,15 @@
       <varlistentry>
        <term><literal>sslmode</literal></term>
        <listitem>
-        <para>
-         Le mode SSL. Les valeurs supportées et leur signification sont listées dans
-         la section <link xlink:href="&url.pgsql.manual;">Documentation PostgreSQL</link>.
-        </para>
+        <simpara>
+         Le mode SSL. Les valeurs acceptées sont <literal>disable</literal>,
+         <literal>allow</literal>, <literal>prefer</literal>,
+         <literal>require</literal>, <literal>verify-ca</literal>, et
+         <literal>verify-full</literal> ; leur signification est décrite dans la
+         <link xlink:href="&url.pgsql.manual;">Documentation PostgreSQL</link>.
+         De nombreux services PostgreSQL hébergés exigent une connexion chiffrée, ainsi
+         <literal>require</literal> ou plus strict est nécessaire pour s'y connecter.
+        </simpara>
        </listitem>
       </varlistentry>
 


### PR DESCRIPTION
Sync EN de l'extension pdo_pgsql (21 fichiers) : dépréciations 8.5 (`#[\Deprecated]` sur les alias `pgsql*`, constantes `PGSQL_TRANSACTION_*` et `ATTR_DISABLE_PREPARES`), nouvelles constantes documentées, exemples ajoutés et code modernisé.

Miroir tag-à-tag de l'EN, code PHP inchangé (commentaires/prose traduits).

Fixes #3055