### PR TITLE
[Sync EN] ext/intl: document the IntlListFormatter class (PHP 8.5)

### DIFF
--- a/appendices/migration85/new-classes.xml
+++ b/appendices/migration85/new-classes.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: ec45af749649dc0d6a23eaedeed1b601f7460813 Maintainer: Fan2Shrek Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: e1b9f588815a51682acf68f9b8929f49ad612488 Maintainer: lacatoire Status: ready -->
 <sect1 xml:id="migration85.new-classes" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Nouvelles classes et interfaces</title>
 
@@ -29,6 +28,13 @@
    <member><classname>Filter\FilterFailedException</classname></member>
   </simplelist>
   <!-- RFC: https://wiki.php.net/rfc/filter_throw_on_failure -->
+ </sect2>
+
+ <sect2 xml:id="migration85.new-classes.intl">
+  <title>Intl</title>
+  <simplelist>
+   <member><classname>IntlListFormatter</classname></member>
+  </simplelist>
  </sect2>
 
  <sect2 xml:id="migration85.new-classes.uri">

--- a/reference/intl/book.xml
+++ b/reference/intl/book.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: e1b9f588815a51682acf68f9b8929f49ad612488 Maintainer: lacatoire Status: ready -->
-<!-- CREDITS: DAnnebicque -->
 
 <book xml:id="book.intl" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <?phpdoc extension-membership="bundled" ?>

