### PR TITLE
[Sync EN] Fix intl_get_error_message() example

### DIFF
--- a/reference/intl/functions/intl-get-error-message.xml
+++ b/reference/intl/functions/intl-get-error-message.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: fed3682684f1af372dc9a7f15d0468e5a884ab16 Maintainer: dams Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: d5e705df751e5d590449c2f910be5753896a7722 Maintainer: lacatoire Status: ready -->
 
 <refentry xml:id="function.intl-get-error-message">
  <refnamediv>
@@ -36,20 +34,30 @@
 
  <refsect1 role="examples">
   &reftitle.examples;
-  <para>
-   <example>
-    <title>Exemple avec <function>intl_get_error_message</function></title>
-    <programlisting role="php">
+  <example>
+   <title>Exemple avec <function>intl_get_error_message</function></title>
+   <programlisting role="php">
 <![CDATA[
 <?php
-if( Collator::getAvailableLocales() === false ) {
-    show_error( intl_get_error_message() );
+
+$bundle = resourcebundle_create('en_US', __DIR__ . '/nexiste-pas', false);
+
+if ($bundle === null) {
+    $errorCode = intl_get_error_code();
+
+    printf("Nom de l'erreur : %s\n", intl_error_name($errorCode));
+    printf("Message d'erreur : %s\n", intl_get_error_message());
 }
-?>
 ]]>
-    </programlisting>
-   </example>
-  </para>
+   </programlisting>
+  </example>
+  &example.outputs;
+  <screen>
+<![CDATA[
+Nom de l'erreur : U_MISSING_RESOURCE_ERROR
+Message d'erreur : resourcebundle_create(): Cannot load libICU resource bundle: U_MISSING_RESOURCE_ERROR
+]]>
+  </screen>
  </refsect1>
 
  <refsect1 role="seealso">


### PR DESCRIPTION
Port of php/doc-en d5e705df751e5d590449c2f910be5753896a7722.

Fixes: #3147