### PR TITLE
[Sync EN] language/control-structures: exemples exécutables (WASM)

### DIFF
--- a/language/control-structures.xml
+++ b/language/control-structures.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
 <!-- EN-Revision: b8147b7f03506e41f01631c32a907b955593525a Maintainer: lacatoire Status: ready -->
 <chapter xml:id="language.control-structures" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" annotations="interactive">
  <title>Les structures de contrôle</title>

--- a/language/control-structures.xml
+++ b/language/control-structures.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: ede9d209f64d4cd71bf22fcfaed14c6fc269523c Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
-<chapter xml:id="language.control-structures" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+<!-- EN-Revision: b8147b7f03506e41f01631c32a907b955593525a Maintainer: lacatoire Status: ready -->
+<chapter xml:id="language.control-structures" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" annotations="interactive">
  <title>Les structures de contrôle</title>
 
  <sect1 xml:id="control-structures.intro">
@@ -58,7 +57,7 @@
  &language.control-structures.include-once;
  &language.control-structures.goto;
 
- </chapter>
+</chapter>
 
 <!-- Keep this comment at the end of the file
 Local variables:

--- a/language/control-structures/alternative-syntax.xml
+++ b/language/control-structures/alternative-syntax.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 22583751fbfdaa3eaa41aeb6470d1343f5cb2c78 Maintainer: yannick Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: b8147b7f03506e41f01631c32a907b955593525a Maintainer: lacatoire Status: ready -->
 
 <sect1 xml:id="control-structures.alternative-syntax"  xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Syntaxe alternative</title>
@@ -20,11 +19,19 @@
   <informalexample>
    <programlisting role="php">
 <![CDATA[
-<?php if ($a == 5): ?>
+<?php
+$a = 5;
+if ($a == 5): ?>
 A égal 5
 <?php endif; ?>
 ]]>
    </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+A égal 5
+]]>
+   </screen>
   </informalexample>
  </para>
  <simpara>
@@ -42,6 +49,7 @@ A égal 5
    <programlisting role="php">
 <![CDATA[
 <?php
+$a = 5;
 if ($a == 5):
     echo "a égale 5";
     echo "...";
@@ -51,9 +59,14 @@ elseif ($a == 6):
 else:
     echo "a ne vaut ni 5 ni 6";
 endif;
-?>
 ]]>
    </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+a égale 5...
+]]>
+   </screen>
   </informalexample>
  </para>
  <note>
@@ -70,12 +83,20 @@ endif;
   <informalexample>
    <programlisting role="php">
 <![CDATA[
-<?php switch ($foo): ?>
+<?php
+$foo = 1;
+switch ($foo): ?>
     <?php case 1: ?>
-    // ...
+    Foo vaut 1
 <?php endswitch; ?>
 ]]>
    </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+Parse error: syntax error, unexpected T_INLINE_HTML "    ", expecting "endswitch" or "case" or "default" in script on line 4
+]]>
+   </screen>
   </informalexample>
   <para>
    Alors que ceci est valide, vu que la dernière nouvelle ligne après
@@ -86,12 +107,20 @@ endif;
   <informalexample>
    <programlisting role="php">
 <![CDATA[
-<?php switch ($foo): ?>
+<?php
+$foo = 1;
+switch ($foo): ?>
 <?php case 1: ?>
-    ...
+    Foo vaut 1
 <?php endswitch; ?>
 ]]>
    </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+    Foo vaut 1
+]]>
+   </screen>
   </informalexample>
  </warning>
  <para>

--- a/language/control-structures/break.xml
+++ b/language/control-structures/break.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 7104ee97ced1768a3231588dfc0bc0d7eb1117ad Maintainer: yannick Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: b8147b7f03506e41f01631c32a907b955593525a Maintainer: lacatoire Status: ready -->
 
 <sect1 xml:id="control-structures.break" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>break</title>
@@ -24,31 +23,65 @@
 <![CDATA[
 <?php
 $arr = array('un', 'deux', 'trois', 'quatre', 'stop', 'cinq');
-foreach ($arr as $val) { 
+foreach ($arr as $val) {
     if ($val == 'stop') {
-        break;    /* Vous pourriez aussi utiliser 'break 1;' ici. */
+        break;    /* Il est aussi possible d'écrire 'break 1;' ici. */
     }
-    echo "$val<br />\n";
+    echo "$val\n";
 }
-
-/* Utilisation de l'argument optionnel. */
-
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+un
+deux
+trois
+quatre
+]]>
+   </screen>
+  </informalexample>
+ </para>
+ <simpara>
+  Utilisation de l'argument optionnel :
+ </simpara>
+ <para>
+  <informalexample>
+   <programlisting role="php">
+<![CDATA[
+<?php
 $i = 0;
 while (++$i) {
     switch ($i) {
         case 5:
-            echo "À 5<br />\n";
+            echo "À 5\n";
             break 1;  /* Termine uniquement le switch. */
         case 10:
-            echo "À 10 ; arrêt<br />\n";
+            echo "À 10 ; arrêt\n";
             break 2;  /* Termine le switch et la boucle while. */
         default:
             break;
     }
+    echo "$i\n";
 }
-?>
 ]]>
    </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+1
+2
+3
+4
+À 5
+5
+6
+7
+8
+9
+À 10 ; arrêt
+]]>
+   </screen>
   </informalexample>
  </para>
 