--- a/reference/intl/book.xml
+++ b/reference/intl/book.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 91791cdde04dd89898656fbec1aa8e7e0bf0460d Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: e1b9f588815a51682acf68f9b8929f49ad612488 Maintainer: lacatoire Status: ready -->
 <!-- CREDITS: DAnnebicque -->
 
 <book xml:id="book.intl" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -12,7 +10,7 @@
  <!-- {{{ Preface -->
  <preface xml:id="intro.intl">
   &reftitle.intro;
-  <para>
+  <simpara>
    L'extension d'Internationalization (qui est aussi appelée Intl) est une 
    interface pour la bibliothèque <link xlink:href="&url.icu.home;">ICU</link>,
    qui permet aux développeurs PHP d'effectuer des opérations
@@ -22,18 +20,18 @@
    <link xlink:href="&url.icu.uca;">UCA</link>-conforme, la
    localisation des limites du texte et l'utilisation des identificateurs
    de paramètres régionaux, des fuseaux horaires et des graphèmes.
-  </para>
+  </simpara>
 
-  <para>
+  <simpara>
    Cette extension tend à suivre de près l'API ICU, ce qui fait que ceux
    qui ont l'expérience de cette bibliothèque en C, C++ ou Java pourront 
    facilement s'y retrouver dans l'API PHP. De plus, la documentation ICU
    peut être très utile pour comprendre les fonctions ICU.
-  </para>
+  </simpara>
 
-  <para>
-   Intl est constitué de plusieurs modules, chacun exposant des API d'ICU : 
-  </para>
+  <simpara>
+   Intl est constitué de plusieurs modules, chacun exposant des API d'ICU :
+  </simpara>
 
   <itemizedlist>
    <listitem>
@@ -105,13 +103,13 @@
    <title>Liens</title>
    <itemizedlist>
     <listitem>
-     <para><link xlink:href="&url.icu.docs;">Diverses docs ICU</link></para>
+     <simpara><link xlink:href="&url.icu.docs;">Diverses docs ICU</link></simpara>
     </listitem>
     <listitem>
-     <para><link xlink:href="&url.icu.userguide;">Guide utilisateur ICU</link></para>
+     <simpara><link xlink:href="&url.icu.userguide;">Guide utilisateur ICU</link></simpara>
     </listitem>
     <listitem>
-     <para><link xlink:href="&url.icu.uca;">Algorithme de collation Unicode</link></para>
+     <simpara><link xlink:href="&url.icu.uca;">Algorithme de collation Unicode</link></simpara>
     </listitem>
    </itemizedlist>
   </section>
@@ -140,6 +138,7 @@
  &reference.intl.intlrulebasedbreakiterator;
  &reference.intl.intlcodepointbreakiterator;
  &reference.intl.intldatepatterngenerator;
+ &reference.intl.intllistformatter;
  &reference.intl.intlpartsiterator;
  &reference.intl.uconverter;
 

--- a/reference/intl/intllistformatter.xml
+++ b/reference/intl/intllistformatter.xml
@@ -1,0 +1,179 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: e1b9f588815a51682acf68f9b8929f49ad612488 Maintainer: lacatoire Status: ready -->
+<reference xml:id="class.intllistformatter" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+ <title>La classe IntlListFormatter</title>
+ <titleabbrev>IntlListFormatter</titleabbrev>
+
+ <partintro>
+
+  <!-- {{{ IntlListFormatter intro -->
+  <section xml:id="intllistformatter.intro">
+   &reftitle.intro;
+   <simpara>
+    Formate, ordonne et ponctue une liste d'éléments selon les règles propres aux
+    paramètres régionaux. Nécessite ICU 67 ou supérieur.
+   </simpara>
+  </section>
+  <!-- }}} -->
+
+  <section xml:id="intllistformatter.synopsis">
+   &reftitle.classsynopsis;
+
+   <!-- {{{ Synopsis -->
+   <classsynopsis class="class">
+    <ooclass>
+     <classname>IntlListFormatter</classname>
+    </ooclass>
+
+    <classsynopsisinfo role="comment">&Constants;</classsynopsisinfo>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="intllistformatter.constants.type-and">IntlListFormatter::TYPE_AND</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="intllistformatter.constants.type-or">IntlListFormatter::TYPE_OR</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="intllistformatter.constants.type-units">IntlListFormatter::TYPE_UNITS</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="intllistformatter.constants.width-wide">IntlListFormatter::WIDTH_WIDE</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="intllistformatter.constants.width-short">IntlListFormatter::WIDTH_SHORT</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="intllistformatter.constants.width-narrow">IntlListFormatter::WIDTH_NARROW</varname>
+    </fieldsynopsis>
+
+    <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.intllistformatter')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='IntlListFormatter'])">
+     <xi:fallback/>
+    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.intllistformatter')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='IntlListFormatter'])">
+     <xi:fallback/>
+    </xi:include>
+   </classsynopsis>
+   <!-- }}} -->
+
+  </section>
+
+  <section xml:id="intllistformatter.constants">
+   &reftitle.constants;
+   <variablelist>
+    <varlistentry xml:id="intllistformatter.constants.type-and">
+     <term><constant>IntlListFormatter::TYPE_AND</constant></term>
+     <listitem>
+      <simpara>
+       Formate une liste en utilisant une conjonction (par exemple "A, B, and C").
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="intllistformatter.constants.type-or">
+     <term><constant>IntlListFormatter::TYPE_OR</constant></term>
+     <listitem>
+      <simpara>
+       Formate une liste en utilisant une disjonction (par exemple "A, B, or C").
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="intllistformatter.constants.type-units">
+     <term><constant>IntlListFormatter::TYPE_UNITS</constant></term>
+     <listitem>
+      <simpara>
+       Formate une liste d'unités (par exemple "3 ft, 7 in").
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="intllistformatter.constants.width-wide">
+     <term><constant>IntlListFormatter::WIDTH_WIDE</constant></term>
+     <listitem>
+      <simpara>
+       Utilise le format de liste le plus large (le plus verbeux), généralement avec
+       les conjonctions écrites en toutes lettres.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="intllistformatter.constants.width-short">
+     <term><constant>IntlListFormatter::WIDTH_SHORT</constant></term>
+     <listitem>
+      <simpara>
+       Utilise un format de liste court, généralement en utilisant des abréviations.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="intllistformatter.constants.width-narrow">
+     <term><constant>IntlListFormatter::WIDTH_NARROW</constant></term>
+     <listitem>
+      <simpara>
+       Utilise le format de liste le plus étroit, avec une ponctuation minimale.
+      </simpara>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </section>
+
+  <section role="changelog" xml:id="intllistformatter.changelog">
+   &reftitle.changelog;
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>8.5.0</entry>
+       <entry>
+        La classe a été ajoutée.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </section>
+
+ </partintro>
+
+ &reference.intl.entities.intllistformatter;
+
+</reference>
+<!-- Keep this comment at the end of the file
+ Local variables:
+ mode: sgml
+ sgml-omittag:t
+ sgml-shorttag:t
+ sgml-minimize-attributes:nil
+ sgml-always-quote-attributes:t
+ sgml-indent-step:1
+ sgml-indent-data:t
+ indent-tabs-mode:nil
+ sgml-parent-document:nil
+ sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+ sgml-exposed-tags:nil
+ sgml-local-catalogs:nil
+ sgml-local-ecat-files:nil
+ End:
+ vim600: syn=xml fen fdm=syntax fdl=2 si
+ vim: et tw=78 syn=sgml
+ vi: ts=1 sw=1
+-->

--- a/reference/intl/intllistformatter/construct.xml
+++ b/reference/intl/intllistformatter/construct.xml
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: e1b9f588815a51682acf68f9b8929f49ad612488 Maintainer: lacatoire Status: ready -->
+<refentry xml:id="intllistformatter.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>IntlListFormatter::__construct</refname>
+  <refpurpose>Crée une nouvelle instance de IntlListFormatter</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <constructorsynopsis role="IntlListFormatter">
+   <modifier>public</modifier> <methodname>IntlListFormatter::__construct</methodname>
+   <methodparam><type>string</type><parameter>locale</parameter></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>type</parameter><initializer><constant>IntlListFormatter::TYPE_AND</constant></initializer></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>width</parameter><initializer><constant>IntlListFormatter::WIDTH_WIDE</constant></initializer></methodparam>
+  </constructorsynopsis>
+  <simpara>
+   Crée une nouvelle instance de <classname>IntlListFormatter</classname> pour les
+   paramètres régionaux fournis.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>locale</parameter></term>
+    <listitem>
+     <simpara>
+      Les paramètres régionaux à utiliser pour le formatage.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>type</parameter></term>
+    <listitem>
+     <simpara>
+      Le type de liste. Une des constantes <constant>IntlListFormatter::TYPE_<replaceable>*</replaceable></constant> :
+      <constant>IntlListFormatter::TYPE_AND</constant>,
+      <constant>IntlListFormatter::TYPE_OR</constant>, ou
+      <constant>IntlListFormatter::TYPE_UNITS</constant>.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>width</parameter></term>
+    <listitem>
+     <simpara>
+      La largeur de la liste. Une des constantes <constant>IntlListFormatter::WIDTH_<replaceable>*</replaceable></constant> :
+      <constant>IntlListFormatter::WIDTH_WIDE</constant>,
+      <constant>IntlListFormatter::WIDTH_SHORT</constant>, ou
+      <constant>IntlListFormatter::WIDTH_NARROW</constant>.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simpara>
+   Lance une <exceptionname>IntlException</exceptionname> si le formateur ne peut pas
+   être créé (par exemple, des paramètres régionaux invalides ou une version d'ICU
+   inférieure à 67).
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       La classe a été ajoutée.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>IntlListFormatter::format</methodname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/intl/intllistformatter/format.xml
+++ b/reference/intl/intllistformatter/format.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: e1b9f588815a51682acf68f9b8929f49ad612488 Maintainer: lacatoire Status: ready -->
+<refentry xml:id="intllistformatter.format" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>IntlListFormatter::format</refname>
+  <refpurpose>Formate une liste d'éléments</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="IntlListFormatter">
+   <modifier>public</modifier> <type class="union"><type>string</type><type>false</type></type><methodname>IntlListFormatter::format</methodname>
+   <methodparam><type>array</type><parameter>list</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Formate une liste d'éléments sous la forme d'une chaîne de caractères adaptée aux
+   paramètres régionaux.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>list</parameter></term>
+    <listitem>
+     <simpara>
+      Un tableau de chaînes de caractères à formater sous la forme d'une liste.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   La liste formatée sous la forme d'une chaîne de caractères, ou &false; en cas d'échec.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Exemple avec <methodname>IntlListFormatter::format</methodname></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$fmt = new IntlListFormatter('en_US', IntlListFormatter::TYPE_AND, IntlListFormatter::WIDTH_WIDE);
+echo $fmt->format(['one', 'two', 'three']);
+// one, two, and three
+
+$fmt = new IntlListFormatter('en_US', IntlListFormatter::TYPE_OR, IntlListFormatter::WIDTH_WIDE);
+echo $fmt->format(['one', 'two', 'three']);
+// one, two, or three
+?>
+]]>
+   </programlisting>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>IntlListFormatter::__construct</methodname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
Sync with php/doc-en@e1b9f588815a51682acf68f9b8929f49ad612488 (php/doc-en#5692).

Fixes: #3132