### PR TITLE
[Sync EN] Fix reference to non-existent "example three"

### DIFF
--- a/language/basic-syntax.xml
+++ b/language/basic-syntax.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: ee1ce6a0e1875b6851274f8c373ca2bd48630fa0 Maintainer: lacatoire Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: fa67e21421448a20fe701a20897c30f93072e64b Maintainer: lacatoire Status: ready -->
 <!-- CREDITS: DavidA -->
 
 <chapter xml:id="language.basic-syntax" xmlns="http://docbook.org/ns/docbook" annotations="interactive">
@@ -41,13 +40,13 @@
     </programlisting>
    </example>
   </para>
-  <para>
-   Les balises courtes (troisième exemple) sont disponibles par défaut,
-   mais peuvent être désactivées soit via l'option
+  <simpara>
+   Les balises courtes (la troisième ligne de l'exemple ci-dessus) sont disponibles
+   par défaut, mais peuvent être désactivées soit via l'option
    <link linkend="ini.short-open-tag">short_open_tag</link>
    du fichier de configuration &php.ini;, ou sont désactivées par défaut si PHP
    est compilé avec l'option <option>--disable-short-tags</option>.
-  </para>
+  </simpara>
   <para>
    <note>
     <para>


### PR DESCRIPTION
Port of php/doc-en fa67e21421448a20fe701a20897c30f93072e64b.

Fixes: #3157