--- a/language/control-structures/break.xml
+++ b/language/control-structures/break.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
 <!-- EN-Revision: b8147b7f03506e41f01631c32a907b955593525a Maintainer: lacatoire Status: ready -->
 
 <sect1 xml:id="control-structures.break" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/language/control-structures/continue.xml
+++ b/language/control-structures/continue.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 16389a7b31069481d6c8c0705172bee5ef1ddf5f Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: b8147b7f03506e41f01631c32a907b955593525a Maintainer: lacatoire Status: ready -->
 
 <sect1 xml:id="control-structures.continue" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>continue</title>
@@ -37,12 +36,11 @@
 <?php
 $arr = ['zero', 'one', 'two', 'three', 'four', 'five', 'six'];
 foreach ($arr as $key => $value) {
-    if (0 === ($key % 2)) { // évite les membres pairs
+    if (0 === ($key % 2)) { // ignore les membres à clé paire
         continue;
     }
     echo $value . "\n";
 }
-?>
 ]]>
    </programlisting>
    &examples.outputs;
@@ -69,7 +67,6 @@ while ($i++ < 5) {
     }
     echo "Ceci non plus.\n";
 }
-?>
 ]]>
    </programlisting>
    &examples.outputs;
@@ -90,36 +87,6 @@ Intérieur
 Extérieur
 Milieu
 Intérieur
-]]>
-   </screen>
-  </informalexample>
- </para>
- <para>
-  Oublier le point-virgule après <literal>continue</literal> peut porter
-  à confusion. Voici un exemple de ce qu'il ne faut pas faire :
- </para>
- <para>
-  <informalexample>
-   <programlisting role="php">
-<![CDATA[
-<?php
-for ($i = 0; $i < 5; ++$i) {
-    if ($i == 2)
-        continue
-    print "$i\n";
-}
-?>
-]]>
-   </programlisting>
-   <para>
-    On peut s'attendre à ce que le résultat soit :
-   </para>
-   <screen>
-<![CDATA[
-0
-1
-3
-4
 ]]>
    </screen>
   </informalexample>

--- a/language/control-structures/declare.xml
+++ b/language/control-structures/declare.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 5499acf9df7e1338d540bde207acc859792cd139 Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: b8147b7f03506e41f01631c32a907b955593525a Maintainer: lacatoire Status: ready -->
 
 <sect1 xml:id="control-structures.declare" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>declare</title>
@@ -32,11 +31,11 @@ declare (directive)
  </para>
 
  <para>
-  Comme les directives sont gérées lors de la compilation du fichier, seulement 
-  les littéraux peuvent être utilisés comme valeur de ces directives. Les variables 
+  Comme les directives sont gérées lors de la compilation du fichier, seulement
+  les littéraux peuvent être utilisés comme valeur de ces directives. Les variables
   et constantes ne peuvent pas être utilisées. Pour illustrer :
   <informalexample>
-   <programlisting role="php">
+   <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 // Ceci est correct:
@@ -45,7 +44,6 @@ declare(ticks=1);
 // Ceci est incorrect:
 const TICK_VALUE = 1;
 declare(ticks=TICK_VALUE);
-?>
 ]]>
    </programlisting>
   </informalexample>
@@ -59,10 +57,10 @@ declare(ticks=TICK_VALUE);
  <para>
   La structure <literal>declare</literal> peut aussi être utilisée
   dans le contexte global. Elle affecte alors tout le code qui la
-  suit (même si le fichier avec <literal>declare</literal> a été 
+  suit (même si le fichier avec <literal>declare</literal> a été
   inclus après, ça n'affecte pas le fichier parent).
   <informalexample>
-   <programlisting role="php">
+   <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 // Ces déclarations sont identiques.
@@ -75,7 +73,6 @@ declare(ticks=1) {
 // ou ceci
 declare(ticks=1);
 // script entier ici
-?>
 ]]>
    </programlisting>
   </informalexample>
@@ -113,7 +110,7 @@ declare(ticks=1);
 // Une fonction appelée à chaque événement tick
 function tick_handler()
 {
-    echo "tick_handler() called\n";
+    echo "tick_handler() appelé\n";
 }
 
 register_tick_function('tick_handler'); // provoque un événement tick
@@ -122,12 +119,20 @@ $a = 1; // provoque un événement tick
 
 if ($a > 0) {
     $a += 2; // provoque un événement tick
-    print $a; // provoque un événement tick
+    print $a . "\n"; // provoque un événement tick
 }
-
-?>
 ]]>
    </programlisting>
+  &example.outputs;
+   <screen>
+<![CDATA[
+tick_handler() appelé
+tick_handler() appelé
+tick_handler() appelé
+3
+tick_handler() appelé
+]]>
+   </screen>
   </example>
  </para>
  <simpara>
@@ -142,12 +147,11 @@ if ($a > 0) {
    directive <literal>encoding</literal>.
   <example>
    <title>Déclaration d'un encodage pour un script</title>
-    <programlisting role="php">
+    <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 declare(encoding='ISO-8859-1');
 // le code
-?>
 ]]>
     </programlisting>
    </example>

--- a/language/control-structures/declare.xml
+++ b/language/control-structures/declare.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
 <!-- EN-Revision: b8147b7f03506e41f01631c32a907b955593525a Maintainer: lacatoire Status: ready -->
 
 <sect1 xml:id="control-structures.declare" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/language/control-structures/do-while.xml
+++ b/language/control-structures/do-while.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
 <!-- EN-Revision: b8147b7f03506e41f01631c32a907b955593525a Maintainer: lacatoire Status: ready -->
 
 <sect1 xml:id="control-structures.do.while" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/language/control-structures/do-while.xml
