### PR TITLE
[Sync EN] Remove 72 unused entities from language-snippets.ent

### DIFF
--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: be246a268d0d5ab0b215c429cb031e70c98327ef Maintainer: lacatoire Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 9eb61e3573bc9af825caa0aba34932850aa1b666 Maintainer: lacatoire Status: ready -->
 <!-- Relecture des Notes, Précautions, Avertissements, Astuces, Divers et Retour le 2018-12-29 par girgias -->
 
 <!--
@@ -14,16 +13,6 @@ la version originale. Merci.
 <!-- Not used in EN anymore -->
 <!ENTITY changelog.randomseed '<row xmlns="http://docbook.org/ns/docbook"><entry>4.2.0</entry><entry>Le générateur
 de nombres aléatoires est initialisé automatiquement.</entry></row>'>
-
-<!ENTITY warn.deprecated.feature-5-3-0.removed-6-0-0 '<warning xmlns="http://docbook.org/ns/docbook"><simpara>
- Cette fonctionnalité est <emphasis>OBSOLÈTE</emphasis> à partir de PHP 5.3.0.
- Dépendre de cette fonctionnalité est fortement déconseillé.
-</simpara></warning>'>
-
-<!ENTITY warn.deprecated.function-5-3-0.removed-6-0-0 '<warning xmlns="http://docbook.org/ns/docbook"><simpara>
- Cette fonction est <emphasis>OBSOLÈTE</emphasis> à partir de PHP 5.3.0.
- Dépendre de cette fonction est fortement déconseillé.
-</simpara></warning>'>
 
 <!-- Cautions / Précautions -->
 <!ENTITY caution.cryptographically-insecure '<caution xmlns="http://docbook.org/ns/docbook">
@@ -124,12 +113,6 @@ de nombres aléatoires est initialisé automatiquement.</entry></row>'>
  Si les arguments sont passés par référence, toutes leurs modifications seront reflétées dans les valeurs
  retournées par cette fonction. À partir de PHP 7, les valeurs courantes seront aussi retournées si les arguments
  sont passés par leur valeur.
-</simpara></note>'>
-
-<!ENTITY note.funcnoparam '<note xmlns="http://docbook.org/ns/docbook"><simpara>
- Parce que cette fonction dépend de la portée courante pour déterminer les détails des paramètres, ils ne
- peuvent pas être utilisés en tant que paramètre d&apos;une fonction dans les versions de PHP antérieures à 5.3.0.
- Si cette valeur doit être passée, le résultat doit être assigné à une variable et cette variable doit être passée.
 </simpara></note>'>
 
 <!ENTITY note.func-named-params '<note xmlns="http://docbook.org/ns/docbook"><simpara>
@@ -288,24 +271,9 @@ de nombres aléatoires est initialisé automatiquement.</entry></row>'>
 <!ENTITY deprecated.function 'Cette fonction est obsolète.'>
 <!ENTITY removed.function 'Cette fonction a été supprimée.'>
 
-<!ENTITY warn.deprecated.feature-5-3-0 '<warning xmlns="http://docbook.org/ns/docbook"><simpara>
- Cette fonctionnalité est <emphasis>OBSOLÈTE</emphasis> à partir de PHP 5.3.0.
- Dépendre de cette fonctionnalité est fortement déconseillé.
-</simpara></warning>'>
-
 <!ENTITY warn.deprecated.feature-5-3-0.removed-5-4-0 '<warning xmlns="http://docbook.org/ns/docbook"><simpara>
  Cette fonctionnalité est <emphasis>OBSOLÈTE</emphasis> à partir de PHP 5.3.0 et a été
  <emphasis>SUPPRIMÉE</emphasis> à partir de PHP 5.4.0.
-</simpara></warning>'>
-
-<!ENTITY warn.deprecated.function-5-3-0.removed-5-4-0 '<warning xmlns="http://docbook.org/ns/docbook"><simpara>
- Cette fonction est <emphasis>OBSOLÈTE</emphasis> à partir de PHP 5.3.0 et a été
- <emphasis>SUPPRIMÉE</emphasis> à partir de PHP 5.4.0.
-</simpara></warning>'>
-
-<!ENTITY warn.deprecated.feature-5-5-0 '<warning xmlns="http://docbook.org/ns/docbook"><simpara>
- Cette fonctionnalité est <emphasis>OBSOLÈTE</emphasis> à partir de PHP 5.5.0.
- Dépendre de cette fonctionnalité est fortement déconseillé.
 </simpara></warning>'>
 
 <!ENTITY warn.deprecated.feature-5-6-0 '<warning xmlns="http://docbook.org/ns/docbook"><simpara>
@@ -313,19 +281,9 @@ de nombres aléatoires est initialisé automatiquement.</entry></row>'>
  Dépendre de cette fonctionnalité est fortement déconseillé.
 </simpara></warning>'>
 
-<!ENTITY warn.deprecated.feature-7-0-0 '<warning xmlns="http://docbook.org/ns/docbook"><simpara>
- Cette fonctionnalité est <emphasis>OBSOLÈTE</emphasis> à partir de PHP 7.0.0.
- Dépendre de cette fonctionnalité est fortement déconseillé.
-</simpara></warning>'>
-
 <!ENTITY warn.deprecated.feature-7-1-0 '<warning xmlns="http://docbook.org/ns/docbook"><simpara>
  Cette fonctionnalité est <emphasis>OBSOLÈTE</emphasis> à partir de PHP 7.1.0.
  Dépendre de cette fonctionnalité est fortement déconseillé.
-</simpara></warning>'>
-
-<!ENTITY warn.deprecated.function-7-1-0 '<warning xmlns="http://docbook.org/ns/docbook"><simpara>
- Cette fonction est <emphasis>OBSOLÈTE</emphasis> à partir de PHP 7.1.0.
- Dépendre de cette fonction est fortement déconseillé.
 </simpara></warning>'>
 
 <!ENTITY warn.deprecated.function-7-0-0.removed-8-0-0 '<warning xmlns="http://docbook.org/ns/docbook"><simpara>
@@ -351,11 +309,6 @@ de nombres aléatoires est initialisé automatiquement.</entry></row>'>
  Dépendre de cette fonctionnalité est fortement déconseillé.
 </simpara></warning>'>
 
