### PR TITLE
[Sync EN] Fix grammar in strings functions

### DIFF
--- a/reference/strings/functions/crypt.xml
+++ b/reference/strings/functions/crypt.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: d76a7fe17dd2488e47d664a8ab38e161b13ac843 Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 46efd980535e8de6f6639a0015d2ad1e4bfe9d00 Maintainer: lacatoire Status: ready -->
 <refentry xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://docbook.org/ns/docbook" xml:id="function.crypt">
  <refnamediv>
   <refname>crypt</refname>
@@ -42,14 +40,14 @@
    passe hachés existants. L'utilisation de la fonction
    <function>password_hash</function> est fortement encouragée.
   </para>
-  <para>
+  <simpara>
    Le type de hash est déclenché par l'argument salt.
-   Si aucun salt n'est fourni, PHP va en générer deux caractères (DES), à moins que le
-   système par défaut soit MD5, auquel cas un salt
-   compatible MD5 sera généré. PHP définit une constante appelée
+   Si aucun salt n'est fourni, PHP génère automatiquement soit un salt standard
+   de deux caractères (DES), soit un salt de douze caractères (MD5), selon la
+   disponibilité de crypt() MD5. PHP définit une constante appelée
    <constant>CRYPT_SALT_LENGTH</constant> permettant d'indiquer la longueur
    du salt disponible pour le système de hachage utilisé.
-  </para>
+  </simpara>
   <para>
    <function>crypt</function>, lorsqu'elle est utilisée avec
    le chiffrement standard DES, retourne le salt

--- a/reference/strings/functions/get-html-translation-table.xml
+++ b/reference/strings/functions/get-html-translation-table.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: eabde0419cf90f596f60db00e31fcb6ebe41ac55 Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 46efd980535e8de6f6639a0015d2ad1e4bfe9d00 Maintainer: lacatoire Status: ready -->
 <refentry xml:id="function.get-html-translation-table" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>get_html_translation_table</refname>
@@ -22,14 +21,14 @@
    <function>htmlentities</function>.
   </para>
   <note>
-   <para>
+   <simpara>
     Les caractères spéciaux peuvent être encodés de différentes façons. Par exemple,
     <literal>"</literal> peut être encodé comme <literal>&amp;quot;</literal>,
-    <literal>&amp;#34;</literal> ou <literal>&amp;#x22</literal>.
+    <literal>&amp;#34;</literal> ou <literal>&amp;#x22;</literal>.
     <function>get_html_translation_table</function> retourne
     uniquement la forme utilisée par <function>htmlspecialchars</function> et
     <function>htmlentities</function>.
-   </para>
+   </simpara>
   </note>
  </refsect1>
  

--- a/reference/strings/functions/localeconv.xml
+++ b/reference/strings/functions/localeconv.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 715a125af5a86f0e6d6d5aa6cfa9c45257a433ac Maintainer: yannick Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 46efd980535e8de6f6639a0015d2ad1e4bfe9d00 Maintainer: lacatoire Status: ready -->
 
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.localeconv">
  <refnamediv>
@@ -93,29 +91,29 @@
       <row>
        <entry>p_cs_precedes</entry>
        <entry>
-        &true; si currency_symbol précède une valeur
-        positive et &false; s'il lui succède.
+        1 si currency_symbol précède une valeur
+        positive et 0 s'il lui succède.
        </entry>
       </row>
       <row>
        <entry>p_sep_by_space</entry>
        <entry>
-        &true; si un espace sépare currency_symbol
-        d'une valeur positive, et &false; sinon.
+        1 si un espace sépare currency_symbol
+        d'une valeur positive, et 0 sinon.
        </entry>
       </row>
       <row>
        <entry>n_cs_precedes</entry>
        <entry>
-        &true; si currency_symbol précède une
-        valeur négative, et &false; s'il lui succède.
+        1 si currency_symbol précède une
+        valeur négative, et 0 s'il lui succède.
        </entry>
       </row>
       <row>
        <entry>n_sep_by_space</entry>
        <entry>