+++ b/language/control-structures/do-while.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 53fb200fed6d316b0616a915eb87a40de1d80f51 Maintainer: yannick Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: b8147b7f03506e41f01631c32a907b955593525a Maintainer: lacatoire Status: ready -->
 
 <sect1 xml:id="control-structures.do.while" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>do-while</title>
@@ -31,9 +30,14 @@ $i = 0;
 do {
     echo $i;
 } while ($i > 0);
-?>
 ]]>
    </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+0
+]]>
+   </screen>
   </informalexample>
  </para>
  <simpara>
@@ -55,23 +59,32 @@ do {
    <programlisting role="php">
 <![CDATA[
 <?php
+$i = 50;
+$factor = 0.5;
+$minimum_limit = 20;
 do {
     if ($i < 5) {
-        echo "i n'est pas suffisamment grand";
+        echo "i n'est pas suffisamment grand\n";
         break;
     }
     $i *= $factor;
     if ($i < $minimum_limit) {
+        echo "i est inférieur à la limite minimale après application du facteur\n";
         break;
     }
-   echo "i est bon";
+    echo $i ." est bon\n";
 
     /* ...traitement de i... */
 
 } while (0);
-?>
 ]]>
    </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+25 est bon
+]]>
+   </screen>
   </informalexample>
  </para>
  <simpara>

--- a/language/control-structures/else.xml
+++ b/language/control-structures/else.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 690c3ea7c7d416c55e2c54d90bfd1f7f4d489288 Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: b8147b7f03506e41f01631c32a907b955593525a Maintainer: lacatoire Status: ready -->
 
 <sect1 xml:id="control-structures.else" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>else</title>
@@ -21,14 +20,21 @@
    <programlisting role="php">
 <![CDATA[
 <?php
+$a = 3;
+$b = 5;
 if ($a > $b) {
-  echo "a est plus grand que b";
+  echo "a est plus grand que b\n";
 } else {
-  echo "a n'est pas plus grand que b";
+  echo "a n'est pas plus grand que b\n";
 }
-?>
 ]]>
    </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+a n'est pas plus grand que b
+]]>
+   </screen>
   </informalexample>
   Les instructions après le <literal>else</literal> ne sont
   exécutées que si l'expression du <literal>if</literal>
@@ -53,9 +59,14 @@ if ($a)
         echo "b";
 else
     echo "c";
-?>
 ]]>
     </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+
+]]>
+   </screen>
    </informalexample>
    Malgré l'indentation (qui n'a pas d'importance en PHP), le
    <literal>else</literal> est associé avec le <literal>if ($b)</literal>,

--- a/language/control-structures/elseif.xml
+++ b/language/control-structures/elseif.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 22583751fbfdaa3eaa41aeb6470d1343f5cb2c78 Maintainer: yannick Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: b8147b7f03506e41f01631c32a907b955593525a Maintainer: lacatoire Status: ready -->
 
 <sect1 xml:id="control-structures.elseif" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>elseif/else if</title>
@@ -22,6 +21,8 @@
    <programlisting role="php">
 <![CDATA[
 <?php
+$a = 1;
+$b = 1;
 if ($a > $b) {
     echo "a est plus grand que b";
 } elseif ($a == $b) {
@@ -29,9 +30,14 @@ if ($a > $b) {
 } else {
     echo "a est plus petit que b";
 }
-?>
 ]]>
    </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+a est égal à b
+]]>
+   </screen>
   </informalexample>
  </para>
  <simpara>
@@ -59,7 +65,7 @@ if ($a > $b) {
    comme dans l'exemple ci-dessus. Lors de l'utilisation de ":" pour définir
    les conditions <literal>if</literal>/<literal>elseif</literal>, l'utilisation
    de <literal>elseif</literal> en un seul mot devient nécessaire. PHP
-   échouera avec une erreur d'analyse si <literal>else if</literal> est utilisé. 
+   échouera avec une erreur d'analyse si <literal>else if</literal> est utilisé.
   </simpara>
  </note>
  <para>
@@ -67,6 +73,8 @@ if ($a > $b) {
    <programlisting role="php">
 <![CDATA[
 <?php
+$a = 3;
+$b = 1;
 
 /* Mauvaise méthode : */
 if ($a > $b):
@@ -76,12 +84,20 @@ else if ($a == $b): // ne compilera pas
 endif;
 ]]>
    </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+Parse error: syntax error, unexpected token "if", expecting ":" in script on line 8
+]]>
+   </screen>
   </informalexample>
 
   <informalexample>
    <programlisting role="php">
 <![CDATA[
 <?php
+$a = 3;
+$b = 1;
 
 /* Bonne méthode : */
 if ($a > $b):
@@ -91,10 +107,14 @@ elseif ($a == $b): // Les deux mots sont collés
 else:
     echo $a." n'est ni plus grand ni égal à ".$b;
 endif;
-
-?>
 ]]>
    </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+3 est plus grand que 1
+]]>
+   </screen>
   </informalexample>
  </para>
 </sect1>

--- a/language/control-structures/for.xml
+++ b/language/control-structures/for.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
 <!-- EN-Revision: b8147b7f03506e41f01631c32a907b955593525a Maintainer: lacatoire Status: ready -->
 
 <sect1 xml:id="control-structures.for" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/language/control-structures/for.xml
