### PR TITLE
[Sync EN] ext/dom: Document the new Dom\ParentNode $children property (PHP 8.5)

### DIFF
--- a/reference/dom/dom/dom-document.xml
+++ b/reference/dom/dom/dom-document.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: ae7db14ea8cb8f3041e114f0ef865d86a95f72d6 Maintainer: Fan2Shrek Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 34314b7c6eab4d9b7efabd42154b38fcc5db1fef Maintainer: lacatoire Status: ready -->
 <reference xml:id="class.dom-document" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>La classe Dom\Document</title>
  <titleabbrev>Dom\Document</titleabbrev>
@@ -107,6 +106,12 @@
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>Dom\HTMLCollection</type>
+     <varname linkend="dom-document.props.children">children</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
      <type class="union"><type>Dom\HTMLElement</type><type>null</type></type>
      <varname linkend="dom-document.props.body">body</varname>
     </fieldsynopsis>
@@ -208,6 +213,11 @@
     </varlistentry>
     <varlistentry xml:id="dom-document.props.childelementcount">
      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domdocument.props.childelementcount')/*)">
+      <xi:fallback/>
+     </xi:include>
+    </varlistentry>
+    <varlistentry xml:id="dom-document.props.children">
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('dom-parentnode.props.children')/*)">
       <xi:fallback/>
      </xi:include>
     </varlistentry>

--- a/reference/dom/dom/dom-documentfragment.xml
+++ b/reference/dom/dom/dom-documentfragment.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: ae7db14ea8cb8f3041e114f0ef865d86a95f72d6 Maintainer: Fan2Shrek Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 34314b7c6eab4d9b7efabd42154b38fcc5db1fef Maintainer: lacatoire Status: ready -->
 <reference xml:id="class.dom-documentfragment" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>La classe Dom\DocumentFragment</title>
  <titleabbrev>Dom\DocumentFragment</titleabbrev>
@@ -61,6 +60,12 @@
      <type>int</type>
      <varname linkend="dom-documentfragment.props.childelementcount">childElementCount</varname>
     </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>Dom\HTMLCollection</type>
+     <varname linkend="dom-documentfragment.props.children">children</varname>
+    </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-node')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
@@ -96,6 +101,11 @@
     </varlistentry>
     <varlistentry xml:id="dom-documentfragment.props.childelementcount">
      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domdocumentfragment.props.childelementcount')/*)">
+      <xi:fallback/>
+     </xi:include>
+    </varlistentry>
+    <varlistentry xml:id="dom-documentfragment.props.children">
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('dom-parentnode.props.children')/*)">
       <xi:fallback/>
      </xi:include>
     </varlistentry>

--- a/reference/dom/dom/dom-element.xml
+++ b/reference/dom/dom/dom-element.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9a5e44a0cadb280477b8341294db85c215eea827 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 34314b7c6eab4d9b7efabd42154b38fcc5db1fef Maintainer: lacatoire Status: ready -->
 <reference xml:id="class.dom-element" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>La classe Dom\Element</title>
  <titleabbrev>Dom\Element</titleabbrev>
@@ -123,6 +123,12 @@
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>Dom\HTMLCollection</type>
+     <varname linkend="dom-element.props.children">children</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
      <type>string</type>
      <varname linkend="dom-element.props.innerhtml">innerHTML</varname>
     </fieldsynopsis>
@@ -233,6 +239,11 @@
     </varlistentry>
     <varlistentry xml:id="dom-element.props.nextelementsibling">
      <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('domelement.props.nextelementsibling')/*)">
+      <xi:fallback/>
+     </xi:include>
+    </varlistentry>
+    <varlistentry xml:id="dom-element.props.children">
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('dom-parentnode.props.children')/*)">
       <xi:fallback/>
      </xi:include>
     </varlistentry>

--- a/reference/dom/dom/dom-parentnode.xml
+++ b/reference/dom/dom/dom-parentnode.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: ae7db14ea8cb8f3041e114f0ef865d86a95f72d6 Maintainer: Fan2Shrek Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 34314b7c6eab4d9b7efabd42154b38fcc5db1fef Maintainer: lacatoire Status: ready -->
 <reference xml:id="class.dom-parentnode" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>L'interface Dom\ParentNode</title>
  <titleabbrev>Dom\ParentNode</titleabbrev>
@@ -23,12 +22,35 @@
      <interfacename>Dom\ParentNode</interfacename>
     </oointerface>
 
+    <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>Dom\HTMLCollection</type>
+     <varname linkend="dom-parentnode.props.children">children</varname>
+    </fieldsynopsis>
+
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dom-parentnode')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Dom\\ParentNode'])">
      <xi:fallback/>
     </xi:include>
    </classsynopsis>
 
+  </section>
+
+  <section xml:id="dom-parentnode.props">
+   &reftitle.properties;
+   <variablelist>
+    <varlistentry xml:id="dom-parentnode.props.children">
+     <term><varname>children</varname></term>
+     <listitem>
+      <simpara>
+       Une <classname>Dom\HTMLCollection</classname> contenant tous les éléments
+       enfants de ce nœud. Disponible à partir de PHP 8.5.0.
+      </simpara>
+     </listitem>
+    </varlistentry>
+   </variablelist>
   </section>
 
  </partintro>


### PR DESCRIPTION
Sync of php/doc-en#5677.

Fixes: #3115