### PR TITLE
[Sync EN] Remove $ sigil from <parameter> names (#5643)

### DIFF
--- a/appendices/migration83/deprecated.xml
+++ b/appendices/migration83/deprecated.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9c828621cbce488cf6306b21c39e208f847eabd5 Maintainer: Fan2Shrek Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 4de6272a1f15efc9e3df21d255965fd890da0d6f Maintainer: lacatoire Status: ready -->
 <sect1 xml:id="migration83.deprecated">
  <title>Fonctionnalités dépréciées</title>
 
@@ -40,10 +39,10 @@
  <sect2 xml:id="migration83.deprecated.core.dba">
   <title>DBA</title>
 
-  <para>
-   Appeler <function>dba_fetch</function> avec <parameter>$dba</parameter> comme
+  <simpara>
+   Appeler <function>dba_fetch</function> avec <parameter>dba</parameter> comme
    troisième argument est désormais déprécié.
-  </para>
+  </simpara>
  </sect2>
 
  <sect2 xml:id="migration83.deprecated.ffi">
@@ -72,21 +71,21 @@
  <sect2 xml:id="migration83.deprecated.ldap">
   <title>LDAP</title>
 
-  <para>
+  <simpara>
    Appeler <function>ldap_connect</function> avec 
-   <parameter>$hostname</parameter> et <parameter>$port</parameter> séparés est
+   <parameter>hostname</parameter> et <parameter>port</parameter> séparés est
    déprécié.
    <!-- RFC: https://wiki.php.net/rfc/deprecations_php_8_3#deprecate_calling_ldap_connect_with_2_parameters -->
-  </para>
+  </simpara>
  </sect2>
 
  <sect2 xml:id="migration83.deprecated.mbstring">
   <title>MBString</title>
 
-  <para>
-   Passer un <parameter>$width</parameter> négatif à
+  <simpara>
+   Passer un <parameter>width</parameter> négatif à
    <function>mb_strimwidth</function> est désormais déprécié.
-  </para>
+  </simpara>
  </sect2>
 
  <sect2 xml:id="migration83.deprecated.phar">
@@ -94,7 +93,7 @@
 
   <para>
    Appeler <methodname>Phar::setStub</methodname> avec une
-   <type>resource</type> et une <parameter>$length</parameter>
+   <type>resource</type> et une <parameter>length</parameter>
    est désormais déprécié. Ces appels devraient être remplacés par :
    <code>$phar->setStub(stream_get_contents($resource));</code>
   </para>

--- a/appendices/migration83/incompatible.xml
+++ b/appendices/migration83/incompatible.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: a989e5f21db7902c0028ad51e9adc94024d13216 Maintainer: lacatoire Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 4de6272a1f15efc9e3df21d255965fd890da0d6f Maintainer: lacatoire Status: ready -->
 <sect1 xml:id="migration83.incompatible" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Changement de rétrocompatibilité</title>
 
@@ -178,25 +177,25 @@
     <member>Une <classname>TypeError</classname> est maintenant lancée lors du passage d'<type>object</type>s,
     <type>resource</type>s, ou <type>array</type>s en tant qu'entrées de limites.</member>
     <member>Une <classname>ValueError</classname> plus descriptive est lancée lors du passage de <literal>0</literal>
-    pour <parameter>$step</parameter>.</member>
-    <member>Une <classname>ValueError</classname> est maintenant lancée lors de l'utilisation d'un <parameter>$step</parameter>
+    pour <parameter>step</parameter>.</member>
+    <member>Une <classname>ValueError</classname> est maintenant lancée lors de l'utilisation d'un <parameter>step</parameter>
     négatif pour les plages croissantes.</member>
-    <member>Si <parameter>$step</parameter> est un flottant qui peut être interprété
+    <member>Si <parameter>step</parameter> est un flottant qui peut être interprété
     comme un entier, c'est maintenant fait.</member>
     <member>Une <classname>ValueError</classname> est maintenant lancée si l'un des arguments
     est infini ou NAN.</member>
     <member>Un <constant>E_WARNING</constant> est émis si 
-    <parameter>$start</parameter> ou <parameter>$end</parameter> est une chaîne
+    <parameter>start</parameter> ou <parameter>end</parameter> est une chaîne
     vide. La valeur continue d'être convertie en la valeur <literal>0</literal>.</member>
     <member>Un <constant>E_WARNING</constant> est maintenant émis si
-    <parameter>$start</parameter> ou <parameter>$end</parameter> a plus d'un
+    <parameter>start</parameter> ou <parameter>end</parameter> a plus d'un
     octet, seulement si c'est une chaîne non numérique.</member>
     <member>Un <constant>E_WARNING</constant> est maintenant émis si
-    <parameter>$start</parameter> ou <parameter>$end</parameter> est converti en un
+    <parameter>start</parameter> ou <parameter>end</parameter> est converti en un
     entier car l'autre entrée de limite est un nombre.
     (par exemple : <code>range(5, 'z');</code>).</member>
     <member>Un <constant>E_WARNING</constant> est maintenant émis si
-    <parameter>$step</parameter> est un flottant lors de la génération d'une plage de
+    <parameter>step</parameter> est un flottant lors de la génération d'une plage de
     caractères, sauf si les deux entrées de limites sont des chaînes numériques (par exemple :
     <code>range('5', '9', 0.5);</code> ne produit pas de warning).</member>
     <member><function>range</function> produit maintenant une liste de caractères si l'une
@@ -218,9 +217,9 @@ range('9', 'A');  // [9, 8, 7, 6, 5, 4, 3, 2, 1, 0], avant PHP 8.3.0
 
   <para>
    <function>number_format</function> gère maintenant les valeurs négatives de
-   <parameter>$decimals</parameter> en arrondissant 
-   <parameter>$num</parameter> à <code>abs($decimals)</code> chiffres avant le
-   séparateur décimal. Précédemment, les valeurs négatives de <parameter>$decimals</parameter>
+   <parameter>decimals</parameter> en arrondissant
+   <parameter>num</parameter> à <code>abs($decimals)</code> chiffres avant le
+   séparateur décimal. Précédemment, les valeurs négatives de <parameter>decimals</parameter>
    étaient ignorées.
   </para>
 

--- a/appendices/migration83/new-features.xml
+++ b/appendices/migration83/new-features.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 330a38c4d45556b49e06ebe6d39e0e311534cd8c Maintainer: lacatoire Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 4de6272a1f15efc9e3df21d255965fd890da0d6f Maintainer: lacatoire Status: ready -->
 <sect1 xml:id="migration83.new-features" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Nouvelles fonctionnalités</title>
 
@@ -154,10 +153,10 @@ echo $user_ini['listen']; // localhost:9000
  <sect2 xml:id="migration83.new-features.posix">
   <title>POSIX</title>
 
-  <para>
+  <simpara>
    <function>posix_getrlimit</function> prend désormais un argument optionnel
-   <parameter>$resource</parameter> pour autoriser la récupération d'une seule limite de ressource.
-  </para>
+   <parameter>resource</parameter> pour autoriser la récupération d'une seule limite de ressource.
+  </simpara>
 
   <para>
    <function>posix_isatty</function> lance désormais des avertissements de type pour les entiers

--- a/appendices/migration83/other-changes.xml
+++ b/appendices/migration83/other-changes.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: b1116af46680f7baf89c46610430a3b63ce9a1f0 Maintainer: Fan2Shrek Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 4de6272a1f15efc9e3df21d255965fd890da0d6f Maintainer: lacatoire Status: ready -->
 <sect1 xml:id="migration83.other-changes" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Autres changements</title>
 
@@ -178,11 +177,11 @@
   <sect3 xml:id="migration83.other-changes.functions.gd">
    <title>Gd</title>
 
-   <para>
+   <simpara>
     La signature de <function>imagerotate</function> a changé.
-    Le paramètre <parameter>$ignore_transparent</parameter> a été supprimé,
+    Le paramètre <parameter>ignore_transparent</parameter> a été supprimé,
     car il était ignoré à partir de PHP 5.5.0.
-   </para>
+   </simpara>
   </sect3>
 
   <sect3 xml:id="migration83.other-changes.functions.intl">
@@ -264,18 +263,18 @@
   <sect3 xml:id="migration83.other-changes.functions.mysqli">
    <title>mysqli</title>
 
-   <para>
+   <simpara>
     <function>mysqli_fetch_object</function> lance désormais une
     <classname>ValueError</classname> au lieu d'une <classname>Exception</classname>
-    lorsque l'argument <parameter>$constructor_args</parameter> n'est pas vide
+    lorsque l'argument <parameter>constructor_args</parameter> n'est pas vide
     avec la classe n'ayant pas de constructeur.
-   </para>
+   </simpara>
 
-   <para>
+   <simpara>
     <function>mysqli_poll</function> lance désormais une <classname>ValueError</classname>
-    lorsque ni l'argument <parameter>$read</parameter>
-    ni l'argument <parameter>$error</parameter> ne sont passés.
-   </para>
+    lorsque ni l'argument <parameter>read</parameter>
+    ni l'argument <parameter>error</parameter> ne sont passés.
+   </simpara>
 
    <para>
     <function>mysqli_field_seek</function> et
@@ -287,23 +286,23 @@
   <sect3 xml:id="migration83.other-changes.functions.odbc">
    <title>ODBC</title>
 
-   <para>
+   <simpara>
     <function>odbc_autocommit</function> accepte désormais &null; pour le
-    paramètre <parameter>$enable</parameter>.
+    paramètre <parameter>enable</parameter>.
     Passer &null; a le même comportement que passer un seul paramètre,
     indiquant si la fonctionnalité autocommit est activée ou non.
-   </para>
+   </simpara>
   </sect3>
 
   <sect3 xml:id="migration83.other-changes.functions.pgsql">
    <title>PGSQL</title>
 
-   <para>
+   <simpara>
     <function>pg_fetch_object</function> lance désormais une
     <classname>ValueError</classname> à la place d'une <classname>Exception</classname>
-    lorsque l'argument <parameter>$constructor_args</parameter> n'est pas vide
+    lorsque l'argument <parameter>constructor_args</parameter> n'est pas vide
     avec la classe n'ayant pas de constructeur.
-   </para>
+   </simpara>
 
    <para>
     <function>pg_insert</function> lance désormais une <classname>ValueError</classname>
@@ -317,12 +316,12 @@
     ne correspond pas correctement au type de PostgreSQL.
    </para>
 
-   <para>
-    Le paramètre <parameter>$row</parameter> de
+   <simpara>
+    Le paramètre <parameter>row</parameter> de
     <function>pg_fetch_result</function>,
     <function>pg_field_prtlen</function>, et
     <function>pg_field_is_null</function> est désormais nullable.
-   </para>
+   </simpara>
   </sect3>
 
   <sect3 xml:id="migration83.other-changes.functions.random">
@@ -373,28 +372,28 @@
     token n'est pas fourni lors du démarrage de la tokenisation.
    </para>
 
-   <para>
+   <simpara>
     <function>password_hash</function> enchaîne désormais l'exception sous-jacente
     <classname>Random\RandomException</classname>
-    dans la <parameter>$previous</parameter> <classname>Exception</classname>
+    dans la <parameter>previous</parameter> <classname>Exception</classname>
     de <classname>ValueError</classname> lorsque la génération de sel échoue.
-   </para>
+   </simpara>
 
-   <para>
-    Si un tableau est utilisé comme <parameter>$command</parameter> pour
+   <simpara>
+    Si un tableau est utilisé comme <parameter>command</parameter> pour
     <function>proc_open</function>, il doit désormais avoir au moins un élément
     non vide. Sinon, une <classname>ValueError</classname>
     est lancée.
-   </para>
+   </simpara>
 
-   <para>
-    <function>proc_open</function> retourne désormais &false; si le tableau <parameter>$command</parameter>
+   <simpara>
+    <function>proc_open</function> retourne désormais &false; si le tableau <parameter>command</parameter>
     est une commande invalide au lieu d'un objet de ressource qui produit un avertissement plus tard.
     C'était déjà le cas pour Windows, mais c'est maintenant aussi le cas si une implémentation posix_spawn
     est utilisée (la plupart des plates-formes Linux, BSD et MacOS). Il reste
     quelques anciennes plates-formes où ce comportement n'a pas changé car posix_spawn n'est pas
     pris en charge là-bas.
-   </para>
+   </simpara>
 
    <para>
     <function>array_sum</function> et <function>array_product</function> émettent désormais
@@ -405,21 +404,21 @@
     <!-- RFC: https://wiki.php.net/rfc/saner-array-sum-product -->
    </para>
 
-   <para>
-    Le <parameter>$decimals</parameter> de <function>number_format</function>
+   <simpara>
+    Le <parameter>decimals</parameter> de <function>number_format</function>
     gère désormais les entiers négatifs.
-    Arrondir avec une valeur négative pour <parameter>$decimals</parameter> signifie
-    que <parameter>$num</parameter> est arrondi à <parameter>$decimals</parameter>
+    Arrondir avec une valeur négative pour <parameter>decimals</parameter> signifie
+    que <parameter>num</parameter> est arrondi à <parameter>decimals</parameter>
     chiffres significatifs avant le séparateur décimal.
-    Auparavant, les entiers négatifs pour <parameter>$decimals</parameter> étaient
+    Auparavant, les entiers négatifs pour <parameter>decimals</parameter> étaient
     silencieusement ignorés et le nombre était arrondi à zéro décimales.
-   </para>
+   </simpara>
 
-   <para>
-    Un nouvel argument <parameter>$before_needle</parameter> a été ajouté à
+   <simpara>
+    Un nouvel argument <parameter>before_needle</parameter> a été ajouté à
     <function>strrchr</function>. Il se comporte comme son homologue dans les
     fonctions <function>strstr</function> ou <function>stristr</function>.
-   </para>
+   </simpara>
 
    <para>
     <function>str_getcsv</function> et <function>fgetcsv</function> retournent désormais

--- a/appendices/migration85/deprecated.xml
+++ b/appendices/migration85/deprecated.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 2def8c3cfec11fcc74f153b337301bbc06c16bc9 Maintainer: Fan2Shrek Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 4de6272a1f15efc9e3df21d255965fd890da0d6f Maintainer: lacatoire Status: ready -->
 <sect1 xml:id="migration85.deprecated">
  <title>Fonctionnalités dépréciées</title>
 
@@ -205,7 +204,7 @@
   </simpara>
 
   <simpara>
-   Le paramètre <parameter>$context</parameter> de la fonction
+   Le paramètre <parameter>context</parameter> de la fonction
    <function>finfo_buffer</function> a été déprécié,
    car il est ignoré.
    <!-- RFC: https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_the_context_parameter_for_finfo_buffer -->
@@ -286,7 +285,7 @@
   <title>OpenSSL</title>
 
   <simpara>
-   Le paramètre <parameter>$key_length</parameter> de la fonction
+   Le paramètre <parameter>key_length</parameter> de la fonction
    <function>openssl_pkey_derive</function> a été déprécié.
    Cela est dû au fait qu'il est soit ignoré, soit tronque la clé, ce qui peut être
    une vulnérabilité de sécurité.

--- a/appendices/migration85/incompatible.xml
+++ b/appendices/migration85/incompatible.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: f81bbcf9d36c28bf067b5514cffdbc7663357cf3 Maintainer: lacatoire Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 4de6272a1f15efc9e3df21d255965fd890da0d6f Maintainer: lacatoire Status: ready -->
 <sect1 xml:id="migration85.incompatible" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Changements non rétrocompatibles</title>
 
@@ -157,12 +156,12 @@
 
   <simpara>
    <function>bzcompress</function> lève désormais une <classname>ValueError</classname>
-   lorsque <parameter>$block_size</parameter> n'est pas compris entre 1 et 9.
+   lorsque <parameter>block_size</parameter> n'est pas compris entre 1 et 9.
   </simpara>
 
   <simpara>
    <function>bzcompress</function> lève désormais une <classname>ValueError</classname>
-   lorsque <parameter>$work_factor</parameter> n'est pas compris entre 0 et 250.
+   lorsque <parameter>work_factor</parameter> n'est pas compris entre 0 et 250.
   </simpara>
 
  </sect2>
@@ -186,7 +185,7 @@
   <simpara>
    <function>finfo_file</function> et <methodname>finfo::file</methodname>
    lèvent désormais une <exceptionname>ValueError</exceptionname> à la place de
-   <exceptionname>TypeError</exceptionname> lorsque <parameter>$filename</parameter>
+   <exceptionname>TypeError</exceptionname> lorsque <parameter>filename</parameter>
    contient des octets nuls.
    Cela aligne le type d'erreur levée pour être cohérent avec le reste du
    langage.
@@ -295,12 +294,12 @@
 
   <simpara>
    <function>pcntl_exec</function> lève désormais une <exceptionname>ValueError</exceptionname>
-   lorsque les entrées du paramètre <parameter>$args</parameter> contiennent des octets nuls.
+   lorsque les entrées du paramètre <parameter>args</parameter> contiennent des octets nuls.
   </simpara>
 
   <simpara>
    <function>pcntl_exec</function> lève désormais une <exceptionname>ValueError</exceptionname>
-   lorsque les entrées ou les clés du paramètre <parameter>$env_vars</parameter>
+   lorsque les entrées ou les clés du paramètre <parameter>env_vars</parameter>
    contiennent des octets nuls.
   </simpara>
 
@@ -487,7 +486,7 @@
 
   <simpara>
    <methodname>SoapClient::__doRequest</methodname> accepte désormais un nouveau
-   paramètre optionnel <parameter>$uriParserClass</parameter> acceptant
+   paramètre optionnel <parameter>uriParserClass</parameter> acceptant
    des arguments de type string ou &null;.
    &null; représente la méthode originale basée sur (<function>parse_url</function>),
    tandis que les nouveaux backends seront utilisés lorsqu'on passe soit
@@ -539,7 +538,7 @@
   </simpara>
 
   <simpara>
-   Le paramètre <parameter>$length</parameter> de
+   Le paramètre <parameter>length</parameter> de
    la fonction <methodname>SplFileObject::fwrite</methodname>
    est désormais nullable.
    La valeur par défaut est passée de <literal>0</literal> à &null;.

--- a/appendices/migration85/new-features.xml
+++ b/appendices/migration85/new-features.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: ce397343296708654c8cdac774e23a9ee47ab27d Maintainer: Fan2Shrek Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 4de6272a1f15efc9e3df21d255965fd890da0d6f Maintainer: lacatoire Status: ready -->
 <sect1 xml:id="migration85.new-features" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Nouvelles fonctionnalités</title>
 
@@ -395,7 +394,7 @@ print T1 . PHP_EOL;   // Affiche "0"
   <simpara>
    La signature de <methodname>SoapFault::__construct</methodname> et
    <methodname>SoapServer::fault</methodname> inclut désormais un paramètre
-   optionnel <parameter>$lang</parameter>.
+   optionnel <parameter>lang</parameter>.
    Ceci résout la compatibilité avec les clients SOAP .NET.
   </simpara>
 
@@ -454,11 +453,11 @@ print T1 . PHP_EOL;   // Affiche "0"
   <title>XSL</title>
 
   <simpara>
-   L'argument <parameter>$namespace</parameter> de <methodname>XSLTProcessor::getParameter</methodname>,
+   L'argument <parameter>namespace</parameter> de <methodname>XSLTProcessor::getParameter</methodname>,
    <methodname>XSLTProcessor::setParameter</methodname> et
    <methodname>XSLTProcessor::removeParameter</methodname> fonctionne désormais réellement
    au lieu d'être traité comme vide.
-   Cela ne fonctionne que si l'argument <parameter>$name</parameter> n'utilise pas la notation Clark et n'est pas un
+   Cela ne fonctionne que si l'argument <parameter>name</parameter> n'utilise pas la notation Clark et n'est pas un
    QName car dans ces cas, l'espace de noms est pris à partir de l'href ou du préfixe de l'espace
    de noms respectivement.
   </simpara>

--- a/appendices/migration85/other-changes.xml
+++ b/appendices/migration85/other-changes.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: c7b445ec851969e669026cfa483b104ea2de5d95 Maintainer: lacatoire Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 4de6272a1f15efc9e3df21d255965fd890da0d6f Maintainer: lacatoire Status: ready -->
 <sect1 xml:id="migration85.other-changes">
  <title>Autres changements</title>
 
@@ -90,7 +89,7 @@
 
    <simpara>
     <function>grapheme_extract</function> assigne correctement la valeur
-    <parameter>$next</parameter> lorsqu'il saute des octets de départ invalides.
+    <parameter>next</parameter> lorsqu'il saute des octets de départ invalides.
     Auparavant, il y avait des cas où il pointait vers le début de la
     limite du grapheme au lieu de la fin.
    </simpara>
@@ -105,7 +104,7 @@
    </simpara>
 
    <simpara>
-    Les fonctions suivantes supportent désormais un argument <parameter>$locale</parameter> :
+    Les fonctions suivantes supportent désormais un argument <parameter>locale</parameter> :
     <function>grapheme_strpos</function>,
     <function>grapheme_stripos</function>,
     <function>grapheme_strrpos</function>,
@@ -145,18 +144,18 @@
    <simpara>
     <function>openssl_public_encrypt</function> et
     <function>openssl_private_decrypt</function> ont un nouveau paramètre
-    <parameter>$digest_algo</parameter> qui permet de spécifier l'algorithme
+    <parameter>digest_algo</parameter> qui permet de spécifier l'algorithme
     de hachage pour le padding OAEP.
    </simpara>
 
    <simpara>
     <function>openssl_sign</function> et <function>openssl_verify</function>
-    ont un nouveau paramètre <parameter>$padding</parameter> pour permettre l'utilisation d'un
+    ont un nouveau paramètre <parameter>padding</parameter> pour permettre l'utilisation d'un
     padding RSA PSS plus sécurisé.
    </simpara>
 
    <simpara>
-    Le paramètre <parameter>$cipher_algo</parameter> de <function>openssl_cms_encrypt</function> 
+    Le paramètre <parameter>cipher_algo</parameter> de <function>openssl_cms_encrypt</function>
     peut être une chaîne avec le nom du chiffrement.
     Cela permet d'utiliser plus d'algorithmes, y compris les algorithmes de chiffrement
     AES GCM pour les données enveloppées authentifiées.
@@ -272,7 +271,7 @@
    <title>Zlib</title>
 
    <simpara>
-    L'argument <parameter>$use_include_path</parameter> des fonctions
+    L'argument <parameter>use_include_path</parameter> des fonctions
     <function>gzfile</function>, <function>gzopen</function> et
     <function>readgzfile</function> a été changé
     de <type>int</type> à <type>bool</type>.

--- a/appendices/migration85/windows-support.xml
+++ b/appendices/migration85/windows-support.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: ec45af749649dc0d6a23eaedeed1b601f7460813 Maintainer: Fan2Shrek Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 4de6272a1f15efc9e3df21d255965fd890da0d6f Maintainer: lacatoire Status: ready -->
 <sect1 xml:id="migration85.windows-support">
  <title>Support de Windows</title>
 
@@ -61,9 +60,9 @@
   <title>Streams</title>
 
   <simpara>
-   Si seuls des flux de type pipe sont contenus dans le tableau <parameter>$read</parameter>,
-   et que les tableaux <parameter>$write</parameter> et
-   <parameter>$except</parameter> sont vides,
+   Si seuls des flux de type pipe sont contenus dans le tableau <parameter>read</parameter>,
+   et que les tableaux <parameter>write</parameter> et
+   <parameter>except</parameter> sont vides,
    <function>stream_select</function> se comporte désormais de manière similaire aux systèmes POSIX,
    c'est-à-dire que la fonction ne retourne que si au moins un pipe est prêt à être lu,
    ou après l'expiration du délai d'attente.

--- a/reference/com/functions/variant-cat.xml
+++ b/reference/com/functions/variant-cat.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 31ab1b9a07ee6fdfd09cafaf22efa1cf78b49798 Maintainer: yannick Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 4de6272a1f15efc9e3df21d255965fd890da0d6f Maintainer: lacatoire Status: ready -->
 
 <refentry xml:id="function.variant-cat" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -19,10 +17,10 @@
    Assemble <parameter>left</parameter> avec <parameter>right</parameter>
    et retourne le résultat.
   </para>
-  <para>
+  <simpara>
    Cette fonction est équivalente à
-   <parameter>$left</parameter> <literal>.</literal> <parameter>$right</parameter>.
-  </para>
+   <parameter>left</parameter> <literal>.</literal> <parameter>right</parameter>.
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;

--- a/reference/datetime/datetime/construct.xml
+++ b/reference/datetime/datetime/construct.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 8b4c3d8dc5e190fbd5d84eede38a4da13537043d Maintainer: girgias Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 4de6272a1f15efc9e3df21d255965fd890da0d6f Maintainer: lacatoire Status: ready -->
 <refentry xml:id="datetime.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>DateTime::__construct</refname>
@@ -31,30 +30,30 @@
     <term><parameter>datetime</parameter></term>
     <listitem>
      <para>&date.formats.parameter;</para>
-     <para>
+     <simpara>
       Passer <literal>"now"</literal> pour obtenir le temps courant lors de
-      l'utilisation du paramètre <parameter>$timezone</parameter>.
-     </para>
+      l'utilisation du paramètre <parameter>timezone</parameter>.
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>timezone</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       Un objet <classname>DateTimeZone</classname> représentant le fuseau
-      horaire de <parameter>$datetime</parameter>.
-     </para>
-     <para>
-      Si <parameter>$timezone</parameter> est omis ou &null;,
+      horaire de <parameter>datetime</parameter>.
+     </simpara>
+     <simpara>
+      Si <parameter>timezone</parameter> est omis ou &null;,
       le fuseau horaire actuel sera utilisé.
-     </para>
+     </simpara>
      <note>
-      <para>
-       Le paramètre <parameter>$timezone</parameter> et le fuseau horaire
-       actuel sont ignorés quand le paramètre <parameter>$datetime</parameter>
+      <simpara>
+       Le paramètre <parameter>timezone</parameter> et le fuseau horaire
+       actuel sont ignorés quand le paramètre <parameter>datetime</parameter>
        est un horodatage UNIX (p. ex. <literal>@946684800</literal>) ou spécifie
        un fuseau horaire (p. ex. <literal>2010-01-28T15:00:00+02:00</literal>).
-      </para>
+      </simpara>
      </note>
     </listitem>
    </varlistentry>

--- a/reference/datetime/datetimeimmutable/construct.xml
+++ b/reference/datetime/datetimeimmutable/construct.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: Fan2Shrek Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 4de6272a1f15efc9e3df21d255965fd890da0d6f Maintainer: lacatoire Status: ready -->
 <refentry xml:id="datetimeimmutable.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>DateTimeImmutable::__construct</refname>
@@ -34,31 +33,31 @@
     <term><parameter>datetime</parameter></term>
     <listitem>
      <para>&date.formats.parameter;</para>
-     <para>
+     <simpara>
       Passer <literal>"now"</literal> pour obtenir le temps courant lors de
-      l'utilisation du paramètre <parameter>$timezone</parameter>.
-     </para>
+      l'utilisation du paramètre <parameter>timezone</parameter>.
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>timezone</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       Un objet <classname>DateTimeZone</classname> représentant le fuseau
-      horaire de <parameter>$datetime</parameter>.
-     </para>
-     <para>
-      Si <parameter>$timezone</parameter> est omis ou &null;,
+      horaire de <parameter>datetime</parameter>.
+     </simpara>
+     <simpara>
+      Si <parameter>timezone</parameter> est omis ou &null;,
       le fuseau horaire actuel sera utilisé.
-     </para>
+     </simpara>
      <note>
-      <para>
-       Le paramètre <parameter>$timezone</parameter> et le fuseau horaire
-       actuel sont ignorés quand le paramètre <parameter>$datetime</parameter>
+      <simpara>
+       Le paramètre <parameter>timezone</parameter> et le fuseau horaire
+       actuel sont ignorés quand le paramètre <parameter>datetime</parameter>
        est un horodatage UNIX (p. ex. <literal>@946684800</literal>) ou spécifie
        un fuseau horaire (p. ex. <literal>2010-01-28T15:00:00+02:00</literal> ou
        <literal>2010-07-05T06:00:00Z</literal>).
-      </para>
+      </simpara>
      </note>
     </listitem>
    </varlistentry>

--- a/reference/mongodb/tutorial/apm.xml
+++ b/reference/mongodb/tutorial/apm.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 4de6272a1f15efc9e3df21d255965fd890da0d6f Maintainer: lacatoire Status: ready -->
 <section xml:id="mongodb.tutorial.apm" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Surveillance de la performance de l'application (Application Performance Monitoring - APM)</title>
 
@@ -19,7 +18,7 @@
   <literal>commandSucceeded</literal>, et <literal>commandFailed</literal>.
   Chacune de ces trois méthodes accepte un seul argument <parameter>event</parameter>
   d'une classe spécifique pour l'événement respectif. Par exemple, l'argument
-  <parameter>$event</parameter> de <literal>commandSucceeded</literal>
+  <parameter>event</parameter> de <literal>commandSucceeded</literal>
   est un objet <classname>MongoDB\Driver\Monitoring\CommandSucceededEvent</classname>.
  </simpara>
 

--- a/reference/pcre/functions/preg-match-all.xml
+++ b/reference/pcre/functions/preg-match-all.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: b731f708be0b9f5c656b81eb6491d04b0d5b19d8 Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 4de6272a1f15efc9e3df21d255965fd890da0d6f Maintainer: lacatoire Status: ready -->
 <refentry xml:id="function.preg-match-all" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>preg_match_all</refname>
@@ -314,7 +312,7 @@ Array
        <entry>7.2.0</entry>
        <entry>
         <constant>PREG_UNMATCHED_AS_NULL</constant> est maintenant supporté pour le
-        paramètre <parameter>$flags</parameter>.
+        paramètre <parameter>flags</parameter>.
        </entry>
       </row>
      </tbody>

--- a/reference/pcre/functions/preg-match.xml
+++ b/reference/pcre/functions/preg-match.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: d6f54016d62904cfd8200604aadd5e3f0d9bad97 Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 4de6272a1f15efc9e3df21d255965fd890da0d6f Maintainer: lacatoire Status: ready -->
 <refentry xml:id="function.preg-match" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>preg_match</refname>
@@ -280,7 +278,7 @@ Array
        <entry>7.2.0</entry>
        <entry>
         <constant>PREG_UNMATCHED_AS_NULL</constant> est maintenant supporté pour le
-        paramètre <parameter>$flags</parameter>.
+        paramètre <parameter>flags</parameter>.
        </entry>
       </row>
      </tbody>

--- a/reference/session/examples.xml
+++ b/reference/session/examples.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 184f3f7bd45643cb80f828d0bb001991ec3a5fad Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
-<!-- CREDITS: DAnnebicque -->
+<!-- EN-Revision: 4de6272a1f15efc9e3df21d255965fd890da0d6f Maintainer: lacatoire Status: ready -->
 
 <appendix xml:id="session.examples" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.examples;
@@ -251,12 +248,12 @@ if (empty($_SESSION['count'])) {
   <para>
    Lorsqu'une session est détruite, PHP appelera <parameter>destroy</parameter> avec l'ID de session.
   </para>
-  <para>
+  <simpara>
    PHP appelera la fonction de rappel <parameter>gc</parameter> de temps en temps pour nettoyer
    les sessions expirées en fonction de leur
    temps de vie maximum. Cet appel devrait mener à la destruction des enregistrements dans
-   le support de stockage qui n'ont pas été accédés depuis plus de <parameter>$lifetime</parameter>.
-  </para>
+   le support de stockage qui n'ont pas été accédés depuis plus de <parameter>lifetime</parameter>.
+  </simpara>
  </section>
 </appendix>
 

--- a/reference/session/functions/session-decode.xml
+++ b/reference/session/functions/session-decode.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 584c3e8805b728ec0cfde0318bb34e00ebc36324 Maintainer: yannick Status: ready -->
-<!-- CREDITS: DAnnebicque -->
+<!-- EN-Revision: 4de6272a1f15efc9e3df21d255965fd890da0d6f Maintainer: lacatoire Status: ready -->
 
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.session-decode">
  <refnamediv>
@@ -15,11 +13,11 @@
    <type>bool</type><methodname>session_decode</methodname>
    <methodparam><type>string</type><parameter>data</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    <function>session_decode</function> décode les données de
-   sessions sérialisées fournies dans le paramètre <parameter>$data</parameter>,
+   sessions sérialisées fournies dans le paramètre <parameter>data</parameter>,
    et peuple la variable superglobale $_SESSION.
-  </para>
+  </simpara>
   <para>
    Par défaut, la méthode de désérialisation utilisée, 
    est interne à PHP et n'est pas la même que la fonction

--- a/reference/session/sessionhandler/destroy.xml
+++ b/reference/session/sessionhandler/destroy.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 601f6f4ce5827d441a7e110184708f0abe9fd447 Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 4de6272a1f15efc9e3df21d255965fd890da0d6f Maintainer: lacatoire Status: ready -->
 <refentry xml:id="sessionhandler.destroy" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>SessionHandler::destroy</refname>
@@ -13,12 +12,12 @@
    <modifier>public</modifier> <type>bool</type><methodname>SessionHandler::destroy</methodname>
    <methodparam><type>string</type><parameter>id</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Détruit une session. Cette fonction est appelée en interne par PHP au moyen de
-   <function>session_regenerate_id</function> (en supposant que <parameter>$destroy</parameter> est
+   <function>session_regenerate_id</function> (en supposant que <parameter>destroy</parameter> est
    mis à &true;) <function>session_destroy</function> ou lorsque la fonction
    <function>session_decode</function> échoue.
-  </para>
+  </simpara>
   <para>
    Cette méthode se substitue au gestionnaire interne de sauvegarde de PHP défini via l'option
    de configuration <link linkend="ini.session.save-handler">session.save_handler</link> qui a été

--- a/reference/session/sessionhandler/read.xml
+++ b/reference/session/sessionhandler/read.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 601f6f4ce5827d441a7e110184708f0abe9fd447 Maintainer: jpauli Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 4de6272a1f15efc9e3df21d255965fd890da0d6f Maintainer: lacatoire Status: ready -->
 <refentry xml:id="sessionhandler.read" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>SessionHandler::read</refname>
@@ -25,14 +24,14 @@
    qui a été définie avant que ce gestionnaire ne soit modifié via la fonction
    <function>session_set_save_handler</function>.
   </para>
-  <para>
+  <simpara>
    Si cette classe est étendue par héritage, l'appel de la méthode parente
    <parameter>read</parameter> invoquera ce gestionnaire pour cette méthode, mais
    aussi, la fonction de rappel interne associée. Ce mécanisme permet à cette méthode
    de surcharger, intercepter et/ou filtrer les données (par exemple,
-   le décryptage de la valeur <parameter>$data</parameter> retournée par la méthode parente
+   le décryptage de la valeur <parameter>data</parameter> retournée par la méthode parente
    <parameter>read</parameter>).
-  </para>
+  </simpara>
   <para>
    Pour plus d'informations sur cette méthode, se référer à la documentation
    sur la fonction <function>SessionHandlerInterface::read</function>.

--- a/reference/session/sessionhandler/write.xml
+++ b/reference/session/sessionhandler/write.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 601f6f4ce5827d441a7e110184708f0abe9fd447 Maintainer: jpauli Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 4de6272a1f15efc9e3df21d255965fd890da0d6f Maintainer: lacatoire Status: ready -->
 <refentry xml:id="sessionhandler.write" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>SessionHandler::write</refname>
@@ -28,14 +27,14 @@
    qui a été définie avant que ce gestionnaire ne soit modifié via la fonction
    <function>session_set_save_handler</function>.
   </para>
-  <para>
+  <simpara>
    Si cette classe est étendue par héritage, l'appel de la méthode parente
    <parameter>write</parameter> invoquera ce gestionnaire pour cette méthode, mais
    aussi, la fonction de rappel interne associée. Ce mécanisme permet à cette méthode
    de surcharger, intercepter et/ou filtrer les données (par exemple, crypter la valeur
-   du paramètre <parameter>$data</parameter> avant de l'envoyer à la méthode parente
+   du paramètre <parameter>data</parameter> avant de l'envoyer à la méthode parente
    <parameter>write</parameter>).
-  </para>
+  </simpara>
   <para>
    Pour plus d'informations sur l'attendu de cette méthode, se référer à la documentation
    sur la fonction <function>SessionHandlerInterface::write</function>.

--- a/reference/stream/constants.xml
+++ b/reference/stream/constants.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 561e36d646b8e48dc53a910234ee9f30cba147d0 Maintainer: jpauli Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 4de6272a1f15efc9e3df21d255965fd890da0d6f Maintainer: lacatoire Status: ready -->
 
 <appendix xml:id="stream.constants" xmlns="http://docbook.org/ns/docbook">
  &reftitle.constants;
@@ -1202,7 +1200,7 @@
      <listitem>
       <simpara>
        Valeur de retour indiquant que le filtre utilisateur
-       a retourné des seaux dans <parameter>$out</parameter>.
+       a retourné des seaux dans <parameter>out</parameter>.
       </simpara>
      </listitem>
     </varlistentry>
@@ -1214,7 +1212,7 @@
      <listitem>
       <simpara>
        Valeur de retour indiquant que le filtre utilisateur
-       n'a pas retourné de seaux dans <parameter>$out</parameter>.
+       n'a pas retourné de seaux dans <parameter>out</parameter>.
        (c'est-à-dire, aucune donnée disponible.)
       </simpara>
      </listitem>

--- a/reference/yac/yac/dump.xml
+++ b/reference/yac/yac/dump.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: b8be4b126c545a0b452be29b6b5ce185471814a1 Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 4de6272a1f15efc9e3df21d255965fd890da0d6f Maintainer: lacatoire Status: ready -->
 
 <refentry xml:id="yac.dump" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,7 +11,7 @@
   &reftitle.description;
   <methodsynopsis>
    <modifier>public</modifier> <type>mixed</type><methodname>Yac::dump</methodname>
-   <methodparam><type>int</type><parameter>$num</parameter></methodparam>
+   <methodparam><type>int</type><parameter>num</parameter></methodparam>
   </methodsynopsis>
   <para>
    Extrait les valeurs stockées dans le cache


### PR DESCRIPTION
Sync de php/doc-en#5643 (commit `4de6272`). Retire le sigil `$` du contenu des balises `<parameter>`.

Closes #3070