+++ b/language/control-structures/for.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: ee1ce6a0e1875b6851274f8c373ca2bd48630fa0 Maintainer: lacatoire Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: b8147b7f03506e41f01631c32a907b955593525a Maintainer: lacatoire Status: ready -->
 
 <sect1 xml:id="control-structures.for" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>for</title>
@@ -58,38 +57,71 @@ for (expr1; expr2; expr3)
    <programlisting role="php">
 <![CDATA[
 <?php
-/* exemple 1 */
-
 for ($i = 1; $i <= 10; $i++) {
-    echo $i;
+    echo $i . " ";
 }
-
-/* exemple 2 */
-
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+1 2 3 4 5 6 7 8 9 10
+]]>
+   </screen>
+  </informalexample>
+  <informalexample>
+   <programlisting role="php">
+<![CDATA[
+<?php
 for ($i = 1; ; $i++) {
     if ($i > 10) {
         break;
     }
-    echo $i;
+    echo $i . " ";
 }
-
-/* exemple 3 */
-
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+1 2 3 4 5 6 7 8 9 10
+]]>
+   </screen>
+  </informalexample>
+  <informalexample>
+   <programlisting role="php">
+<![CDATA[
+<?php
 $i = 1;
 for (; ; ) {
     if ($i > 10) {
         break;
     }
-    echo $i;
+    echo $i . " ";
     $i++;
 }
-
-/* exemple 4 */
-
-for ($i = 1, $j = 0; $i <= 10; $j += $i, print $i, $i++);
-?>
 ]]>
    </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+1 2 3 4 5 6 7 8 9 10
+]]>
+   </screen>
+  </informalexample>
+  <informalexample>
+   <programlisting role="php">
+<![CDATA[
+<?php
+for ($i = 1, $j = 0; $i <= 10; $j += $i, print $i . " ", $i++);
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+1 2 3 4 5 6 7 8 9 10
+]]>
+   </screen>
   </informalexample>
  </para>
  <simpara>
@@ -131,11 +163,32 @@ $people = array(
 );
 
 for($i = 0; $i < count($people); ++$i) {
-    $people[$i]['salt'] = mt_rand(000000, 999999);
+    $people[$i]['salt'] = random_int(100000, 999999);
 }
-?>
+var_dump($people);
 ]]>
    </programlisting>
+   &example.outputs.similar;
+   <screen>
+<![CDATA[
+array(2) {
+  [0]=>
+  array(2) {
+    ["name"]=>
+    string(5) "Kalle"
+    ["salt"]=>
+    int(454478)
+  }
+  [1]=>
+  array(2) {
+    ["name"]=>
+    string(6) "Pierre"
+    ["salt"]=>
+    int(776978)
+  }
+}
+]]>
+   </screen>
   </informalexample>
  </para>
  <simpara>
@@ -143,7 +196,6 @@ for($i = 0; $i < count($people); ++$i) {
   itération. Étant donné que la taille ne change jamais, il peut facilement être
   optimisé en utilisant une variable intermédiaire pour stocker la taille au lieu
   d'appeler de façon répétitive la fonction <function>count</function> :
-  
  </simpara>
  <para>
   <informalexample>
@@ -156,11 +208,32 @@ $people = array(
 );
 
 for($i = 0, $size = count($people); $i < $size; ++$i) {
-    $people[$i]['salt'] = mt_rand(000000, 999999);
+    $people[$i]['salt'] = random_int(100000, 999999);
 }
-?>
+var_dump($people);
 ]]>
    </programlisting>
+   &example.outputs.similar;
+   <screen>
+<![CDATA[
+array(2) {
+  [0]=>
+  array(2) {
+    ["name"]=>
+    string(5) "Kalle"
+    ["salt"]=>
+    int(454478)
+  }
+  [1]=>
+  array(2) {
+    ["name"]=>
+    string(6) "Pierre"
+    ["salt"]=>
+    int(776978)
+  }
+}
+]]>
+   </screen>
   </informalexample>
  </para>
 </sect1>

--- a/language/control-structures/foreach.xml
+++ b/language/control-structures/foreach.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: ba7093cf7f30dbcd301c62536ac7ef8664d891f4 Maintainer: jpauli Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: b8147b7f03506e41f01631c32a907b955593525a Maintainer: lacatoire Status: ready -->
 
 <sect1 xml:id="control-structures.foreach" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>foreach</title>
