### PR TITLE
[Sync EN] Corrections codespell dans les extensions PECL (#5633)

### DIFF
--- a/reference/gearman/gearmantask/create.xml
+++ b/reference/gearman/gearmantask/create.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: cf0a919c126e45b5df583d188e77fa62015b714a Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 6047c10c1f9c7f5f2cc76603807b14b3ac3637b0 Maintainer: yannick Status: ready -->
 <!-- Reviewed: no -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="gearmantask.create">
  <refnamediv>

--- a/reference/ibm_db2/functions/db2-escape-string.xml
+++ b/reference/ibm_db2/functions/db2-escape-string.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 020edc73be983e8e2aca04782ff7c901da4afad7 Maintainer: jsgoupil Status: ready -->
+<!-- EN-Revision: 6047c10c1f9c7f5f2cc76603807b14b3ac3637b0 Maintainer: jsgoupil Status: ready -->
 <!-- Reviewed: no -->
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.db2-escape-string">
  <refnamediv>

--- a/reference/imagick/examples.xml
+++ b/reference/imagick/examples.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 3739933b8c796d45aad74410caebb2734dc00aa7 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 6047c10c1f9c7f5f2cc76603807b14b3ac3637b0 Maintainer: yannick Status: ready -->
 <!-- Reviewed: yes -->
 
 <chapter xml:id="imagick.examples" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/reference/imagick/imagick/brightnesscontrastimage.xml
+++ b/reference/imagick/imagick/brightnesscontrastimage.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 1ef9c7a76700b3e72844050d75e6ed1b870f9ca7 Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: 6047c10c1f9c7f5f2cc76603807b14b3ac3637b0 Maintainer: Fan2Shrek Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="imagick.brightnesscontrastimage" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -15,9 +15,9 @@
    <methodparam><type>float</type><parameter>contrast</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>channel</parameter><initializer>Imagick::CHANNEL_DEFAULT</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Change la luminosité et/ou le contraste d'une image. Il convertit les paramètres de luminosité et de contraste en pente et en ordonnée à l'origine et appelle une fonction polynomiale à appliquer à l'image.
-  </para>
+  </simpara>
 
  </refsect1>
 

--- a/reference/imagick/imagick/distortimage.xml
+++ b/reference/imagick/imagick/distortimage.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 0ffb9c9fc8f4bf1589a1a573644e1c23b6b451d1 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 6047c10c1f9c7f5f2cc76603807b14b3ac3637b0 Maintainer: yannick Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="imagick.distortimage">

--- a/reference/imagick/imagick/evaluateimage.xml
+++ b/reference/imagick/imagick/evaluateimage.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 65c4446ab35754d2f3cd8abec11302650a150bf9 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 6047c10c1f9c7f5f2cc76603807b14b3ac3637b0 Maintainer: yannick Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="imagick.evaluateimage">
@@ -17,11 +17,11 @@
    <methodparam><type>float</type><parameter>constant</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>channel</parameter><initializer>Imagick::CHANNEL_DEFAULT</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Applique une expression arithmétique, relationnelle ou logique à une image.
    Utiliser ces opérateurs pour éclaircir ou assombrir une image, pour
    augmenter ou réduire le contraste, ou encore, produire une image inversée.
-  </para>
+  </simpara>
  </refsect1>
  
  <refsect1 role="parameters">

--- a/reference/imagick/imagick/extentimage.xml
+++ b/reference/imagick/imagick/extentimage.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 0ffb9c9fc8f4bf1589a1a573644e1c23b6b451d1 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 6047c10c1f9c7f5f2cc76603807b14b3ac3637b0 Maintainer: yannick Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="imagick.extentimage">
@@ -27,7 +27,7 @@
   </para>
   
   <caution>
-   <para>
+   <simpara>
     Avant ImageMagick 6.5.7-8 (1623), $x était positif lors d'un déplacement
     vers la gauche, et négatif lors d'un déplacement vers la droite, et $y
     était positif lors d'un déplacement de l'image vers le haut, et négatif lors
@@ -39,8 +39,8 @@
     vers le bas. Quelque part entre les versions ImageMagick 6.5.7-8 (1623) et
     ImageMagick 6.6.9-7 (1641), le comportement est revenu tel qu'il était
     avant ImageMagick 6.5.7-8 (1623).
-    
-   </para>
+
+   </simpara>
   </caution>
  </refsect1>
  

--- a/reference/imagick/imagick/getimageproperties.xml
+++ b/reference/imagick/imagick/getimageproperties.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 0ffb9c9fc8f4bf1589a1a573644e1c23b6b451d1 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 6047c10c1f9c7f5f2cc76603807b14b3ac3637b0 Maintainer: yannick Status: ready -->
 <!-- Reviewed: yes -->
 
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="imagick.getimageproperties">

--- a/reference/imagick/imagick/sigmoidalcontrastimage.xml
+++ b/reference/imagick/imagick/sigmoidalcontrastimage.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 52d113ac0ae010b8229ac7a7e98b837ff2c755b3 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 6047c10c1f9c7f5f2cc76603807b14b3ac3637b0 Maintainer: yannick Status: ready -->
 <!-- Reviewed: yes -->
 
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="imagick.sigmoidalcontrastimage" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -60,10 +60,10 @@
     <varlistentry>
      <term><parameter>beta</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Où doit se situer le milieu du gradient. Cette valeur doit être dans
        l'intervalle 0-1, multiplié par la valeur du quantum pour ImageMagick.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>

--- a/reference/imagick/imagick/trimimage.xml
+++ b/reference/imagick/imagick/trimimage.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 0ffb9c9fc8f4bf1589a1a573644e1c23b6b451d1 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 6047c10c1f9c7f5f2cc76603807b14b3ac3637b0 Maintainer: yannick Status: ready -->
 <!-- Reviewed: yes -->
 
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="imagick.trimimage">

--- a/reference/imagick/imagickdraw/affine.xml
+++ b/reference/imagick/imagickdraw/affine.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 668b6fc28891062b1c96202009ccb70b7147740d Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 6047c10c1f9c7f5f2cc76603807b14b3ac3637b0 Maintainer: yannick Status: ready -->
 <!-- Reviewed: yes -->
 
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="imagickdraw.affine">
@@ -80,7 +80,7 @@ function affine($strokeColor, $fillColor, $backgroundColor) {
     //Translate (offset) the drawing
     $affineTranslate = array("sx" => 1, "sy" => 1, "rx" => 0, "ry" => 0, "tx" => 30, "ty" => 30);
 
-    //The identiy affine matrix
+    //The identity affine matrix
     $affineIdentity = array("sx" => 1, "sy" => 1, "rx" => 0, "ry" => 0, "tx" => 0, "ty" => 0);
 
     $examples = [$affineScale, $affineShear, $affineRotate, $affineTranslate, $affineIdentity,];

--- a/reference/imagick/imagickpixeliterator/resetiterator.xml
+++ b/reference/imagick/imagickpixeliterator/resetiterator.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: fa0c88f1e36a3f28b4fcee0b2d1e188b54e0c44b Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 6047c10c1f9c7f5f2cc76603807b14b3ac3637b0 Maintainer: yannick Status: ready -->
 <!-- Reviewed: yes -->
 
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="imagickpixeliterator.resetiterator">

--- a/reference/memcached/memcached/ispersistent.xml
+++ b/reference/memcached/memcached/ispersistent.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: a996df6b949ae2db2cf19a07e68ce367137d3ecb Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 6047c10c1f9c7f5f2cc76603807b14b3ac3637b0 Maintainer: yannick Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="memcached.ispersistent" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>

--- a/reference/mongodb/bson/document/tophp.xml
+++ b/reference/mongodb/bson/document/tophp.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 6047c10c1f9c7f5f2cc76603807b14b3ac3637b0 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="mongodb-bson-document.tophp" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>

--- a/reference/mongodb/bson/objectid/tostring.xml
+++ b/reference/mongodb/bson/objectid/tostring.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ --> 
-<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 6047c10c1f9c7f5f2cc76603807b14b3ac3637b0 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="mongodb-bson-objectid.tostring" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/reference/mongodb/bson/objectidinterface/tostring.xml
+++ b/reference/mongodb/bson/objectidinterface/tostring.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 6047c10c1f9c7f5f2cc76603807b14b3ac3637b0 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 
 <refentry xml:id="mongodb-bson-objectidinterface.tostring" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/reference/mongodb/bson/timestamp/getincrement.xml
+++ b/reference/mongodb/bson/timestamp/getincrement.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 6047c10c1f9c7f5f2cc76603807b14b3ac3637b0 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="mongodb-bson-timestamp.getincrement" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/reference/mongodb/functions/bson/tophp.xml
+++ b/reference/mongodb/functions/bson/tophp.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 6047c10c1f9c7f5f2cc76603807b14b3ac3637b0 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="function.mongodb.bson-tophp" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>

--- a/reference/mongodb/mongodb/driver/bulkwrite.xml
+++ b/reference/mongodb/mongodb/driver/bulkwrite.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 6047c10c1f9c7f5f2cc76603807b14b3ac3637b0 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes --> 
 <reference xml:id="class.mongodb-driver-bulkwrite" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>La classe MongoDB\Driver\BulkWrite</title>

--- a/reference/mongodb/mongodb/driver/manager/executebulkwrite.xml
+++ b/reference/mongodb/mongodb/driver/manager/executebulkwrite.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 6047c10c1f9c7f5f2cc76603807b14b3ac3637b0 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="mongodb-driver-manager.executebulkwrite" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>

--- a/reference/mongodb/mongodb/driver/manager/executecommand.xml
+++ b/reference/mongodb/mongodb/driver/manager/executecommand.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 6047c10c1f9c7f5f2cc76603807b14b3ac3637b0 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="mongodb-driver-manager.executecommand" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>

--- a/reference/mongodb/mongodb/driver/manager/executequery.xml
+++ b/reference/mongodb/mongodb/driver/manager/executequery.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 6047c10c1f9c7f5f2cc76603807b14b3ac3637b0 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="mongodb-driver-manager.executequery" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>

--- a/reference/mongodb/mongodb/driver/server/executebulkwrite.xml
+++ b/reference/mongodb/mongodb/driver/server/executebulkwrite.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 6047c10c1f9c7f5f2cc76603807b14b3ac3637b0 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="mongodb-driver-server.executebulkwrite" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/reference/mongodb/mongodb/driver/server/executecommand.xml
+++ b/reference/mongodb/mongodb/driver/server/executecommand.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 6047c10c1f9c7f5f2cc76603807b14b3ac3637b0 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="mongodb-driver-server.executecommand" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/reference/mongodb/mongodb/driver/server/executequery.xml
+++ b/reference/mongodb/mongodb/driver/server/executequery.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 6047c10c1f9c7f5f2cc76603807b14b3ac3637b0 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="mongodb-driver-server.executequery" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/reference/mongodb/mongodb/driver/session/committransaction.xml
+++ b/reference/mongodb/mongodb/driver/session/committransaction.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 6047c10c1f9c7f5f2cc76603807b14b3ac3637b0 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="mongodb-driver-session.committransaction" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>

--- a/reference/mongodb/security.xml
+++ b/reference/mongodb/security.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 6047c10c1f9c7f5f2cc76603807b14b3ac3637b0 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <chapter xml:id="mongodb.security" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Sécurité</title>

--- a/reference/oci8/functions/oci-get-implicit-resultset.xml
+++ b/reference/oci8/functions/oci-get-implicit-resultset.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: ed6de1ae20ce16c0c7be0b3fef282b6065bebfac Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 6047c10c1f9c7f5f2cc76603807b14b3ac3637b0 Maintainer: yannick Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.oci-get-implicit-resultset" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -16,15 +16,15 @@
    <type class="union"><type>resource</type><type>false</type></type><methodname>oci_get_implicit_resultset</methodname>
    <methodparam><type>resource</type><parameter>statement</parameter></methodparam>
   </methodsynopsis>
-  <para>
-   Utilisé pour récupérer des jeux récursifs de résultats de requêtes
+  <simpara>
+   Utilisé pour récupérer des jeux consécutifs de résultats de requêtes
    après l'exécution d'un bloc stocké ou anonyme Oracle PL/SQL où ce bloc
    retourne des résultats de requêtes avec la fonction
    <emphasis>DBMS_SQL.RETURN_RESULT</emphasis> Oracle PL/SQL de la base de données
    Oracle 12 (ou ultérieur).
    Ceci permet aux blocs PL/SQL de retourner facilement des résultats
    de requêtes.
-  </para>
+  </simpara>
   <para>
    La requête fils peut être utilisée avec n'importe laquelle des fonctions
    de récupération OCI8 : <function>oci_fetch</function>, <function>oci_fetch_all</function>,

--- a/reference/oci8/ini.xml
+++ b/reference/oci8/ini.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: d4d5216e7a965ca194f6b1c9dee84cecab2674e5 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 6047c10c1f9c7f5f2cc76603807b14b3ac3637b0 Maintainer: yannick Status: ready -->
 <!-- Reviewed: yes -->
 <section xml:id="oci8.configuration" xmlns="http://docbook.org/ns/docbook">
  &reftitle.runtime;

--- a/reference/sqlsrv/constants.xml
+++ b/reference/sqlsrv/constants.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 2471b0dc9ba5f9aff8b1b73060515dd9ce41b634 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 6047c10c1f9c7f5f2cc76603807b14b3ac3637b0 Maintainer: yannick Status: ready -->
 <!-- Reviewed: no -->
 <appendix xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="sqlsrv.constants">
  &reftitle.constants;

--- a/reference/sqlsrv/functions/sqlsrv-close.xml
+++ b/reference/sqlsrv/functions/sqlsrv-close.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: c758e862cf7648f657acb9e073bcc657f368a701 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 6047c10c1f9c7f5f2cc76603807b14b3ac3637b0 Maintainer: yannick Status: ready -->
 <!-- Reviewed: no -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.sqlsrv-close">
  <refnamediv>

--- a/reference/sqlsrv/functions/sqlsrv-num-rows.xml
+++ b/reference/sqlsrv/functions/sqlsrv-num-rows.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: c758e862cf7648f657acb9e073bcc657f368a701 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 6047c10c1f9c7f5f2cc76603807b14b3ac3637b0 Maintainer: yannick Status: ready -->
 <!-- Reviewed: no -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.sqlsrv-num-rows">
  <refnamediv>

--- a/reference/swoole/constants.xml
+++ b/reference/swoole/constants.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: ecc53915a8e9eee17065ce22bef4dca3e42537d1 Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: 6047c10c1f9c7f5f2cc76603807b14b3ac3637b0 Maintainer: Fan2Shrek Status: ready -->
 <!-- Reviewed: yes -->
 <appendix xml:id="swoole.constants" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.constants;

--- a/reference/swoole/functions/swoole-async-read.xml
+++ b/reference/swoole/functions/swoole-async-read.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 322606e4f1742a6f959e952c63fb1f8bcd6d6ba0 Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: 6047c10c1f9c7f5f2cc76603807b14b3ac3637b0 Maintainer: Fan2Shrek Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="function.swoole-async-read" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -53,9 +53,9 @@
        <varlistentry>
         <term><parameter>content</parameter></term>
         <listitem>
-         <para>
+         <simpara>
           Le contenu lu du flux de fichier.
-         </para>
+         </simpara>
         </listitem>
        </varlistentry>
       </variablelist>

--- a/reference/swoole/functions/swoole-last-error.xml
+++ b/reference/swoole/functions/swoole-last-error.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 17623bf363758688a477a430af75e05a28661779 Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: 6047c10c1f9c7f5f2cc76603807b14b3ac3637b0 Maintainer: Fan2Shrek Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="function.swoole-last-error" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>

--- a/reference/swoole/swoole/async/read.xml
+++ b/reference/swoole/swoole/async/read.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 86e6094e86b84a51d00ab217ac50ce8dde33d82a Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: 6047c10c1f9c7f5f2cc76603807b14b3ac3637b0 Maintainer: Fan2Shrek Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="swoole-async.read" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -53,9 +53,9 @@
        <varlistentry>
         <term><parameter>content</parameter></term>
         <listitem>
-         <para>
+         <simpara>
           Le contenu lu depuis le flux de fichier.
-         </para>
+         </simpara>
         </listitem>
        </varlistentry>
       </variablelist>

--- a/reference/swoole/swoole/async/readfile.xml
+++ b/reference/swoole/swoole/async/readfile.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 322606e4f1742a6f959e952c63fb1f8bcd6d6ba0 Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: 6047c10c1f9c7f5f2cc76603807b14b3ac3637b0 Maintainer: Fan2Shrek Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="swoole-async.readfile" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -51,9 +51,9 @@
        <varlistentry>
         <term><parameter>content</parameter></term>
         <listitem>
-         <para>
+         <simpara>
           Le contenu lu depuis le fichier.
-         </para>
+         </simpara>
         </listitem>
        </varlistentry>
       </variablelist>


### PR DESCRIPTION
Synchronise les 37 fichiers FR avec la correction de typos codespell côté EN (php/doc-en@6047c10, PR php/doc-en#5633).

## Changements
- **Hash EN-Revision** mis à jour vers `6047c10` sur les 37 fichiers.
- **`<para>` → `<simpara>`** reporté sur les blocs concernés : brightnesscontrastimage, evaluateimage, extentimage, sigmoidalcontrastimage, oci-get-implicit-resultset, swoole-async-read, swoole/async/read, swoole/async/readfile.
- **Typo de commentaire de code** `identiy` → `identity` dans imagickdraw/affine.xml (commentaire resté en anglais, aligné sur EN).
- **Correction de traduction** dans oci-get-implicit-resultset.xml : « jeux récursifs » → « jeux consécutifs » (`consecutive` était un faux-ami, mis en évidence par la correction EN `consectutive`→`consecutive`).

Les autres typos EN portaient sur de la prose anglaise ou des commentaires/chaînes déjà correctement traduits en français : aucun changement de texte nécessaire, seulement la mise à jour du hash.

Closes #3059