### PR TITLE
[Sync EN] bookinfo: drop the removed frontpage entities

### DIFF
--- a/bookinfo.xml
+++ b/bookinfo.xml
@@ -1,13 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 7d2dd02b7bdd1f1c3becbe06444c354f5e6f0e34 Maintainer: lacatoire Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 75772fd985edd7dc6f94b067bd2ef3ab59511cb5 Maintainer: lacatoire Status: ready -->
 
 <info xmlns="http://docbook.org/ns/docbook" xml:id="bookinfo">
- &frontpage.authors;
  <pubdate><?dbtimestamp format="Y-m-d"?></pubdate>
- &frontpage.editors;
- 
+
  <authorgroup xml:id="translators">
   <author>
    <personname>
@@ -52,7 +48,7 @@
    </personname>
   </author>
  </authorgroup>
- 
+
  <authorgroup xml:id="translators.old">
   <author>
    <personname>
@@ -80,7 +76,7 @@
    </personname>
   </author>
  </authorgroup>
- 
+
  <legalnotice xml:id="copyright" xmlns:xlink="http://www.w3.org/1999/xlink">
   <info><title>Copyright</title></info>
   <simpara>


### PR DESCRIPTION
Port of php/doc-en 75772fd985edd7dc6f94b067bd2ef3ab59511cb5. The French translator authorgroups are kept.

Fixes: #3142