@@ -53,16 +52,14 @@ foreach (iterable_expression as $key => $value) {
 <![CDATA[
 <?php
 
-/* Exemple : valeur uniquement */
-
+echo "Valeur uniquement\n";
 $array = [1, 2, 3, 17];
 
 foreach ($array as $value) {
     echo "Valeur courante de \$array: $value.\n";
 }
 
-/* Exemple : clé et valeur */
-
+echo "\n\nClé et valeur :\n";
 $array = [
     "un" => 1,
     "deux" => 2,
@@ -74,7 +71,7 @@ foreach ($array as $key => $value) {
     echo "\$array[$key] => $value.\n";
 }
 
-/* Exemple : tableaux clé-valeur multidimensionnels */
+echo "\n\nTableaux clé-valeur multidimensionnels :\n";
 $grid = [];
 $grid[0][0] = "a";
 $grid[0][1] = "b";
@@ -87,14 +84,44 @@ foreach ($grid as $y => $row) {
     }
 }
 
-/* Exemple : tableaux dynamiques */
-
+echo "\n\nTableaux dynamiques :\n";
 foreach (range(1, 5) as $value) {
     echo "$value\n";
 }
-?>
 ]]>
   </programlisting>
+  &example.outputs;
+  <screen>
+<![CDATA[
+Valeur uniquement
+Valeur courante de $array: 1.
+Valeur courante de $array: 2.
+Valeur courante de $array: 3.
+Valeur courante de $array: 17.
+
+
+Clé et valeur :
+$array[un] => 1.
+$array[deux] => 2.
+$array[trois] => 3.
+$array[dix-sept] => 17.
+
+
+Tableaux clé-valeur multidimensionnels :
+Valeur à la position x=0 et y=0 : a
+Valeur à la position x=1 et y=0 : b
+Valeur à la position x=0 et y=1 : y
+Valeur à la position x=1 et y=1 : z
+
+
+Tableaux dynamiques :
+1
+2
+3
+4
+5
+]]>
+  </screen>
  </example>
  <note>
   <para>
@@ -132,8 +159,8 @@ foreach (range(1, 5) as $value) {
      le deuxième élément :
     </simpara>
     <programlisting role="php">
-     <![CDATA[
-     <?php
+<![CDATA[
+<?php
 $array = [
     [1, 2],
     [3, 4],
@@ -146,7 +173,6 @@ foreach ($array as [$a, $b]) {
 foreach ($array as list($a, $b)) {
     echo "A: $a; B: $b\n";
 }
-?>
 ]]>
     </programlisting>
     &example.outputs;
@@ -182,8 +208,6 @@ foreach ($array as [, , $c]) {
     // Ignorer $a et $b
     echo "$c\n";
 }
-
-?>
 ]]>
     </programlisting>
     &example.outputs;
@@ -214,7 +238,6 @@ $array = [
 foreach ($array as [$a, $b, $c]) {
     echo "A: $a; B: $b; C: $c\n";
 }
-?>
 ]]>
     </programlisting>
     &example.outputs;
@@ -247,10 +270,25 @@ foreach ($arr as &$value) {
     $value = $value * 2;
 }
 // $arr est maintenant [2, 4, 6, 8]
+var_dump($arr);
 unset($value); // rompre la référence avec le dernier élément
-?>
 ]]>
     </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+array(4) {
+  [0]=>
+  int(2)
+  [1]=>
+  int(4)
+  [2]=>
+  int(6)
+  [3]=>
+  &int(8)
+}
+]]>
+    </screen>
    </informalexample>
   </para>
   <warning>
@@ -269,25 +307,48 @@ foreach ($arr as &$value) {
     $value = $value * 2;
 }
 // $arr est maintenant [2, 4, 6, 8]
+var_dump($arr);
 
 // sans unset($value), $value est toujours une référence au dernier élément : $arr[3]
 
+echo "\nUne autre boucle :\n";
 foreach ($arr as $key => $value) {
     // $arr[3] sera mis à jour avec chaque valeur de $arr...
-    echo "{$key} => {$value} ";
-    print_r($arr);
+    echo "{$key} => {$value}\n";
 }
 // ...jusqu'à ce que finalement l'avant-dernière valeur soit copiée sur la dernière valeur
-?>
+var_dump($arr);
 ]]>
     </programlisting>
     &example.outputs;
     <screen>
 <![CDATA[
-0 => 2 Array ( [0] => 2, [1] => 4, [2] => 6, [3] => 2 )
-1 => 4 Array ( [0] => 2, [1] => 4, [2] => 6, [3] => 4 )
-2 => 6 Array ( [0] => 2, [1] => 4, [2] => 6, [3] => 6 )
-3 => 6 Array ( [0] => 2, [1] => 4, [2] => 6, [3] => 6 )
+array(4) {
+  [0]=>
+  int(2)
+  [1]=>
+  int(4)
+  [2]=>
+  int(6)
+  [3]=>
+  &int(8)
+}
+
+Une autre boucle :
+0 => 2
+1 => 4
+2 => 6
+3 => 6
+array(4) {
+  [0]=>
+  int(2)
+  [1]=>
+  int(4)
+  [2]=>
+  int(6)
+  [3]=>
+  &int(6)
+}
 ]]>
     </screen>
    </informalexample>
@@ -299,10 +360,19 @@ foreach ($arr as $key => $value) {
 <?php
 foreach ([1, 2, 3, 4] as &$value) {
     $value = $value * 2;
+    echo $value . "\n";
 }
-?>
 ]]>
    </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+2
+4
+6
+8
+]]>
+   </screen>
   </example>
  </sect2>
 

--- a/language/control-structures/foreach.xml
+++ b/language/control-structures/foreach.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
 <!-- EN-Revision: b8147b7f03506e41f01631c32a907b955593525a Maintainer: lacatoire Status: ready -->
 
 <sect1 xml:id="control-structures.foreach" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/language/control-structures/goto.xml
+++ b/language/control-structures/goto.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 7204e2dbb9b484c8b67bb5ad4a93fa1369c5b317 Maintainer: yannick Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: b8147b7f03506e41f01631c32a907b955593525a Maintainer: lacatoire Status: ready -->
 
 <sect1 xml:id="control-structures.goto" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>goto</title>
@@ -38,14 +37,11 @@
    <programlisting role="php">
 <![CDATA[
 <?php
-
 goto a;
 echo 'Foo';
- 
+
 a:
 echo 'Bar';
-
-?>
 ]]>
    </programlisting>
    &example.outputs;
