### PR TITLE
switch.xml: sync changelog/dépréciation du point-virgule après case (8.5)

### DIFF
--- a/language/control-structures/switch.xml
+++ b/language/control-structures/switch.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: cdc9d28d334bbc08386fecf8aade66080004a9dd Maintainer: yannick Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: d149b6ddca64beb9de38cbd4bfd8d19d3bd0b60e Maintainer: lacatoire Status: ready -->
 
 <sect1 xml:id="control-structures.switch" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>switch</title>
@@ -300,8 +298,32 @@ switch($beer)
 ]]>
    </programlisting>
   </informalexample>
+  &warn.deprecated.feature-8-5-0;
  </para>
- 
+
+ <sect2 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       La syntaxe alternative utilisant un point-virgule après
+       <literal>case</literal> a été dépréciée.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </sect2>
+
   <sect2 role="seealso">
   &reftitle.seealso;
   <para>


### PR DESCRIPTION
Sync de php/doc-en#4895 (issue #3093). Ajoute le `warn.deprecated.feature-8-5-0` et le `sect2` changelog (8.5.0 : point-virgule après `case` déprécié).