### PR TITLE
Sync EN: ext/operator documentation (#3063)

### DIFF
--- a/language/operators.xml
+++ b/language/operators.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: 6043cd25418a3c45c64a4af118ee939c1835251b Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
 <chapter xml:id="language.operators" xmlns="http://docbook.org/ns/docbook" annotations="interactive">
  <title>Les opérateurs</title>
  <simpara>

--- a/language/operators.xml
+++ b/language/operators.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 2946c8a267734a9e8696e1764f7436e6caa8909c Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 6043cd25418a3c45c64a4af118ee939c1835251b Maintainer: yannick Status: ready -->
 <!-- Reviewed: no -->
 <chapter xml:id="language.operators" xmlns="http://docbook.org/ns/docbook" annotations="interactive">
  <title>Les opérateurs</title>
@@ -29,6 +29,11 @@
   Cette section explique aussi la précédence des opérateurs et l'associativité, c'est-à-dire
   les priorités d'exécution des opérateurs.
  </para>
+ <simpara>
+  Une extension PECL permet de surcharger certains opérateurs pour les objets.
+  Pour plus d'informations, voir la section
+  <link linkend="book.operator">Surcharge d'opérateurs pour les objets</link>.
+ </simpara>
 
  &language.operators.precedence;
  &language.operators.arithmetic;

--- a/reference/operator/book.xml
+++ b/reference/operator/book.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: 6043cd25418a3c45c64a4af118ee939c1835251b Maintainer: lacatoire Status: ready -->
-<!-- Reviewed: no -->
 <book xml:id="book.operator" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <?phpdoc extension-membership="pecl" ?>
  <title>Surcharge d'opérateurs pour les objets</title>

--- a/reference/operator/book.xml
+++ b/reference/operator/book.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 6043cd25418a3c45c64a4af118ee939c1835251b Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+<book xml:id="book.operator" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <?phpdoc extension-membership="pecl" ?>
+ <title>Surcharge d'opérateurs pour les objets</title>
+ <titleabbrev>Surcharge d'opérateurs</titleabbrev>
+
+ <!-- {{{ preface -->
+ <preface xml:id="intro.operator">
+  &reftitle.intro;
+  <simpara>
+   Cette extension définit et implémente la surcharge d'opérateurs pour les objets.
+   Elle permet de définir comment un objet réagit lorsqu'un opérateur lui est appliqué.
+  </simpara>
+  <simpara>
+   Un exemple est la création d'un objet de type collection dont l'opérateur
+   d'addition est surchargé pour permettre d'ajouter des éléments à la collection
+   ou d'additionner deux collections ensemble.
+  </simpara>
+  <simpara>
+   Un autre exemple est la création d'une classe de chaîne améliorée dont l'opérateur
+   de multiplication est surchargé pour permettre de répéter la chaîne un certain
+   nombre de fois.
+  </simpara>
+ </preface>
+ <!-- }}} -->
+ &reference.operator.setup;
+ &reference.operator.overloading;
+</book>

--- a/reference/operator/overloading.xml
+++ b/reference/operator/overloading.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: 6043cd25418a3c45c64a4af118ee939c1835251b Maintainer: lacatoire Status: ready -->
-<!-- Reviewed: no -->
 
 <chapter xml:id="operator.overloading" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Méthodes magiques de surcharge d'opérateurs</title>

--- a/reference/operator/overloading.xml
+++ b/reference/operator/overloading.xml
@@ -1,0 +1,341 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 6043cd25418a3c45c64a4af118ee939c1835251b Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+
+<chapter xml:id="operator.overloading" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <title>Méthodes magiques de surcharge d'opérateurs</title>
+ <simpara>
+  L'extension de surcharge d'opérateurs permet de définir comment un objet réagit aux opérateurs. Cela se fait en implémentant les méthodes magiques suivantes :
+ </simpara>
+ <para>
+  Opérateurs arithmétiques :
+  <simplelist>
+   <member><literal>$a::__add($b)</literal></member>
+   <member><literal>$a::__sub($b)</literal></member>
+   <member><literal>$a::__mul($b)</literal></member>
+   <member><literal>$a::__div($b)</literal></member>
+   <member><literal>$a::__mod($b)</literal></member>
+   <member><literal>$a::__pow($b)</literal></member>
+  </simplelist>
+ </para>
+ <para>
+  Opérateurs d'affectation :
+  <simplelist>
+   <member><literal>$a::__assign($b)</literal></member>
+   <member><literal>$a::__assign_add($b)</literal></member>
+   <member><literal>$a::__assign_sub($b)</literal></member>
+   <member><literal>$a::__assign_mul($b)</literal></member>
+   <member><literal>$a::__assign_div($b)</literal></member>
+   <member><literal>$a::__assign_mod($b)</literal></member>
+   <member><literal>$a::__assign_pow($b)</literal></member>
+   <member><literal>$a::__assign_bw_and($b)</literal></member>
+   <member><literal>$a::__assign_bw_or($b)</literal></member>
+   <member><literal>$a::__assign_bw_xor($b)</literal></member>
+   <member><literal>$a::__assign_sl($b)</literal></member>
+   <member><literal>$a::__assign_sr($b)</literal></member>
+   <member><literal>$a::__assign_concat($b)</literal></member>
+  </simplelist>
+ </para>
+ <para>
+  Opérateurs sur les bits :
+  <simplelist>
+   <member><literal>$a::__bw_and($b)</literal></member>
+   <member><literal>$a::__bw_or($b)</literal></member>
+   <member><literal>$a::__bw_xor($b)</literal></member>
+   <member><literal>$a::__bw_not()</literal></member>
+   <member><literal>$a::__sl($b)</literal></member>
+   <member><literal>$a::__sr($b)</literal></member>
+  </simplelist>
+ </para>
+ <para>
+  Opérateurs de comparaison :
+  <simplelist>
+   <member><literal>$a::__is_equal($b)</literal></member>
+   <member><literal>$a::__is_not_equal($b)</literal></member>
+   <member><literal>$a::__is_identical($b)</literal></member>
+   <member><literal>$a::__is_not_identical($b)</literal></member>
+   <member><literal>$a::__is_smaller($b)</literal></member>
+   <member><literal>$a::__is_smaller_or_equal($b)</literal></member>
+   <member><literal>$a::__is_greater($b)</literal></member>
+   <member><literal>$a::__is_greater_or_equal($b)</literal></member>
+   <member><literal>$a::__spaceship($b)</literal></member>
+  </simplelist>
+ </para>
+ <para>
+  Opérateurs d'incrémentation et de décrémentation :
+  <simplelist>
+   <member><literal>$a::__pre_inc()</literal></member>
+   <member><literal>$a::__post_inc()</literal></member>
+   <member><literal>$a::__pre_dec()</literal></member>
+   <member><literal>$a::__post_dec()</literal></member>
+  </simplelist>
+ </para>
+ <para>
+  Opérateurs de chaînes :
+  <simplelist>
+   <member><literal>$a::__concat($b)</literal></member>
+  </simplelist>
+ </para>
+ <section>
+  <title>Exemples de surcharge d'opérateurs</title>
+  <simpara>
+   Ce qui suit est la classe utilisée pour les tests de l'extension de surcharge d'opérateurs.
+   Elle surcharge tous les opérateurs qu'il est possible de surcharger à des fins de test.
+  </simpara>
+  <example xml:id="operator.overloading.complete-class">
+   <title>Classe complète pour la surcharge d'opérateurs</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+class OperatorOverloading {
+    protected mixed $value;
+
+    //region Méthodes magiques standards
+    public function __get(string $name)
+    {
+        return $this->value;
+    }
+
+    public function __set(string $name, mixed $value)
+    {
+        $this->value = $value;
+    }
+
+    public function __construct(mixed $init = null)
+    {
+        $this->value = $init;
+    }
+    //endregion
+
+    //region Opérateurs arithmétiques
+    public function __add(mixed $val): int|float
+    {
+        return $this->value + $val;
+    }
+
+    public function __div(mixed $val): int|float
+    {
+        return $this->value / $val;
+    }
+
+    public function __mod(mixed $val): int
+    {
+        return $this->value % $val;
+    }
+
+    public function __mul(mixed $val): int|float
+    {
+        return $this->value * $val;
+    }
+
+    public function __pow(mixed $val): int|float
+    {
+        return $this->value ** $val;
+    }
+
+    public function __sub(mixed $val): int|float
+    {
+        return $this->value - $val;
+    }
+    //endregion
+
+    //region Opérateurs d'affectation
+    public function __assign(mixed $val): mixed
+    {
+        return $this->value = $val;
+    }
+
+    public function __assign_add(mixed $val): mixed
+    {
+        return $this->value += $val;
+    }
+
+    public function __assign_bw_and(mixed $val): mixed
+    {
+        return $this->value &= $val;
+    }
+
+    public function __assign_bw_or(mixed $val): mixed
+    {
+        return $this->value |= $val;
+    }
+
+    public function __assign_concat(mixed $val): string
+    {
+        return $this->value .= $val;
+    }
+
+    public function __assign_div(mixed $val): mixed
+    {
+        return $this->value /= $val;
+    }
+
+    public function __assign_mod(mixed $val): mixed
+    {
+        return $this->value %= $val;
+    }
+
+    public function __assign_mul(mixed $val): mixed
+    {
+        return $this->value *= $val;
+    }
+
+    public function __assign_pow(mixed $val): mixed
+    {
+        return $this->value **= $val;
+    }
+
+    public function __assign_sl(mixed $val): mixed
+    {
+        return $this->value <<= $val;
+    }
+
+    public function __assign_sr(mixed $val): mixed
+    {
+        return $this->value >>= $val;
+    }
+
+    public function __assign_sub(mixed $val): mixed
+    {
+        return $this->value -= $val;
+    }
+    //endregion
+
+    //region Opérateurs sur les bits
+    public function __bw_and(mixed $val): int
+    {
+        return $this->value & $val;
+    }
+
+    public function __bw_not(): int|string
+    {
+        return ~$this->value;
+    }
+
+    public function __bw_or(mixed $val): int
+    {
+        return $this->value | $val;
+    }
+
+    public function __bw_xor(mixed $val): int
+    {
+        return $this->value ^ $val;
+    }
+
+    public function __sl(mixed $val): int
+    {
+        return $this->value << $val;
+    }
+
+    public function __sr(mixed $val): int
+    {
+        return $this->value >> $val;
+    }
+    //endregion
+
+    //region Opérateurs de comparaison
+    public function __is_equal(mixed $val): bool
+    {
+        return $this->value == $val;
+    }
+
+    public function __is_greater(mixed $val): bool
+    {
+        return $this->value > $val;
+    }
+
+    public function __is_greater_or_equal(mixed $val): bool
+    {
+        return $this->value >= $val;
+    }
+
+    public function __is_identical(mixed $val): bool
+    {
+        return $this->value === $val;
+    }
+
+    public function __is_not_equal(mixed $val): bool
+    {
+        return $this->value != $val;
+    }
+
+    public function __is_not_identical(mixed $val): bool
+    {
+        return $this->value !== $val;
+    }
+
+    public function __is_smaller(mixed $val): bool
+    {
+        return $this->value < $val;
+    }
+
+    public function __is_smaller_or_equal(mixed $val): bool
+    {
+        return $this->value <= $val;
+    }
+
+    public function __spaceship(mixed $val): int
+    {
+        return $this->value <=> $val;
+    }
+    //endregion
+
+    //region Opérateurs d'incrémentation/décrémentation
+    public function __post_dec(): mixed
+    {
+        return $this->value--;
+    }
+
+    public function __post_inc(): mixed
+    {
+        return $this->value++;
+    }
+
+    public function __pre_dec(): mixed
+    {
+        return --$this->value;
+    }
+
+    public function __pre_inc(): mixed
+    {
+        return ++$this->value;
+    }
+    //endregion
+
+    //region Opérateurs de chaînes
+    public function __concat(mixed $val): string
+    {
+        return $this->value . $val;
+    }
+    //endregion
+
+}
+
+]]>
+   </programlisting>
+   <simpara>
+    En utilisant la classe ci-dessus, il est possible de surcharger les opérateurs comme suit :
+   </simpara>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$a = new OperatorOverloading(5);
+var_dump($a + 10);
+var_dump($a - 10);
+$b = new OperatorOverloading("Hello");
+var_dump($b . " World");
+]]>
+   </programlisting>
+   <simpara>
+    L'exemple ci-dessus va afficher :
+   </simpara>
+   <screen>
+<![CDATA[
+int(15)
+int(-5)
+string(11) "Hello World"
+]]>
+   </screen>
+  </example>
+ </section>
+</chapter>

