### PR TITLE
[Sync EN] ext/ssh2: ssh2_sftp_* return types include false (#3068)

### DIFF
--- a/reference/ssh2/functions/ssh2-sftp-lstat.xml
+++ b/reference/ssh2/functions/ssh2-sftp-lstat.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 12f0e72200ea9249d0fc2f118528bd24b24c44a6 Maintainer: yannick Status: ready -->
-<!-- Reviewed: yes -->
-<refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.ssh2-sftp-lstat">
+<!-- EN-Revision: cad275c0c1bac225cc295e2ee52ecf2564b6fcda Maintainer: lacatoire Status: ready -->
+<refentry xml:id="function.ssh2-sftp-lstat" xmlns="http://docbook.org/ns/docbook" >
  <refnamediv>
   <refname>ssh2_sftp_lstat</refname>
   <refpurpose>Obtient les informations d'un lien symbolique</refpurpose>
@@ -11,7 +9,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>array</type><methodname>ssh2_sftp_lstat</methodname>
+   <type class="union"><type>array</type><type>false</type></type><methodname>ssh2_sftp_lstat</methodname>
    <methodparam><type>resource</type><parameter>sftp</parameter></methodparam>
    <methodparam><type>string</type><parameter>path</parameter></methodparam>
   </methodsynopsis>
@@ -52,6 +50,8 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
+   Retourne un tableau de statistiques pour le lien symbolique donné en cas
+   de succès&return.falseforfailure;.
    Voir la documentation de la fonction <function>stat</function>
    pour les détails concernant les valeurs retournées.
   </simpara>

--- a/reference/ssh2/functions/ssh2-sftp-readlink.xml
+++ b/reference/ssh2/functions/ssh2-sftp-readlink.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 12f0e72200ea9249d0fc2f118528bd24b24c44a6 Maintainer: yannick Status: ready -->
-<!-- Reviewed: yes -->
-<refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.ssh2-sftp-readlink">
+<!-- EN-Revision: cad275c0c1bac225cc295e2ee52ecf2564b6fcda Maintainer: lacatoire Status: ready -->
+<refentry xml:id="function.ssh2-sftp-readlink" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>ssh2_sftp_readlink</refname>
   <refpurpose>Retourne la cible d'un lien symbolique</refpurpose>
@@ -11,7 +9,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>string</type><methodname>ssh2_sftp_readlink</methodname>
+   <type class="union"><type>string</type><type>false</type></type><methodname>ssh2_sftp_readlink</methodname>
    <methodparam><type>resource</type><parameter>sftp</parameter></methodparam>
    <methodparam><type>string</type><parameter>link</parameter></methodparam>
   </methodsynopsis>
@@ -45,7 +43,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   Retourne la cible du lien symbolique <parameter>link</parameter>.
+   Retourne la cible du lien symbolique <parameter>link</parameter>&return.falseforfailure;.
   </simpara>
  </refsect1>
 

--- a/reference/ssh2/functions/ssh2-sftp-realpath.xml
+++ b/reference/ssh2/functions/ssh2-sftp-realpath.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 12f0e72200ea9249d0fc2f118528bd24b24c44a6 Maintainer: yannick Status: ready -->
-<!-- Reviewed: yes -->
-<refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.ssh2-sftp-realpath">
+<!-- EN-Revision: cad275c0c1bac225cc295e2ee52ecf2564b6fcda Maintainer: lacatoire Status: ready -->
+<refentry xml:id="function.ssh2-sftp-realpath" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>ssh2_sftp_realpath</refname>
   <refpurpose>Résout le chemin réel d'un chemin fourni</refpurpose>
@@ -11,7 +9,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>string</type><methodname>ssh2_sftp_realpath</methodname>
+   <type class="union"><type>string</type><type>false</type></type><methodname>ssh2_sftp_realpath</methodname>
    <methodparam><type>resource</type><parameter>sftp</parameter></methodparam>
    <methodparam><type>string</type><parameter>filename</parameter></methodparam>
   </methodsynopsis>
@@ -45,7 +43,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   Retourne le chemin réel, sous la forme d'une &string;.
+   Retourne le chemin réel, sous la forme d'une &string;&return.falseforfailure;.
   </simpara>
  </refsect1>
 

--- a/reference/ssh2/functions/ssh2-sftp-stat.xml
+++ b/reference/ssh2/functions/ssh2-sftp-stat.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 12f0e72200ea9249d0fc2f118528bd24b24c44a6 Maintainer: yannick Status: ready -->
-<!-- Reviewed: yes -->
-<refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.ssh2-sftp-stat">
+<!-- EN-Revision: cad275c0c1bac225cc295e2ee52ecf2564b6fcda Maintainer: lacatoire Status: ready -->
+<refentry xml:id="function.ssh2-sftp-stat" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>ssh2_sftp_stat</refname>
   <refpurpose>Lit les informations d'un fichier sur un système de fichiers distant</refpurpose>
@@ -11,7 +9,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>array</type><methodname>ssh2_sftp_stat</methodname>
+   <type class="union"><type>array</type><type>false</type></type><methodname>ssh2_sftp_stat</methodname>
    <methodparam><type>resource</type><parameter>sftp</parameter></methodparam>
    <methodparam><type>string</type><parameter>path</parameter></methodparam>
   </methodsynopsis>
@@ -51,6 +49,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
+   Retourne un tableau de statistiques pour le fichier donné en cas de succès&return.falseforfailure;.
    Voir la documentation de la fonction
    <function>stat</function> pour les détails concernant les valeurs retournées.
   </simpara>


### PR DESCRIPTION
Closes #3068

Sync de https://github.com/php/doc-en/commit/cad275c0c1bac225cc295e2ee52ecf2564b6fcda (doc-en #5640) : ajout du type `false` aux signatures et de `&return.falseforfailure;` aux valeurs de retour de `ssh2_sftp_lstat`, `ssh2_sftp_readlink`, `ssh2_sftp_realpath` et `ssh2_sftp_stat`.