### PR TITLE
Sync EN: ldap_exop() signature (#3066)

### DIFF
--- a/reference/ldap/functions/ldap-exop.xml
+++ b/reference/ldap/functions/ldap-exop.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9faf0215daa7a2b5d84525d7d2b3d6b066cc85ec Maintainer: lacatoire Status: ready -->
-<!-- Reviewed: yes -->
-<!-- CREDITS: Fan2Shrek -->
+<!-- EN-Revision: 6400027855e1ef2a1a95f62db200fc1ae35a7b2e Maintainer: lacatoire Status: ready -->
 <refentry xml:id="function.ldap-exop" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>ldap_exop</refname>
@@ -11,11 +9,11 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>mixed</type><methodname>ldap_exop</methodname>
+   <type class="union"><type>LDAP\Result</type><type>bool</type></type><methodname>ldap_exop</methodname>
    <methodparam><type>LDAP\Connection</type><parameter>ldap</parameter></methodparam>
    <methodparam><type>string</type><parameter>request_oid</parameter></methodparam>
-   <methodparam choice="opt"><type>string</type><parameter>request_data</parameter><initializer>&null;</initializer></methodparam>
-   <methodparam choice="opt"><type>array</type><parameter>controls</parameter><initializer>&null;</initializer></methodparam>
+   <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>request_data</parameter><initializer>&null;</initializer></methodparam>
+   <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>controls</parameter><initializer>&null;</initializer></methodparam>
    <methodparam choice="opt"><type>string</type><parameter role="reference">response_data</parameter></methodparam>
    <methodparam choice="opt"><type>string</type><parameter role="reference">response_oid</parameter></methodparam>
   </methodsynopsis>


### PR DESCRIPTION
Closes #3066

Synchronise la signature de `ldap_exop()` : type de retour `LDAP\Result|bool`, paramètres `request_data`/`controls` nullables.