### PR TITLE
[Sync EN] ext/session: add PHP 8.4 deprecation notices for session directives

### DIFF
--- a/reference/session/ini.xml
+++ b/reference/session/ini.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 7f1b75ed358430c1db0e37c832d2926735d5f5c2 Maintainer: yannick Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 7fabff299de8a894888e8064797ed3278f50b356 Maintainer: lacatoire Status: ready -->
 
 <section xml:id="session.configuration" xmlns="http://docbook.org/ns/docbook">
  &reftitle.runtime;
@@ -118,13 +117,13 @@
       <entry><link linkend="ini.session.use-only-cookies">session.use_only_cookies</link></entry>
       <entry>"1"</entry>
       <entry><constant>INI_ALL</constant></entry>
-      <entry></entry>
+      <entry>Désactiver ce réglage est obsolète à partir de PHP 8.4.0.</entry>
      </row>
      <row>
       <entry><link linkend="ini.session.referer-check">session.referer_check</link></entry>
       <entry>""</entry>
       <entry><constant>INI_ALL</constant></entry>
-      <entry></entry>
+      <entry>Définir une valeur non vide est obsolète à partir de PHP 8.4.0.</entry>
      </row>
      <row>
       <entry><link linkend="ini.session.cache-limiter">session.cache_limiter</link></entry>
@@ -142,20 +141,25 @@
       <entry><link linkend="ini.session.use-trans-sid">session.use_trans_sid</link></entry>
       <entry>"0"</entry>
       <entry><constant>INI_ALL</constant></entry>
-      <entry>
-      </entry>
+      <entry>Activer ce réglage est obsolète à partir de PHP 8.4.0.</entry>
      </row>
      <row>
       <entry><link linkend="ini.session.trans-sid-tags">session.trans_sid_tags</link></entry>
       <entry>"a=href,area=href,frame=src,form="</entry>
       <entry><constant>INI_ALL</constant></entry>
-      <entry>&php.version.added; 7.1.0.</entry>
+      <entry>
+       &php.version.added; 7.1.0.
+       Modifier ce réglage est obsolète à partir de PHP 8.4.0.
+      </entry>
      </row>
      <row>
       <entry><link linkend="ini.session.trans-sid-hosts">session.trans_sid_hosts</link></entry>
       <entry><literal>$_SERVER['HTTP_HOST']</literal></entry>
       <entry><constant>INI_ALL</constant></entry>
-      <entry>&php.version.added; 7.1.0.</entry>
+      <entry>
+       &php.version.added; 7.1.0.
+       Définir une valeur non vide est obsolète à partir de PHP 8.4.0.
+      </entry>
      </row>
      <row>
       <entry><link linkend="ini.session.sid-length">session.sid_length</link></entry>
@@ -461,6 +465,12 @@
       été trouvée, l'identifiant de session sera considéré comme invalide.
       Par défaut, cette option est une chaîne vide.
      </simpara>
+     <warning>
+      <simpara>
+       Définir <literal>session.referer_check</literal> à une valeur non vide
+       est obsolète à partir de PHP 8.4.0.
+      </simpara>
+     </warning>
     </listitem>
    </varlistentry>
 
@@ -579,6 +589,12 @@
       identifiants de sessions dans les URL.
       Par défaut, vaut <literal>1</literal> (activé).
      </simpara>
+     <warning>
+      <simpara>
+       Désactiver <literal>session.use_only_cookies</literal> est obsolète
+       à partir de PHP 8.4.0.
+      </simpara>
+     </warning>
     </listitem>
    </varlistentry>
 
@@ -737,6 +753,12 @@
       Spécifie si le support du SID est transparent ou pas. Par défaut vaut &zero;
       (désactivé).
      </simpara>
+     <warning>
+      <simpara>
+       Activer <literal>session.use_trans_sid</literal> est obsolète
+       à partir de PHP 8.4.0.
+      </simpara>
+     </warning>
      <note>
       <simpara>
        Le système de gestion des sessions par URL pose un risque
@@ -765,13 +787,19 @@
       <literal>session.trans_sid_tags</literal> spécifie les balises HTML qui
       sont réécrites pour inclure l'ID de session lorsque le support du SID
       transparent est activé. Par défaut
-      <literal>a=href,area=href,frame=src,input=src,form=</literal>
+      <literal>a=href,area=href,frame=src,form=</literal>
      </simpara>
      <simpara>
       <literal>form</literal> est une balise spéciale. La variable de formulaire
       <literal>&lt;input hidden="session_id" name="session_name"&gt;</literal>
       est ajoutée.
      </simpara>
+     <warning>
+      <simpara>
+       Modifier <literal>session.trans_sid_tags</literal> par rapport à sa
+       valeur par défaut est obsolète à partir de PHP 8.4.0.
+      </simpara>
+     </warning>
      <note>
       <simpara>
        Antérieur à PHP 7.1.0, <link linkend="ini.url-rewriter.tags">url_rewriter.tags</link>
@@ -797,6 +825,12 @@
       entre les hôtes. Par exemple :
       <literal>php.net,wiki.php.net,bugs.php.net</literal>
      </simpara>
+     <warning>
+      <simpara>
+       Définir <literal>session.trans_sid_hosts</literal> à une valeur non
+       vide est obsolète à partir de PHP 8.4.0.
+      </simpara>
+     </warning>
     </listitem>
    </varlistentry>
 


### PR DESCRIPTION
Port of php/doc-en 7fabff299de8a894888e8064797ed3278f50b356.

Fixes: #3152