### PR TITLE
[Sync EN] ext/curl: documenter d'autres dépréciations cURL

### DIFF
--- a/reference/curl/constants_curl_getinfo.xml
+++ b/reference/curl/constants_curl_getinfo.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: ee972f53e1a95967cd65c6de63ea4b422b987bd3 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 5cdc4c99779c1bd1b770b15a5fc6438b39223c28 Maintainer: lacatoire Status: ready -->
 <variablelist xml:id="constant.curl-getinfo.constants" role="constant_list">
  <title><function>curl_getinfo</function></title>
  <varlistentry xml:id="constant.curlinfo-appconnect-time">
@@ -113,7 +113,7 @@
   </term>
   <listitem>
    <simpara>
-    La longueur du contenu téléchargé, lue depuis le champ Content-Length:
+    La longueur du contenu téléchargé, lue depuis le champ Content-Length:. Dépréciée à partir de cURL 7.55.0. Utiliser <constant>CURLINFO_CONTENT_LENGTH_DOWNLOAD_T</constant> à la place.
    </simpara>
   </listitem>
  </varlistentry>
@@ -136,7 +136,7 @@
   </term>
   <listitem>
    <simpara>
-    La taille spécifiée de l'envoi
+    La taille spécifiée de l'envoi. Dépréciée à partir de cURL 7.55.0. Utiliser <constant>CURLINFO_CONTENT_LENGTH_UPLOAD_T</constant> à la place.
    </simpara>
   </listitem>
  </varlistentry>
@@ -454,7 +454,7 @@
   <listitem>
    <simpara>
     Le protocole utilisé dans la dernière connexion HTTP. La valeur de retour sera exactement une des valeurs <constant>CURLPROTO_<replaceable>*</replaceable></constant>.
-    Disponible à partir de PHP 7.3.0 et cURL 7.52.0
+    Disponible à partir de PHP 7.3.0 et cURL 7.52.0. Déprécié à partir de cURL 7.85.0. Utiliser <constant>CURLINFO_SCHEME</constant> à la place.
    </simpara>
   </listitem>
  </varlistentry>
@@ -672,7 +672,7 @@
   </term>
   <listitem>
    <simpara>
-    Le nombre total d'octets téléchargés
+    Le nombre total d'octets téléchargés. Déprécié à partir de cURL 7.55.0. Utiliser <constant>CURLINFO_SIZE_DOWNLOAD_T</constant> à la place.
    </simpara>
   </listitem>
  </varlistentry>
@@ -695,7 +695,7 @@
   </term>
   <listitem>
    <simpara>
-    Le nombre total d'octets téléversés
+    Le nombre total d'octets téléversés. Déprécié à partir de cURL 7.55.0. Utiliser <constant>CURLINFO_SIZE_UPLOAD_T</constant> à la place.
    </simpara>
   </listitem>
  </varlistentry>
@@ -718,7 +718,7 @@
   </term>
   <listitem>
    <simpara>
-    La vitesse moyenne de téléchargement
+    La vitesse moyenne de téléchargement. Dépréciée à partir de cURL 7.55.0. Utiliser <constant>CURLINFO_SPEED_DOWNLOAD_T</constant> à la place.
    </simpara>
   </listitem>
  </varlistentry>
@@ -741,7 +741,7 @@
   </term>
   <listitem>
    <simpara>
-    La vitesse moyenne de téléversement 
+    La vitesse moyenne de téléversement. Dépréciée à partir de cURL 7.55.0. Utiliser <constant>CURLINFO_SPEED_UPLOAD_T</constant> à la place.
    </simpara>
   </listitem>
  </varlistentry>

--- a/reference/curl/constants_curl_setopt.xml
+++ b/reference/curl/constants_curl_setopt.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e7e81a179eabc75e1b37947c7696afd557cef656 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 5cdc4c99779c1bd1b770b15a5fc6438b39223c28 Maintainer: lacatoire Status: ready -->
  <variablelist role="constant_list">
   <title><function>curl_setopt</function></title>
   <varlistentry xml:id="constant.curlopt-abstract-unix-socket">
@@ -1530,7 +1530,7 @@
      <literal>private</literal> est utilisé.
      Définir cette option à &null; désactivera la prise en charge de Kerberos pour FTP.
      Par défaut à &null;.
-     Disponible à partir de cURL 7.16.4.
+     Disponible à partir de cURL 7.16.4 et déprécié à partir de cURL 8.17.0.
     </para>
    </listitem>
   </varlistentry>
@@ -2276,13 +2276,13 @@
     (<type>int</type>)
    </term>
    <listitem>
-    <para>
+    <simpara>
      Un masque de bits de valeurs <constant>CURLPROTO_<replaceable>*</replaceable></constant>.
      Si utilisé, ce masque limite les protocoles que cURL peut utiliser dans le transfert.
      Par défaut, cela vaut <constant>CURLPROTO_ALL</constant>, c'est-à-dire que cURL acceptera tous les protocoles qu'il prend en charge.
-     Voir <constant>CURLOPT_REDIR_PROTOCOLS</constant>.
+     Voir <constant>CURLOPT_REDIR_PROTOCOLS_STR</constant>.
      Disponible à partir de cURL 7.19.4 et déprécié à partir de cURL 7.85.0.
-    </para>
+    </simpara>
    </listitem>
   </varlistentry>
   <varlistentry xml:id="constant.curlopt-protocols-str">
@@ -3707,12 +3707,12 @@
     (<type>int</type>)
    </term>
    <listitem>
-    <para>
+    <simpara>
      &true; pour activer et &false; pour désactiver le démarrage anticipé de TLS,
      qui est un mode où un client TLS commence à envoyer des données d'application
      avant de vérifier le message <literal>Finished</literal> du serveur.
-     Disponible à partir de PHP 7.0.7 et cURL 7.42.0.
-    </para>
+     Disponible à partir de PHP 7.0.7 et cURL 7.42.0. Déprécié à partir de cURL 8.15.0.
+    </simpara>
    </listitem>
   </varlistentry>
   <varlistentry xml:id="constant.curlopt-ssl-options">


### PR DESCRIPTION
Portage de php/doc-en@5cdc4c9 (php/doc-en#5678) sur `constants_curl_getinfo.xml` et `constants_curl_setopt.xml`.

Fixes: #3128