### PR TITLE
[Sync EN] Add note that the mssql_query() example uses a removed extension

### DIFF
--- a/security/database.xml
+++ b/security/database.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 7204e2dbb9b484c8b67bb5ad4a93fa1369c5b317 Maintainer: lacatoire Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 0009ebd09f938e8f066779bb9bb774baed10bd8a Maintainer: lacatoire Status: ready -->
 
 <chapter xml:id="security.database" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Sécurité des bases de données</title>
@@ -338,6 +336,17 @@ $result = mssql_query($query);
    service MSSQLSERVER disposait d'un niveau de droits suffisant, le pirate
    disposerait désormais d'un compte avec accès au serveur.
    </para>
+   <note>
+    <simpara>
+     La fonction <function>mssql_query</function> appartenait à l'extension
+     <literal>mssql</literal>, qui a été
+     <link linkend="migration70.removed-exts-sapis">supprimée en PHP 7.0.0</link>.
+     Elle n'est utilisée ici que pour illustrer l'attaque ; le code actuel se
+     connectant à MSSQL Server devrait utiliser les extensions
+     <link linkend="book.sqlsrv">sqlsrv</link> ou
+     <link linkend="ref.pdo-sqlsrv">pdo_sqlsrv</link> à la place.
+    </simpara>
+   </note>
    <note>
     <para>
      Certains exemples ci-dessus sont spécifiques à certains serveurs de


### PR DESCRIPTION
Port of php/doc-en 0009ebd09f938e8f066779bb9bb774baed10bd8a.

Fixes: #3155