### PR TITLE
[Sync EN] Fix incorrect claim that opcache_invalidate() skips the file cache

### DIFF
--- a/reference/opcache/functions/opcache-invalidate.xml
+++ b/reference/opcache/functions/opcache-invalidate.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 87d6bb1bbd5f118f5b0cf0160438f06c0f91ea45 Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 82cdc19b6292e0f840e6b22ca430105d9f0aa89e Maintainer: lacatoire Status: ready -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.opcache-invalidate">
  <refnamediv>
   <refname>opcache_invalidate</refname>
@@ -20,7 +18,9 @@
    Si le paramètre <parameter>force</parameter> n'est pas défini ou vaut &false;,
    le script ne sera invalidé que si la date/heure de modification du script
    est plus récente que l'opcode en cache.
-   Cette fonction n'invalide que le cache en mémoire et non le cache fichier.
+   Si la directive <link linkend="ini.opcache.file-cache">opcache.file_cache</link>
+   est activée, cette fonction invalide également l'entrée correspondante
+   du cache fichier.
   </simpara>
  </refsect1>
 


### PR DESCRIPTION
Port of php/doc-en 82cdc19b6292e0f840e6b22ca430105d9f0aa89e.

Fixes: #3159