-        &true; si un espace sépare currency_symbol
-        d'une valeur négative, et &false; sinon.
+        1 si un espace sépare currency_symbol
+        d'une valeur négative, et 0 sinon.
        </entry>
       </row>
       <row valign="top">
@@ -146,11 +144,11 @@
     </tgroup>
    </informaltable>
   </para>
-  <para>
+  <simpara>
    Les champs <literal>p_sign_posn</literal> et <literal>n_sign_posn</literal> contiennent
    une chaîne formatée d'options. Chaque nombre représente une des conditions listées
    ci-dessus.
-  </para>
+  </simpara>
   <para>
    Les champs de regroupements contiennent des tableaux qui
    définissent la manière dont les nombres doivent être regroupés.

--- a/reference/strings/functions/ltrim.xml
+++ b/reference/strings/functions/ltrim.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 27ae0a4a16cdfc868a884c0f0dad7023b5f2709c Maintainer: yannick Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 17c238517825dfb7ec3edfef5972acd944ffbc1e Maintainer: lacatoire Status: ready -->
 <refentry xml:id="function.ltrim" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>ltrim</refname>
@@ -19,7 +18,7 @@
   </simpara>
   <simpara>
    Sans le second paramètre,
-   <function>mb_ltrim</function> supprimera ces caractères :
+   <function>ltrim</function> supprimera ces caractères :
   </simpara>
   &strings.stripped.characters;
  </refsect1>
