### PR TITLE
[Sync EN] Fix examples whose documented output doesn't match Run code

### DIFF
--- a/language/control-structures/foreach.xml
+++ b/language/control-structures/foreach.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: b8147b7f03506e41f01631c32a907b955593525a Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 17c238517825dfb7ec3edfef5972acd944ffbc1e Maintainer: lacatoire Status: ready -->
 
 <sect1 xml:id="control-structures.foreach" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>foreach</title>
@@ -177,6 +177,8 @@ foreach ($array as list($a, $b)) {
     &example.outputs;
     <screen>
 <![CDATA[
+A: 1; B: 2
+A: 3; B: 4
 A: 1; B: 2
 A: 3; B: 4
 ]]>

--- a/language/control-structures/goto.xml
+++ b/language/control-structures/goto.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: b8147b7f03506e41f01631c32a907b955593525a Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 17c238517825dfb7ec3edfef5972acd944ffbc1e Maintainer: lacatoire Status: ready -->
 
 <sect1 xml:id="control-structures.goto" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>goto</title>
@@ -92,7 +92,7 @@ for ($i = 0, $j = 50; $i < 100; $i++) {
 echo "$i = $i";
 ]]>
    </programlisting>
-   &example.outputs;
+   &example.outputs.similar;
    <screen>
 <![CDATA[
 Fatal error: 'goto' into loop or switch statement is disallowed in script on line 2

--- a/language/control-structures/match.xml
+++ b/language/control-structures/match.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: b8147b7f03506e41f01631c32a907b955593525a Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 17c238517825dfb7ec3edfef5972acd944ffbc1e Maintainer: lacatoire Status: ready -->
 
 <sect1 xml:id="control-structures.match" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>match</title>
@@ -226,7 +226,7 @@ object(UnhandledMatchError)#1 (7) {
   ["file":protected]=>
   string(6) "script"
   ["line":protected]=>
-  int(6)
+  int(5)
   ["trace":"Error":private]=>
   array(0) {
   }

--- a/language/control-structures/switch.xml
+++ b/language/control-structures/switch.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: b8147b7f03506e41f01631c32a907b955593525a Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 17c238517825dfb7ec3edfef5972acd944ffbc1e Maintainer: lacatoire Status: ready -->
 
 <sect1 xml:id="control-structures.switch" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>switch</title>
@@ -343,14 +343,15 @@ switch($beer)
    &example.outputs;
    <screen>
 <![CDATA[
-
 Deprecated: Case statements followed by a semicolon (;) are deprecated, use a colon (:) instead in script on line 6
 
 Deprecated: Case statements followed by a semicolon (;) are deprecated, use a colon (:) instead in script on line 7
 
 Deprecated: Case statements followed by a semicolon (;) are deprecated, use a colon (:) instead in script on line 8
 
-Deprecated: Case statements followed by a semicolon (;) are deprecated, use a colon (:) instead in script on line 11
+Deprecated: Case statements followed by a semicolon (;) are deprecated, use a colon (:) instead in script on line 9
+
+Deprecated: Case statements followed by a semicolon (;) are deprecated, use a colon (:) instead in script on line 12
 Merci de faire un nouveau choix...
 ]]>
    </screen>

--- a/language/oop5/basic.xml
+++ b/language/oop5/basic.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: fc068b4857342eb409efeafe6723058f39ab1045 Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 17c238517825dfb7ec3edfef5972acd944ffbc1e Maintainer: lacatoire Status: ready -->
  <sect1 xml:id="language.oop5.basic" xmlns="http://docbook.org/ns/docbook">
   <title>Syntaxe de base</title>
   <sect2 xml:id="language.oop5.basic.class">
@@ -329,8 +328,8 @@ var_dump($assigned);
 NULL
 NULL
 object(SimpleClass)#1 (1) {
-   ["var"]=>
-     string(27) "$assigned aura cette valeur"
+  ["var"]=>
+  string(27) "$assigned aura cette valeur"
 }
 ]]>
     </screen>

--- a/language/oop5/lazy-objects.xml
+++ b/language/oop5/lazy-objects.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: ee1ce6a0e1875b6851274f8c373ca2bd48630fa0 Maintainer: lacatoire Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 17c238517825dfb7ec3edfef5972acd944ffbc1e Maintainer: lacatoire Status: ready -->
 <sect1 xml:id="language.oop5.lazy-objects" xmlns="http://docbook.org/ns/docbook">
  <title>Objets paresseux</title>
 
@@ -83,8 +82,8 @@ var_dump($lazyObject->prop);
    <screen>
 <![CDATA[
 lazy ghost object(Example)#3 (0) {
-["prop"]=>
-uninitialized(int)
+  ["prop"]=>
+  uninitialized(int)
 }
 string(7) "Example"
 Example::__construct

--- a/language/oop5/overloading.xml
+++ b/language/oop5/overloading.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 911fe79de766ef4475bf22446903667a0f3a24d3 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 17c238517825dfb7ec3edfef5972acd944ffbc1e Maintainer: lacatoire Status: ready -->
  <sect1 xml:id="language.oop5.overloading" xmlns="http://docbook.org/ns/docbook">
   <title>Surcharge magique</title>
 
@@ -226,8 +226,7 @@ Manipulons maintenant la propriété privée nommée 'hidden' :
 'hidden' n'est pas visible en dehors de la classe, donc __get() est utilisée...
 Récupération de 'hidden'
 
-
-Notice: Propriété non-définie via __get() : hidden dans <file> à la ligne 70 dans <file> à la ligne 29
+Notice: Propriété non-définie via __get() : hidden dans script à la ligne 71 dans script à la ligne 27
 ]]>
     </screen>
 

--- a/language/types/array.xml
+++ b/language/types/array.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 911fe79de766ef4475bf22446903667a0f3a24d3 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 17c238517825dfb7ec3edfef5972acd944ffbc1e Maintainer: lacatoire Status: ready -->
 <sect1 xml:id="language.types.array">
  <title>Les tableaux</title>
 
