### PR TITLE
[Sync EN] ext/reflection: document ReflectionProperty::getMangledName() (PHP 8.5)

### DIFF
--- a/reference/reflection/reflectionproperty/getmangledname.xml
+++ b/reference/reflection/reflectionproperty/getmangledname.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 844a420240e6944d391d6ae022af239c4961ed04 Maintainer: lacatoire Status: ready -->
+<refentry xml:id="reflectionproperty.getmangledname" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>ReflectionProperty::getMangledName</refname>
+  <refpurpose>Récupère le nom décoré de la propriété</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="ReflectionProperty">
+   <modifier>public</modifier> <type>string</type><methodname>ReflectionProperty::getMangledName</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   Retourne le nom décoré (<literal>mangled</literal>, c'est-à-dire interne) de la
+   propriété, qui encode la portée de visibilité pour les propriétés privées et
+   protégées.
+  </simpara>
+  <simpara>
+   Pour les propriétés publiques, le nom décoré est identique au nom de la propriété.
+   Pour les propriétés protégées, le nom décoré est de la forme
+   <literal>\0*\0<replaceable>nom</replaceable></literal>.
+   Pour les propriétés privées, le nom décoré est de la forme
+   <literal>\0<replaceable>NomDeClasse</replaceable>\0<replaceable>nom</replaceable></literal>.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Le nom décoré de la propriété reflétée.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Cette méthode a été introduite.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>ReflectionProperty::getName</methodname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
Sync with php/doc-en@844a420240e6944d391d6ae022af239c4961ed04 (php/doc-en#5693).

Fixes: #3133