### PR TITLE
ci: track XInclude href and xpointer in the structure check

### DIFF
--- a/.github/scripts/check-structure.php
+++ b/.github/scripts/check-structure.php
@@ -27,7 +27,9 @@
 
 // Attributs qui font partie de la « structure » : on les inclut dans la
 // signature d'un élément (un role= ou un xml:id qui change = dérive).
-const STRUCTURAL_ATTRIBUTES = ['role', 'choice', 'class', 'xml:id', 'rep'];
+// href et xpointer viennent de XInclude : une cible traduite ne sélectionne
+// plus rien et casse le build, ils doivent donc être identiques à doc-en.
+const STRUCTURAL_ATTRIBUTES = ['role', 'choice', 'class', 'xml:id', 'rep', 'href', 'xpointer'];
 
 // Éléments dont le contenu est du texte (inline). On enregistre l'élément
 // lui-même mais on NE descend PAS dedans : sa prose est l'affaire du traducteur.


### PR DESCRIPTION
Follow-up to a review remark on php/doc-pt_br#787: XInclude `xpointer` (and `href`) are structural, so they belong in the element signature. A translated target selects nothing and breaks the build.

Checked over every file using XInclude in this repo: no new false positive. The same run on doc-es surfaced a real one (`@role='procedimental'` inside an xpointer predicate), which is exactly the class of bug this is meant to catch.