@@ -62,7 +58,6 @@ Bar
    <programlisting role="php">
 <![CDATA[
 <?php
-
 for ($i = 0, $j = 50; $i < 100; $i++) {
     while ($j--) {
         if ($j == 17) {
@@ -73,8 +68,6 @@ for ($i = 0, $j = 50; $i < 100; $i++) {
 echo "i = $i";
 end:
 echo 'j a atteint 17';
-
-?>
 ]]>
    </programlisting>
    &example.outputs;
@@ -91,7 +84,6 @@ j a atteint 17
    <programlisting role="php">
 <![CDATA[
 <?php
-
 goto loop;
 for ($i = 0, $j = 50; $i < 100; $i++) {
     while ($j--) {
@@ -99,15 +91,12 @@ for ($i = 0, $j = 50; $i < 100; $i++) {
     }
 }
 echo "$i = $i";
-
-?>
 ]]>
    </programlisting>
    &example.outputs;
    <screen>
 <![CDATA[
-Fatal error: 'goto' into loop or switch statement is disallowed in
-script on line 2
+Fatal error: 'goto' into loop or switch statement is disallowed in script on line 2
 ]]>
    </screen>
   </example>

--- a/language/control-structures/goto.xml
+++ b/language/control-structures/goto.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
 <!-- EN-Revision: b8147b7f03506e41f01631c32a907b955593525a Maintainer: lacatoire Status: ready -->
 
 <sect1 xml:id="control-structures.goto" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/language/control-structures/if.xml
+++ b/language/control-structures/if.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
 <!-- EN-Revision: b8147b7f03506e41f01631c32a907b955593525a Maintainer: lacatoire Status: ready -->
 
 <sect1 xml:id="control-structures.if" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/language/control-structures/if.xml
+++ b/language/control-structures/if.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 7104ee97ced1768a3231588dfc0bc0d7eb1117ad Maintainer: yannick Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: b8147b7f03506e41f01631c32a907b955593525a Maintainer: lacatoire Status: ready -->
 
 <sect1 xml:id="control-structures.if" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>if</title>
@@ -39,11 +38,18 @@ if (expression)
    <programlisting role="php">
 <![CDATA[
 <?php
+$a = 3;
+$b = 1;
 if ($a > $b)
-  echo "a est plus grand que b";
-?>
+  echo "a est plus grand que b\n";
 ]]>
    </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+a est plus grand que b
+]]>
+   </screen>
   </informalexample>
  </para>
  <para>
@@ -59,13 +65,22 @@ if ($a > $b)
    <programlisting role="php">
 <![CDATA[
 <?php
+$a = 3;
+$b = 1;
 if ($a > $b) {
-  echo "a est plus grand que b";
+  echo "a est plus grand que b\n";
   $b = $a;
 }
-?>
+var_dump($b);
 ]]>
    </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+a est plus grand que b
+int(3)
+]]>
+   </screen>
   </informalexample>
  </para>
  <simpara>

--- a/language/control-structures/include.xml
+++ b/language/control-structures/include.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 911fe79de766ef4475bf22446903667a0f3a24d3 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: b8147b7f03506e41f01631c32a907b955593525a Maintainer: lacatoire Status: ready -->
 
 <sect1 xml:id="function.include" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>include</title>
@@ -52,7 +52,7 @@
  <para>
   <example>
    <title>Exemple avec <literal>include</literal></title>
-   <programlisting role="php">
+   <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 vars.php
 <?php
@@ -87,7 +87,7 @@ echo "Une $fruit $couleur"; // Une pomme verte
  <para>
   <example>
    <title>Inclusion de fichiers dans une fonction</title>
-   <programlisting role="php">
+   <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 
@@ -107,8 +107,6 @@ function foo()
 
 foo();                      // Une pomme verte
 echo "Une $fruit $couleur"; // Une verte
-
-?>
 ]]>
    </programlisting>
   </example>
@@ -137,7 +135,7 @@ echo "Une $fruit $couleur"; // Une verte
  <para>
   <example>
    <title>Utiliser l'instruction <literal>include</literal> via HTTP</title>
-   <programlisting role="php">
+   <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 
@@ -156,7 +154,6 @@ include 'file.php?foo=1&bar=2';
 
 // Réussi
 include 'http://www.example.com/file.php?foo=1&bar=2';
-?>
 ]]>
    </programlisting>
   </example>
@@ -203,7 +200,7 @@ include 'http://www.example.com/file.php?foo=1&bar=2';
   lors de la comparaison de la valeur retournée.
   <example>
    <title>Comparaison de la valeur de retour d'une inclusion</title>
-   <programlisting role="php">
+   <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 // Ne fonctionne pas, évalué comme include(('vars.php') == TRUE), i.e. include('1')
@@ -215,7 +212,6 @@ if (include('vars.php') == TRUE) {
 if ((include 'vars.php') == TRUE) {
     echo 'OK';
 }
-?>
 ]]>
    </programlisting>
   </example>
@@ -223,7 +219,7 @@ if ((include 'vars.php') == TRUE) {
  <para>
   <example>
    <title><literal>include</literal> et <function>return</function></title>
-   <programlisting role="php">
+   <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 return.php
 <?php
@@ -286,7 +282,7 @@ echo $bar; // affiche 1
   <example>
    <title>Utilisation de la sortie du buffer pour inclure un fichier PHP dans
    une chaîne</title>
-   <programlisting role="php">
+   <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 $string = get_include_contents('somefile.php');
@@ -299,8 +295,6 @@ function get_include_contents($filename) {
     }
     return false;
 }