-<!ENTITY warn.deprecated.function-7-2-0 '<warning xmlns="http://docbook.org/ns/docbook"><simpara>
- Cette fonction est <emphasis>OBSOLÈTE</emphasis> à partir de PHP 7.2.0.
- Dépendre de cette fonction est fortement déconseillé.
-</simpara></warning>'>
-
 <!ENTITY warn.deprecated.function-7-2-0.removed-8-0-0 '<warning xmlns="http://docbook.org/ns/docbook"><simpara>
  Cette fonctionnalité est <emphasis>OBSOLÈTE</emphasis> à partir de PHP 7.2.0 et a été
  <emphasis>SUPPRIMÉE</emphasis> à partir de PHP 8.0.0.
@@ -366,21 +319,11 @@ de nombres aléatoires est initialisé automatiquement.</entry></row>'>
  Dépendre de cette fonctionnalité est fortement déconseillé.
 </simpara></warning>'>
 
-<!ENTITY warn.deprecated.function-7-3-0 '<warning xmlns="http://docbook.org/ns/docbook"><simpara>
- Cette fonction est <emphasis>OBSOLÈTE</emphasis> à partir de PHP 7.3.0.
- Dépendre de cette fonction est fortement déconseillé.
-</simpara></warning>'>
-
 <!ENTITY warn.deprecated.function-7-3-0.removed-8-0-0 '<warning
 xmlns="http://docbook.org/ns/docbook"><simpara>
  Cette fonction est <emphasis>OBSOLÈTE</emphasis> à partir de PHP 7.3.0,
  et a été <emphasis>SUPPRIMÉE</emphasis> à partir de PHP 8.0.0.
  Dépendre de cette fonction est fortement déconseillé.
-</simpara></warning>'>
-
-<!ENTITY warn.deprecated.feature-7-4-0 '<warning xmlns="http://docbook.org/ns/docbook"><simpara>
- Cette fonctionnalité est <emphasis>OBSOLÈTE</emphasis> à partir de PHP 7.4.0.
- Dépendre de cette fonctionnalité est fortement déconseillé.
 </simpara></warning>'>
 
 <!ENTITY warn.deprecated.function-7-4-0 '<warning xmlns="http://docbook.org/ns/docbook"><simpara>
@@ -428,11 +371,6 @@ xmlns="http://docbook.org/ns/docbook"><simpara>Cette fonctionnalité est
  Dépendre de cette fonction est fortement déconseillé.
 </simpara></warning>'>
 
-<!ENTITY warn.deprecated.feature-8-4-0 '<warning xmlns="http://docbook.org/ns/docbook"><simpara>
- Cette fonctionnalité est <emphasis>OBSOLÈTE</emphasis> à partir de PHP 8.4.0.
- Dépendre de cette fonctionnalité est fortement déconseillé.
-</simpara></warning>'>
-
 <!ENTITY warn.deprecated.function-8-4-0 '<warning xmlns="http://docbook.org/ns/docbook"><simpara>
  Cette fonction est <emphasis>OBSOLÈTE</emphasis> à partir de PHP 8.4.0.
  Dépendre de cette fonction est fortement déconseillé.
@@ -451,61 +389,13 @@ xmlns="http://docbook.org/ns/docbook"><simpara>Cette fonctionnalité est
 <!ENTITY removed.php.future 'Cette fonctionnalité obsolète <emphasis xmlns="http://docbook.org/ns/docbook">sera</emphasis>
 certainement <emphasis xmlns="http://docbook.org/ns/docbook">supprimée</emphasis> dans le futur.'>
 
-<!ENTITY warn.deprecated.function.removed-5-3-0 '<warning xmlns="http://docbook.org/ns/docbook"><simpara>
- Cette fonction est <emphasis>OBSOLÈTE</emphasis> et a été <emphasis>SUPPRIMÉE</emphasis> à partir de PHP 5.3.0.
-</simpara></warning>'>
-
-<!ENTITY warn.deprecated.function.removed-5-5-0 '<warning xmlns="http://docbook.org/ns/docbook"><simpara>
- Cette fonction est <emphasis>OBSOLÈTE</emphasis>, et a été <emphasis>SUPPRIMÉE</emphasis> à partir de PHP 5.5.0.
-</simpara></warning>'>
-
-<!ENTITY warn.deprecated.alias-5-3-0 '<warning xmlns="http://docbook.org/ns/docbook"><simpara>
- Cet alias est <emphasis>OBSOLÈTE</emphasis> à partir de PHP 5.3.0.
- Dépendre de cet alias est fortement déconseillé.
-</simpara></warning>'>
-
-<!ENTITY warn.deprecated.func-5-4-0 '<warning xmlns="http://docbook.org/ns/docbook"><simpara>
- Cette fonction est <emphasis>OBSOLÈTE</emphasis> à partir de PHP 5.4.0.
- Dépendre de cette fonction est fortement déconseillé.
-</simpara></warning>'>
-
 <!ENTITY warn.deprecated.alias-5-4-0 '<warning xmlns="http://docbook.org/ns/docbook"><simpara>
  Cet alias est <emphasis>OBSOLÈTE</emphasis> à partir de PHP 5.4.0.
  Dépendre de cet alias est fortement déconseillé.
 </simpara></warning>'>
 
-<!ENTITY warn.deprecated.func-5-5-0 '<warning xmlns="http://docbook.org/ns/docbook"><simpara>
- Cette fonction est <emphasis>OBSOLÈTE</emphasis> à partir de PHP 5.5.0.
- Dépendre de cette fonction est fortement déconseillé.
-</simpara></warning>'>
-
-<!ENTITY warn.deprecated.feature-5-5-0.removed-7-0-0 '<warning xmlns="http://docbook.org/ns/docbook"><simpara>
- Cette fonctionnalité est <emphasis>OBSOLÈTE</emphasis> à partir de PHP 5.5.0 et a été
- <emphasis>SUPPRIMÉE</emphasis> à partir de PHP 7.0.0.
-</simpara></warning>'>
-
-<!ENTITY warn.deprecated.function-5-5-0.removed-7-0-0 '<warning xmlns="http://docbook.org/ns/docbook"><simpara>
- Cette fonction est <emphasis>OBSOLÈTE</emphasis> à partir de PHP 5.5.0 et a été
- <emphasis>SUPPRIMÉE</emphasis> à partir de PHP 7.0.0.
-</simpara></warning>'>
-
-<!ENTITY warn.deprecated.function-4-1-0.removed-7-0-0 '<warning xmlns="http://docbook.org/ns/docbook"><simpara>
- Cette fonction est <emphasis>OBSOLÈTE</emphasis> à partir de PHP 4.1.0 et a été
- <emphasis>SUPPRIMÉE</emphasis> à partir de PHP 7.0.0.
-</simpara></warning>'>
-
-<!ENTITY warn.deprecated.function-5-3-0.removed-7-0-0 '<warning xmlns="http://docbook.org/ns/docbook"><simpara>
- Cette fonction est <emphasis>OBSOLÈTE</emphasis> à partir de PHP 5.3.0 et a été
- <emphasis>SUPPRIMÉE</emphasis> à partir de PHP 7.0.0.
-</simpara></warning>'>
-
 <!ENTITY warn.deprecated.alias-5-3-0.removed-7-0-0 '<warning xmlns="http://docbook.org/ns/docbook"><simpara>
  Cet alias est <emphasis>OBSOLÈTE</emphasis> à partir de PHP 5.4.0. et a été
