### PR TITLE
[Sync EN] pdo_pgsql : lecture paresseuse ATTR_PREFETCH, signature copyFromArray

### DIFF
--- a/reference/pdo/constants.xml
+++ b/reference/pdo/constants.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 5d8e96f9b174f7471daebce760657eb0f190b0ba Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 205c3b8ad9af665e2b49dcc6020005bb479217a3 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <appendix xml:id="pdo.constants" xmlns="http://docbook.org/ns/docbook">
  &reftitle.constants;
@@ -250,6 +250,13 @@
       de la mémoire pour l'application. Toutes les combinaisons de bases de données/pilotes ne prennent pas
       en charge la définition de la taille de prélecture. Une taille de prélecture plus grande entraîne une
       augmentation des performances au prix d'une utilisation de la mémoire plus élevée.
+     </simpara>
+     <simpara>
+      Le pilote PDO_PGSQL traite plutôt cet attribut comme un commutateur : à
+      partir de PHP 8.5.0, une valeur de <literal>0</literal> active la lecture
+      paresseuse (ligne par ligne) ; voir la
+      <link linkend="pdo-pgsql.constants.attr-prefetch">documentation du pilote PDO_PGSQL</link>
+      pour plus de détails.
      </simpara>
     </listitem>
    </varlistentry>

--- a/reference/pdo_pgsql/pdo-pgsql.xml
+++ b/reference/pdo_pgsql/pdo-pgsql.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 858400b07586b88dcb1e17a95e7a178b54b89d86 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 205c3b8ad9af665e2b49dcc6020005bb479217a3 Maintainer: lacatoire Status: ready -->
 <reference xml:id="class.pdo-pgsql" xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" role="class">
  <title>La classe Pdo\Pgsql</title>
  <titleabbrev>Pdo\Pgsql</titleabbrev>
@@ -154,6 +154,35 @@
        de <classname>PDOStatement</classname> de résultat de requête spécifiée,
        ou &null; si aucun résultat n'existe avant l'exécution de la requête.
       </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="pdo-pgsql.constants.attr-prefetch">
+     <term><constant>PDO::ATTR_PREFETCH</constant></term>
+     <listitem>
+      <simpara>
+       À partir de PHP 8.5.0, définir cet attribut à <literal>0</literal>
+       active la lecture paresseuse (ligne par ligne) : les lignes sont
+       récupérées depuis le serveur une par une au fur et à mesure de leur
+       lecture, au lieu de mettre en mémoire tampon l'ensemble du jeu de
+       résultats avant le premier appel à
+       <methodname>PDOStatement::fetch</methodname>. Cela réduit l'utilisation
+       de la mémoire pour les grands jeux de résultats. Toute autre valeur
+       conserve le comportement par défaut avec mise en mémoire tampon.
+      </simpara>
+      <simpara>
+       Il peut être défini par connexion avec
+       <methodname>PDO::setAttribute</methodname>, ou par instruction via
+       les options de pilote de <methodname>PDO::prepare</methodname> ou
+       <methodname>PDO::query</methodname>.
+      </simpara>
+      <caution>
+       <simpara>
+        En mode paresseux, une connexion ne peut avoir qu'une seule
+        instruction active à la fois. L'exécution d'une autre instruction
+        ignore silencieusement les lignes non lues de la précédente ;
+        aucune erreur n'est levée.
+       </simpara>
+      </caution>
      </listitem>
     </varlistentry>
     <varlistentry xml:id="pdo-pgsql.constants.transaction-idle">

--- a/reference/pdo_pgsql/pdo/pgsql/copyfromarray.xml
+++ b/reference/pdo_pgsql/pdo/pgsql/copyfromarray.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 858400b07586b88dcb1e17a95e7a178b54b89d86 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 205c3b8ad9af665e2b49dcc6020005bb479217a3 Maintainer: lacatoire Status: ready -->
 <refentry xml:id="pdo-pgsql.copyfromarray" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>Pdo\Pgsql::copyFromArray</refname>
@@ -11,7 +11,7 @@
   <methodsynopsis role="Pdo\\Pgsql">
    <modifier>public</modifier> <type>bool</type><methodname>Pdo\Pgsql::copyFromArray</methodname>
    <methodparam><type>string</type><parameter>tableName</parameter></methodparam>
-   <methodparam><type>array</type><parameter>rows</parameter></methodparam>
+   <methodparam><type class="union"><type>array</type><type>Traversable</type></type><parameter>rows</parameter></methodparam>
    <methodparam choice="opt"><type>string</type><parameter>separator</parameter><initializer>"\t"</initializer></methodparam>
    <methodparam choice="opt"><type>string</type><parameter>nullAs</parameter><initializer>"\\\\N"</initializer></methodparam>
    <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>fields</parameter><initializer>&null;</initializer></methodparam>
@@ -38,8 +38,9 @@
     <term><parameter>rows</parameter></term>
     <listitem>
      <simpara>
-      Un <type>array</type> indexé de <type>string</type>s avec les champs
-      séparés par <parameter>separator</parameter>.
+      Un <type>array</type> indexé (ou <type>Traversable</type>) de
+      <type>string</type>s avec les champs séparés par
+      <parameter>separator</parameter>.
      </simpara>
     </listitem>
    </varlistentry>


### PR DESCRIPTION
Synchronisation EN : documentation de la lecture paresseuse (ligne par ligne) activée par `ATTR_PREFETCH = 0` à partir de PHP 8.5.0 sur le pilote PDO_PGSQL, et correction de la signature de `copyFromArray` (`rows` accepte aussi `Traversable`).

Fixes #3057