### PR TITLE
[Sync EN] PDO : obsolescences PHP 8.5.0 dans les constantes et méthodes (#5635)

### DIFF
--- a/reference/pdo/constants.xml
+++ b/reference/pdo/constants.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 205c3b8ad9af665e2b49dcc6020005bb479217a3 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 8d40a1fab3f89d6e35caece522991b67fb9df246 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <appendix xml:id="pdo.constants" xmlns="http://docbook.org/ns/docbook">
  &reftitle.constants;
@@ -734,6 +734,12 @@
      (<type>int</type>)
     </term>
     <listitem>
+     <warning>
+      <simpara>
+       Cette constante est <emphasis>OBSOLÈTE</emphasis> à partir de PHP 8.5.0.
+       Utiliser <constant>Pdo\Sqlite::DETERMINISTIC</constant> à la place.
+      </simpara>
+     </warning>
      <simpara>
        Spécifie qu'une fonction créée avec <methodname>PDO::sqliteCreateFunction</methodname>
        est déterministe, c'est-à-dire qu'elle renvoie toujours le même résultat donné les mêmes entrées dans

--- a/reference/pdo_firebird/constants.xml
+++ b/reference/pdo_firebird/constants.xml
@@ -1,11 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: b9cf1a2e7307131913ac3c16c2fb67ed9ad38527 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 8d40a1fab3f89d6e35caece522991b67fb9df246 Maintainer: yannick Status: ready -->
 <!-- Reviewed: yes -->
 
 <section xml:id="ref.pdo-firebird.constants" xmlns="http://docbook.org/ns/docbook">
  &reftitle.constants;
  &pdo.driver-constants;
+ <warning>
+  <simpara>
+   Les constantes listées ci-dessous sont <emphasis>OBSOLÈTES</emphasis>
+   à partir de PHP 8.5.0. Utiliser les constantes <classname>Pdo\Firebird</classname>
+   correspondantes à la place.
+  </simpara>
+ </warning>
  <variablelist>
   <varlistentry xml:id="pdo.constants.fb-attr-date-format">
    <term>
@@ -13,9 +20,9 @@
     (<type>int</type>)
    </term>
    <listitem>
-    <para>
+    <simpara>
      &Alias; <constant>Pdo\Firebird::ATTR_DATE_FORMAT</constant>.
-    </para>
+    </simpara>
    </listitem>
   </varlistentry>
   <varlistentry xml:id="pdo.constants.fb-attr-time-format">
@@ -24,9 +31,9 @@
     (<type>int</type>)
    </term>
    <listitem>
-    <para>
+    <simpara>
      &Alias; <constant>Pdo\Firebird::ATTR_TIME_FORMAT</constant>.
-    </para>
+    </simpara>
    </listitem>
   </varlistentry>
   <varlistentry xml:id="pdo.constants.fb-attr-timestamp-format">
@@ -35,9 +42,9 @@
     (<type>int</type>)
    </term>
    <listitem>
-    <para>
+    <simpara>
      &Alias; <constant>Pdo\Firebird::ATTR_TIMESTAMP_FORMAT</constant>.
-    </para>
+    </simpara>
    </listitem>
   </varlistentry>
  </variablelist>

--- a/reference/pdo_mysql/constants.xml
+++ b/reference/pdo_mysql/constants.xml
@@ -1,9 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 5d8e96f9b174f7471daebce760657eb0f190b0ba Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 8d40a1fab3f89d6e35caece522991b67fb9df246 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <section xml:id="ref.pdo-mysql.constants" xmlns="http://docbook.org/ns/docbook">
  &reftitle.constants;
  &pdo.driver-constants;
+ <warning>
+  <simpara>
+   Les constantes listées ci-dessous sont <emphasis>OBSOLÈTES</emphasis>
+   à partir de PHP 8.5.0. Utiliser les constantes <classname>Pdo\Mysql</classname>
+   correspondantes à la place.
+  </simpara>
+ </warning>
  <variablelist>
   <varlistentry xml:id="pdo.constants.mysql-attr-use-buffered-query">
    <term>

--- a/reference/pdo_odbc/constants.xml
+++ b/reference/pdo_odbc/constants.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 220e1d0ef80ba8f68254db56ee9f2203be4cd8e6 Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: 8d40a1fab3f89d6e35caece522991b67fb9df246 Maintainer: Fan2Shrek Status: ready -->
 <!-- Reviewed: yes -->
 <section xml:id="pdo-odbc.global.constants" xmlns="http://docbook.org/ns/docbook">
  &reftitle.constants;
@@ -11,11 +11,22 @@
     (<type>string</type>)
    </term>
    <listitem>
-    <para>
-
-    </para>
+    <simpara>
+     Décrit la bibliothèque ODBC à laquelle l'extension PDO_ODBC est liée.
+     Les valeurs possibles incluent <literal>unixODBC</literal>,
+     <literal>iODBC</literal>, ou <literal>generic</literal>.
+    </simpara>
    </listitem>
   </varlistentry>
+ </variablelist>
+ <warning>
+  <simpara>
+   Les constantes listées ci-dessous sont <emphasis>OBSOLÈTES</emphasis>
+   à partir de PHP 8.5.0. Utiliser les constantes <classname>Pdo\Odbc</classname>
+   correspondantes à la place.
+  </simpara>
+ </warning>
+ <variablelist>
   <varlistentry xml:id="pdo.constants.odbc-attr-use-cursor-library">
    <term>
     <constant>PDO::ODBC_ATTR_USE_CURSOR_LIBRARY</constant>

--- a/reference/pdo_sqlite/pdo_overloaded/sqliteCreateAggregate.xml
+++ b/reference/pdo_sqlite/pdo_overloaded/sqliteCreateAggregate.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 1993c38d254743d8c0a2140ff6f797660997083d Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 8d40a1fab3f89d6e35caece522991b67fb9df246 Maintainer: yannick Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="pdo.sqlitecreateaggregate" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -8,6 +8,10 @@
    &Alias; <methodname>Pdo\Sqlite::createAggregate</methodname>
   </refpurpose>
  </refnamediv>
+
+ <refsynopsisdiv>
+  &warn.deprecated.function-8-5-0;
+ </refsynopsisdiv>
 
  <refsect1 role="description">
   &reftitle.description;

--- a/reference/pdo_sqlite/pdo_overloaded/sqliteCreateCollation.xml
+++ b/reference/pdo_sqlite/pdo_overloaded/sqliteCreateCollation.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 1993c38d254743d8c0a2140ff6f797660997083d Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 8d40a1fab3f89d6e35caece522991b67fb9df246 Maintainer: yannick Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="pdo.sqlitecreatecollation" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -8,6 +8,10 @@
    &Alias; <methodname>Pdo\Sqlite::createCollation</methodname>
   </refpurpose>
  </refnamediv>
+
+ <refsynopsisdiv>
+  &warn.deprecated.function-8-5-0;
+ </refsynopsisdiv>
 
  <refsect1 role="description">
   &reftitle.description;

--- a/reference/pdo_sqlite/pdo_overloaded/sqliteCreateFunction.xml
+++ b/reference/pdo_sqlite/pdo_overloaded/sqliteCreateFunction.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 1993c38d254743d8c0a2140ff6f797660997083d Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 8d40a1fab3f89d6e35caece522991b67fb9df246 Maintainer: yannick Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="pdo.sqlitecreatefunction" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -8,6 +8,10 @@
    &Alias; <methodname>Pdo\Sqlite::createFunction</methodname>
   </refpurpose>
  </refnamediv>
+
+ <refsynopsisdiv>
+  &warn.deprecated.function-8-5-0;
+ </refsynopsisdiv>
 
  <refsect1 role="description">
   &reftitle.description;


### PR DESCRIPTION
Synchronise les 7 fichiers FR avec php/doc-en@8d40a1f (PR php/doc-en#5635).

## Changements
- **`PDO::SQLITE_DETERMINISTIC`** (pdo/constants.xml) : ajout de l'avertissement d'obsolescence PHP 8.5.0 (→ `Pdo\Sqlite::DETERMINISTIC`).
- **Constantes pilotes obsolètes** : bloc `<warning>` ajouté en tête de pdo_firebird, pdo_mysql et pdo_odbc (→ constantes `Pdo\Firebird` / `Pdo\Mysql` / `Pdo\Odbc`).
- **`PDO_ODBC_TYPE`** (pdo_odbc) : description auparavant vide, désormais traduite (« Décrit la bibliothèque ODBC… »).
- **sqliteCreateAggregate / Collation / Function** : ajout du `<refsynopsisdiv>&warn.deprecated.function-8-5-0;</refsynopsisdiv>`.
- Report des `<para>` → `<simpara>` conformément à EN et mise à jour du hash EN-Revision.

Closes #3060