--- a/reference/operator/setup.xml
+++ b/reference/operator/setup.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 6043cd25418a3c45c64a4af118ee939c1835251b Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+
+<chapter xml:id="operator.setup" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ &reftitle.setup;
+ <section xml:id="operator.installation">
+  &reftitle.install;
+  <simpara>
+   &pecl.info;
+   <link xlink:href="&url.pecl.package;operator">&url.pecl.package;operator</link>.
+  </simpara>
+  <simpara>
+   Les utilisateurs Windows peuvent télécharger les binaires précompilés depuis le site
+   <link xlink:href="&url.pecl.package;operator">PECL</link>.
+  </simpara>
+  <simpara>
+   Les versions d'operator sont hébergées par PECL et le code source par
+   <link xlink:href="&url.git.hub;jb-lopez/pecl-php-operator">github</link>.
+  </simpara>
+ </section>
+</chapter>

--- a/reference/operator/setup.xml
+++ b/reference/operator/setup.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: 6043cd25418a3c45c64a4af118ee939c1835251b Maintainer: lacatoire Status: ready -->
-<!-- Reviewed: no -->
 
 <chapter xml:id="operator.setup" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.setup;


### PR DESCRIPTION
Closes #3063

- `language/operators.xml` : ajout du renvoi vers la surcharge d'opérateurs (hash bump)
- nouveaux fichiers `reference/operator/{book,setup,overloading}.xml`