### PR TITLE
[Sync EN] predefined/error: l'exemple getPrevious utilise TypeError (#5656)

### DIFF
--- a/language/predefined/error/getprevious.xml
+++ b/language/predefined/error/getprevious.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 09c49da6f0167fcdfe53a76e3ea28ecfc0eb337b Maintainer: girgias Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: e565d17dc87b0c5946ea603fbcfb1777316fb6fc Maintainer: lacatoire Status: ready -->
 <refentry xml:id="error.getprevious" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Error::getPrevious</refname>
@@ -46,7 +45,7 @@ class MyCustomError extends Error {}
 
 function doStuff() {
     try {
-        throw new InvalidArgumentError("You are doing it wrong!", 112);
+        throw new TypeError("You are doing it wrong!", 112);
     } catch(Error $e) {
         throw new MyCustomError("Something happened", 911, $e);
     }
@@ -67,7 +66,7 @@ try {
     <screen>
 <![CDATA[
 /home/bjori/ex.php:8 Something happened (911) [MyCustomError]
-/home/bjori/ex.php:6 You are doing it wrong! (112) [InvalidArgumentError]
+/home/bjori/ex.php:6 You are doing it wrong! (112) [TypeError]
 ]]>
     </screen>
    </example>


### PR DESCRIPTION
Sync de https://github.com/php/doc-en/pull/5656

Closes #3087