-
-?>
 ]]>
    </programlisting>
   </example>

--- a/language/control-structures/match.xml
+++ b/language/control-structures/match.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 840bdb9be79855ee4b2cc66c22cf3e88b781398a Maintainer: lacatoire Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: b8147b7f03506e41f01631c32a907b955593525a Maintainer: lacatoire Status: ready -->
 
 <sect1 xml:id="control-structures.match" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>match</title>
@@ -19,14 +18,13 @@
 
  <example>
   <title>Structure d'une expression <literal>match</literal></title>
-  <programlisting role="php">
+  <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 $return_value = match (subject_expression) {
     single_conditional_expression => return_expression,
     conditional_expression1, conditional_expression2 => return_expression,
 };
-?>
 ]]>
   </programlisting>
 
@@ -44,7 +42,6 @@ $return_value = match ($food) {
 };
 
 var_dump($return_value);
-?>
 ]]>
   </programlisting>
   &example.outputs;
@@ -71,7 +68,6 @@ $output = match (true) {
 };
 
 var_dump($output);
-?>
 ]]>
   </programlisting>
   &example.outputs;
@@ -98,7 +94,7 @@ string(10) "Adolescent"
 
  <para>
   L'expression <literal>match</literal> est similaire à une instruction
-  <literal>switch</literal> mais présente quelques différences essentielles:
+  <literal>switch</literal> mais présente quelques différences essentielles :
 
   <itemizedlist>
    <listitem>
@@ -134,7 +130,7 @@ string(10) "Adolescent"
   Seule l'expression de retour correspondant à l'expression conditionnelle correspondante sera évaluée.
   Par exemple :
   <informalexample>
-   <programlisting role="php">
+   <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 $result = match ($x) {
@@ -143,7 +139,6 @@ $result = match ($x) {
     $this->baz => beep(), // beep() n'est pas appelé sauf si $x === $this->baz
     // etc.
 };
-?>
 ]]>
    </programlisting>
   </informalexample>
@@ -156,7 +151,7 @@ $result = match ($x) {
  </para>
  <para>
   <informalexample>
-   <programlisting role="php">
+   <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 $result = match ($x) {
@@ -167,7 +162,6 @@ $result = match ($x) {
     $b => 5,
     $c => 5,
 };
-?>
 ]]>
    </programlisting>
   </informalexample>
@@ -177,7 +171,7 @@ $result = match ($x) {
   Ce motif correspond à tout ce qui n'a pas été recherché précédemment.
   Par exemple :
   <informalexample>
-   <programlisting role="php">
+   <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 $expressionResult = match ($condition) {
@@ -185,7 +179,6 @@ $expressionResult = match ($condition) {
     3, 4 => bar(),
     default => baz(),
 };
-?>
 ]]>
    </programlisting>
   </informalexample>
@@ -218,7 +211,6 @@ try {
 } catch (\UnhandledMatchError $e) {
     var_dump($e);
 }
-?>
 ]]>
   </programlisting>
   &example.outputs;
@@ -226,13 +218,13 @@ try {
 <![CDATA[
 object(UnhandledMatchError)#1 (7) {
   ["message":protected]=>
-  string(33) "Unhandled match value of type int"
+  string(22) "Unhandled match case 5"
   ["string":"Error":private]=>
   string(0) ""
   ["code":protected]=>
   int(0)
   ["file":protected]=>
-  string(9) "/in/ICgGK"
+  string(6) "script"
   ["line":protected]=>
   int(6)
   ["trace":"Error":private]=>
@@ -257,7 +249,6 @@ object(UnhandledMatchError)#1 (7) {
    <programlisting role="php">
 <![CDATA[
 <?php
-
 $age = 23;
 
 $result = match (true) {
@@ -268,7 +259,6 @@ $result = match (true) {
 };
 
 var_dump($result);
-?>
 ]]>
    </programlisting>
    &example.outputs;
@@ -294,7 +284,6 @@ $result = match (true) {
 };
 
 var_dump($result);
-?>
 ]]>
    </programlisting>
    &example.outputs;

--- a/language/control-structures/switch.xml
+++ b/language/control-structures/switch.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: d149b6ddca64beb9de38cbd4bfd8d19d3bd0b60e Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: b8147b7f03506e41f01631c32a907b955593525a Maintainer: lacatoire Status: ready -->
 
 <sect1 xml:id="control-structures.switch" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>switch</title>
@@ -40,32 +40,39 @@
    <programlisting role="php">
 <![CDATA[
 <?php
+$i = 1;
+
 // Ce switch:
 
 switch ($i) {
     case 0:
-        echo "i égal 0";
+        echo "i égal 0\n";
         break;
     case 1:
-        echo "i égal 1";
+        echo "i égal 1\n";
         break;
     case 2:
-        echo "i égal 2";
+        echo "i égal 2\n";
         break;
 }
 
 // Équivaut à:
-
 if ($i == 0) {
-    echo "i égal 0";
+    echo "i égal 0\n";
 } elseif ($i == 1) {
-    echo "i égal 1";
+    echo "i égal 1\n";
 } elseif ($i == 2) {
-    echo "i égal 2";
+    echo "i égal 2\n";
 }
-?>
 ]]>
    </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+i égal 1
+i égal 1
+]]>
+   </screen>
   </example>
  </para>
  <para>