- <emphasis>SUPPRIMÉE</emphasis> à partir de PHP 7.0.0.
-</simpara></warning>'>
-
-<!ENTITY warn.deprecated.feature-5-6-0.removed-7-0-0 '<warning xmlns="http://docbook.org/ns/docbook"><simpara>
- Cette fonctionnalité est <emphasis>OBSOLÈTE</emphasis> à partir de PHP 5.6.0 et a été
  <emphasis>SUPPRIMÉE</emphasis> à partir de PHP 7.0.0.
 </simpara></warning>'>
 
@@ -572,14 +462,6 @@ xmlns="http://docbook.org/ns/docbook"><simpara>Cette fonctionnalité a été
  c&#39;est au développeur de détecter et supprimer l&#39;avertissement.
 </simpara></warning>'>
 
-<!ENTITY warn.undocumented.class '
-<warning xmlns="http://docbook.org/ns/docbook">
-<simpara>
- Cette classe est actuellement non documentée ; seule la liste de ses propriétés et de ses méthodes est disponible.
-</simpara>
-</warning>
-'>
-
 <!ENTITY warn.undocumented.func '
 <warning xmlns="http://docbook.org/ns/docbook">
 <simpara>
@@ -591,64 +473,6 @@ xmlns="http://docbook.org/ns/docbook"><simpara>Cette fonctionnalité a été
 <!-- Deprecation and removal warnings designed for use with a list of
     alternatives. See en/reference/regex/functions/ereg.xml and
     en/reference/regex/reference.xml for examples of these in action. -->
-
-<!ENTITY warn.deprecated.function.4-1-0.removed.7-0-0.alternatives '
-<simpara xmlns="http://docbook.org/ns/docbook">
- Cette fonction est <emphasis>OBSOLÈTE</emphasis> à partir de PHP 4.1.0 et a été
- <emphasis>SUPPRIMÉE</emphasis> à partir de PHP 7.0.0.
-</simpara>
-<simpara xmlns="http://docbook.org/ns/docbook">
- Les alternatives à cette fonction incluent :
-</simpara>
-'>
-
-<!ENTITY warn.deprecated.feature.5-3-0.removed.7-0-0.alternatives '
-<simpara xmlns="http://docbook.org/ns/docbook">
- Cette fonctionnalité est <emphasis>OBSOLÈTE</emphasis> à partir de PHP 5.3.0 et a été
- <emphasis>SUPPRIMÉE</emphasis> à partir de PHP 7.0.0.
-</simpara>
-<simpara xmlns="http://docbook.org/ns/docbook">
- Les alternatives à cette fonctionnalité incluent :
-</simpara>
-'>
-
-<!ENTITY warn.deprecated.function.5-3-0.removed.7-0-0.alternatives '
-<simpara xmlns="http://docbook.org/ns/docbook">
- Cette fonction est <emphasis>OBSOLÈTE</emphasis> à partir de PHP 5.3.0 et a été
- <emphasis>SUPPRIMÉE</emphasis> à partir de PHP 7.0.0.
-</simpara>
-<simpara xmlns="http://docbook.org/ns/docbook">
- Les alternatives à cette fonction incluent :
-</simpara>
-'>
-
-<!ENTITY warn.deprecated.function.5-5-0.removed.7-0-0.alternatives '
-<simpara xmlns="http://docbook.org/ns/docbook">
- Cette fonction est <emphasis>OBSOLÈTE</emphasis> à partir de PHP 5.5.0 et a été
- <emphasis>SUPPRIMÉE</emphasis> à partir de PHP 7.0.0.
-</simpara>
-<simpara xmlns="http://docbook.org/ns/docbook">
- Les alternatives à cette fonction incluent :
-</simpara>
-'>
-
-<!ENTITY warn.removed.feature.7-0-0.alternatives '
-<simpara xmlns="http://docbook.org/ns/docbook">
- Cette fonctionnalité a été <emphasis>SUPPRIMÉE</emphasis> à partir de PHP 7.0.0.
-</simpara>
-<simpara xmlns="http://docbook.org/ns/docbook">
- Les alternatives à cette fonctionnalité incluent :
-</simpara>
-'>
-
-<!ENTITY warn.removed.function.7-0-0.alternatives '
-<simpara xmlns="http://docbook.org/ns/docbook">
- Cette fonction a été <emphasis>SUPPRIMÉE</emphasis> à partir de PHP 7.0.0.
-</simpara>
-<simpara xmlns="http://docbook.org/ns/docbook">
- Les alternatives à cette fonction incluent :
-</simpara>
-'>
 
 <!ENTITY warn.deprecated.feature.7-1-0.removed.7-2-0.alternatives '
 <simpara xmlns="http://docbook.org/ns/docbook">
@@ -683,8 +507,6 @@ Il est fortement recommandé de les éviter.</simpara></warning>
 
 <!ENTITY version.exists.asof 'Existe à partir de PHP '>
 
-<!ENTITY version.trunk.changelog 'Futur'>
-
 <!ENTITY no.function.parameters '<simpara xmlns="http://docbook.org/ns/docbook">Cette fonction ne contient aucun paramètre.</simpara>'>
 
 <!ENTITY example.outputs '<simpara xmlns="http://docbook.org/ns/docbook">L&#39;exemple ci-dessus va afficher :</simpara>'>
