### PR TITLE
[Sync EN] ext/curl: CURLOPT_TCP_KEEPCNT instead of CURL_TCP_KEEPCNT

### DIFF
--- a/appendices/migration84/constants.xml
+++ b/appendices/migration84/constants.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 8a6397d39aefd23c61d64aa4e9af919772541e2a Maintainer: Fan2Shrek Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: d0ac0a55fc0606f0c0c2f0b277d7d38699cc025a Maintainer: lacatoire Status: ready -->
 <sect1 xml:id="migration84.constants">
  <title>Nouvelles constantes globales</title>
 
@@ -28,7 +27,7 @@
     <constant>CURL_HTTP_VERSION_3ONLY</constant>
    </member>
    <member>
-    <constant>CURL_TCP_KEEPCNT</constant>
+    <constant>CURLOPT_TCP_KEEPCNT</constant>
    </member>
    <member>
     <constant>CURLOPT_PREREQFUNCTION</constant>


### PR DESCRIPTION
Sync of php/doc-en#5684.

Fixes: #3117