### PR TITLE
[Sync EN] Fix broken examples in snmp2_getnext and SOAP pages

### DIFF
--- a/reference/snmp/functions/snmp2-getnext.xml
+++ b/reference/snmp/functions/snmp2-getnext.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 40906725410aac6fe8cac4913a557a1784bf04b9 Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 84534c795fc64cc1866ae267fec3574249ec5f74 Maintainer: lacatoire Status: ready -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.snmp2-getnext">
  <refnamediv>
   <refname>snmp2_getnext</refname>
@@ -19,7 +18,7 @@
    <methodparam choice="opt"><type>int</type><parameter>retries</parameter><initializer>-1</initializer></methodparam>
   </methodsynopsis>
   <simpara>
-   La fonction <function>snmp2_get_next</function> est utilisée pour lire
+   La fonction <function>snmp2_getnext</function> est utilisée pour lire
    la valeur de l'objet <acronym>SNMP</acronym> qui suit immédiatement
    l'objet <parameter>object_id</parameter> spécifié.
   </simpara>
@@ -86,11 +85,11 @@
  <refsect1 role="examples">
   &reftitle.examples;
   <example>
-   <title>Exemple avec <function>snmp2_get_next</function></title>
+   <title>Exemple avec <function>snmp2_getnext</function></title>
    <programlisting role="php">
 <![CDATA[
 <?php
-$nameOfSecondInterface = snmp2_get_next('localhost', 'public', 'IF-MIB::ifName.1');
+$nameOfSecondInterface = snmp2_getnext('localhost', 'public', 'IF-MIB::ifName.1');
 ?>
 ]]>
    </programlisting>

--- a/reference/soap/soapclient/getlastrequestheaders.xml
+++ b/reference/soap/soapclient/getlastrequestheaders.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: fe4e8b87d18f17394e7177917c498774b062448c Maintainer: jpauli Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 84534c795fc64cc1866ae267fec3574249ec5f74 Maintainer: lacatoire Status: ready -->
 <refentry xml:id="soapclient.getlastrequestheaders" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>SoapClient::__getLastRequestHeaders</refname>
@@ -45,7 +44,7 @@
     <programlisting role="php">
 <![CDATA[
 <?php
-$client = SoapClient("some.wsdl", array('trace' => 1));
+$client = new SoapClient("some.wsdl", array('trace' => 1));
 $result = $client->SomeFunction();
 echo "REQUEST HEADERS:\n" . $client->__getLastRequestHeaders() . "\n";
 ?>

--- a/reference/soap/soapclient/getlastresponse.xml
+++ b/reference/soap/soapclient/getlastresponse.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: fe4e8b87d18f17394e7177917c498774b062448c Maintainer: jpauli Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 84534c795fc64cc1866ae267fec3574249ec5f74 Maintainer: lacatoire Status: ready -->
 <refentry xml:id="soapclient.getlastresponse" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>SoapClient::__getLastResponse</refname>
@@ -45,7 +44,7 @@
     <programlisting role="php">
 <![CDATA[
 <?php
-$client = SoapClient("some.wsdl", array('trace' => 1));
+$client = new SoapClient("some.wsdl", array('trace' => 1));
 $result = $client->SomeFunction();
 echo "Response:\n" . $client->__getLastResponse() . "\n";
 ?>

--- a/reference/soap/soapclient/getlastresponseheaders.xml
+++ b/reference/soap/soapclient/getlastresponseheaders.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: fe4e8b87d18f17394e7177917c498774b062448c Maintainer: jpauli Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 84534c795fc64cc1866ae267fec3574249ec5f74 Maintainer: lacatoire Status: ready -->
 <refentry xml:id="soapclient.getlastresponseheaders" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>SoapClient::__getLastResponseHeaders</refname>
@@ -45,7 +44,7 @@
     <programlisting role="php">
 <![CDATA[
 <?php
-$client = SoapClient("some.wsdl", array('trace' => 1));
+$client = new SoapClient("some.wsdl", array('trace' => 1));
 $result = $client->SomeFunction();
 echo "RESPONSE HEADERS:\n" . $client->__getLastResponseHeaders() . "\n";
 ?>

--- a/reference/soap/soapserver/getlastresponse.xml
+++ b/reference/soap/soapserver/getlastresponse.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 7e1f81cbbe7613ce7bbe65cc93c45fae38e0942b Maintainer: Fan2Shrek Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 84534c795fc64cc1866ae267fec3574249ec5f74 Maintainer: lacatoire Status: ready -->
 <refentry xml:id="soapserver.getlastresponse" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>SoapServer::__getLastResponse</refname>
@@ -43,7 +42,7 @@
    <programlisting role="php">
 <![CDATA[
 <?php
-$server = SoapServer("some.wsdl", ["trace" => 1]);
+$server = new SoapServer("some.wsdl", ["trace" => 1]);
 $server->handle();
 echo "Response:\n" . $server->__getLastResponse() . "\n";
 ?>


### PR DESCRIPTION
Port of php/doc-en 84534c795fc64cc1866ae267fec3574249ec5f74.

Fixes: #3144