@@ -704,8 +526,6 @@ Il est fortement recommandé de les éviter.</simpara></warning>
 <!ENTITY example.outputs.70 '<simpara xmlns="http://docbook.org/ns/docbook">Résultat de l&#39;exemple ci-dessus en PHP 7.0 :</simpara>'>
 
 <!ENTITY example.outputs.71 '<simpara xmlns="http://docbook.org/ns/docbook">Résultat de l&#39;exemple ci-dessus en PHP 7.1 :</simpara>'>
-
-<!ENTITY example.outputs.72 '<simpara xmlns="http://docbook.org/ns/docbook">Résultat de l&#39;exemple ci-dessus en PHP 7.2:</simpara>'>
 
 <!ENTITY example.outputs.73 '<simpara xmlns="http://docbook.org/ns/docbook">Résultat de l&#39;exemple ci-dessus en PHP 7.3 :</simpara>'>
 
@@ -730,8 +550,6 @@ Il est fortement recommandé de les éviter.</simpara></warning>
 
 <!ENTITY example.outputs.84.similar '<simpara xmlns="http://docbook.org/ns/docbook">La sortie de l&#39;exemple ci-dessus en PHP 8.4 est similaire à :</simpara>'>
 
-<!ENTITY example.outputs.85 '<simpara xmlns="http://docbook.org/ns/docbook">Sortie de l&#39;exemple ci-dessus en PHP 8.5&nbsp;:</simpara>'>
-
 <!ENTITY example.outputs.85.similar '<simpara xmlns="http://docbook.org/ns/docbook">La sortie de l&#39;exemple ci-dessus en PHP 8.5 est similaire à :</simpara>'>
 
 <!ENTITY example.outputs.32bit '<simpara xmlns="http://docbook.org/ns/docbook">Résultat de l&#39;exemple ci-dessus sur une machine 32 bits :</simpara>'>
@@ -741,10 +559,6 @@ Il est fortement recommandé de les éviter.</simpara></warning>
 <!ENTITY example.outputs.similar '<simpara xmlns="http://docbook.org/ns/docbook">Résultat de l&#39;exemple ci-dessus est similaire à :</simpara>'>
 
 <!ENTITY examples.outputs '<simpara xmlns="http://docbook.org/ns/docbook">Les exemples ci-dessus vont afficher :</simpara>'>
-
-<!ENTITY examples.outputs.32bit '<simpara xmlns="http://docbook.org/ns/docbook">Résultat des exemples ci-dessus sur une machine 32 bits :</simpara>'>
-
-<!ENTITY examples.outputs.64bit '<simpara xmlns="http://docbook.org/ns/docbook">Résultat des exemples ci-dessus sur une machine 64 bits :</simpara>'>
 
 <!ENTITY examples.outputs.similar '<simpara xmlns="http://docbook.org/ns/docbook">Les exemples ci-dessus vont afficher quelque chose de similaire à :</simpara>'>
 
@@ -866,10 +680,6 @@ l&#39;alias obsolète suivant peut être utilisé : '>
 <!ENTITY info.function.alias 'Cette fonction est un alias de : '>
 
 <!ENTITY info.method.alias 'Cette méthode est un alias de: '>
-
-<!ENTITY info.function.alias.deprecated '<simpara xmlns="http://docbook.org/ns/docbook">Cet alias est obsolète
-et n&#39;existe que pour des raisons de compatibilité. Il est recommandé
-de ne pas utiliser cette fonction car elle peut être supprimée dans une version future de PHP.</simpara>'>
 
 <!ENTITY ext.windows.path.dll 'Afin de faire fonctionner cette extension, quelques bibliothèques
 <acronym xmlns="http://docbook.org/ns/docbook">DLL</acronym> doivent être disponibles via le
@@ -999,21 +809,8 @@ de ce manuel pour une description des <literal xmlns="http://docbook.org/ns/docb
 </listitem>
 </varlistentry>'>
 
-<!ENTITY openssl.param.key '<varlistentry xmlns="http://docbook.org/ns/docbook">
-<term><parameter>key</parameter></term>
-<listitem>
-    <simpara>
-        Voir les <link linkend="openssl.certparams">paramètres clé publique/privé</link> pour obtenir une liste des valeurs valides.
-    </simpara>
-</listitem>
-</varlistentry>'>
-
 
 <!-- Image (GD) Notes -->
-<!ENTITY note.config.t1lib '<note xmlns="http://docbook.org/ns/docbook"><simpara>Cette fonction n&#39;est disponible
-    que si PHP est compilé en utilisant <option
-            role="configure">--enable-t1lib[=DIR]</option>.</simpara></note>'>
-
 <!ENTITY note.freetype '<note xmlns="http://docbook.org/ns/docbook"><simpara>Cette fonction n&#39;est disponible que si
     si PHP est compilé avec le support Freetype (<option role="configure">--with-freetype-dir=DIR</option>)
 </simpara></note>'>
@@ -1175,10 +972,6 @@ Utilisé avec la fonction <function>imageflip</function>, disponible à partir d
 Utilisé avec la fonction <function>imagesetinterpolation</function>, disponible à partir de PHP 5.5.0.
 </simpara>'>
 
-<!ENTITY gd.changlog.t1lib '<row xmlns="http://docbook.org/ns/docbook">
-<entry>7.0.0</entry><entry>La prise en charge de T1Lib a été supprimé de PHP, ainsi cette fonction a été supprimée.</entry>
-</row>'>
-
 <!ENTITY gd.deprecated.gd-formats '<warning xmlns="http://docbook.org/ns/docbook"><simpara>
 Les formats d&apos;image GD et GD2 sont des formats d&apos;images propriétaire de libgd.
 Ils doivent être considérés <emphasis>obsolète</emphasis>, et devraient seulement
@@ -1203,12 +996,6 @@ Ils doivent être considérés <emphasis>obsolète</emphasis>, et devraient seul
 </simpara></warning>'>
 
 <!-- DBM notes -->
-
-<!ENTITY dbm.dbm-identifier.description '<varlistentry xmlns="http://docbook.org/ns/docbook">
-<term><parameter>dbm_identifier</parameter></term><listitem><simpara>
- L&#39;identifiant de lien DBM, retourné par la fonction
- <function>dbmopen</function>.
-</simpara></listitem></varlistentry>'>
 
 <!-- JSON notes -->
 
@@ -1353,11 +1140,6 @@ Chaque champs est converti en type PHP approprié, sauf :
 </simpara></listitem></varlistentry>'>
 
 <!-- Deprecated -->
