### PR TITLE
[Sync EN] Migration 8.5: déplacer setlocale vers la section Standard

### DIFF
--- a/appendices/migration85/incompatible.xml
+++ b/appendices/migration85/incompatible.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4de6272a1f15efc9e3df21d255965fd890da0d6f Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 570cdc0ceb6db0452b080c97bb5990b2a11dfbc3 Maintainer: lacatoire Status: ready -->
 <sect1 xml:id="migration85.incompatible" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Changements non rétrocompatibles</title>
 
@@ -443,12 +443,6 @@
    si la valeur read_and_close n'est pas d'un type valide compatible avec int.
   </simpara>
 
-  <simpara>
-   Passer un entier <literal>0</literal> comme argument <parameter>locales</parameter>
-   à <function>setlocale</function> n'est plus supporté et lève désormais une
-   <exceptionname>TypeError</exceptionname>.
-  </simpara>
-
  </sect2>
 
  <sect2 xml:id="migration85.incompatible.simplexml">
@@ -553,6 +547,12 @@
    L'utilisation d'une fonction de la famille printf avec un formateur qui ne spécifiait pas la
    précision réinitialisait incorrectement la précision au lieu de la traiter
    comme une précision de 0.
+  </simpara>
+
+  <simpara>
+   Passer un entier <literal>0</literal> comme argument <parameter>locales</parameter>
+   à <function>setlocale</function> n'est plus supporté et lève désormais une
+   <exceptionname>TypeError</exceptionname>.
   </simpara>
 
  </sect2>


### PR DESCRIPTION
Fixes: #3101