### PR TITLE
Entités : traduire 3 manquantes rendues en anglais et retirer 6 mortes

### DIFF
--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -3956,6 +3956,7 @@ local: {
 <!ENTITY mongodb.returns.bulkwritecommandresult '<simpara xmlns="http://docbook.org/ns/docbook">Retourne un <classname>MongoDB\Driver\BulkWriteCommandResult</classname> en cas de succès.</simpara>'>
 <!ENTITY mongodb.throws.std '&mongodb.throws.authentication;&mongodb.throws.connection;'>
 <!ENTITY mongodb.throws.session-unacknowledged '<member xmlns="http://docbook.org/ns/docbook">Lance une exception <classname>MongoDB\Driver\Exception\InvalidArgumentException</classname> si l&#39;option <literal>"session"</literal> est utilisée conjointement avec une préoccupation d&#39;écriture non reconnu.</member>'>
+<!ENTITY mongodb.throws.session-readwriteconcern '<member xmlns="http://docbook.org/ns/docbook">Lance une exception <classname>MongoDB\Driver\Exception\InvalidArgumentException</classname> si l&#39;option <literal>"session"</literal> est utilisée avec une transaction associée en combinaison avec une option <literal>"readConcern"</literal> ou <literal>"writeConcern"</literal>.</member>'>
 <!ENTITY mongodb.throws.bulkwritecommandexception '<member xmlns="http://docbook.org/ns/docbook">Lance une exception <classname>MongoDB\Driver\Exception\BulkWriteCommandException</classname> lors d&#39;une erreur d&#39;écriture (par exemple, échec de commande, erreur d&#39;écriture ou d&#39;écriture préoccupante)</member>'> 
 <!ENTITY mongodb.throws.bulkwriteexception '<member xmlns="http://docbook.org/ns/docbook">Lance une exception <classname>MongoDB\Driver\BulkWriteException</classname> lors d&#39;une erreur d&#39;une opération en écriture (une erreur WriteError et WriteConcern)</member>'>
 <!ENTITY mongodb.throws.argumentparsing '<member xmlns="http://docbook.org/ns/docbook">Lance une exception <classname>MongoDB\Driver\InvalidArgumentException</classname> lors d&#39;une erreur survenue pendant l&#39;analyse d&#39;un argument.</member>'>
@@ -4846,6 +4847,24 @@ Antérieur à PHP 8.0.0, un <constant>E_WARNING</constant> était émis à la pl
 Antérieur à PHP 8.0.0, &false; était retourné et un <constant>E_WARNING</constant> était émis à la place.
 </simpara>
 '>
+<!ENTITY strings.errors.vsprintf '
+  <simpara xmlns="http://docbook.org/ns/docbook">
+À partir de PHP 8.0.0, une <classname>ValueError</classname> est lancée si le nombre d&apos;arguments est nul.
+Antérieur à PHP 8.0.0, un <constant>E_WARNING</constant> était émis à la place.
+</simpara>
+<simpara xmlns="http://docbook.org/ns/docbook">
+À partir de PHP 8.0.0, une <classname>ValueError</classname> est lancée si <literal>[width]</literal> est inférieur à zéro ou supérieur à <constant>PHP_INT_MAX</constant>.
+Antérieur à PHP 8.0.0, un <constant>E_WARNING</constant> était émis à la place.
+</simpara>
+<simpara xmlns="http://docbook.org/ns/docbook">
+À partir de PHP 8.0.0, une <classname>ValueError</classname> est lancée si <literal>[precision]</literal> est inférieur à zéro ou supérieur à <constant>PHP_INT_MAX</constant>.
+Antérieur à PHP 8.0.0, un <constant>E_WARNING</constant> était émis à la place.
+</simpara>
+<simpara xmlns="http://docbook.org/ns/docbook">
+À partir de PHP 8.0.0, une <classname>ValueError</classname> est lancée lorsque moins d&apos;arguments sont donnés que requis.
+Antérieur à PHP 8.0.0, &false; était retourné et un <constant>E_WARNING</constant> était émis à la place.
+</simpara>
+'>
 
 <!ENTITY strings.comparison.return '
   <simpara xmlns="http://docbook.org/ns/docbook">
@@ -5056,6 +5075,21 @@ xmlns="http://docbook.org/ns/docbook"><simpara>Cette fonction a été
   désormais; auparavent, une <type>resource</type> <literal>xml</literal> était attendue.
  </entry>
 </row>'>
+<!ENTITY xml.changelog.handler-param '<row xmlns="http://docbook.org/ns/docbook">
+ <entry>8.4.0</entry>
+ <entry>
+  Passer une <type>string</type> non-<type>callable</type> à
+  <parameter>handler</parameter> est désormais obsolète,
+  utiliser un callable adéquat pour les méthodes, ou &null; pour réinitialiser le gestionnaire.
+ </entry>
+</row>
+<row xmlns="http://docbook.org/ns/docbook">
+ <entry>8.4.0</entry>
+ <entry>
+  La validité de <parameter>handler</parameter> en tant que <type>callable</type>
+  est désormais vérifiée lors de la définition du gestionnaire au lieu d&apos;être vérifiée lors de son appel.
+ </entry>
+</row>'>
 
 <!-- Migration Guide snippets -->
 <!ENTITY migration56.openssl.peer-verification '
@@ -5096,15 +5130,7 @@ anglais. On devrait penser à leur utilité :
 -->
 
 <!ENTITY php.version.added 'Disponible à partir de PHP '>
-<!ENTITY php.version.in 'Disponible en PHP '>
-<!ENTITY php.version.retired 'Disponible jusqu&#39;en PHP '>
 
-<!ENTITY imagick.imagickdraw.return.success 'Retourne &true; en cas de succès, et lance une exception
-<classname>ImagickDrawException</classname> si une erreur survient.'>
-<!ENTITY imagick.imagickpixel.return.success 'Retourne &true; en cas de succès, et lance une exception
-<classname>ImagickPixelException</classname> si une erreur survient.'>
-<!ENTITY imagick.imagickpixeliterator.return.success 'Retourne &true; en cas de succès, et lance une exception
-<classname>ImagickPixelIteratorException</classname> si une erreur survient.'>
 
 <!-- Easy links -->
 
@@ -5115,7 +5141,6 @@ anglais. On devrait penser à leur utilité :
 <!ENTITY array '<link xmlns="http://docbook.org/ns/docbook" linkend="language.types.array">tableau</link>'>
 <!ENTITY object '<link xmlns="http://docbook.org/ns/docbook" linkend="language.types.object">objet</link>'>
 <!ENTITY void '<link xmlns="http://docbook.org/ns/docbook" linkend="language.types.declarations.void">void</link>'>
-<!ENTITY iterable '<link xmlns="http://docbook.org/ns/docbook" linkend="language.types.iterable">iterable</link>'>
 
 
 <!ENTITY zero '<literal xmlns="http://docbook.org/ns/docbook">0</literal>'>


### PR DESCRIPTION
Deux corrections sur `language-snippets.ent`, trouvées en comparant le jeu d'entités avec doc-en.

**1) Trois entités qui rendaient en anglais.** `&mongodb.throws.session-readwriteconcern;`, `&strings.errors.vsprintf;` et `&xml.changelog.handler-param;` sont définies dans doc-en mais étaient absentes ici : elles s'affichaient donc en anglais sur les pages FR (mongodb, vsprintf, xml). Traduites en suivant la voix des entités voisines.

**2) Six entités mortes retirées.** Supprimées de doc-en et plus référencées nulle part dans doc-fr (`php.version.in`, `php.version.retired`, les trois `imagick.*return.success`, `iterable`) : du code mort.