-<!ENTITY imap.imap-stream.description '<varlistentry xmlns="http://docbook.org/ns/docbook">
-<term><parameter>imap</parameter></term><listitem><simpara>
- Un flux IMAP retourné par la fonction <function>imap_open</function>.
-</simpara></listitem></varlistentry>'>
-
 <!ENTITY imap.pattern '<simpara xmlns="http://docbook.org/ns/docbook">Spécifie la position dans la hiérarchie des boîtes
 aux lettres, où il faut commencer à chercher.</simpara><simpara xmlns="http://docbook.org/ns/docbook">Il y a deux caractères
 spéciaux que vous pouvez utiliser dans <parameter>pattern</parameter> :
@@ -1532,10 +1314,6 @@ sera utilisé.</simpara>'>
 <!ENTITY mcrypt.parameter.cipher '<simpara xmlns="http://docbook.org/ns/docbook">Une constante parmi les constantes
 <constant>MCRYPT_ciphername</constant>, ou le nom de l&#39;algorithme, sous la forme d&#39;une chaîne de caractères.</simpara>'>
 
-<!ENTITY mcrypt.parameter.iv '<simpara xmlns="http://docbook.org/ns/docbook">Utilisé pour l&#39;initialisation des modes CBC, CFB, OFB,
-ainsi que dans quelques algorithmes du mode STREAM. Si vous ne fournissez pas un IV, alors que cela est nécessaire
-pour l&#39;algorithme, la fonction émettra une alerte et utilisera un IV dont tous les octets vaudront "<literal>\0</literal>".</simpara>'>
-
 <!ENTITY mcrypt.parameter.iv.strict '<simpara xmlns="http://docbook.org/ns/docbook">Utilisé pour l&#39;initialisation des modes CBC, CFB, OFB,
 ainsi que dans quelques algorithmes du mode STREAM. Si la taille de l&#39;IV fourni n&#39;est pas supporté par le mode d&#39;opération ou si vous ne fournissez pas d&#39;IV, mais que le mode d&#39;opération en requiert un, la fonction émettra un avertissement et retournera &false;.</simpara>'>
 
@@ -1543,11 +1321,6 @@ ainsi que dans quelques algorithmes du mode STREAM. Si la taille de l&#39;IV fou
 <constant>MCRYPT_MODE_modename</constant>, ou une des chaînes suivantes : "ecb", "cbc", "cfb", "ofb", "nofb" ou "stream".</simpara>'>
 
 <!-- MCVE notes -->
-
-<!ENTITY mcve.conn.description '<varlistentry xmlns="http://docbook.org/ns/docbook">
-<term><parameter>conn</parameter></term><listitem><simpara>
- Une ressource MCVE_CONN retournée par la fonction <function>m_initengine</function>.
-</simpara></listitem></varlistentry>'>
 
 <!-- memcached notes -->
 
@@ -1662,8 +1435,6 @@ RNP_LOAD_SAVE_<replaceable>*</replaceable></constant>.'>
 
 <!ENTITY gearman.parameter.workload 'Données sérialisées à analyser'>
 
-<!ENTITY gearman.parameter.data 'Données additionnelles nécessaires pour terminer le travail'>
-
 <!ENTITY gearman.parameter.context 'Contexte de l&#39;application à associer avec une tâche'>
 
 <!ENTITY gearman.parameter.unique 'Un identifiant unique utilisé pour identifier une tâche particulière'>
@@ -1751,12 +1522,6 @@ horaire  pour votre emplacement, tel que <literal>Asia/Shanghai</literal> ou
 <literal>Australia/Perth</literal> pour les exemples précédents.
 </simpara>'>
 
-<!ENTITY date.timezone.abbrev-volatile '<simpara xmlns="http://docbook.org/ns/docbook">
-Ces abréviations de fuseaux horaires doivent être considérées comme non pérennes, i.e.
-elles peuvent être différentes pour chaque version de la base de données des fuseaux
-horaires, et ne doivent donc pas être utilisées. Il est fortement recommandé de les éviter.
-</simpara>'>
-
 <!ENTITY date.timezone.errors.description '<simpara xmlns="http://docbook.org/ns/docbook">
 Chaque appel à une fonction date/heure générera un diagnostic de type
 <constant>E_WARNING</constant> si le fuseau horaire n&#39;est pas valide.
@@ -1789,10 +1554,7 @@ Voir aussi <function>date_default_timezone_set</function></simpara>'>
  retourné par <function>timezone_open</function>
 </simpara></listitem></varlistentry>'>
 
-<!ENTITY date.datetime.return.modifiedobjectorfalseforfailure 'Retourne l&#39;objet modifié <classname xmlns="http://docbook.org/ns/docbook">DateTime</classname> pour chainer les méthodes&return.falseforfailure;.'>
 <!ENTITY date.datetime.return.modifiedobject 'Retourne l&#39;objet modifié <classname xmlns="http://docbook.org/ns/docbook">DateTime</classname> pour chainer les méthodes.'>
-<!ENTITY date.datetimeimmutable.return.modifiedobjectorfalseforfailure 'Retourne un nouvel objet
- <classname xmlns="http://docbook.org/ns/docbook">DateTimeImmutable</classname> avec les données modifiées &return.falseforfailure;.'>
 <!ENTITY date.datetimeimmutable.return.modifiedobject 'Retourne un nouvel objet
  <classname xmlns="http://docbook.org/ns/docbook">DateTimeImmutable</classname> avec les données modifiées.'>
 
@@ -1809,8 +1571,6 @@ Voir aussi <function>date_default_timezone_set</function></simpara>'>
 <!ENTITY date.timezone.indian 'Indien'>
 <!ENTITY date.timezone.pacific 'Pacifique'>
 <!ENTITY date.timezone.others 'Autres'>
-<!ENTITY date.timezone.abbreviations 'Abréviations'>
-
 <!ENTITY date.formats 'Les formats valides sont expliqués dans la documentation sur les
 <link xmlns="http://docbook.org/ns/docbook" linkend="datetime.formats">formats Date et Heure</link>.'>
 <!ENTITY date.formats.parameter 'Une chaîne date/heure. &date.formats;'>
@@ -2085,8 +1845,6 @@ et <literal>"none"</literal> sont considérés comme &false;. <literal>"null"</l
 <!ENTITY gnupg.fingerprint '<simpara xmlns="http://docbook.org/ns/docbook">L&#39;empreinte de la clé.</simpara>'>
 
 <!-- HaruDoc -->
