### PR TITLE
[Sync EN] features/commandline: clarify the Windows note for multiple workers

### DIFF
--- a/features/commandline.xml
+++ b/features/commandline.xml
@@ -1,12 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: b08b472de7041be8dbae153556b714efa93f20c0 Maintainer: lacatoire Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 07b2f1dcff1d8beb846f5671e5f4bf2ab8d33ebf Maintainer: lacatoire Status: ready -->
 
 <chapter xml:id="features.commandline" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Utiliser PHP en ligne de commande</title>
  <titleabbrev>Utilisation des lignes de commande</titleabbrev>
  
- <!--Introduction: {{{-->
  <section xml:id="features.commandline.introduction" annotations="chunk:false">
   <title>Introduction</title>
   
@@ -84,9 +82,7 @@
    </para>
   </note>
  </section>
- <!--}}}-->
- 
- <!--Differences: {{{-->
+
  <section xml:id="features.commandline.differences">
   <title>Différences avec les autres <acronym>SAPI</acronym>s</title>
   
@@ -327,9 +323,7 @@ $ php -f autre_dossier/test.php
    </itemizedlist>
   </para>
  </section>
- <!--}}}-->
- 
- <!--Options: {{{-->
+
  <section xml:id="features.commandline.options">
   <title>Options de ligne de commande</title>
   <titleabbrev>Options</titleabbrev>
@@ -1050,9 +1044,7 @@ date.sunrise_zenith => 90.583333 => 90.583333
    </para>
   </note>
  </section>
- <!--}}}-->
- 
- <!--Usage: {{{-->
+
  <section xml:id="features.commandline.usage">
   <title>Exécution de fichiers PHP</title>
   <titleabbrev>Utilisation</titleabbrev>
@@ -1337,9 +1329,7 @@ C'est une ligne de commande à une option.
   </note>
   
  </section>
- <!--}}}-->
- 
- <!--I/O Streams: {{{-->
+
  <section xml:id="features.commandline.io-streams">
   <title>Flux d'entrée/sortie</title>
   <titleabbrev>Flux I/O</titleabbrev>
@@ -1443,9 +1433,7 @@ php -r 'fwrite(STDERR, "stderr\n");'
    </para>
   </note>
  </section>
- <!--}}}-->
- 
- <!--Interactive shell: {{{-->
+
  <section xml:id="features.commandline.interactive">
   <title>Shell Interactif</title>
   
@@ -1664,9 +1652,7 @@ php >
    </para>
   </section>
  </section>
- <!--}}}-->
- 
- <!--Built-in CLI Web Server: {{{-->
+
  <section xml:id="features.commandline.webserver">
   <title>Serveur web interne</title>
   
@@ -1779,7 +1765,7 @@ php >
   </simpara>
   <note>
    <simpara>
-    Cette fonctionnalité n'est pas prise en charge sur Windows.
+    Les processus de travail multiples ne sont pas pris en charge sur Windows.
    </simpara>
   </note>
   <note>
@@ -1957,7 +1943,6 @@ $ php -S 0.0.0.0:8000
   </example>
   
  </section>
- <!--}}}-->
  
  <section xml:id="features.commandline.ini">
   <title>Configurations INI</title>


### PR DESCRIPTION
Port of php/doc-en 07b2f1dcff1d8beb846f5671e5f4bf2ab8d33ebf, plus the skeleton comments cleanup from c62ef37e0d.

Fixes: #3137