### PR TITLE
[Sync EN] Print minutes as minutes in the date_sun_info() length of day example

### DIFF
--- a/reference/datetime/functions/date-sun-info.xml
+++ b/reference/datetime/functions/date-sun-info.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: Fan2Shrek Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 631587d37135c0bfd7a4f30e37f33e2fb213dc2f Maintainer: lacatoire Status: ready -->
 <refentry xml:id="function.date-sun-info" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>date_sun_info</refname>
@@ -278,13 +277,13 @@ $si = date_sun_info(strtotime('2022-08-26'), 50.45, 30.52);
 $diff = $si['sunset'] - $si['sunrise'];
 echo "Durée du jour: ",
     floor($diff / 3600), "h ",
-    floor(($diff % 3600) / 60), "s\n";
+    floor(($diff % 3600) / 60), "m\n";
 ]]>
     </programlisting>
     &example.outputs;
     <screen>
 <![CDATA[
-Durée du jour: 13h 56s
+Durée du jour: 13h 53m
 ]]>
     </screen>
    </example>


### PR DESCRIPTION
Port of php/doc-en 631587d37135c0bfd7a4f30e37f33e2fb213dc2f, including the screen fix from 17c2385178 that precedes it on this file.

Fixes: #3162