### PR TITLE
[Sync EN] ext/intl: offset négatif pour les fonctions grapheme_strr (#4864)

### DIFF
--- a/reference/intl/grapheme/grapheme-strripos.xml
+++ b/reference/intl/grapheme/grapheme-strripos.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 9a8c593c09cf7d84085989e42f3b2b23536279db Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 2583cd865645eea478d9a9b265d95c28a1ee5525 Maintainer: lacatoire Status: ready -->
 
 <refentry xml:id="function.grapheme-strripos" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -53,6 +51,9 @@
        La position retournée est toujours donnée par rapport au début de
        <parameter>haystack</parameter>, quelle que soit la valeur de <parameter>offset</parameter>.
       </para>
+      <simpara>
+       Le paramètre optionnel offset permet de spécifier l'endroit dans <parameter>haystack</parameter> où débuter la recherche, sous forme d'un <parameter>offset</parameter> exprimé en graphèmes (et non pas en octets ou caractères). Si l'<parameter>offset</parameter> est négatif, il est traité par rapport à la fin de la chaîne. La position retournée est toujours donnée par rapport au début de <parameter>haystack</parameter>, quelle que soit la valeur de offset. La recherche est effectuée de droite à gauche, en cherchant la première occurrence de <parameter>needle</parameter> à partir du groupe de graphèmes sélectionné.
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>

--- a/reference/intl/grapheme/grapheme-strrpos.xml
+++ b/reference/intl/grapheme/grapheme-strrpos.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 9a8c593c09cf7d84085989e42f3b2b23536279db Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 2583cd865645eea478d9a9b265d95c28a1ee5525 Maintainer: lacatoire Status: ready -->
 
 <refentry xml:id="function.grapheme-strrpos" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -53,6 +51,9 @@
        La position retournée est toujours donnée par rapport au début de
        <parameter>haystack</parameter>, quelle que soit la valeur de <parameter>offset</parameter>.
       </para>
+      <simpara>
+       Le paramètre optionnel offset permet de spécifier l'endroit dans <parameter>haystack</parameter> où débuter la recherche, sous forme d'un <parameter>offset</parameter> exprimé en graphèmes (et non pas en octets ou caractères). Si l'<parameter>offset</parameter> est négatif, il est traité par rapport à la fin de la chaîne. La position retournée est toujours donnée par rapport au début de <parameter>haystack</parameter>, quelle que soit la valeur de offset. La recherche est effectuée de droite à gauche, en cherchant la première occurrence de <parameter>needle</parameter> à partir du groupe de graphèmes sélectionné.
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>


### PR DESCRIPTION
Sync de php/doc-en#4864 (commit 2583cd8). Closes #3075.