### PR TITLE
dom: synchronise Dom\Element::$outerHTML (PHP 8.5)

### DIFF
--- a/reference/dom/dom/dom-element.xml
+++ b/reference/dom/dom/dom-element.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: ae7db14ea8cb8f3041e114f0ef865d86a95f72d6 Maintainer: Fan2Shrek Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 9a5e44a0cadb280477b8341294db85c215eea827 Maintainer: lacatoire Status: ready -->
 <reference xml:id="class.dom-element" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>La classe Dom\Element</title>
  <titleabbrev>Dom\Element</titleabbrev>
@@ -130,6 +129,11 @@
     <fieldsynopsis>
      <modifier>public</modifier>
      <type>string</type>
+     <varname linkend="dom-element.props.outerhtml">outerHTML</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <type>string</type>
      <varname linkend="dom-element.props.substitutednodevalue">substitutedNodeValue</varname>
     </fieldsynopsis>
 
@@ -236,6 +240,15 @@
      <term><varname>innerHTML</varname></term>
      <listitem>
       <simpara>L'HTML interne (ou XML pour les documents XML) de l'élément.</simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="dom-element.props.outerhtml">
+     <term><varname>outerHTML</varname></term>
+     <listitem>
+      <simpara>
+       L'HTML externe (ou XML pour les documents XML) de l'élément, y compris
+       l'élément lui-même. Disponible à partir de PHP 8.5.0.
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry xml:id="dom-element.props.substitutednodevalue">


### PR DESCRIPTION
Synchronise la propriété `$outerHTML` de `Dom\Element` documentée en amont dans doc-en (php/doc-en#5676).

Fixes: #3111