@@ -89,8 +88,8 @@ var_dump($clean);
     &example.outputs;
     <screen>
 <![CDATA[
-string(32) "        These are a few words :) ...  "
-string(16) "    Example string
+string(32) "		These are a few words :) ...  "
+string(16) "	Example string
 "
 string(11) "Hello World"
 

--- a/reference/strings/functions/quoted-printable-decode.xml
+++ b/reference/strings/functions/quoted-printable-decode.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 6330e4d73192c49a6867c6bbc3cbf09d63a1e36a Maintainer: yannick Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 46efd980535e8de6f6639a0015d2ad1e4bfe9d00 Maintainer: lacatoire Status: ready -->
 <refentry xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://docbook.org/ns/docbook" xml:id="function.quoted-printable-decode">
  <refnamediv>
   <refname>quoted_printable_decode</refname>
@@ -14,14 +12,14 @@
    <type>string</type><methodname>quoted_printable_decode</methodname>
    <methodparam><type>string</type><parameter>string</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    <function>quoted_printable_decode</function> retourne la chaîne de
    caractères <parameter>string</parameter>, après l'avoir convertie du format
    <literal>quoted printable</literal> binaire 8 bits (en accord avec la
    <link xlink:href="&url.rfc;2045">RFC2045</link>, section 6.7, et non pas la
    <link xlink:href="&url.rfc;2821">RFC2821</link>, section 4.5.2, pour que les
-   points additionnels ne soient pas effacés du début de la ligne).
-  </para>
+   points additionnels ne soient pas effacés du début d'une ligne).
+  </simpara>
   <para>
    Cette fonction est similaire à <function>imap_qprint</function>, hormis le fait
    qu'elle n'exige pas le module IMAP pour fonctionner.

--- a/reference/strings/functions/setlocale.xml
+++ b/reference/strings/functions/setlocale.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: ec01a42be50e84f192c0b19fc6e9cf40a0f7ac31 Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 46efd980535e8de6f6639a0015d2ad1e4bfe9d00 Maintainer: lacatoire Status: ready -->
 <refentry xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://docbook.org/ns/docbook" xml:id="function.setlocale">
  <refnamediv>
   <refname>setlocale</refname>
@@ -25,7 +24,7 @@
    Définit les informations de localisation.
   </para>
   <warning>
-   <para>
+   <simpara>
     L'information locale est maintenue par processus, non par thread. Si
     l'on fait fonctionner PHP sur un serveur multithreadé,
     il serait possible d'obtenir des changements soudains des
@@ -37,7 +36,7 @@
     fonction <function>setlocale</function>.
     Sur Windows, les informations de locale sont maintenue par thread à partir
     de PHP 7.0.5.
-   </para>
+   </simpara>
   </warning>
  </refsect1>
  

--- a/reference/strings/functions/str-repeat.xml
+++ b/reference/strings/functions/str-repeat.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: e095023e408c8cb6378ae16bb6870343a3946919 Maintainer: yannick Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 46efd980535e8de6f6639a0015d2ad1e4bfe9d00 Maintainer: lacatoire Status: ready -->
 <refentry xml:id="function.str-repeat" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>str_repeat</refname>
@@ -36,10 +34,10 @@
     <varlistentry>
      <term><parameter>times</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Nombre de fois où la chaîne <parameter>string</parameter>
        doit être multipliée.
-      </para>
+      </simpara>
       <para>
        <parameter>times</parameter> doit être positif ou nul. 
        Si <parameter>times</parameter> vaut 0, la fonction retourne

--- a/reference/strings/functions/stripos.xml
+++ b/reference/strings/functions/stripos.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4b72b23513caa3a8bc520d459a0417defc7b3880 Maintainer: yannick Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 46efd980535e8de6f6639a0015d2ad1e4bfe9d00 Maintainer: lacatoire Status: ready -->
 <refentry xml:id="function.stripos" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>stripos</refname>
@@ -19,10 +18,10 @@
    Cherche la position numérique de la première occurrence de
    <parameter>needle</parameter> dans la chaîne <parameter>haystack</parameter>.
   </para>
-  <para>
-   Contrairement à la fonction <function>strpos</function>,
+  <simpara>
+   Contrairement à <function>strpos</function>,
    <function>stripos</function> est insensible à la casse.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">

--- a/reference/strings/functions/strncasecmp.xml
+++ b/reference/strings/functions/strncasecmp.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 9b68bf2b63200534e022bc65e800cae6c75abf26 Maintainer: yannick Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 46efd980535e8de6f6639a0015d2ad1e4bfe9d00 Maintainer: lacatoire Status: ready -->
 <refentry xml:id="function.strncasecmp" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>strncasecmp</refname>

--- a/reference/strings/functions/strpbrk.xml
+++ b/reference/strings/functions/strpbrk.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 45042fef652f1b4e904e809fcbfcf31f6c60670b Maintainer: yannick Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 46efd980535e8de6f6639a0015d2ad1e4bfe9d00 Maintainer: lacatoire Status: ready -->
 <refentry xml:id="function.strpbrk" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>strpbrk</refname>
@@ -14,10 +13,10 @@
    <methodparam><type>string</type><parameter>string</parameter></methodparam>
    <methodparam><type>string</type><parameter>characters</parameter></methodparam>
   </methodsynopsis>
-  <para>
-   <function>strpbrk</function> recherche l'ensemble de caractères
-   <parameter>characters</parameter> dans la chaîne <parameter>string</parameter>.
-  </para>
+  <simpara>
+   <function>strpbrk</function> recherche dans la chaîne <parameter>string</parameter>
+   n'importe lequel des caractères de <parameter>characters</parameter>.
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">

--- a/reference/strings/functions/strripos.xml
+++ b/reference/strings/functions/strripos.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 95d05546430b9e5db225dd42a0d285b870f0da42 Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 46efd980535e8de6f6639a0015d2ad1e4bfe9d00 Maintainer: lacatoire Status: ready -->
 <refentry xml:id="function.strripos" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>strripos</refname>
@@ -21,10 +20,10 @@
    <parameter>needle</parameter> dans la chaîne de caractères
    <parameter>haystack</parameter>.
   </para>
-  <para>
-   Contrairement à la fonction <function>strrpos</function>,
+  <simpara>
+   Contrairement à <function>strrpos</function>,
    <function>strripos</function> est insensible à la casse.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">


### PR DESCRIPTION
Port of php/doc-en 46efd980535e8de6f6639a0015d2ad1e4bfe9d00. localeconv.xml and ltrim.xml also carry the preceding commits on those files (92367aee7c, 17c2385178) so the branch stands on its own.

Fixes: #3161
Fixes: #3154