@@ -1133,13 +1133,26 @@ var_dump((array) new B());
 ?>
 ]]>
    </programlisting>
-   &example.outputs;
+   &example.outputs.80;
    <screen>
 <![CDATA[
 array(3) {
   ["BA"]=>
   NULL
   ["AA"]=>
+  NULL
+  ["AA"]=>
+  NULL
+}
+]]>
+   </screen>
+   &example.outputs.81;
+   <screen>
+<![CDATA[
+array(3) {
+  ["AA"]=>
+  NULL
+  ["BA"]=>
   NULL
   ["AA"]=>
   NULL

--- a/language/types/callable.xml
+++ b/language/types/callable.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 312c0c7b39d0722c419f6784cbda24823220dfb3 Maintainer: Fan2Shrek Status: ready -->
+<!-- EN-Revision: 17c238517825dfb7ec3edfef5972acd944ffbc1e Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes Maintainer: girgias -->
 <!-- CREDITS: DavidA -->
 <sect1 xml:id="language.types.callable">
@@ -268,7 +268,7 @@ Hello World!
 Hello World!
 Hello World!
 
-Deprecated: Callables of the form ["B", "parent::who"] are deprecated in script on line 41
+Deprecated: Callables of the form ["B", "parent::who"] are deprecated in script on line 44
 A
 Hello PHP!
 ]]>

--- a/reference/array/functions/array-fill.xml
+++ b/reference/array/functions/array-fill.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 2e60c5134e7a847c99f81eb3f7ecee1f5efeeace Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 17c238517825dfb7ec3edfef5972acd944ffbc1e Maintainer: lacatoire Status: ready -->
 <refentry xml:id="function.array-fill" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>array_fill</refname>
@@ -123,11 +122,11 @@ print_r($a);
 <![CDATA[
 Array
 (
-    [5]  => banana
-    [6]  => banana
-    [7]  => banana
-    [8]  => banana
-    [9]  => banana
+    [5] => banana
+    [6] => banana
+    [7] => banana
+    [8] => banana
+    [9] => banana
     [10] => banana
 )
 ]]>

--- a/reference/array/functions/array-map.xml
+++ b/reference/array/functions/array-map.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 1f5bcc30ee06e452b98362460ea7b7bf2b20f4a1 Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 17c238517825dfb7ec3edfef5972acd944ffbc1e Maintainer: lacatoire Status: ready -->
 <!-- CREDITS: DavidA. -->
 <refentry xml:id="function.array-map" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -165,6 +164,14 @@ print_r(array_map(fn($value): int => $value * 2, range(1, 5)));
     &example.outputs;
     <screen>
 <![CDATA[
+Array
+(
+    [0] => 2
+    [1] => 4
+    [2] => 6
+    [3] => 8
+    [4] => 10
+)
 Array
 (
     [0] => 2

--- a/reference/array/functions/array-udiff-assoc.xml
+++ b/reference/array/functions/array-udiff-assoc.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 56509d07ae636f076057f55bbb2572ab7b7a39eb Maintainer: yannick Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 17c238517825dfb7ec3edfef5972acd944ffbc1e Maintainer: lacatoire Status: ready -->
 
 <refentry xml:id="function.array-udiff-assoc" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -113,18 +111,19 @@ Array
 (
     [0.1] => cr Object
         (
-            [priv_member:private] => 9
+            [priv_member:cr:private] => 9
         )
 
     [0.5] => cr Object
         (
-            [priv_member:private] => 12
+            [priv_member:cr:private] => 12
         )
 
     [0] => cr Object
         (
-            [priv_member:private] => 23
+            [priv_member:cr:private] => 23
         )
+
 )
 ]]>
     </screen>

--- a/reference/array/functions/array-unique.xml
+++ b/reference/array/functions/array-unique.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 651fad6c6677036edd2871bb78199e17586a3acd Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 17c238517825dfb7ec3edfef5972acd944ffbc1e Maintainer: lacatoire Status: ready -->
 <!-- CREDITS: DavidA. -->
 <refentry xml:id="function.array-unique" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -164,8 +162,10 @@ var_dump($result);
     <screen role="php">
 <![CDATA[
 array(2) {
-  [0] => int(4)
-  [2] => string(1) "3"
+  [0]=>
+  int(4)
+  [2]=>
+  string(1) "3"
 }
 ]]>
     </screen>

--- a/reference/array/functions/array-unshift.xml
+++ b/reference/array/functions/array-unshift.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 0987e913fcaed76897aeb239c6ed83d765a895e1 Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 17c238517825dfb7ec3edfef5972acd944ffbc1e Maintainer: lacatoire Status: ready -->
 
 <refentry xml:id="function.array-unshift" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -107,13 +105,13 @@ var_dump($queue);
     <screen role="php">
 <![CDATA[
 array(4) {
-  [0] =>
+  [0]=>
   string(5) "apple"
-  [1] =>
+  [1]=>
   string(9) "raspberry"
-  [2] =>
+  [2]=>
   string(6) "orange"
-  [3] =>
+  [3]=>
   string(6) "banana"
 }
 ]]>

--- a/reference/array/functions/natsort.xml
+++ b/reference/array/functions/natsort.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: f781803449007bb0e3a96c693e0eee067f7eb466 Maintainer: yannick Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 17c238517825dfb7ec3edfef5972acd944ffbc1e Maintainer: lacatoire Status: ready -->
 
 <refentry xml:id="function.natsort" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -160,7 +158,6 @@ Array
     [1] => 3
     [5] => 9
 )
-
 Alignement avec zéros
 Array
 (
@@ -175,8 +172,8 @@ Array
 (
     [5] => 0
     [1] => 8
-    [3] => 009
     [0] => 09
+    [3] => 009
     [2] => 10
     [4] => 011
 )

--- a/reference/datetime/formats.xml
+++ b/reference/datetime/formats.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 17c238517825dfb7ec3edfef5972acd944ffbc1e Maintainer: lacatoire Status: ready -->
 <chapter xml:id="datetime.formats" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Formats supportés de temps et de dates</title>
 
- <para>
+ <simpara>
   Cette section décrit, dans un format de type BNF, tous les formats différents
   que l'analyseur de <classname>DateTimeImmutable</classname>, 
   <classname>DateTime</classname>, <function>date_create_immutable</function>,
@@ -18,16 +18,16 @@
   casse (<literal>'t'</literal> pourrait s'écrire <literal>t</literal> ou
   <literal>T</literal>), les caractères écrits entre guillemets doubles, eux,
   sont sensibles à la casse (<literal>"T"</literal> et seulement <literal>T</literal>).
- </para>
- <para>
+ </simpara>
+ <simpara>
   Pour formater des objets <classname>DateTimeImmutable</classname> et
   <classname>DateTime</classname>, se référer à la documentation
   de la méthode <function>DateTimeInterface::format</function>.
- </para>
+ </simpara>
 
- <para>
+ <simpara>
   Un ensemble de règles générales devrait être pris en compte.
- </para>
+ </simpara>
  <orderedlist>
   <listitem>
    <simpara>
@@ -91,7 +91,7 @@ var_dump($res["warnings"]);
      <screen>
 <![CDATA[
 array(1) {
-  [11] =>
+  [11]=>
   string(27) "The parsed date was invalid"
 }
 ]]>
@@ -130,22 +130,21 @@ object(DateTimeImmutable)#1 (3) {
   </listitem>
  </orderedlist>
 
- <!--Time Formats: {{{-->
  <sect1 annotations="chunk:false" xml:id="datetime.formats.time">
   <title>Formats pour les temps (Time)</title>
 
-  <para>
+  <simpara>
    Cette page décrit les différents formats dans une syntaxe de type BNF
    que les analyseurs de <classname>DateTimeImmutable</classname>, 
    <classname>DateTime</classname>, <function>date_create</function>,
    <function>date_create_immutable</function>, et
    <function>strtotime</function> comprennent.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Pour formater des objets <classname>DateTimeImmutable</classname> et
    <classname>DateTime</classname>, se référer à la documentation
    de la méthode <function>DateTimeInterface::format</function>.
-  </para>
+  </simpara>
 
   <table>
    <title>Symboles utilisés</title>
@@ -292,24 +291,22 @@ object(DateTimeImmutable)#1 (3) {
    </tgroup>
   </table>
  </sect1>
- <!--}}}-->
 
- <!--Date Formats: {{{-->
  <sect1 annotations="chunk:false" xml:id="datetime.formats.date">
   <title>Formats de dates</title>
 
-  <para>
+  <simpara>
    Cette page décrit les différents formats dans une syntaxe de type BNF 
    que les analyseurs de <classname>DateTimeImmutable</classname>, 
    <classname>DateTime</classname>, <function>date_create</function>,
    <function>date_create_immutable</function>, et
    <function>strtotime</function> comprennent.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Pour formater des objets <classname>DateTimeImmutable</classname> et
    <classname>DateTime</classname>, se référer à la documentation
    de la méthode <function>DateTimeInterface::format</function>.
-  </para>
+  </simpara>
 
   <table>
    <title>Symboles utilisés</title>
@@ -532,7 +529,7 @@ object(DateTimeImmutable)#1 (3) {
   </table>
 
   <note>
-   <para>
+   <simpara>
     Pour les formats <literal>y</literal> et <literal>yy</literal>, les années
     avant 100 sont considérées d'une manière spéciale lorsque les
     symboles <literal>y</literal> ou <literal>yy</literal> sont utilisés.
@@ -540,79 +537,77 @@ object(DateTimeImmutable)#1 (3) {
     2000 sera ajouté. Si l'année est comprise entre 70 (inclusif) et
     99 (inclusif) alors 1900 sera ajouté. Cela signifie que "00-01-01" est
     interprété comme "2000-01-01".
-   </para>
+   </simpara>
   </note>
 
   <note>
-   <para>
+   <simpara>
     Le format "Jour, mois et année sur deux chiffres avec tabulations ou points"
     (<literal>dd</literal> [.\t] <literal>mm</literal> "."
     <literal>yy</literal>) ne fonctionne que pour des valeurs d'années de 61 (inclusif)
     à 99 (inclusif) - en dehors de ces bornes, le <emphasis>format du temps</emphasis>
     "<literal>HH</literal> [.:] <literal>MM</literal> [.:] <literal>SS</literal>" a une
     précédence plus forte et primera.
-   </para>
+   </simpara>
   </note>
 
   <note>
-   <para>
+   <simpara>
     Le format "Année (et seulement l'année)" ne fonctionne de manière fiable que si une chaîne
     de temps a déjà été trouvée. Sinon, si l'année à quatre chiffres correspond
     à <literal>HH</literal> <literal>MM</literal>, ces deux éléments de date
     sont définis à la place.
-   </para>
-   <para>
+   </simpara>
+   <simpara>
     Pour analyser de manière cohérente seulement une année, utiliser
     <function>DateTimeImmutable::createFromFormat</function> avec le
     spécificateur <literal>Y</literal>.
-   </para>
+   </simpara>
   </note>
 
   <caution>
-   <para>
+   <simpara>
     Il est possible d'ajouter ou soustraire une retenue pour les formats
     <literal>dd</literal> et <literal>DD</literal>. Le jour 0 signifie le dernier
     jour du mois précédent, les retenues positives compteront le mois suivant.
     Ainsi, "2008-08-00" est équivalent à "2008-07-31" et "2008-06-31" est équivalent
     à "2008-07-01" (juin ne possède que 30 jours).
-   </para>
-   <para>
+   </simpara>
+   <simpara>
     Il est à noter que la plage de jour est limitée à 0-31 comme
     indiqué par l'expression régulière ci-dessus. Ainsi, "2008-06-32" n'est 
     pas une chaîne de date valide, par exemple.
-   </para>
-   <para>
+   </simpara>
+   <simpara>
     Il est aussi possible de jouer avec les retenues des formats <literal>mm</literal> et
     <literal>MM</literal> grâce à la valeur 0. Une valeur de mois de 0 signifie Décembre
     de l'année précédente. Par exemple "2008-00-22" est équivalent à "2007-12-22".
-   </para>
-   <para>
+   </simpara>
+   <simpara>
     Si l'on combine les deux notions précédentes et utilise une retenue négative sur le jour
     et le mois, alors il se passe ceci : "2008-00-00" est converti d'abord vers
     "2007-12-00" puis vers "2007-11-30". Ceci arrive aussi avec la chaîne
     "0000-00-00" qui est alors transformée vers "-0001-11-30" (l'année -1 dans le calendrier
     ISO 8601, qui est 2 BC dans le calendrier Grégorien).
-   </para>
+   </simpara>
   </caution>
  </sect1>
- <!--}}}-->
 
- <!--Compound Formats: {{{-->
  <sect1 annotations="chunk:false" xml:id="datetime.formats.compound">
   <title>Formats composés</title>
 
-  <para>
+  <simpara>
    Cette page décrit les différents formats dans une syntaxe de type BNF que les analyseurs de
    <classname>DateTimeImmutable</classname>, <classname>DateTime</classname>,
    <function>date_create</function>,
    <function>date_create_immutable</function>, et
    <function>strtotime</function> comprennent.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Pour formater des objets <classname>DateTimeImmutable</classname> et
    <classname>DateTime</classname>, se référer à la documentation
    de la méthode <function>DateTimeInterface::format</function>.
-  </para>
+  </simpara>
 
   <table>
    <title>Symboles utilisés</title>
@@ -851,37 +846,35 @@ object(DateTimeImmutable)#1 (3) {
   </table>
 
   <note>
-   <para>
+   <simpara>
     Le "W" dans les formats "Année ISO avec semaine ISO" et "Année ISO avec semaine ISO et jour"
     est sensible à la casse ; l'on ne peut utiliser que la majuscule "W".
-   </para>
-   <para>
+   </simpara>
+   <simpara>
     Le "T" dans les formats SOAP, XMLRPC et WDDX est sensible à la casse ; utiliser toujours
     la majuscule "T".
-   </para>
-   <para>
+   </simpara>
+   <simpara>
     Le format timestamp Unix définit le fuseau horaire à UTC.
-   </para>
+   </simpara>
   </note>
  </sect1>
- <!--}}}-->
 
- <!--Relative Formats: {{{-->
  <sect1 annotations="chunk:false" xml:id="datetime.formats.relative">
   <title>Formats relatifs</title>
 
-  <para>
+  <simpara>
    Cette page décrit les différents formats dans une syntaxe de type BNF 
    que les analyseurs de <classname>DateTimeImmutable</classname>, 
    <classname>DateTime</classname>, <function>date_create</function>,
    <function>date_create_immutable</function>, et
    <function>strtotime</function> comprennent.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Pour formater des objets <classname>DateTimeImmutable</classname> et
    <classname>DateTime</classname>, se référer à la documentation
    de la méthode <function>DateTimeInterface::format</function>.
-  </para>
+  </simpara>
 
   <table>
    <title>Symboles utilisés</title>
@@ -1040,26 +1033,26 @@ object(DateTimeImmutable)#1 (3) {
   </table>
 
   <note>
-   <para>
+   <simpara>
     Les expressions relatives sont toujours traitées <emphasis>après</emphasis>
     les expressions non relatives. Ceci fait en sorte que "+1 week july 2008" et "july
     2008 +1 week" sont équivalents.
-   </para>
-   <para>
+   </simpara>
+   <simpara>
     "yesterday", "midnight", "today", "noon" et "tomorrow" sont des exceptions à cette
     règle. Il est à noter que "tomorrow 11:00" et "11:00 tomorrow" sont différents. Soit la date
     d'aujourd'hui à "July 23rd, 2008", la première expression donne "2008-07-24 11:00"
     alors que la seconde donnera "2008-07-24 00:00". La raison est que ces cinq expressions
     influencent directement la date courante.
-   </para>
-   <para>
+   </simpara>
+   <simpara>
     Les mots clés tels que "first day of" dépendent du contexte dans lequel
     la chaîne de format relative est utilisée. Si utilisé avec une méthode
     statique ou une fonction, le référent est l'horodatage actuel du système.
     Cependant, si utilisé dans <function>DateTime::modify</function> ou
     <function>DateTimeImmutable::modify</function>, le référent est l'objet
     sur lequel la méthode <literal>modify()</literal> est appelée.
-   </para>
+   </simpara>
   </note>
 
   <note>
@@ -1118,13 +1111,13 @@ object(DateTimeImmutable)#1 (3) {
      </simpara>
     </listitem>
    </orderedlist>
-   <para>
+   <simpara>
     Il est à noter que le "of" dans "<literal>ordinal</literal>
     <literal>space</literal> <literal>dayname</literal>
     <literal>space</literal> 'of' " et "'last' <literal>space</literal>
     <literal>dayname</literal> <literal>espace</literal> 'of' " fait quelque
     chose de spécial.
-   </para>
+   </simpara>
    <orderedlist>
     <listitem>
      <simpara>
@@ -1165,21 +1158,21 @@ object(DateTimeImmutable)#1 (3) {
    </orderedlist>
   </note>
   <note>
-   <para>
+   <simpara>
     Les valeurs relatives des mois calculés sont basées sur le nombre de jours des mois que 
     l'on utilise. Par exemple, "+2 month 2011-11-30", donnera comme résultat la date "2012-01-30".
     Ceci est dû au fait que le mois de novembre comporte 30 jours, et
     que le mois de décembre en comporte 31, soit un ajout total de 61 jours.
-   </para>
+   </simpara>
   </note>
   <note>
-   <para>
+   <simpara>
     <literal>number</literal> est un nombre <emphasis>entier</emphasis> ; si un
     nombre décimal est donné, le point (ou la virgule) sera probablement interprété 
     comme un délimiteur.
     Par exemple, <literal>'+1.5 hours'</literal> sera analysé en tant que
     <literal>'+1 5 hours'</literal>, et non pas comme <literal>'+1 hour +30 minutes'</literal>.
-   </para>
+   </simpara>
   </note>
 
   <sect2 role="changelog">
@@ -1222,7 +1215,6 @@ object(DateTimeImmutable)#1 (3) {
    </para>
   </sect2>
  </sect1>
- <!--}}}-->
 
 </chapter>
 

--- a/reference/datetime/functions/date-default-timezone-get.xml
+++ b/reference/datetime/functions/date-default-timezone-get.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: Fan2Shrek Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 17c238517825dfb7ec3edfef5972acd944ffbc1e Maintainer: lacatoire Status: ready -->
 <refentry xml:id="function.date-default-timezone-get" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>date_default_timezone_get</refname>
@@ -86,7 +85,8 @@ date.timezone : Europe/London
 <![CDATA[
 <?php
 date_default_timezone_set('America/Los_Angeles');
-echo date_default_timezone_get() . ' => ' . date('e') . ' => ' . date('T');
+$ts = mktime(0, 0, 0, 1, 1, 2024);
+echo date_default_timezone_get() . ' => ' . date('e') . ' => ' . date('T', $ts);
 ]]>
     </programlisting>
     &example.outputs;

--- a/reference/dom/dom/characterdata/before.xml
+++ b/reference/dom/dom/characterdata/before.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 8c0d111851c38647956dc6a4527746787dd606eb Maintainer: Fan2Shrek Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 17c238517825dfb7ec3edfef5972acd944ffbc1e Maintainer: lacatoire Status: ready -->
 <refentry xml:id="dom-characterdata.before" xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude">
  <refnamediv>
   <refname>Dom\CharacterData::before</refname>
@@ -42,7 +41,7 @@ echo $doc->saveXML();
    &example.outputs;
    <screen>
 <![CDATA[
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <container>hello<beautiful/><![CDATA[world]]]]><![CDATA[></container>
 ]]>
    </screen>

--- a/reference/dom/dom/characterdata/remove.xml
+++ b/reference/dom/dom/characterdata/remove.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 8c0d111851c38647956dc6a4527746787dd606eb Maintainer: Fan2Shrek Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 17c238517825dfb7ec3edfef5972acd944ffbc1e Maintainer: lacatoire Status: ready -->
 <refentry xml:id="dom-characterdata.remove" xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude">
  <refnamediv>
   <refname>Dom\CharacterData::remove</refname>
@@ -41,7 +40,7 @@ echo $doc->saveXML();
    &example.outputs;
    <screen>
 <![CDATA[
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <container><world/></container>
 ]]>
    </screen>

--- a/reference/dom/dom/characterdata/replacewith.xml
+++ b/reference/dom/dom/characterdata/replacewith.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 8c0d111851c38647956dc6a4527746787dd606eb Maintainer: Fan2Shrek Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 17c238517825dfb7ec3edfef5972acd944ffbc1e Maintainer: lacatoire Status: ready -->
 <refentry xml:id="dom-characterdata.replacewith" xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude">
  <refnamediv>
   <refname>Dom\CharacterData::replaceWith</refname>
@@ -42,7 +41,7 @@ echo $doc->saveXML();
    &example.outputs;
    <screen>
 <![CDATA[
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <container>beautiful<world/></container>
 ]]>
    </screen>

--- a/reference/dom/dom/htmldocument/createfromstring.xml
+++ b/reference/dom/dom/htmldocument/createfromstring.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: a8b6f4dd3a23875b066d4e47ea4a4977a63e0655 Maintainer: Fan2Shrek Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 17c238517825dfb7ec3edfef5972acd944ffbc1e Maintainer: lacatoire Status: ready -->
 <refentry xml:id="dom-htmldocument.createfromstring" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Dom\HTMLDocument::createFromString</refname>
@@ -75,7 +74,7 @@ $dom = Dom\HTMLDocument::createFromString(<<<'HTML'
 <!DOCTYPE html>
 <html>
 <body>
-   <p>Hello, world!</p>
+    <p>Hello, world!</p>
 </body>
 </html>
 HTML);

--- a/reference/dom/domdocument/append.xml
+++ b/reference/dom/domdocument/append.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: c1349f9574ed77c268c6312a07466f06d59e5078 Maintainer: Fan2Shrek Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 17c238517825dfb7ec3edfef5972acd944ffbc1e Maintainer: lacatoire Status: ready -->
 <refentry xml:id="domdocument.append" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <refnamediv>
   <refname>DOMDocument::append</refname>
@@ -45,6 +44,7 @@ echo $doc->saveXML();
    &example.outputs;
    <screen>
 <![CDATA[
+<?xml version="1.0"?>
 <hello/>
 beautiful
 <world/>

--- a/reference/dom/domdocumentfragment/replacechildren.xml
+++ b/reference/dom/domdocumentfragment/replacechildren.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: d6f54016d62904cfd8200604aadd5e3f0d9bad97 Maintainer: Fan2Shrek Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 17c238517825dfb7ec3edfef5972acd944ffbc1e Maintainer: lacatoire Status: ready -->
 <refentry xml:id="domdocumentfragment.replacechildren" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <refnamediv>
   <refname>DOMDocumentFragment::replaceChildren</refname>
@@ -47,8 +46,7 @@ echo $doc->saveXML($fragment);
    &example.outputs;
    <screen>
 <![CDATA[
-beautiful
-<world/>
+beautiful<world/>
 ]]>
    </screen>
   </example>

--- a/reference/dom/domelement/before.xml
+++ b/reference/dom/domelement/before.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: c1349f9574ed77c268c6312a07466f06d59e5078 Maintainer: Fan2Shrek Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 17c238517825dfb7ec3edfef5972acd944ffbc1e Maintainer: lacatoire Status: ready -->
 <refentry xml:id="domelement.before" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <refnamediv>
   <refname>DOMElement::before</refname>
@@ -46,6 +45,7 @@ echo $doc->saveXML();
    &example.outputs;
    <screen>
 <![CDATA[
+<?xml version="1.0"?>
 hello
 <beautiful/>
 <world/>

--- a/reference/dom/domelement/getattributenames.xml
+++ b/reference/dom/domelement/getattributenames.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: cdbee08c7312e25ad733047ae65c4628c24aa1b8 Maintainer: Fan2Shrek Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 17c238517825dfb7ec3edfef5972acd944ffbc1e Maintainer: lacatoire Status: ready -->
 <refentry xml:id="domelement.getattributenames" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>DOMElement::getAttributeNames</refname>
@@ -48,12 +47,12 @@ var_dump($dom->documentElement->getAttributeNames());
    <screen>
 <![CDATA[
 array(3) {
- [0]=>
- string(10) "xmlns:some"
- [1]=>
- string(9) "some:test"
- [2]=>
- string(5) "test2"
+  [0]=>
+  string(10) "xmlns:some"
+  [1]=>
+  string(9) "some:test"
+  [2]=>
+  string(5) "test2"
 }
 ]]>
    </screen>

--- a/reference/dom/domnode/getlineno.xml
+++ b/reference/dom/domnode/getlineno.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: eaf26c34fd4d7da430403fe221ed11e4083fae5a Maintainer: dams Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 17c238517825dfb7ec3edfef5972acd944ffbc1e Maintainer: lacatoire Status: ready -->
 <refentry xml:id="domnode.getlineno" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>DOMNode::getLineNo</refname>

--- a/reference/libxml/functions/libxml-get-errors.xml
+++ b/reference/libxml/functions/libxml-get-errors.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: fed3682684f1af372dc9a7f15d0468e5a884ab16 Maintainer: dams Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 17c238517825dfb7ec3edfef5972acd944ffbc1e Maintainer: lacatoire Status: ready -->
 <refentry xml:id="function.libxml-get-errors" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>libxml_get_errors</refname>
@@ -107,10 +105,10 @@ function display_xml_error($error, $xml)
     <screen>
 <![CDATA[
   <titles>PHP: Behind the Parser</title>
-----------------------------------------------^
+-----------------------------------------^
 Fatal Error 76: Opening and ending tag mismatch: titles line 4 and title
   Line: 4
-  Column: 46
+  Column: 41
 
 --------------------------------------------
 ]]>

--- a/reference/libxml/functions/libxml-set-external-entity-loader.xml
+++ b/reference/libxml/functions/libxml-set-external-entity-loader.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 5b7646656eb183ea568b8261d6d87a10a1b961c7 Maintainer: jpauli Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 17c238517825dfb7ec3edfef5972acd944ffbc1e Maintainer: lacatoire Status: ready -->
 <refentry xml:id="function.libxml-set-external-entity-loader" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>libxml_set_external_entity_loader</refname>
@@ -144,10 +142,14 @@ var_dump($dd->validate());
 string(10) "-//FOO/BAR"
 string(25) "http://example.com/foobar"
 array(4) {
-    ["directory"]    => NULL
-    ["intSubName"]   => NULL
-    ["extSubURI"]    => NULL
-    ["extSubSystem"] => NULL
+  ["directory"]=>
+  NULL
+  ["intSubName"]=>
+  NULL
+  ["extSubURI"]=>
+  NULL
+  ["extSubSystem"]=>
+  NULL
 }
 bool(true)
 ]]>

--- a/reference/pcre/functions/preg-replace.xml
+++ b/reference/pcre/functions/preg-replace.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 79c53e3fa2afc0f09373b17c23896465d8d41d0a Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 17c238517825dfb7ec3edfef5972acd944ffbc1e Maintainer: lacatoire Status: ready -->
 <refentry xml:id="function.preg-replace" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>preg_replace</refname>
@@ -275,6 +273,7 @@ echo $str;
 $count = 0;
 
 echo preg_replace(array('/\d/', '/\s/'), '*', 'xp 4 to', -1 , $count);
+echo "\n";
 echo $count; //3
 ?>
 ]]>

--- a/reference/reflection/reflectionclass/getdefaultproperties.xml
+++ b/reference/reflection/reflectionclass/getdefaultproperties.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: ec2fe9a592f794978114ef5021db9f1d00c2e05d Maintainer: yannick Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 17c238517825dfb7ec3edfef5972acd944ffbc1e Maintainer: lacatoire Status: ready -->
 <refentry xml:id="reflectionclass.getdefaultproperties" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>ReflectionClass::getDefaultProperties</refname>
@@ -70,16 +69,16 @@ var_dump($reflectionClass->getDefaultProperties());
     <screen>
 <![CDATA[
 array(5) {
-   ["staticProperty"]=>
-   string(14) "staticProperty"
-   ["property"]=>
-   string(15) "propertyDefault"
-   ["privateProperty"]=>
-   string(22) "privatePropertyDefault"
-   ["defaultlessProperty"]=>
-   NULL
-   ["inheritedProperty"]=>
-   string(16) "inheritedDefault"
+  ["staticProperty"]=>
+  string(14) "staticProperty"
+  ["property"]=>
+  string(15) "propertyDefault"
+  ["privateProperty"]=>
+  string(22) "privatePropertyDefault"
+  ["defaultlessProperty"]=>
+  NULL
+  ["inheritedProperty"]=>
+  string(16) "inheritedDefault"
 }
 ]]>
     </screen>

--- a/reference/reflection/reflectionclass/getdoccomment.xml
+++ b/reference/reflection/reflectionclass/getdoccomment.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: ec2fe9a592f794978114ef5021db9f1d00c2e05d Maintainer: yannick Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 17c238517825dfb7ec3edfef5972acd944ffbc1e Maintainer: lacatoire Status: ready -->
 <refentry xml:id="reflectionclass.getdoccomment" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>ReflectionClass::getDocComment</refname>
@@ -58,7 +57,7 @@ var_dump($rc->getDocComment());
     &example.outputs;
     <screen>
 <![CDATA[
-string(61) "/**
+string(60) "/**
  * A test class
  *
  * @param  foo bar

--- a/reference/reflection/reflectionconstant/getshortname.xml
+++ b/reference/reflection/reflectionconstant/getshortname.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: c477749c82111cbbdd657a0e98eeaeeec0d90c91 Maintainer: Fan2Shrek Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 17c238517825dfb7ec3edfef5972acd944ffbc1e Maintainer: lacatoire Status: ready -->
 <refentry xml:id="reflectionconstant.getshortname" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>ReflectionConstant::getShortName</refname>
@@ -41,7 +40,7 @@ namespace Foo;
 
 const BAR = 'bar';
 
-echo (new \ReflectionConstant('Foo\BAR'))->getName();
+echo (new \ReflectionConstant('Foo\BAR'))->getShortName();
 ?>
 ]]>
    </programlisting>

--- a/reference/simplexml/functions/simplexml-load-string.xml
+++ b/reference/simplexml/functions/simplexml-load-string.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: c142be811735a5542c8a2e4c4ed2f81e8cc3acc6 Maintainer: yannick Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 17c238517825dfb7ec3edfef5972acd944ffbc1e Maintainer: lacatoire Status: ready -->
 <refentry xml:id="function.simplexml-load-string" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>simplexml_load_string</refname>
@@ -128,11 +126,12 @@ print_r($xml);
 <![CDATA[
 SimpleXMLElement Object
 (
-  [title] => Forty What?
-  [from] => Joe
-  [to] => Jane
-  [body] =>
-   I know that's the answer -- but what's the question?
+    [title] => Forty What?
+    [from] => Joe
+    [to] => Jane
+    [body] =>
+  I know that's the answer -- but what's the question?
+
 )
 ]]>
     </screen>

--- a/reference/simplexml/simplexmlelement/children.xml
+++ b/reference/simplexml/simplexmlelement/children.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 770c6facae667218f69c8ea2715ea20f6fab32f3 Maintainer: jpauli Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 17c238517825dfb7ec3edfef5972acd944ffbc1e Maintainer: lacatoire Status: ready -->
 <refentry xml:id="simplexmlelement.children" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>SimpleXMLElement::children</refname>
@@ -97,8 +96,7 @@ foreach ($xml->children() as $second_gen) {
     &example.outputs;
     <screen>
 <![CDATA[
-The person begot a son who begot a daughter; The person
-begot a daughter who begot a son; and that son begot a son
+ The person begot a son who begot a daughter; The person begot a daughter who begot a son; and that son begot a son
 ]]>
     </screen>
    </example>

--- a/reference/simplexml/simplexmlelement/getDocNamespaces.xml
+++ b/reference/simplexml/simplexmlelement/getDocNamespaces.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 770c6facae667218f69c8ea2715ea20f6fab32f3 Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 17c238517825dfb7ec3edfef5972acd944ffbc1e Maintainer: lacatoire Status: ready -->
 <refentry xml:id="simplexmlelement.getdocnamespaces" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>SimpleXMLElement::getDocNamespaces</refname>
@@ -84,8 +83,8 @@ var_dump($namespaces);
     <screen>
 <![CDATA[
 array(1) {
-   ["p"]=>
-   string(21) "http://example.org/ns"
+  ["p"]=>
+  string(21) "http://example.org/ns"
 }
 ]]>
     </screen>

--- a/reference/strings/functions/explode.xml
+++ b/reference/strings/functions/explode.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 45042fef652f1b4e904e809fcbfcf31f6c60670b Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 17c238517825dfb7ec3edfef5972acd944ffbc1e Maintainer: lacatoire Status: ready -->
 <refentry xml:id="function.explode" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>explode</refname>
@@ -168,20 +167,22 @@ var_dump( explode( ',', $input3 ) );
     &example.outputs;
     <screen>
 <![CDATA[
-array(1)
-(
-    [0] => string(5) "hello"
-)
-array(2)
-(
-    [0] => string(5) "hello"
-    [1] => string(5) "there"
-)
-array(2)
-(
-    [0] => string(0) ""
-    [1] => string(0) ""
-)
+array(1) {
+  [0]=>
+  string(5) "hello"
+}
+array(2) {
+  [0]=>
+  string(5) "hello"
+  [1]=>
+  string(5) "there"
+}
+array(2) {
+  [0]=>
+  string(0) ""
+  [1]=>
+  string(0) ""
+}
 ]]>
     </screen>
    </example>

--- a/reference/strings/functions/htmlentities.xml
+++ b/reference/strings/functions/htmlentities.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 06394ea77c2f8972e3884c00bede861ef5eb04da Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 17c238517825dfb7ec3edfef5972acd944ffbc1e Maintainer: lacatoire Status: ready -->
 <refentry xml:id="function.htmlentities" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>htmlentities</refname>
@@ -213,7 +212,7 @@ echo htmlentities($str, ENT_COMPAT);
 <![CDATA[
 Un &#039;apostrophe&#039; en &lt;b&gt;gras&lt;/b&gt;
 
-Un 'apostrophe' en &lt;b&gt;gras&lt;/b&gt
+Un 'apostrophe' en &lt;b&gt;gras&lt;/b&gt;
 ]]>
     </screen>
    </example>

--- a/reference/strings/functions/rtrim.xml
+++ b/reference/strings/functions/rtrim.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 27ae0a4a16cdfc868a884c0f0dad7023b5f2709c Maintainer: yannick Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 17c238517825dfb7ec3edfef5972acd944ffbc1e Maintainer: lacatoire Status: ready -->
 <refentry xml:id="function.rtrim" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>rtrim</refname>
@@ -88,15 +87,15 @@ var_dump($clean);
     &example.outputs;
     <screen>
 <![CDATA[
-string(32) "        Voici quelques mots :) ...  "
-string(16) "    Chaîne exemple
+string(32) "		Voici quelques mots :) ...  "
+string(16) "	Chaîne exemple
 "
 string(14) "Bonjour le Monde"
 
-string(30) "        Voici quelques mots :) ..."
-string(26) "        Voici quelques mots :)"
+string(30) "		Voici quelques mots :) ..."
+string(26) "		Voici quelques mots :)"
 string(10) "Bonjour le M"
-string(15) "    Chaîne exemple"
+string(15) "	Chaîne exemple"
 ]]>
     </screen>
    </example>

--- a/reference/strings/functions/str-word-count.xml
+++ b/reference/strings/functions/str-word-count.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: d335ba69a16f4013280de8e3e71d9ba19fe3cb3c Maintainer: dams Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 17c238517825dfb7ec3edfef5972acd944ffbc1e Maintainer: lacatoire Status: ready -->
 <refentry xml:id="function.str-word-count" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>str_word_count</refname>
@@ -143,7 +141,6 @@ echo str_word_count($str);
     &example.outputs;
     <screen>
 <![CDATA[
-
 Array
 (
     [0] => Salut
@@ -161,13 +158,12 @@ Array
     [0] => Salut
     [6] => l'ami
     [13] => vous
-    [27] => avez
-    [41] => une
-    [45] => b
-    [47] => lle
-    [51] => mine
+    [26] => avez
+    [40] => une
+    [44] => b
+    [46] => lle
+    [50] => mine
 )
-
 Array
 (
     [0] => Salut
@@ -178,7 +174,6 @@ Array
     [5] => b3lle
     [6] => mine
 )
-
 8
 ]]>
     </screen>

--- a/reference/strings/functions/strtok.xml
+++ b/reference/strings/functions/strtok.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 45042fef652f1b4e904e809fcbfcf31f6c60670b Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 17c238517825dfb7ec3edfef5972acd944ffbc1e Maintainer: lacatoire Status: ready -->
 <refentry xml:id="function.strtok" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>strtok</refname>
@@ -150,8 +149,8 @@ var_dump($first_token, $second_token);
     &example.outputs;
     <screen>
 <![CDATA[
-    string(9) "something"
-    bool(false)
+string(9) "something"
+bool(false)
 ]]>
     </screen>
    </example>

--- a/reference/strings/functions/trim.xml
+++ b/reference/strings/functions/trim.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 27ae0a4a16cdfc868a884c0f0dad7023b5f2709c Maintainer: yannick Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 17c238517825dfb7ec3edfef5972acd944ffbc1e Maintainer: lacatoire Status: ready -->
 <refentry xml:id="function.trim" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>trim</refname>
@@ -91,8 +90,8 @@ var_dump($clean);
     &example.outputs;
     <screen>
 <![CDATA[
-string(32) "        These are a few words :) ...  "
-string(16) "    Example string
+string(32) "		These are a few words :) ...  "
+string(16) "	Example string
 "
 string(11) "Hello World"
 

--- a/reference/uri/uri/rfc3986/uri/withfragment.xml
+++ b/reference/uri/uri/rfc3986/uri/withfragment.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 39596f1226fd3b502bfbba09068ad6701235426f Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 17c238517825dfb7ec3edfef5972acd944ffbc1e Maintainer: lacatoire Status: ready -->
 <refentry xml:id="uri-rfc3986-uri.withfragment" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Uri\Rfc3986\Uri::withFragment</refname>
@@ -49,6 +49,7 @@
    <title>Exemple simple avec <methodname>Uri\Rfc3986\Uri::withFragment</methodname></title>
    <programlisting role="php">
 <![CDATA[
+<?php
 $uri = new \Uri\Rfc3986\Uri("https://example.com/#foo");
 $uri = $uri->withFragment("bar");
 

--- a/reference/xmlwriter/xmlwriter/writecdata.xml
+++ b/reference/xmlwriter/xmlwriter/writecdata.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4a742792da6fd1ba27acd118bfeeed326c8d9aaf Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 17c238517825dfb7ec3edfef5972acd944ffbc1e Maintainer: lacatoire Status: ready -->
 <!-- CREDITS: DavidA -->
 <refentry xml:id="xmlwriter.writecdata" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -95,6 +95,7 @@ echo $xml->outputMemory(true);
    &example.outputs;
    <screen>
 <![CDATA[
+<?xml version="1.0" encoding="UTF-8"?>
 <mydoc>
  <myele>
   <mycdataelement><![CDATA[text for inclusion as CData]​]></mycdataelement>


### PR DESCRIPTION
Port of php/doc-en 17c238517825dfb7ec3edfef5972acd944ffbc1e. formats.xml also carries the skeleton cleanup c62ef37e0d that precedes it on that file. date-sun-info.xml and ltrim.xml are handled in their own branches, where a later doc-en commit applies.

The str_word_count() offsets were recomputed against the French example string with php:8.4-cli.

Fixes: #3158