### PR TITLE
[Sync EN] exec: remove dead code in the example

### DIFF
--- a/reference/exec/functions/exec.xml
+++ b/reference/exec/functions/exec.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: b412bbd26214f7281ac7dd858710e09952a275f2 Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 462dddda87baa86fd760dcb1e3a0d2096e00a59b Maintainer: lacatoire Status: ready -->
 <refentry xml:id="function.exec" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>exec</refname>
@@ -127,10 +125,8 @@
 <?php
 // Affiche le nom d'utilisateur qui fait tourner le processus php/http
 // (sur un système ayant "whoami" dans le chemin d'exécutables)
-$output=null;
-$retval=null;
-exec('whoami', $output, $retval);
-echo "Returned with status $retval and output:\n";
+exec('whoami', $output, $result_code);
+echo "Returned with status $result_code and output:\n";
 print_r($output);
 ?>
 ]]>


### PR DESCRIPTION
Port of php/doc-en 462dddda87baa86fd760dcb1e3a0d2096e00a59b.

Fixes: #3141