-<!ENTITY haru.error '<simpara xmlns="http://docbook.org/ns/docbook">Émet une exception <classname>HaruException</classname> en cas d&#39;erreur.</simpara>'>
-
 <!-- ODBC -->
 <!ENTITY odbc.connection.id '<simpara xmlns="http://docbook.org/ns/docbook">L&#39;objet de connexion ODBC,
 voir la documentation de la fonction <function>odbc_connect</function> pour plus
@@ -2345,10 +2103,6 @@ PHP, ou bien chargée au moment de l&#39;exécution.</simpara>'>
 toujours disponibles dans PHP.</simpara>'>
 
 <!-- Used in reference/$extname/classes.xml -->
-<!ENTITY extension.classes '<simpara xmlns="http://docbook.org/ns/docbook">Ces classes sont définies par cette
-extension, et elles ne seront disponibles que si cette extension a été compilée
-avec PHP, ou bien chargée dynamiquement.</simpara>'>
-
 <!-- PDO entities -->
 <!ENTITY pdo.driver-constants '<simpara xmlns="http://docbook.org/ns/docbook">Les constantes ci-dessous sont
 définies par ce pilote et seront seulement disponibles lorsque l&#39;extension
@@ -2378,8 +2132,6 @@ Lève une exception <classname>PDOException</classname> si l&#39;attribut <const
 <!-- PECL entities -->
 <!ENTITY pecl.moved 'Cette extension &link.pecl; n&#39;est pas intégrée à PHP.'>
 
-<!ENTITY pecl.bundled 'Cette extension &link.pecl; est intégrée à PHP.'>
-
 <!ENTITY pecl.info 'Des informations sur l&#39;installation de ces extensions PECL
         peuvent être trouvées dans le chapitre du manuel intitulé <link xmlns="http://docbook.org/ns/docbook" linkend="install.pecl">Installation
 des extensions PECL</link>. D&#39;autres informations comme les notes sur les nouvelles
@@ -2402,8 +2154,6 @@ des extensions PECL</link>. D&#39;autres informations comme les notes sur les no
 <!ENTITY pecl.windows.download.avail 'Les binaires Windows
         (les fichiers <acronym xmlns="http://docbook.org/ns/docbook">DLL</acronym>)
         pour cette extension <acronym xmlns="http://docbook.org/ns/docbook">PECL</acronym> sont disponibles sur le site web PECL.'>
-
-<!ENTITY pecl.windows.download.unbundled '&pecl.windows.download;'>
 
 <!ENTITY pecl.moved-ver 'Cette extension a été déplacée dans le module &link.pecl; et ne sera plus intégrée dans PHP à partir de PHP '>
 
@@ -2493,8 +2243,6 @@ dispose du support automatique de cette extension. Vous n&#39;avez pas à ajoute
 de bibliothèque supplémentaire pour disposer de ces fonctions.</simpara>'>
 
 <!-- These are here as helpers for manual consistency and brievety-->
-<!ENTITY safemode '<link xmlns="http://docbook.org/ns/docbook" linkend="ini.safe-mode">safe mode</link>'>
-
 <!ENTITY sqlsafemode '<link xmlns="http://docbook.org/ns/docbook" linkend="ini.sql.safe-mode">safe mode SQL</link>'>
 
 <!-- CTYPE Notes -->
@@ -2599,36 +2347,6 @@ est une alternative à l&#39;implémentation PHP FastCGI avec des fonctionnalit�
     objets.</simpara></note>'>
 
 <!-- SQLite Notes -->
-<!ENTITY sqlite.case-fold '<simpara xmlns="http://docbook.org/ns/docbook">Les noms de colonnes retournés par
-<constant>SQLITE_ASSOC</constant> et <constant>SQLITE_BOTH</constant>
-suivent les règles concernant la case définie par l&#39;option de configuration
-<link linkend="ini.sqlite.assoc-case">sqlite.assoc_case</link>.</simpara>'>
-
-<!ENTITY sqlite.decode-bin '<simpara xmlns="http://docbook.org/ns/docbook">Lorsque <parameter>decode_binary</parameter>
-vaut &true; (par défaut), PHP va décoder les données binaires, si elles ont été
-codées avec la fonction <function>sqlite_escape_string</function>.
-Vous allez généralement laisser cette valeur à sa valeur par défaut,
-à moins que vous ne travailliez avec des bases opérées par d&#39;autres
-applications.</simpara>'>
-
-<!ENTITY sqlite.no-unbuffered '<note xmlns="http://docbook.org/ns/docbook"><simpara>Cette fonction ne fonctionnera pas sur des
-    résultats non tamponné.</simpara></note>'>
-
-<!ENTITY sqlite.param-compat '<note xmlns="http://docbook.org/ns/docbook"><simpara>Deux syntaxes alternatives sont
-    supportées pour assurer la compatibilité avec les autres bases de données
-    (telles que MySQL) : la forme recommandée est la première, où le paramètre
-    <parameter>dbhandle</parameter> est le premier dans la fonction.</simpara></note>'>
-
-<!ENTITY sqlite.result-type '<simpara xmlns="http://docbook.org/ns/docbook">Le paramètre optionnel
-<parameter>result_type</parameter> accepte une constante et détermine comment
-le tableau retourné doit être indexé. L&#39;utilisation de
-<constant>SQLITE_ASSOC</constant> retournera uniquement un tableau associatif
-(nom des champs) tandis que <constant>SQLITE_NUM</constant> retournera un
-tableau indexé numériquement (numéro ordinal des champs).
-<constant>SQLITE_BOTH</constant> retournera des indices numériques et associatifs.
-<constant>SQLITE_BOTH</constant> est la valeur par défaut pour cette
-fonction.</simpara>'>
-
 <!-- Database Notes -->
 <!ENTITY database.field-case '<note xmlns="http://docbook.org/ns/docbook"><simpara>Les noms des champs retournés par
     cette fonction sont <emphasis>sensibles à la casse</emphasis>.</simpara></note>'>
@@ -2698,12 +2416,6 @@ en PHP 5.4.0, et la totalité de <link linkend="book.mysql">l&#39;extension orig
 <link linkend="ref.pdo-mysql">PDO_MySQL</link>. Voir aussi <link linkend="mysqlinfo.api.choosing">MySQL : choisir
     une API</link> du guide. Alternatives à cette fonction :</simpara>'>
 
