### PR TITLE
[Sync EN] ext/ldap: ldap_count_entries() retourne -1 en cas d'erreur (#5218)

### DIFF
--- a/reference/ldap/functions/ldap-count-entries.xml
+++ b/reference/ldap/functions/ldap-count-entries.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: bc90525a5a5ebcf8412ef34b8355d2de12166fff Maintainer: yannick Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: cf27955fcbad1b75678cd6bb12bfdfa1e2005b63 Maintainer: lacatoire Status: ready -->
 <refentry xml:id="function.ldap-count-entries" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>ldap_count_entries</refname>
@@ -46,9 +45,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
-   Retourne le nombre d'entrées dans le résultat,&return.falseforfailure;.
-  </para>
+  <simpara>
+   Retourne le nombre d'entrées dans le résultat, ou <literal>-1</literal> en cas d'erreur.
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">


### PR DESCRIPTION
Sync de php/doc-en#5218 (commit cf27955). Closes #3078.