### PR TITLE
[Sync EN] ext/libxml: Add a warning about the usage of `LIBXML_PARSEHUGE` (#5647)

### DIFF
--- a/reference/libxml/constants.xml
+++ b/reference/libxml/constants.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 64e1182c986582df32ed7e629e42b4fea204de2e Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 77ae1d1908566c7d20972011c2ea067480a4f42e Maintainer: lacatoire Status: ready -->
 
 <appendix xml:id="libxml.constants" xmlns="http://docbook.org/ns/docbook">
  &reftitle.constants;
@@ -283,6 +281,15 @@
      maximale d'un document ou la récursion d'entités, mais aussi
      les limites de la taille du texte des nœuds.
     </simpara>
+    <caution>
+     <simpara>
+      Comme ceci relâche les limites codées en dur, il ne devrait être utilisé
+      qu'avec des données de confiance. Retirer la limite de profondeur sur des
+      entrées non fiables peut conduire à une consommation excessive de
+      ressources, comme un débordement de pile lors du traitement d'un document
+      profondément imbriqué.
+     </simpara>
+    </caution>
     <note>
      <para>
       Seulement disponible avec Libxml &gt;= 2.7.0 (à partir de PHP


### PR DESCRIPTION
Sync de php/doc-en#5647 (commit `77ae1d1`). Ajoute un avertissement sur l'usage de `LIBXML_PARSEHUGE` (limites désactivées → à réserver aux données de confiance).

Closes #3072