### PR TITLE
[Sync EN] shell_exec: note that the backtick operator is deprecated

### DIFF
--- a/reference/exec/functions/shell-exec.xml
+++ b/reference/exec/functions/shell-exec.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 7973fd533364af4dd6282ca9e7bee2dffec39b1c Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 81593f08db3320d5366bf925c8561f097a9d69ad Maintainer: lacatoire Status: ready -->
 <refentry xml:id="function.shell-exec" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>shell_exec</refname>
@@ -16,10 +14,10 @@
    <type class="union"><type>string</type><type>false</type><type>null</type></type><methodname>shell_exec</methodname>
    <methodparam><type>string</type><parameter>command</parameter></methodparam>
   </methodsynopsis>
-  <para>
-   <function>shell_exec</function> est identique aux 
-   <link linkend="language.operators.execution">guillemets obliques</link>.
-  </para>
+  <simpara>
+   <function>shell_exec</function> est identique aux
+   <link linkend="language.operators.execution">guillemets obliques</link>, désormais obsolètes.
+  </simpara>
   <note>
    <para>
     Sur Windows, le tube sous-jacent est ouvert en mode texte, ce qui peut


### PR DESCRIPTION
Port of php/doc-en 81593f08db3320d5366bf925c8561f097a9d69ad.

Fixes: #3151