@@ -88,17 +95,25 @@ if ($i == 0) {
    <programlisting role="php">
 <![CDATA[
 <?php
+$i = 1;
+
 switch ($i) {
     case 0:
-        echo "i égal 0";
+        echo "i égal 0\n";
     case 1:
-        echo "i égal 1";
+        echo "i égal 1\n";
     case 2:
-        echo "i égal 2";
+        echo "i égal 2\n";
 }
-?>
 ]]>
    </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+i égal 1
+i égal 2
+]]>
+   </screen>
   </informalexample>
  </para>
  <simpara>
@@ -130,6 +145,8 @@ switch ($i) {
    <programlisting role="php">
 <![CDATA[
 <?php
+$i = 1;
+
 switch ($i) {
     case 0:
     case 1:
@@ -139,9 +156,14 @@ switch ($i) {
     case 3:
         echo "i égal 3";
 }
-?>
 ]]>
    </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+i est plus petit que 3 mais n'est pas négatif
+]]>
+   </screen>
   </informalexample>
  </para>
  <para>
@@ -151,6 +173,8 @@ switch ($i) {
    <programlisting role="php">
 <![CDATA[
 <?php
+$i = 4;
+
 switch ($i) {
     case 0:
         echo "i égal 0";
@@ -164,9 +188,14 @@ switch ($i) {
     default:
        echo "i n'est ni égal à 2, ni à 1, ni à 0.";
 }
-?>
 ]]>
    </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+i n'est ni égal à 2, ni à 1, ni à 0.
+]]>
+   </screen>
   </informalexample>
   <note>
    <simpara>
@@ -210,11 +239,14 @@ switch ($target) {
         print "D";
         break;
 }
-
-// Affiche "B"
-?>
 ]]>
    </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+B
+]]>
+   </screen>
   </informalexample>
  </para>
  <para>
@@ -241,11 +273,14 @@ switch (true) {
         print "D";
         break;
 }
-
-// Affiche "B"
-?>
 ]]>
    </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+B
+]]>
+   </screen>
   </informalexample>
  </para>
  <para>
@@ -257,6 +292,8 @@ switch (true) {
    <programlisting role="php">
 <![CDATA[
 <?php
+$i = 1;
+
 switch ($i):
     case 0:
         echo "i égal 0";
@@ -270,18 +307,25 @@ switch ($i):
     default:
         echo "i n'est ni égal à 2, ni à 1, ni à 0";
 endswitch;
-?>
 ]]>
    </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+i égal 1
+]]>
+   </screen>
   </informalexample>
  </para>
  <para>
   Il est possible d'utiliser un point-virgule plutôt que deux points après
-  un case, comme ceci :
+  un case. À partir de PHP 8.5.0, cette syntaxe est dépréciée.
   <informalexample>
    <programlisting role="php">
 <![CDATA[
 <?php
+$beer = 'cola';
+
 switch($beer)
 {
     case 'leffe';
@@ -294,9 +338,22 @@ switch($beer)
         echo 'Merci de faire un nouveau choix...';
         break;
 }
-?>
 ]]>
    </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+
+Deprecated: Case statements followed by a semicolon (;) are deprecated, use a colon (:) instead in script on line 6
+
+Deprecated: Case statements followed by a semicolon (;) are deprecated, use a colon (:) instead in script on line 7
+
+Deprecated: Case statements followed by a semicolon (;) are deprecated, use a colon (:) instead in script on line 8
+
+Deprecated: Case statements followed by a semicolon (;) are deprecated, use a colon (:) instead in script on line 11
+Merci de faire un nouveau choix...
+]]>
+   </screen>
   </informalexample>
   &warn.deprecated.feature-8-5-0;
  </para>

--- a/language/control-structures/while.xml
+++ b/language/control-structures/while.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
 <!-- EN-Revision: b8147b7f03506e41f01631c32a907b955593525a Maintainer: lacatoire Status: ready -->
 
 <sect1 xml:id="control-structures.while" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/language/control-structures/while.xml
+++ b/language/control-structures/while.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 7104ee97ced1768a3231588dfc0bc0d7eb1117ad Maintainer: yannick Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: b8147b7f03506e41f01631c32a907b955593525a Maintainer: lacatoire Status: ready -->
 
 <sect1 xml:id="control-structures.while" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>while</title>
@@ -59,24 +58,55 @@ endwhile;
    <programlisting role="php">
 <![CDATA[
 <?php
-/* exemple 1 */
-
 $i = 1;
 while ($i <= 10) {
-    echo $i++;  /* La valeur affichée est $i avant l'incrémentation
-                   (post-incrémentation)  */
+    echo $i++ . "\n";  /* La valeur affichée est $i avant l'incrémentation
+                          (post-incrémentation) */
 }
-
-/* exemple 2 */
-
-$i = 1;
-while ($i <= 10):
-    echo $i;
-    $i++;
-endwhile;
-?>
 ]]>
    </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+1
+2
+3
+4
+5
+6
+7
+8
+9
+10
+]]>
+   </screen>
+  </informalexample>
+  <informalexample>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$i = 1;
+while ($i <= 10):
+    echo $i . "\n";
+    $i++;
+endwhile;
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+1
+2
+3
+4
+5
+6
+7
+8
+9
+10
+]]>
+   </screen>
   </informalexample>
  </para>
 </sect1>


### PR DESCRIPTION
Portage de php/doc-en@b8147b7 (php/doc-en#5462) sur les 16 fichiers de `language/control-structures`.

Fixes: #3124