### PR TITLE
[Sync EN] Fix dead external links in the manual

### DIFF
--- a/install/windows/commandline.xml
+++ b/install/windows/commandline.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 2dbf3d9064d4cb07f0a2f7d06641c877a2e5ed24 Maintainer: Fan2Shrek Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 10e6a2b042104bd7481b6c21ddbfda594683e3c4 Maintainer: lacatoire Status: ready -->
 <sect1 xml:id="install.windows.commandline" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Exécution de PHP en ligne de commande sur les systèmes Windows</title>
  <para>
@@ -178,12 +177,9 @@ Windows Registry Editor Version 5.00
 "InheritConsoleHandles"=dword:00000001
 ]]>
    </screen>
-   Plus d'informations sur ce problème peuvent être trouvées dans cet <link
-   xlink:href="http://support.microsoft.com/default.aspx?scid=kb;en-us;321788">article de la base de connaissances Microsoft : 321788</link>.
+   Plus d'informations sur ce problème peuvent être trouvées dans l'article de la base de connaissances Microsoft 321788.
    À partir de Windows 10, ce paramètre semble être inversé, rendant l'installation par défaut de
-   Windows 10 supportant automatiquement les gestionnaires de console hérités. Ce <link
-   xlink:href="https://social.msdn.microsoft.com/Forums/en-US/f19d740d-21c8-4dc2-a9ab-d5c0527e932b/nasty-file-association-regression-bug-in-windows-10-console?forum=windowssdk">
-   post du forum Microsoft</link> fournit l'explication.
+   Windows 10 supportant automatiquement les gestionnaires de console hérités.
   </para>
  </note>
 </sect1>

--- a/reference/ldap/constants.xml
+++ b/reference/ldap/constants.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 5b3a84935252a553528cb81b3dacb88647b57c7b Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 10e6a2b042104bd7481b6c21ddbfda594683e3c4 Maintainer: lacatoire Status: ready -->
 
 <appendix xml:id="ldap.constants" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.constants;

--- a/reference/mongodb/architecture.xml
+++ b/reference/mongodb/architecture.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9f4cb232d01a06077a2324e38f767d63f87f2e5f Maintainer: lacatoire Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 10e6a2b042104bd7481b6c21ddbfda594683e3c4 Maintainer: lacatoire Status: ready -->
 <chapter xml:id="mongodb.architecture" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <titleabbrev>Architecture et fonctionnalités spéciales</titleabbrev>
  <title>Explications de l'architecture du pilote et des fonctionnalités spéciales</title>
@@ -35,7 +34,7 @@
    En haut de cette pile se trouve une
    <link xlink:href="&url.mongodb.library;">bibliothèque PHP</link>,
    qui distribue un
-   <link xlink:href="&url.packagist.package;/mongodb/mongodb">package Composer</link>.
+   <link xlink:href="&url.packagist.package;mongodb/mongodb">package Composer</link>.
    Cette bibliothèque fournit une API cohérente avec d'autres
    <link xlink:href="&url.mongodb.drivers;">drivers</link>
    MongoDB et implémente diverses


### PR DESCRIPTION
Sync of php/doc-en#5664.

Fixes: #3122