-<!ENTITY mysql.alternative.note.5-5-0 '<simpara xmlns="http://docbook.org/ns/docbook">Cette fonction était obsolète
-en PHP 5.5.0, et la totalité de <link linkend="book.mysql">l&#39;extension original MySQL</link> a été supprimée en PHP 7.0.0.
-À la place, vous pouvez utiliser soit l&#39;extension <link linkend="book.mysqli">MySQLi</link>, soit l&#39;extension
-<link linkend="ref.pdo-mysql">PDO_MySQL</link>. Voir aussi <link linkend="mysqlinfo.api.choosing">MySQL : choisir
-    une API</link> du guide. Alternatives à cette fonction :</simpara>'>
-
 <!ENTITY mysql.close.connections.result.sets '<simpara xmlns="http://docbook.org/ns/docbook">
 Les connexions et les jeux de résultats ouverts de façon non persistantes sont automatiquement
 détruits lorsqu&#39;un script PHP termine son exécution. Aussi, le fait de fermer une connexion
@@ -2729,22 +2441,6 @@ défaut, mais vous pouvez changer cela en utilisant l&#39;argument
 
 <!-- Notes for tidy -->
 <!ENTITY tidy.object 'L&#39;objet <classname xmlns="http://docbook.org/ns/docbook">Tidy</classname>'>
-
-<!ENTITY tidy.conf-enc '<simpara xmlns="http://docbook.org/ns/docbook">Le paramètre <parameter>config</parameter> peut
-prendre la forme d&#39;un tableau ou d&#39;une chaîne de caractères. Sous forme
-de chaîne, il représente le nom du fichier de configuration et sinon, c&#39;est
-un tableau avec les options de configuration. Lisez <link xmlns:xlink="http://www.w3.org/1999/xlink"
-                                                          xlink:href="&url.tidy.conf;">&url.tidy.conf;</link> pour en savoir plus sur chaque
-option.</simpara>
-<simpara>Le paramètre <parameter>encoding</parameter> spécifie le jeu de caractères
-utilisé pour les documents en entrées et sorties. Les valeurs possibles de
-<parameter>encoding</parameter> sont :
-<literal>ascii</literal>, <literal>latin0</literal>, <literal>latin1</literal>,
-<literal>raw</literal>, <literal>utf8</literal>, <literal>iso2022</literal>,
-<literal>mac</literal>, <literal>win1252</literal>, <literal>ibm858</literal>,
-<literal>utf16</literal>, <literal>utf16le</literal>,
-<literal>utf16be</literal>, <literal>big5</literal> et
-<literal>shiftjis</literal>.</simpara>'>
 
 <!-- Snippets for the installation section -->
 <!ENTITY warn.apache2.compat '<warning xmlns="http://docbook.org/ns/docbook"><simpara>Nous ne recommandons pas
@@ -2870,10 +2566,6 @@ avec libfann &gt;= 2.2.</simpara></note>'>
 <!-- Imagick generic return types -->
 <!ENTITY imagick.return.success 'Retourne &true; en cas de succès.'>
 <!ENTITY imagick.imagick.throws 'Lance une exception <classname xmlns="http://docbook.org/ns/docbook">ImagickException</classname> si une erreur survient.'>
-<!ENTITY imagick.imagickdraw.throws 'Lance une exception <classname xmlns="http://docbook.org/ns/docbook">ImagickDrawException</classname> si une erreur survient.'>
-<!ENTITY imagick.imagickpixel.throws 'Lance une exception <classname xmlns="http://docbook.org/ns/docbook">ImagickPixelException</classname> si une erreur survient.'>
-<!ENTITY imagick.imagickpixeliterator.throws 'Lance une exception <classname xmlns="http://docbook.org/ns/docbook">ImagickPixelIteratorException</classname> si une erreur survient.'>
-
 <!-- Imagick version infos -->
 <!ENTITY imagick.method.available.0x629 'Cette méthode n&#39;est disponible que si Imagick a été compilé avec ImageMagick version 6.2.9 ou supérieur.'>
 <!ENTITY imagick.method.available.0x631 'Cette méthode n&#39;est disponible que si Imagick a été compilé avec ImageMagick version 6.3.1 ou supérieur.'>
@@ -2883,14 +2575,10 @@ avec libfann &gt;= 2.2.</simpara></note>'>
 <!ENTITY imagick.method.available.0x638 'Cette méthode n&#39;est disponible que si Imagick a été compilé avec ImageMagick version 6.3.8 ou supérieur.'>
 <!ENTITY imagick.method.available.0x639 'Cette méthode n&#39;est disponible que si Imagick a été compilé avec ImageMagick version 6.3.9 ou supérieur.'>
 <!ENTITY imagick.method.available.0x640 'Cette méthode n&#39;est disponible que si Imagick a été compilé avec ImageMagick version 6.4.0 ou supérieur.'>
-<!ENTITY imagick.method.available.0x641 'Cette méthode n&#39;est disponible que si Imagick a été compilé avec ImageMagick version 6.4.1 ou supérieur.'>
-<!ENTITY imagick.method.available.0x642 'Cette méthode n&#39;est disponible que si Imagick a été compilé avec ImageMagick version 6.4.2 ou supérieur.'>
-<!ENTITY imagick.method.available.0x643 'Cette méthode n&#39;est disponible que si Imagick a été compilé avec ImageMagick version 6.4.3 ou supérieur.'>
 <!ENTITY imagick.method.available.0x644 'Cette méthode n&#39;est disponible que si Imagick a été compilé avec ImageMagick version 6.4.4 ou supérieur.'>
 <!ENTITY imagick.method.available.0x645 'Cette méthode n&#39;est disponible que si Imagick a été compilé avec ImageMagick version 6.4.5 ou supérieur.'>
 <!ENTITY imagick.method.available.0x647 'Cette méthode n&#39;est disponible que si Imagick a été compilé avec ImageMagick version 6.4.7 ou supérieur.'>
 <!ENTITY imagick.method.available.0x649 'Cette méthode n&#39;est disponible que si Imagick a été compilé avec ImageMagick version 6.4.9 ou supérieur.'>
