### PR TITLE
Synchronise DateInterval::createFromDateString

### DIFF
--- a/reference/datetime/dateinterval/createfromdatestring.xml
+++ b/reference/datetime/dateinterval/createfromdatestring.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9eb962113cadccc164d196003062ff5d893de3a5 Maintainer: lacatoire Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 82f00c8d4d4f09fa5a363bc0c6f48e0c80eea72d Maintainer: lacatoire Status: ready -->
 <refentry xml:id="dateinterval.createfromdatestring" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>DateInterval::createFromDateString</refname>
@@ -85,6 +84,8 @@
        A désormais un type de retour provisoire de <type>DateInterval</type>.
        Auparavant, il était <type class="union"><type>DateInterval</type><type>false</type></type>.
       </entry>
+     </row>
+     <row>
       <entry>8.3.0</entry>
       <entry>
        <methodname>DateInterval::createFromDateString</methodname> lance désormais


### PR DESCRIPTION
Synchronisation avec doc-en : l'entrée 8.3.0 du journal des modifications est désormais dans sa propre `<row>` (elle était fusionnée avec 8.4.0).