-<!ENTITY imagick.method.available.0x653 'Cette méthode n&#39;est disponible que si Imagick a été compilé avec ImageMagick version 6.5.3 ou supérieur.'>
 <!ENTITY imagick.method.available.0x657 'Cette méthode n&#39;est disponible que si Imagick a été compilé avec ImageMagick version 6.5.7 ou supérieur.'>
 
 <!ENTITY imagick.method.not.available.0x700 'Cette méthode n&#39;est pas disponible si Imagick a été compilé avec ImageMagick version 7.0.0 ou supérieur.'>
@@ -3013,7 +2701,6 @@ Par défaut, le paramètre <parameter>notext</parameter> vaut &true;.
 <!ENTITY stream.bucket.return 'Cette fonction retourne désormais une instance de <classname>StreamBucket</classname> ; auparavant, une <classname>stdClass</classname> était retournée.'>
 
 <!-- Gmagick -->
-<!ENTITY gmagick.return.success 'Retourne &true; en cas de succès.'>
 <!ENTITY gmagick.gmagickexception.throw 'Émet une exception
 <classname xmlns="http://docbook.org/ns/docbook">GmagickException</classname> en cas d&#39;erreur.'>
 
@@ -3062,7 +2749,6 @@ Par défaut, le paramètre <parameter>notext</parameter> vaut &true;.
 
 <!-- Win32Service -->
 <!ENTITY win32service.false.error ', &false; if there is a problem with the parameters or a <link xmlns="http://docbook.org/ns/docbook" linkend="win32service.constants.errors">Win32 Error Code</link> on failure.'>
-<!ENTITY win32service.success.false.error 'Returns &true; on success&win32service.false.error;'>
 <!ENTITY win32service.noerror.false.error 'retournait <constant xmlns="http://docbook.org/ns/docbook">WIN32_NO_ERROR</constant> on success&win32service.false.error;'>
 
 <!-- SNMP -->
@@ -3218,7 +2904,6 @@ xmlns="http://docbook.org/ns/docbook"><simpara xmlns="http://docbook.org/ns/docb
 <!ENTITY trader.arg.fast.ma.type 'Type de moyenne mobile pour fast MA. Une constante de la série <link xmlns="http://docbook.org/ns/docbook" linkend="trader.constants">TRADER_MA_TYPE_*</link> doit être utilisée.'>
 <!ENTITY trader.arg.slow.ma.type 'Type de moyenne mobile pour slow MA. Une constante de la série <link xmlns="http://docbook.org/ns/docbook" linkend="trader.constants">TRADER_MA_TYPE_*</link> doit être utilisée.'>
 <!ENTITY trader.arg.fastd.ma.type 'Type de moyenne mobile pour Fast-D. Une constante de la série <link xmlns="http://docbook.org/ns/docbook" linkend="trader.constants">TRADER_MA_TYPE_*</link> doit être utilisée.'>
-<!ENTITY trader.arg.fastk.ma.type 'Type de moyenne mobile pour Fast-K. Une constante de la série <link xmlns="http://docbook.org/ns/docbook" linkend="trader.constants">TRADER_MA_TYPE_*</link> doit être utilisée.'>
 <!ENTITY trader.arg.slowd.ma.type 'Type de moyenne mobile pour Slow-D. Une constante de la série <link xmlns="http://docbook.org/ns/docbook" linkend="trader.constants">TRADER_MA_TYPE_*</link> doit être utilisée.'>
 <!ENTITY trader.arg.slowk.ma.type 'Type de moyenne mobile pour Slow-K. Une constante de la série <link xmlns="http://docbook.org/ns/docbook" linkend="trader.constants">TRADER_MA_TYPE_*</link> doit être utilisée.'>
 <!ENTITY trader.arg.signal.ma.type 'Type de moyenne mobile pour la ligne du signal. Une constante de la série <link xmlns="http://docbook.org/ns/docbook" linkend="trader.constants">TRADER_MA_TYPE_*</link> doit être utilisée.'>
@@ -3971,8 +3656,6 @@ local: {
 '>
 
 <!-- Not used in EN anymore -->
-<!ENTITY mongodb.note.queryable-encryption-preview ''>
-
 <!ENTITY mongodb.note.decimal128 '
 <note xmlns="http://docbook.org/ns/docbook">
 <simpara>
@@ -4701,17 +4384,6 @@ a été définie de façon incorrecte pour l&#39;entrée fournie.
  </entry>
 </row>'>
 
-<!ENTITY strings.changelog.encoding '
-<row xmlns="http://docbook.org/ns/docbook">
-<entry>5.6.0</entry>
-<entry>
-    La valeur par défaut pour le paramètre <parameter>encoding</parameter>
-    a été modifiée pour être la valeur de l&#39;option de configuration
-    <link linkend="ini.default-charset">default_charset</link>.
-</entry>
-</row>
-'>
-
 <!ENTITY strings.changelog.ascii-case-conversion '
  <row xmlns="http://docbook.org/ns/docbook">
   <entry>8.2.0</entry>
@@ -4880,26 +4552,6 @@ Antérieur à PHP 8.0.0, &false; était retourné et un <constant>E_WARNING</con
 
 <!-- filter snippets -->
 <!-- TODO: Remove -->
-<!ENTITY filter.param.filter '
-<varlistentry xmlns="http://docbook.org/ns/docbook">
-<term><parameter>filter</parameter></term>
-<listitem>
-    <simpara>
-     Le filtre à appliquer.  
-     Peut être un filtre de validation en utilisant l&apos;une des constantes  
-     <constant>FILTER_VALIDATE_<replaceable>*</replaceable></constant>, un filtre de  
-     nettoyage en utilisant l&apos;une des constantes  
-     <constant>FILTER_SANITIZE_<replaceable>*</replaceable></constant> ou <constant>FILTER_UNSAFE_RAW</constant>,  
-     ou encore un filtre personnalisé en utilisant <constant>FILTER_CALLBACK</constant>.
-    </simpara>
-    <simpara>
-     La valeur par défaut est <constant>FILTER_DEFAULT</constant>,  
-     qui est un alias de <constant>FILTER_UNSAFE_RAW</constant>.
-    </simpara>
-</listitem>
-</varlistentry>
-'>
-
 <!-- csprng snippets -->
 <!ENTITY csprng.sources '
 <simpara xmlns="http://docbook.org/ns/docbook">


### PR DESCRIPTION
Port of php/doc-en 9eb61e3573bc9af825caa0aba34932850aa1b666. None of the removed entities is referenced anywhere in doc-fr.

Fixes: #3143