### PR TITLE
[Sync EN] Bulk PDO and mysqli grammar fixes

### DIFF
--- a/appendices/migration72/new-features.xml
+++ b/appendices/migration72/new-features.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 6d29533483657c036e49edb5ea88c7103d126681 Maintainer: jbnahan Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: lacatoire Status: ready -->
 
 <sect1 xml:id="migration72.new-features" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Nouvelles fonctionnalités</title>
@@ -157,14 +155,14 @@ $db->quote('über', PDO::PARAM_STR | PDO::PARAM_STR_NATL);
  <sect2 xml:id="migration72.new-features.additional-emulated-prepares-debugging-info">
   <title>Ajout d'information de débogage pour l'émulation des requêtes préparées pour <link linkend="book.pdo">PDO</link></title>
 
-  <para>
-   La méthode <function>PDOStatement::debugDumpParams</function> a été mise à 
-   jour pour inclure le SQL envoyé à la DB, où la requête complète, requête 
-   brute (y compris les espaces réservés remplacés par leurs valeurs liées) 
-   sera montrée. Ceci a été ajouté afin de faciliter le débogage 
-   de l'émulation des requêtes préparées (et donc il sera disponible lorsque 
+  <simpara>
+   La méthode <function>PDOStatement::debugDumpParams</function> a été mise à
+   jour pour inclure le SQL envoyé à la DB, où la requête complète, requête
+   brute (y compris les espaces réservés remplacés par leurs valeurs liées)
+   sera montrée. Ceci a été ajouté afin de faciliter le débogage
+   de l'émulation des requêtes préparées (et donc il sera disponible lorsque
    l'émulation des requêtes préparées est activée).
-  </para>
+  </simpara>
  </sect2>
 
  <sect2 xml:id="migration72.new-features.extended-ops-in-ldap">

--- a/appendices/migration83/other-changes.xml
+++ b/appendices/migration83/other-changes.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4de6272a1f15efc9e3df21d255965fd890da0d6f Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: lacatoire Status: ready -->
 <sect1 xml:id="migration83.other-changes" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Autres changements</title>
 

--- a/reference/mysqli/book.xml
+++ b/reference/mysqli/book.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 038bdb1d98c2481e291616a310945b38523965da Maintainer: yannick Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: lacatoire Status: ready -->
 <book xml:id="book.mysqli" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <?phpdoc extension-membership="bundledexternal" ?>
 
@@ -31,10 +29,10 @@
    xlink:href="&url.mysql.docs;">&url.mysql.docs;</link>.
   </para>
 
-  <para>
+  <simpara>
    Des morceaux du manuel MySQL ont été inclus dans la documentation PHP
    avec la permission d'Oracle Corporation.
-  </para>
+  </simpara>
   
   <para>
    Les exemples utilisent soit la base de données

--- a/reference/mysqli/configure.xml
+++ b/reference/mysqli/configure.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 050e16021ff71318012fa16322e98d8603d5ab38 Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: lacatoire Status: ready -->
 
 <section xml:id="mysqli.installation" xmlns="http://docbook.org/ns/docbook"
 xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -36,15 +34,16 @@ xmlns:xlink="http://www.w3.org/1999/xlink">
    mais aussi les bibliothèques clientes de chaque extension.
   </para>
   
-  <para>
-   Le driver natif MySQL est la bibliothèque cliente recommandée, vu qu'il apporte
+  <simpara>
+   Le driver natif MySQL est la bibliothèque cliente recommandée, et depuis
+   PHP 8.2.0 la seule possible, vu qu'il apporte
    un gain de performance et donne l'accès à des fonctionnalités
    qui ne sont pas disponibles lors de l'utilisation de la bibliothèque
    cliente MySQL. Se reporter à la section
    <link linkend="mysqli.overview.mysqlnd">Qu'est-ce que le driver
     natif MySQL de PHP ?</link> pour une brève description des avantages
    du driver natif MySQL.
-  </para>
+  </simpara>
   
   <para>
    <literal>/path/to/mysql_config</literal> représente le chemin du programme
@@ -65,7 +64,14 @@ xmlns:xlink="http://www.w3.org/1999/xlink">
     </thead>
     <tbody>
      <row>
-      <entry>5.4.x et ultérieur</entry>
+      <entry>8.2.0 et ultérieur</entry>
+      <entry>mysqlnd</entry>
+      <entry><option role="configure">--with-mysqli</option></entry>
+      <entry>libmysqlclient n'est pas supporté</entry>
+      <entry>mysqlnd est la seule option</entry>
+     </row>
+     <row>
+      <entry>5.4.0 à 8.1.x</entry>
       <entry>mysqlnd</entry>
       <entry><option role="configure">--with-mysqli</option></entry>
       <entry><option role="configure">--with-mysqli=/path/to/mysql_config</option></entry>
@@ -88,14 +94,7 @@ xmlns:xlink="http://www.w3.org/1999/xlink">
     </tbody>
    </tgroup>
   </table>
-  
-  <para>
-   Il est à noter qu'il est possible de mélanger les extensions MySQL ainsi que les
-   bibliothèques clientes. Par exemple, il est possible d'activer l'extension
-   MySQL pour utiliser la bibliothèque cliente MySQL (libmysqlclient) tout en configurant
-   l'extension <literal>mysqli</literal> pour utiliser le driver natif MySQL.
-   Toutes les combinaisons d'extensions et bibliothèques clientes sont possibles.
-  </para>
+
  </section>
  
  <section xml:id="mysqli.installation.windows">

--- a/reference/mysqli/constants.xml
+++ b/reference/mysqli/constants.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 5208882ce3910d599e339209f967e183b49ba6ef Maintainer: lacatoire Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: lacatoire Status: ready -->
 <appendix xml:id="mysqli.constants" xmlns="http://docbook.org/ns/docbook">
  &reftitle.constants;
  &extension.constants;
@@ -459,9 +458,9 @@
     (<type>int</type>)
    </term>
    <listitem>
-    <para>
+    <simpara>
      Le champ fait partie d'un index multiple.
-    </para>
+    </simpara>
    </listitem>
   </varlistentry>
   <varlistentry xml:id="constant.mysqli-group-flag">

--- a/reference/mysqli/ini.xml
+++ b/reference/mysqli/ini.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 90787fda14dcb0976a9738423e6c6013c037d048 Maintainer: yannick Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: lacatoire Status: ready -->
 <section xml:id="mysqli.configuration" xmlns="http://docbook.org/ns/docbook">
  &reftitle.runtime;
  &extension.runtime;
@@ -149,10 +148,10 @@
      <type>int</type>
     </term>
     <listitem>
-     <para>
-      Nombre maximal de connexions persistantes pouvant être réalisé.
+     <simpara>
+      Le nombre maximal de connexions persistantes pouvant être réalisé.
       Définir à 0 pour "illimité".
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry xml:id="ini.mysqli.max-links">
@@ -161,10 +160,10 @@
      <type>int</type>
     </term>
     <listitem>
-     <para>
-      Le nombre maximal de connexions MySQL par processus, incluant les
+     <simpara>
+      Le nombre maximal de connexions par processus, incluant les
       connexions persistantes.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry xml:id="ini.mysqli.default-port">

--- a/reference/mysqli/mysqli/change-user.xml
+++ b/reference/mysqli/mysqli/change-user.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: ee14f82484f6289278255f798f1e8b93cdc2cab5 Maintainer: yannick Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: lacatoire Status: ready -->
 <refentry xml:id="mysqli.change-user" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>mysqli::change_user</refname>
@@ -32,14 +31,14 @@
    Contrairement à <methodname>mysqli::connect</methodname>, cette méthode
    ne déconnectera pas la connexion actuelle si la nouvelle connexion ne peut pas être établie.
   </para>
-  <para>
-   Pour que cette fonction réussisse, les paramètres 
-   <parameter>username</parameter> et <parameter>password</parameter> doivent 
+  <simpara>
+   Pour que cette fonction réussisse, les paramètres
+   <parameter>username</parameter> et <parameter>password</parameter> doivent
    être valides et l'utilisateur en question doit avoir les permissions
    d'accès à la base de données désirée.
-   Si pour une raison ou une autre, l'autorisation échoue, l'utilisateur 
+   Si pour une raison ou une autre, l'autorisation échoue, l'utilisateur
    courant sera conservé.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -179,13 +178,13 @@ Base de données par défaut :
  <refsect1 role="notes">
   &reftitle.notes;
   <note>
-   <para>
+   <simpara>
     L'utilisation de cette commande implique toujours que la connexion soit
     considérée comme neuve, que la fonction réussisse ou non.
     Un appel à cette fonction annulera donc toutes les transactions actives,
     fermera les tables temporaires et déverrouillera les tables
     verrouillées.
-   </para>
+   </simpara>
   </note>
  </refsect1>
 

--- a/reference/mysqli/mysqli/dump-debug-info.xml
+++ b/reference/mysqli/mysqli/dump-debug-info.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 035c126c0393fe154bac46e2c3c489ebadce48a5 Maintainer: yannick Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: lacatoire Status: ready -->
 <refentry xml:id="mysqli.dump-debug-info" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>mysqli::dump_debug_info</refname>
@@ -20,12 +19,12 @@
    <type>bool</type><methodname>mysqli_dump_debug_info</methodname>
    <methodparam><type>mysqli</type><parameter>mysql</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Cette fonction est à utiliser par un utilisateur possédant le privilège
    SUPER et est utilisée pour écrire quelques informations de débogage
    dans le journal pour le serveur MySQL relatif à la connexion spécifiée par
    le paramètre <parameter>link</parameter>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">

--- a/reference/mysqli/mysqli/errno.xml
+++ b/reference/mysqli/mysqli/errno.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 614d77598aa2aaa3ddf3e8494812a3b82864d590 Maintainer: itanea Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: lacatoire Status: ready -->
 <refentry xml:id="mysqli.errno" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>mysqli::$errno</refname>
@@ -36,10 +34,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
-   La valeur du code erreur pour le dernier appel, s'il échoue. &zero; signifie qu'aucune erreur
-   n'est survenue.
-  </para>
+  <simpara>
+   La valeur du code erreur pour le dernier appel, s'il échoue.
+   <literal>0</literal> signifie qu'aucune erreur n'est survenue.
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/mysqli/mysqli/init.xml
+++ b/reference/mysqli/mysqli/init.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9b1673cf114a1e10c4563ab9223cb56aed552b89 Maintainer: yannick Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: lacatoire Status: ready -->
 <refentry xml:id="mysqli.init" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>mysqli::init</refname>
@@ -26,12 +25,12 @@
    <function>mysqli_options</function> et <function>mysqli_real_connect</function>.
   </para>
   <note>
-   <para>
-    Tous les appels suivants à n'importe quelle fonction MySQLi (exceptée de
+   <simpara>
+    Tout appel suivant à n'importe quelle fonction MySQLi (exceptée de
     <function>mysqli_options</function> et <function>mysqli_ssl_set</function>)
-    échoueront en attendant que la fonction
-    <function>mysqli_real_connect</function> soit appelée.
-   </para>
+    échouera tant que la fonction
+    <function>mysqli_real_connect</function> n'est pas appelée.
+   </simpara>
   </note>
  </refsect1>
 

--- a/reference/mysqli/mysqli/multi-query.xml
+++ b/reference/mysqli/mysqli/multi-query.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 1beae37b6904f55cfd33dbe99ad83a23eb78b144 Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: lacatoire Status: ready -->
 <refentry xml:id="mysqli.multi-query" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>mysqli::multi_query</refname>

--- a/reference/mysqli/mysqli/options.xml
+++ b/reference/mysqli/mysqli/options.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e309a62b16c7dc48883b1b426bb8c15918488681 Maintainer: jpauli Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: lacatoire Status: ready -->
 <refentry xml:id="mysqli.options" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>mysqli::options</refname>
@@ -77,7 +76,7 @@
           </row>
           <row>
            <entry><constant>MYSQLI_INIT_COMMAND</constant></entry>
-           <entry>Commande à exécuter après la connexion au serveur MySQL</entry>
+           <entry>Commande à exécuter après l'établissement d'une connexion au serveur MySQL</entry>
           </row>
           <row>
            <entry><constant>MYSQLI_SET_CHARSET_NAME</constant></entry>

--- a/reference/mysqli/mysqli/ping.xml
+++ b/reference/mysqli/mysqli/ping.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9b1673cf114a1e10c4563ab9223cb56aed552b89 Maintainer: yannick Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: lacatoire Status: ready -->
 <refentry xml:id="mysqli.ping" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>mysqli::ping</refname>
@@ -83,8 +82,8 @@
       <entry>
        Les méthodes <methodname>mysqli::ping</methodname> et
        <function>mysqli_ping</function> sont désormais obsolètes.
-       La fonctionnalité <literal>reconnect</literal> n'est plus
-       disponible à partir de PHP 8.2.0, rendant cette fonction obsolète.
+       À partir de PHP 8.2.0, la fonctionnalité <literal>reconnect</literal>
+       n'est plus disponible, rendant cette fonction obsolète.
       </entry>
      </row>
     </tbody>

--- a/reference/mysqli/mysqli/poll.xml
+++ b/reference/mysqli/mysqli/poll.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: c5ccd084c8f830801a939bf1829ddddcaf019730 Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: lacatoire Status: ready -->
 <refentry xml:id="mysqli.poll" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>mysqli::poll</refname>
@@ -56,20 +55,19 @@
     <varlistentry>
      <term><parameter>error</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Liste des connexions sur lesquelles une erreur est survenue,
        par exemple, des échecs de requêtes, ou des pertes de connexion.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>reject</parameter></term>
      <listitem>
-      <para>
-       Liste des connexions rejetées car des requêtes non-asynchrones
-       y ont été exécutées et pour lesquelles la fonction
-       pourrait sortir des résultats.
-      </para>
+      <simpara>
+       Liste des connexions rejetées car aucune requête asynchrone en attente
+       n'existe pour laquelle sonder des résultats.
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>

--- a/reference/mysqli/mysqli/rollback.xml
+++ b/reference/mysqli/mysqli/rollback.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 976425d4f6eec32448be3cc22ec063015921b753 Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: lacatoire Status: ready -->
 <refentry xml:id="mysqli.rollback" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>mysqli::rollback</refname>
@@ -23,9 +22,9 @@
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>0</initializer></methodparam>
    <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>name</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Annule la transaction courante pour la base de données.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">

--- a/reference/mysqli/mysqli/select-db.xml
+++ b/reference/mysqli/mysqli/select-db.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 63b99082ef83eade08151f8cb528246fded81db9 Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: lacatoire Status: ready -->
 <refentry xml:id="mysqli.select-db" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>mysqli::select_db</refname>
@@ -28,11 +27,11 @@
    <parameter>mysql</parameter>.
   </para>
   <note>
-   <para>
-    Cette fonction ne doit être utilisée que pour changer la base de données par défaut pour 
+   <simpara>
+    Cette fonction ne doit être utilisée que pour changer la base de données par défaut pour
     la connexion courante. Il est possible de sélectionner la base de données par défaut avec
     le 4ème paramètre de la fonction <function>mysqli_connect</function>.
-   </para>
+   </simpara>
   </note>
  </refsect1>
 

--- a/reference/mysqli/mysqli/sqlstate.xml
+++ b/reference/mysqli/mysqli/sqlstate.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: d9de192baa45cdf33168eea8a45d14216def4395 Maintainer: yannick Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: lacatoire Status: ready -->
 <refentry xml:id="mysqli.sqlstate" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>mysqli::$sqlstate</refname>
@@ -25,11 +23,11 @@
    possibles, voir : <link xlink:href="&url.mysql.docs.error;">&url.mysql.docs.error;</link>.
   </para>
   <note>
-   <para>
+   <simpara>
     Il est à noter que toutes les erreurs de MySQL n'ont pas encore de correspondance
     avec les erreurs SQLSTATE. La valeur <literal>HY000</literal>
     (erreur générale) est utilisée pour les erreurs sans correspondance.
-   </para>
+   </simpara>
   </note>
  </refsect1>
 

--- a/reference/mysqli/mysqli/stmt-init.xml
+++ b/reference/mysqli/mysqli/stmt-init.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 035c126c0393fe154bac46e2c3c489ebadce48a5 Maintainer: yannick Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: lacatoire Status: ready -->
 <refentry xml:id="mysqli.stmt-init" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>mysqli::stmt_init</refname>
@@ -25,10 +24,10 @@
    <function>mysqli_stmt_prepare</function>.
   </para>
   <note>
-   <para>
-    Tous les appels ultérieurs aux fonctions mysqli_stmt_* échoueront,
+   <simpara>
+    Tout appel ultérieur à une méthode <classname>mysqli_stmt</classname> échouera,
     tant que <function>mysqli_stmt_prepare</function> n'a pas été appelée.
-   </para>
+   </simpara>
   </note>
  </refsect1>
 
@@ -43,9 +42,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
-   Retourne un objet.
-  </para>
+  <simpara>
+   Retourne un objet <classname>mysqli_stmt</classname>.
+  </simpara>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/mysqli/mysqli/use-result.xml
+++ b/reference/mysqli/mysqli/use-result.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 63b99082ef83eade08151f8cb528246fded81db9 Maintainer: yannick Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: lacatoire Status: ready -->
 <refentry xml:id="mysqli.use-result" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>mysqli::use_result</refname>
@@ -33,15 +32,15 @@
    à la base de données.
   </para>
   <note>
-   <para>
+   <simpara>
     La fonction <function>mysqli_use_result</function> ne transfère pas
     le jeu de résultats en entier à partir de la base de données
-    et on ne peut donc pas utiliser des fonctions telle
+    et ne peut donc pas être utilisée avec des fonctions telles que
     <function>mysqli_data_seek</function> pour se déplacer entre les
     enregistrements. Pour utiliser cette fonctionnalité, l'on doit
     récupérer le jeu de résultats en utilisant
     <function>mysqli_store_result</function>.
-   </para>
+   </simpara>
   </note>
  </refsect1>
 

--- a/reference/mysqli/mysqli_driver.xml
+++ b/reference/mysqli/mysqli_driver.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: jpauli Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: lacatoire Status: ready -->
 <reference xml:id="class.mysqli-driver" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>La classe mysqli_driver</title>
  <titleabbrev>mysqli_driver</titleabbrev>
@@ -10,11 +9,11 @@
 <!-- {{{ ClassName intro -->
   <section xml:id="mysqli-driver.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     La classe <classname>mysqli_driver</classname> est une instance du pattern
     monostate, c.à.d. il n'y a qu'un seul pilote qui peut accéder à travers un
     nombre arbitraire d'instances <classname>mysqli_driver</classname>.
-   </para>
+   </simpara>
   </section>
 <!-- }}} -->
 

--- a/reference/mysqli/mysqli_result/fetch-fields.xml
+++ b/reference/mysqli/mysqli_result/fetch-fields.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 5152c78db935ea2463e20a01ae0e3f3573314d78 Maintainer: jpauli Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: lacatoire Status: ready -->
 <refentry xml:id="mysqli-result.fetch-fields" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>mysqli_result::fetch_fields</refname>

--- a/reference/mysqli/mysqli_result/fetch-object.xml
+++ b/reference/mysqli/mysqli_result/fetch-object.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: c5ccd084c8f830801a939bf1829ddddcaf019730 Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: lacatoire Status: ready -->
 <refentry xml:id="mysqli-result.fetch-object" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>mysqli_result::fetch_object</refname>
@@ -86,10 +85,10 @@
 
  <refsect1 role="errors">
   &reftitle.errors;
-  <para>
+  <simpara>
    Une <classname>ValueError</classname> est lancée quand
    <parameter>constructor_args</parameter> n'est pas vide et que la classe n'a pas de constructeur.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">

--- a/reference/mysqli/mysqli_result/num-rows.xml
+++ b/reference/mysqli/mysqli_result/num-rows.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 181e9c5572ed04ed712b8d7f858f61a94647c6ac Maintainer: yannick Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: lacatoire Status: ready -->
 <refentry xml:id="mysqli-result.num-rows" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>mysqli_result::$num_rows</refname>
@@ -98,11 +96,11 @@ Le jeu de résultats a 239 lignes.
  <refsect1 role="notes">
   &reftitle.notes;
   <note>
-   <para>
+   <simpara>
     Contrairement à la fonction <function>mysqli_stmt_num_rows</function>,
     cette fonction n'a pas de variante de méthode orientée objet.
     Dans le style orienté objet, utiliser le getter de la propriété.
-   </para>
+   </simpara>
   </note>
  </refsect1>
 

--- a/reference/mysqli/mysqli_sql_exception/getsqlstate.xml
+++ b/reference/mysqli/mysqli_sql_exception/getsqlstate.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 035c126c0393fe154bac46e2c3c489ebadce48a5 Maintainer: Fan2Shrek Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: lacatoire Status: ready -->
 <refentry xml:id="mysqli-sql-exception.getsqlstate" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>mysqli_sql_exception::getSqlState</refname>
@@ -20,10 +19,10 @@
    <link xlink:href="&url.mysql.docs.error;">&url.mysql.docs.error;</link>.
   </para>
   <note>
-   <para>
+   <simpara>
     Il est à noter que toutes les erreurs MySQL ne sont pas encore mappées aux SQLSTATE.
     La valeur <literal>HY000</literal> (erreur générale) est utilisée pour les erreurs non mappées.
-   </para>
+   </simpara>
   </note>
  </refsect1>
 

--- a/reference/mysqli/mysqli_stmt/affected-rows.xml
+++ b/reference/mysqli/mysqli_stmt/affected-rows.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 2d5c6bed30ea22d847bf03dad1072f075694b4c3 Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: lacatoire Status: ready -->
 <refentry xml:id="mysqli-stmt.affected-rows" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>mysqli_stmt::$affected_rows</refname>
@@ -18,13 +17,13 @@
    <type class="union"><type>int</type><type>string</type></type><methodname>mysqli_stmt_affected_rows</methodname>
    <methodparam><type>mysqli_stmt</type><parameter>statement</parameter></methodparam>
   </methodsynopsis>
-  <para>
-   Retourne le nombre de lignes affectées par une requête
+  <simpara>
+   Retourne le nombre de lignes affectées par la requête
    <literal>INSERT</literal>, <literal>UPDATE</literal>
    ou <literal>DELETE</literal>.
    Fonctionne comme <function>mysqli_stmt_num_rows</function> pour
    les requêtes <literal>SELECT</literal>.
-  </para>
+  </simpara>
  </refsect1>
  
  <refsect1 role="parameters">
@@ -49,11 +48,11 @@
    <function>mysqli_stmt_store_result</function>.
   </para>
   <note>
-   <para>
+   <simpara>
     Si le nombre de lignes affectées est plus grand que la valeur maximale
     (<constant>PHP_INT_MAX</constant>) que peut prendre un entier, le nombre
     de lignes affectées sera retourné en tant que chaîne de caractères.
-   </para>
+   </simpara>
   </note>
  </refsect1>
  

--- a/reference/mysqli/mysqli_stmt/bind-result.xml
+++ b/reference/mysqli/mysqli_stmt/bind-result.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 2e61d37d1d91ec32ecadf2a872e0a4109d02bc68 Maintainer: yannick Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: lacatoire Status: ready -->
 <refentry xml:id="mysqli-stmt.bind-result" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>mysqli_stmt::bind_result</refname>
@@ -53,11 +52,11 @@
    </para>
   </note>
   <tip>
-   <para>
+   <simpara>
     Cette fonction est utile pour les résultats basiques.
     Pour récupérer un ensemble de résultats itérable, ou récupérer chaque ligne sous forme
     de tableau ou d'objet, utiliser la <function>mysqli_stmt_get_result</function>.
-   </para>
+   </simpara>
   </tip>
  </refsect1>
 

--- a/reference/mysqli/mysqli_stmt/execute.xml
+++ b/reference/mysqli/mysqli_stmt/execute.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: ec946465e5ee9dc4dc19f1a28510697066a19eac Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: lacatoire Status: ready -->
 <refentry xml:id="mysqli-stmt.execute" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>mysqli_stmt::execute</refname>

--- a/reference/mysqli/mysqli_stmt/reset.xml
+++ b/reference/mysqli/mysqli_stmt/reset.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 035c126c0393fe154bac46e2c3c489ebadce48a5 Maintainer: yannick Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: lacatoire Status: ready -->
 <refentry xml:id="mysqli-stmt.reset" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>mysqli_stmt::reset</refname>
@@ -20,9 +19,9 @@
    <type>bool</type><methodname>mysqli_stmt_reset</methodname>
    <methodparam><type>mysqli_stmt</type><parameter>statement</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Annule une requête préparée sur le client et sur le serveur après avoir été préparée.
-  </para>
+  </simpara>
   <para>
    Cette fonction annule la requête sur le serveur, annule les données envoyées en
    utilisant la fonction <function>mysqli_stmt_send_long_data</function>,

--- a/reference/mysqli/mysqli_stmt/send-long-data.xml
+++ b/reference/mysqli/mysqli_stmt/send-long-data.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 035c126c0393fe154bac46e2c3c489ebadce48a5 Maintainer: yannick Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: lacatoire Status: ready -->
 <refentry xml:id="mysqli-stmt.send-long-data" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>mysqli_stmt::send_long_data</refname>
@@ -23,12 +22,12 @@
    <methodparam><type>int</type><parameter>param_num</parameter></methodparam>
    <methodparam><type>string</type><parameter>data</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Envoie les données au serveur par paquets, si la taille des données excède
    la limite de <literal>max_allowed_packet</literal>. Cette fonction peut
    être appelée plusieurs fois pour envoyer les données textes ou binaires
    de champs comme les BLOB ou TEXT.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">

--- a/reference/mysqli/mysqli_stmt/sqlstate.xml
+++ b/reference/mysqli/mysqli_stmt/sqlstate.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: d68e83b719028bb068785cccc3205c23be530564 Maintainer: yannick Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: lacatoire Status: ready -->
 <refentry xml:id="mysqli-stmt.sqlstate" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>mysqli_stmt::$sqlstate</refname>
@@ -136,11 +134,11 @@ Erreur : 42S02.
  <refsect1 role="notes">
   &reftitle.notes;
   <note>
-   <para>
+   <simpara>
     Il est à noter que toutes les erreurs MySQL n'ont pas encore de correspondance
     en SQLSTATE. La valeur <literal>HY000</literal> (erreur générale) est
     utilisée pour les erreurs sans correspondance.
-   </para>
+   </simpara>
   </note>
  </refsect1>
 

--- a/reference/mysqli/overview.xml
+++ b/reference/mysqli/overview.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e8ac70bf549a723cb36465667a6109d9933b8619 Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: lacatoire Status: ready -->
 
 <chapter xml:id="mysqli.overview" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
 
@@ -82,13 +81,13 @@
     pilote PDO MYSQL, qui permet de faire l'interface avec MySQL.
   </para>
 
-  <para>
+  <simpara>
     Parfois, les développeurs utilisent les termes de connecteur et de pilote
-    de manière interchangeable, et cela peut être confus. Dans les
+    de manière interchangeable, ce qui peut être confus. Dans les
     documentations MySQL, le terme de <quote>pilote</quote> est réservé
     aux logiciels qui sont la face spécifique avec la base de données du
     paquet.
-  </para>
+  </simpara>
 
   <para>
     <emphasis role="bold">Qu'est-ce qu'une extension?</emphasis>
@@ -299,14 +298,14 @@
     <literal>libmysqlclient</literal> pour les applications PHP.
   </para>
 
-  <para>
+  <simpara>
    L'extension <literal>mysqli</literal> et le pilote MySQL natif peuvent
    tous deux être configurés individuellement pour utiliser soit
     <literal>libmysqlclient</literal> soit <literal>mysqlnd</literal>. Comme
     <literal>mysqlnd</literal> a été conçu spécifiquement pour utiliser le système
-    PHP, il propose de nombreux avantages et améliorations par rapport à 
+    PHP, il propose de nombreux avantages et améliorations par rapport à
     <literal>libmysqlclient</literal>. On est vivement encouragés à en profiter.
-  </para>
+  </simpara>
 
   <para>
     Le MySQL Native Driver est implémenté sur la base du framework

--- a/reference/mysqli/quickstart.xml
+++ b/reference/mysqli/quickstart.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: c2088ac3e8ffe9d7b316f0b9a5bf7c3d9eeae5c0 Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: lacatoire Status: ready -->
 
 <chapter xml:id="mysqli.quickstart" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Guide de démarrage rapide</title>
@@ -236,11 +234,11 @@ mysqli.default_socket=/tmp/mysql.sock
    un tube nommé. S'il n'est pas fourni ou vide, alors le socket (tube nommé)
    vaudra par défaut <literal>\\.\pipe\MySQL</literal>.
   </para>
-  <para>
+  <simpara>
    Si ni un socket de domaine Unix, ni un tube nommé Windows n'est fourni, une connexion
    de base sera établie et si la valeur du port n'est pas définie, la bibliothèque
    utilisera le port <literal>3306</literal>.
-  </para>
+  </simpara>
   <para>
    La bibliothèque <link linkend="mysqlnd.overview">mysqlnd</link> et la bibliothèque
    cliente MySQL (libmysqlclient) implémentent la même logique pour déterminer les valeurs
@@ -300,7 +298,7 @@ mysqli.default_socket=/tmp/mysql.sock
    restreint avec la directive <link linkend="ini.mysqli.max-persistent">mysqli.max_persistent</link>.
    Veuillez noter que le serveur web peut engendrer plusieurs processus PHP.
   </para>
-  <para>
+  <simpara>
    Une plainte courante contre les connexions persistantes est que leur
    statut n'est pas réinitialisé avant la ré-utilisation. Par exemple,
    les transactions ouvertes et non terminées ne sont pas automatiquement
@@ -310,7 +308,7 @@ mysqli.default_socket=/tmp/mysql.sock
    bord non désiré. Au contraire, le nom <literal>persistent</literal>
    peut être compris comme une promesse sur le fait que le statut persiste
    réellement.
-  </para>
+  </simpara>
   <para>
    L'extension mysqli supporte deux interprétations d'une connexion persistante :
    statut persistant, et un statut réinitialisé avant ré-utilisation. Par
@@ -992,9 +990,9 @@ array(2) {
   <para>
    <emphasis role="bold">Émulation côté client de la préparation d'une requête</emphasis>
   </para>
-  <para>
-   L'API n'inclut pas d'émulation côté client de la préparation d'une requête.
-  </para>
+  <simpara>
+   L'API ne prend pas en charge l'émulation côté client de la préparation d'une requête.
+  </simpara>
   <para>
    <emphasis role="bold">Voir aussi</emphasis>
   </para>
@@ -1106,13 +1104,13 @@ Hi!
     </screen>
    </example>
   </para>
-  <para>
+  <simpara>
    Les développeurs d'application et de framework peuvent fournir une API
    plus conviviale utilisant un mix des variables de session et une inspection
-   du catalogue de la base de données. Cependant, veuillez garder à l'esprit
+   du catalogue de la base de données. Cependant, il faut garder à l'esprit
    l'impact sur les performances dû à une solution personnalisée basée
    sur l'inspection du catalogue.
-  </para>
+  </simpara>
   <para>
    <emphasis role="bold">Gestion des jeux de résultats</emphasis>
   </para>

--- a/reference/mysqli/summary.xml
+++ b/reference/mysqli/summary.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4e8c90ca8a4a63575341cde6f5fbdc34419d2cff Maintainer: yannick Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: lacatoire Status: ready -->
 <chapter xml:id="mysqli.summary" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
 
  <title>Le sommaire des fonctions de l'extension MySQLi</title>
@@ -204,7 +203,7 @@
      <entry><methodname>mysqli::get_warnings</methodname></entry>
      <entry><function>mysqli_get_warnings</function></entry>
      <entry>N/A</entry>
-     <entry>Non documenté</entry>
+     <entry>Récupère le résultat de SHOW WARNINGS</entry>
     </row>
     <row>
      <entry><methodname>mysqli::init</methodname></entry>
@@ -390,7 +389,7 @@
      <entry><link linkend="mysqli-stmt.field-count">$mysqli_stmt::field_count</link></entry>
      <entry><function>mysqli_stmt_field_count</function></entry>
      <entry>N/A</entry>
-     <entry>Le nombre de champs présents dans la requête donnée</entry>
+     <entry>Le nombre de champs présents dans la requête</entry>
     </row>
     <row>
      <entry><link linkend="mysqli-stmt.insert-id">$mysqli_stmt::insert_id</link></entry>
@@ -402,19 +401,19 @@
      <entry><link linkend="mysqli-stmt.num-rows">$mysqli_stmt::num_rows</link></entry>
      <entry><function>mysqli_stmt_num_rows</function></entry>
      <entry>N/A</entry>
-     <entry>Le nombre de lignes d'un résultat MySQL</entry>
+     <entry>Le nombre de lignes du jeu de résultats de la requête</entry>
     </row>
     <row>
      <entry><link linkend="mysqli-stmt.param-count">$mysqli_stmt::param_count</link></entry>
      <entry><function>mysqli_stmt_param_count</function></entry>
      <entry>N/A</entry>
-     <entry>Le nombre de paramètres d'une commande SQL</entry>
+     <entry>Le nombre de paramètres de la requête</entry>
     </row>
     <row>
      <entry><link linkend="mysqli-stmt.sqlstate">$mysqli_stmt::sqlstate</link></entry>
      <entry><function>mysqli_stmt_sqlstate</function></entry>
      <entry>N/A</entry>
-     <entry>Le code SQLSTATE de la dernière opération MySQL</entry>
+     <entry>Le code SQLSTATE de l'opération précédente</entry>
     </row>
     <row>
      <entry><emphasis role="bold">&Methods;</emphasis></entry>
@@ -423,7 +422,7 @@
      <entry><methodname>mysqli_stmt::attr_get</methodname></entry>
      <entry><function>mysqli_stmt_attr_get</function></entry>
      <entry>N/A</entry>
-     <entry>Récupère la valeur courante d'un attribut de requête</entry>
+     <entry>Récupère la valeur courante d'un attribut de la requête</entry>
     </row>
     <row>
      <entry><methodname>mysqli_stmt::attr_set</methodname></entry>

--- a/reference/mysqlinfo/set.xml
+++ b/reference/mysqlinfo/set.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 7cff4d34f0324c9de72d15957e1b62e20f37dfaf Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: lacatoire Status: ready -->
 <set xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="set.mysqlinfo">
  <title>Plugins et drivers MySQL</title>
  <titleabbrev>MySQL</titleabbrev>

--- a/reference/pdo/configure.xml
+++ b/reference/pdo/configure.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 78cd8f0ba32f4d9921bb8b7eca066de8de29924d Maintainer: jpauli Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: lacatoire Status: ready -->
 
 <section xml:id="pdo.installation" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.install;
@@ -11,14 +10,14 @@
  <procedure xml:id="pdo.install.unix51up">
   <title>Installer PDO sur les systèmes Unix</title>
   <step>
-   <para>
+   <simpara>
     PDO et le pilote <link linkend="ref.pdo-sqlite">PDO_SQLITE</link>
     sont activés par défaut. Il faut activer
     le pilote PDO de la base de données de son choix ; consulter
     la documentation pour les
     <link linkend="pdo.drivers">pilotes spécifiques aux bases
      de données</link> pour plus d'informations.
-   </para>
+   </simpara>
    <note>
     <para>
      À noter que lors de la compilation de PDO comme extension partagée

--- a/reference/pdo/connections.xml
+++ b/reference/pdo/connections.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e7e4ffe9a10a4dcd9903a7abf125a811d0eda023 Maintainer: yannick Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: lacatoire Status: ready -->
 
 <chapter xml:id="pdo.connections" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Connexions et gestionnaire de connexion</title>
@@ -112,7 +111,7 @@ $dbh = new PDO('mysql:host=localhost;dbname=test', $user, $pass, array(
    </programlisting>
   </example>
  </para>
- <para>
+ <simpara>
   La valeur de l'option <constant>PDO::ATTR_PERSISTENT</constant> est convertie
   en &boolean; (activer/désactiver les connexions persistantes), sauf si c'est
   une &string; non-numérique, auquel cas ceci autorise l'utilisation de
@@ -120,7 +119,7 @@ $dbh = new PDO('mysql:host=localhost;dbname=test', $user, $pass, array(
   Ceci est utile si les connexions différentes utilisent des paramètres
   incompatibles, par exemple, des valeurs différentes de
   <constant>PDO::MYSQL_ATTR_USE_BUFFERED_QUERY</constant>.
- </para>
+ </simpara>
  <note>
   <para>
    Pour utiliser des connexions persistantes, il faut

--- a/reference/pdo/constants.xml
+++ b/reference/pdo/constants.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 8d40a1fab3f89d6e35caece522991b67fb9df246 Maintainer: lacatoire Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: lacatoire Status: ready -->
 <appendix xml:id="pdo.constants" xmlns="http://docbook.org/ns/docbook">
  &reftitle.constants;
  &extension.constants;
@@ -424,7 +423,10 @@
     </term>
     <listitem>
      <simpara>
-      Définit le nom de la classe des déclarations retournées.
+      Définit le nom de la classe et les arguments du constructeur pour
+      l'extension de l'objet <classname>PDOStatement</classname>. Le premier
+      élément du tableau est le nom de la classe, et le second élément est un
+      tableau d'arguments du constructeur.
      </simpara>
     </listitem>
    </varlistentry>
@@ -517,8 +519,9 @@
     </term>
     <listitem>
      <simpara>
-      Définit le type de paramètre de chaîne par défaut, cela peut être l'un de <constant>PDO::PARAM_STR_NATL</constant>
-      et <constant>PDO::PARAM_STR_CHAR</constant>.
+      Définit le type de paramètre de chaîne par défaut, qui peut être soit
+      <constant>PDO::PARAM_STR_NATL</constant>,
+      soit <constant>PDO::PARAM_STR_CHAR</constant>.
      </simpara>
      <simpara>
       Disponible à partir de PHP 7.2.0.

--- a/reference/pdo/ini.xml
+++ b/reference/pdo/ini.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: d4d5216e7a965ca194f6b1c9dee84cecab2674e5 Maintainer: jpauli Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: lacatoire Status: ready -->
 
 <section xml:id="pdo.configuration" xmlns="http://docbook.org/ns/docbook">
  &reftitle.runtime;

--- a/reference/pdo/pdo/connect.xml
+++ b/reference/pdo/pdo/connect.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: dfd68fd22aef25658bc9348176b55b504d26ab11 Maintainer: lacatoire Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: lacatoire Status: ready -->
 <refentry xml:id="pdo.connect" xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude">
  <refnamediv>
   <refname>PDO::connect</refname>
@@ -23,9 +22,7 @@
   </simpara>
  </refsect1>
 
- <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('pdo.construct')/db:refsect1[@role='parameters']/.)">
-  <xi:fallback/>
- </xi:include>
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('pdo.construct')/db:refsect1[@role='parameters']/.)"/>
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
@@ -36,9 +33,7 @@
   </simpara>
  </refsect1>
 
- <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('pdo.construct')/db:refsect1[@role='errors']/.)">
-  <xi:fallback/>
- </xi:include>
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('pdo.construct')/db:refsect1[@role='errors']/.)"/>
 
  <refsect1 role="seealso">
   &reftitle.seealso;

--- a/reference/pdo/pdo/errorcode.xml
+++ b/reference/pdo/pdo/errorcode.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 661e6858acade9f5a08fc8f9c07b605f42f4a700 Maintainer: yannick Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: lacatoire Status: ready -->
 <refentry xml:id="pdo.errorcode" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>PDO::errorCode</refname>
@@ -24,7 +23,7 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    <methodname>PDO::errorCode</methodname> retourne un SQLSTATE,
    un identifiant alphanumérique de cinq caractères défini dans le standard ANSI SQL.
    Brièvement, un SQLSTATE consiste en une valeur de classe de deux caractères suivi
@@ -35,7 +34,7 @@
    elle-même de PDO (ou peut-être ODBC, lors de l'utilisation du driver ODBC).
    La valeur de sous-classe '000' dans n'importe quelle classe, indique qu'il n'y a pas de
    sous-classe pour cet SQLSTATE.
-  </para>
+  </simpara>
   <para>
    <methodname>PDO::errorCode</methodname> retourne uniquement les codes erreurs 
    pour les opérations exécutées directement sur le gestionnaire de la base de données.

--- a/reference/pdo/pdo/errorinfo.xml
+++ b/reference/pdo/pdo/errorinfo.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 661e6858acade9f5a08fc8f9c07b605f42f4a700 Maintainer: yannick Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: lacatoire Status: ready -->
 <refentry xml:id="pdo.errorinfo" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>PDO::errorInfo</refname>

--- a/reference/pdo/pdo/getavailabledrivers.xml
+++ b/reference/pdo/pdo/getavailabledrivers.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 661e6858acade9f5a08fc8f9c07b605f42f4a700 Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: lacatoire Status: ready -->
 <refentry xml:id="pdo.getavailabledrivers" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>PDO::getAvailableDrivers</refname>

--- a/reference/pdo/pdo/prepare.xml
+++ b/reference/pdo/pdo/prepare.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 525aa5f198d482c0d03be54ddee5af13b376ab99 Maintainer: lacatoire Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: lacatoire Status: ready -->
 <refentry xml:id="pdo.prepare" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>PDO::prepare</refname>
@@ -35,13 +34,13 @@
    le mode émulation ne soit actif.
   </para>
 <note>
-   <para>
-    Les marqueurs de paramètres peuvent représenter uniquement un littéral de 
+   <simpara>
+    Les marqueurs de paramètres peuvent représenter uniquement un littéral de
     données complet.
-    Ni une partie de littéral, ni un mot clé, ni un identifiant, ni toute autre 
-    requête arbitraire ne peuvent être liés en utilisant les paramètres.       
-    Par exemple, il n'est pas possible d'associer plusieurs valeurs à un seul marqueur de nom entrant, dans la clause IN() d'une requête SQL. 
-   </para>
+    Ni une partie de littéral, ni un mot clé, ni un identifiant, ni toute autre
+    requête arbitraire ne peuvent être liés en utilisant les paramètres.
+    Par exemple, il n'est pas possible d'associer plusieurs valeurs à un seul marqueur de nom entrant, dans la clause IN() d'une requête SQL.
+   </simpara>
   </note>
   <para>
    Appeler <methodname>PDO::prepare</methodname> et
@@ -120,11 +119,11 @@
    <link linkend="pdo.error-handling">gestionnaire des erreurs</link>).
   </para>
   <note>
-   <para>
+   <simpara>
     L'émulation de requêtes préparées ne communique pas avec le serveur de base
     de données. Aussi, la fonction <methodname>PDO::prepare</methodname> ne vérifie
     pas la requête.
-   </para>
+   </simpara>
   </note>
  </refsect1>
 

--- a/reference/pdo/pdo/quote.xml
+++ b/reference/pdo/pdo/quote.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: c142be811735a5542c8a2e4c4ed2f81e8cc3acc6 Maintainer: yannick Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: lacatoire Status: ready -->
 <refentry xml:id="pdo.quote" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>PDO::quote</refname>
@@ -32,10 +31,10 @@
    requêtes, étant donné que les côtés client et serveur peuvent mettre
    en cache une version compilée de la requête.
   </para>
-  <para>
+  <simpara>
    Tous les pilotes PDO n'implémentent pas cette méthode (comme PDO_ODBC). Utiliser
    les requêtes préparées à la place.
-  </para>
+  </simpara>
   <caution>
    <title>Sécurité : le jeu de caractères par défaut</title>
    <para>
@@ -55,21 +54,21 @@
     <varlistentry>
      <term><parameter>string</parameter></term>
       <listitem>
-       <para>
+       <simpara>
         La chaîne à protéger.
-       </para>
+       </simpara>
       </listitem>
      </varlistentry>
     <varlistentry>
      <term><parameter>type</parameter></term>
       <listitem>
-       <para>
+       <simpara>
         Le type de données pour les drivers qui ont des styles particuliers
         de protection.
-        Fournit un indice au type de donnée pour les pilotes qui ont un style
+        Fournit un indice quant au type de donnée pour les pilotes qui ont un style
         d'échappement différent. Par exemple <constant>PDO_PARAM_LOB</constant>
         indique au pilote d'échapper des données binaires.
-       </para>
+       </simpara>
       </listitem>
      </varlistentry>
    </variablelist>
@@ -77,11 +76,11 @@
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retourne une chaîne protégée, qui est théoriquement sûre à utiliser
    dans une requête SQL. Retourne &false; si le pilote ne supporte pas
    ce type de protections.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/pdo/pdorow.xml
+++ b/reference/pdo/pdorow.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 812ed835faa11b611c112d2a16777aebf70eb020 Maintainer: Fan2Shrek Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: lacatoire Status: ready -->
 <reference xml:id="class.pdorow" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>La classe PDORow</title>
  <titleabbrev>PDORow</titleabbrev>
@@ -18,13 +17,13 @@
    <para>
     Les objets de cette classe ne peuvent pas être instanciés et ne sont pas sérialisables.
    </para>
-   <para>
-    La classe <classname>PDORow</classname> permet d'accéder aux 
+   <simpara>
+    La classe <classname>PDORow</classname> permet d'accéder aux
     données retournées comme si les modes <constant>PDO::FETCH_OBJ</constant>
     et <constant>PDO::FETCH_BOTH</constant> étaient utilisés.
     Cela signifie que les données retournées peuvent être accédées comme des propriétés d'objet,
     et comme un tableau indexé par le nom de la colonne et un numéro de position de colonne.
-   </para>
+   </simpara>
    <caution>
     <simpara>
      Accéder à une propriété non définie retourne &null;

--- a/reference/pdo/pdostatement/debugdumpparams.xml
+++ b/reference/pdo/pdostatement/debugdumpparams.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 661e6858acade9f5a08fc8f9c07b605f42f4a700 Maintainer: yannick Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: lacatoire Status: ready -->
 <refentry xml:id="pdostatement.debugdumpparams" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>PDOStatement::debugDumpParams</refname>

--- a/reference/pdo/pdostatement/errorinfo.xml
+++ b/reference/pdo/pdostatement/errorinfo.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 661e6858acade9f5a08fc8f9c07b605f42f4a700 Maintainer: yannick Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: lacatoire Status: ready -->
 <refentry xml:id="pdostatement.errorinfo" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>PDOStatement::errorInfo</refname>

--- a/reference/pdo/pdostatement/execute.xml
+++ b/reference/pdo/pdostatement/execute.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 216c5dc1ef01b98d6ccafe51056e4df68e77cbf6 Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: lacatoire Status: ready -->
 <refentry xml:id="pdostatement.execute" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>PDOStatement::execute</refname>
@@ -179,10 +178,10 @@ $sth->execute($params);
  <refsect1 role="notes">
   &reftitle.notes;
   <note>
-   <para>
-    Quelques drivers nécessitent de <link linkend="pdostatement.closecursor">fermer
-    le curseur</link> avant d'exécuter la requête suivante.
-   </para>
+   <simpara>
+    Quelques drivers nécessitent que le <link linkend="pdostatement.closecursor">curseur
+    soit fermé</link> avant d'exécuter la requête suivante.
+   </simpara>
   </note>
  </refsect1>
 

--- a/reference/pdo/pdostatement/fetch.xml
+++ b/reference/pdo/pdostatement/fetch.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: c142be811735a5542c8a2e4c4ed2f81e8cc3acc6 Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: lacatoire Status: ready -->
 <refentry xml:id="pdostatement.fetch" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>PDOStatement::fetch</refname>
@@ -16,7 +15,7 @@
    <methodparam choice="opt"><type>int</type><parameter>cursorOrientation</parameter><initializer><constant>PDO::FETCH_ORI_NEXT</constant></initializer></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>cursorOffset</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
-  
+
   <para>
    Récupère une ligne depuis un jeu de résultats associé à l'objet
    <literal>PDOStatement</literal>. Le paramètre
@@ -24,7 +23,7 @@
    la ligne.
   </para>
  </refsect1>
- 
+
  <refsect1 role="parameters">
   &reftitle.parameters;
   <para>
@@ -38,67 +37,87 @@
        et par défaut, vaut la valeur de <literal>PDO::ATTR_DEFAULT_FETCH_MODE</literal>
        (qui vaut par défaut la valeur de la constante <literal>PDO::FETCH_BOTH</literal>).
        <itemizedlist>
-        <listitem><para>
-         <literal>PDO::FETCH_ASSOC</literal>: retourne un tableau indexé par le nom
-         de la colonne comme retourné dans le jeu de résultats
-         </para></listitem>
-        <listitem><para>
-         <literal>PDO::FETCH_BOTH</literal> (défaut): retourne un tableau indexé
-         par les noms de colonnes et aussi par les numéros de colonnes, 
-         commençant à l'index 0, comme retournés dans le jeu de résultats
-         </para></listitem>
-        <listitem><para>
-         <literal>PDO::FETCH_BOUND</literal>: retourne &true; et assigne les valeurs
-         des colonnes du jeu de résultats dans les variables PHP auxquelles
-         elles sont liées avec la méthode
-         <methodname>PDOStatement::bindColumn</methodname>
-         </para></listitem>
-        <listitem><para>
-         <literal>PDO::FETCH_CLASS</literal>: retourne une nouvelle instance
-         de la classe demandée. L'objet est initialisé en mappant les colonnes du jeu de résultats aux
-         propriétés de la classe. Ce processus se produit avant que le constructeur ne soit
-         appelé, permettant la population des propriétés, indépendamment de leur
-         visibilité ou de leur marqueur comme <literal>readonly</literal>. Si
-         une propriété n'existe pas dans la classe, la méthode magique
-         <link linkend="object.set">__set()</link>
-         sera invoquée si elle existe ; sinon, une propriété publique dynamique
-         sera créée. Cependant, lorsque <constant>PDO::FETCH_PROPS_LATE</constant>
-         est également spécifié, le constructeur est appelé <emphasis>avant</emphasis> que
-         les propriétés soient peuplées.
-         </para></listitem>
-        <listitem><para>
-         <literal>PDO::FETCH_INTO</literal> : met à jour une instance existante 
-         de la classe demandée, liant les colonnes du jeu de résultats aux noms des propriétés
-         de la classe
-         </para></listitem>
-        <listitem><para>
-         <literal>PDO::FETCH_LAZY</literal> : combine
-         <literal>PDO::FETCH_BOTH</literal> et <literal>PDO::FETCH_OBJ</literal>,
-         et renvoie un objet <classname>PDORow</classname>
-         qui crée les noms de propriété de l'objet au fur et à mesure de leur accès.
-         </para></listitem>
-        <listitem><para>
-         <literal>PDO::FETCH_NAMED</literal> : retourne un tableau de la même
-         forme que <literal>PDO::FETCH_ASSOC</literal>, excepté que s'il y a
-         plusieurs colonnes avec les mêmes noms, la valeur pointée par cette clé
-         sera un tableau de toutes les valeurs de la ligne qui a ce nom comme colonne
-         </para></listitem>
-        <listitem><para>
-         <literal>PDO::FETCH_NUM</literal> : retourne un tableau indexé par le
-         numéro de la colonne comme elle est retournée dans le jeu de résultats,
-         commençant à 0
-         </para></listitem>
-        <listitem><para>
-         <literal>PDO::FETCH_OBJ</literal> : retourne un objet anonyme avec les
-         noms de propriétés qui correspondent aux noms des colonnes retournés dans le
-         jeu de résultats
-         </para></listitem>
-        <listitem><para>
-         <literal>PDO::FETCH_PROPS_LATE</literal> : lorsqu'il est utilisé avec 
-         <literal>PDO::FETCH_CLASS</literal>, le constructeur de la classe est 
-         appelé avant que les propriétés ne soient assignées à partir des 
-         valeurs de colonne respectives.
-         </para></listitem>
+        <listitem>
+         <simpara>
+          <literal>PDO::FETCH_ASSOC</literal>: retourne un tableau indexé par le nom
+          de la colonne comme retourné dans le jeu de résultats
+         </simpara>
+        </listitem>
+        <listitem>
+         <simpara>
+          <literal>PDO::FETCH_BOTH</literal> (défaut): retourne un tableau indexé
+          par les noms de colonnes et aussi par les numéros de colonnes,
+          commençant à l'index 0, comme retournés dans le jeu de résultats
+         </simpara>
+        </listitem>
+        <listitem>
+         <simpara>
+          <literal>PDO::FETCH_BOUND</literal>: retourne &true; et assigne les valeurs
+          des colonnes du jeu de résultats dans les variables PHP auxquelles
+          elles sont liées avec la méthode
+          <methodname>PDOStatement::bindColumn</methodname>
+         </simpara>
+        </listitem>
+        <listitem>
+         <simpara>
+          <literal>PDO::FETCH_CLASS</literal>: retourne une nouvelle instance
+          de la classe demandée. L'objet est initialisé en mappant les colonnes du jeu de résultats aux
+          propriétés de la classe. Ce processus se produit avant que le constructeur ne soit
+          appelé, permettant la population des propriétés, indépendamment de leur
+          visibilité ou de leur marqueur comme <literal>readonly</literal>. Si
+          une propriété n'existe pas dans la classe, la méthode magique
+          <link linkend="object.set">__set()</link>
+          sera invoquée si elle existe ; sinon, une propriété publique dynamique
+          sera créée. Cependant, lorsque <constant>PDO::FETCH_PROPS_LATE</constant>
+          est également spécifié, le constructeur est appelé <emphasis>avant</emphasis> que
+          les propriétés soient peuplées.
+         </simpara>
+        </listitem>
+        <listitem>
+         <simpara>
+          <literal>PDO::FETCH_INTO</literal> : met à jour une instance existante
+          de la classe demandée, liant les colonnes du jeu de résultats aux noms des propriétés
+          de la classe
+         </simpara>
+        </listitem>
+        <listitem>
+         <simpara>
+          <literal>PDO::FETCH_LAZY</literal> : combine
+          <literal>PDO::FETCH_BOTH</literal> et <literal>PDO::FETCH_OBJ</literal>,
+          et renvoie un objet <classname>PDORow</classname>
+          qui crée les noms de propriété de l'objet au fur et à mesure de leur accès.
+         </simpara>
+        </listitem>
+        <listitem>
+         <simpara>
+          <literal>PDO::FETCH_NAMED</literal> : retourne un tableau de la même
+          forme que <literal>PDO::FETCH_ASSOC</literal>, excepté que s'il y a
+          plusieurs colonnes avec les mêmes noms, la valeur pointée par cette clé
+          sera un tableau de toutes les valeurs de la ligne qui a ce nom comme colonne
+         </simpara>
+        </listitem>
+        <listitem>
+         <simpara>
+          <literal>PDO::FETCH_NUM</literal> : retourne un tableau indexé par le
+          numéro de la colonne comme elle est retournée dans le jeu de résultats,
+          commençant à 0
+         </simpara>
+        </listitem>
+        <listitem>
+         <simpara>
+          <literal>PDO::FETCH_OBJ</literal> : retourne un objet anonyme avec les
+          noms de propriétés qui correspondent aux noms des colonnes retournés dans le
+          jeu de résultats
+         </simpara>
+        </listitem>
+        <listitem>
+         <simpara>
+          <literal>PDO::FETCH_PROPS_LATE</literal> : lorsqu'il est utilisé avec
+          <literal>PDO::FETCH_CLASS</literal>, le constructeur de la classe est
+          appelé avant que les propriétés ne soient assignées à partir des
+          valeurs de colonne respectives.
+         </simpara>
+        </listitem>
        </itemizedlist>
       </para>
      </listitem>
@@ -109,8 +128,8 @@
       <para>
        Pour un objet PDOStatement représentant un curseur scrollable,
        cette valeur détermine quelle ligne sera retournée à l'appelant.
-       Cette valeur doit être une des constantes 
-       <literal>PDO::FETCH_ORI_*</literal>, et par défaut, vaut 
+       Cette valeur doit être une des constantes
+       <literal>PDO::FETCH_ORI_*</literal>, et par défaut, vaut
        <literal>PDO::FETCH_ORI_NEXT</literal>. Pour demander un curseur
        scrollable pour l'objet PDOStatement, il faut définir
        l'attribut <literal>PDO::ATTR_CURSOR</literal> à <literal>PDO::CURSOR_SCROLL</literal>
@@ -122,7 +141,7 @@
     <varlistentry>
      <term><parameter>cursorOffset</parameter></term>
      <listitem>
-      <para> 
+      <para>
        Pour un objet PDOStatement représentant un curseur scrollable pour
        lequel le paramètre <parameter>cursorOrientation</parameter> est défini
        à <literal>PDO::FETCH_ORI_ABS</literal>, cette valeur spécifie
@@ -141,7 +160,7 @@
    </variablelist>
   </para>
  </refsect1>
- 
+
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
@@ -154,7 +173,7 @@
   &reftitle.errors;
   &pdo.errors;
  </refsect1>
- 
+
  <refsect1 role="examples">
   &reftitle.examples;
   <para>
@@ -270,11 +289,11 @@ Lecture en arrière :
 ]]>
     </screen>
    </example>
-   
+
    <example><title>Ordre de construction</title>
     <simpara>
-     Lorsque des objets sont récupérés via <constant>PDO::FETCH_CLASS</constant>, 
-     les propriétés de l'objet sont assignées en premier, puis le constructeur 
+     Lorsque des objets sont récupérés via <constant>PDO::FETCH_CLASS</constant>,
+     les propriétés de l'objet sont assignées en premier, puis le constructeur
      de la classe est appelé. Cependant, lorsque <constant>PDO::FETCH_PROPS_LATE</constant> est également spécifié,
      cet ordre est inversé, c'est-à-dire que le constructeur est d'abord appelé, puis
      les propriétés sont assignées.
@@ -323,7 +342,7 @@ Je suis Bob.
    </example>
   </para>
  </refsect1>
- 
+
  <refsect1 role="seealso">
   &reftitle.seealso;
   <para>

--- a/reference/pdo/pdostatement/fetchall.xml
+++ b/reference/pdo/pdostatement/fetchall.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 44bcc82c7d1a0dea5578093833d3172c0c742f5a Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: lacatoire Status: ready -->
 <refentry xml:id="pdostatement.fetchall" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>PDOStatement::fetchAll</refname>

--- a/reference/pdo/pdostatement/getattribute.xml
+++ b/reference/pdo/pdostatement/getattribute.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 661e6858acade9f5a08fc8f9c07b605f42f4a700 Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: lacatoire Status: ready -->
 <refentry xml:id="pdostatement.getattribute" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>PDOStatement::getAttribute</refname>
@@ -19,10 +18,13 @@
    Récupère un attribut de la requête. Actuellement, aucun attribut générique n'existe, mais uniquement
    des spécificités du driver :
    <itemizedlist>
-    <listitem><para><literal>PDO::ATTR_CURSOR_NAME</literal>
+    <listitem>
+     <simpara>
+      <literal>PDO::ATTR_CURSOR_NAME</literal>
       (spécificité de Firebird et d'ODBC) :
       Récupère le nom du curseur pour <literal>UPDATE ... WHERE CURRENT OF</literal>.
-     </para></listitem>
+     </simpara>
+    </listitem>
    </itemizedlist>
    Il est à noter que les attributs spécifiques au pilote <emphasis>ne doivent pas</emphasis>
    être utilisés avec d'autres pilotes.

--- a/reference/pdo/pdostatement/rowcount.xml
+++ b/reference/pdo/pdostatement/rowcount.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: a5950d8ae47e8befb9fa5f774ddb96a860833ed5 Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: lacatoire Status: ready -->
 <refentry xml:id="pdostatement.rowcount" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>PDOStatement::rowCount</refname>
@@ -29,12 +28,12 @@
    et il ne faut pas s'y fier pour des applications portables.
   </para>
   <note>
-   <para>
+   <simpara>
     Cette méthode retourne toujours "0" (zéro) avec le pilote PostgreSQL,
     quand l'attribut de déclaration
     <constant>PDO::ATTR_CURSOR</constant> est défini à
     <constant>PDO::CURSOR_SCROLL</constant>.
-   </para>
+   </simpara>
   </note>
  </refsect1>
 

--- a/reference/pdo/pdostatement/setattribute.xml
+++ b/reference/pdo/pdostatement/setattribute.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 661e6858acade9f5a08fc8f9c07b605f42f4a700 Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: lacatoire Status: ready -->
 <refentry xml:id="pdostatement.setattribute" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>PDOStatement::setAttribute</refname>
@@ -20,10 +19,13 @@
    Définit un attribut de la requête. Actuellement, aucun attribut générique n'est défini, mais uniquement
    des spécificités du driver :
    <itemizedlist>
-    <listitem><para><literal>PDO::ATTR_CURSOR_NAME</literal>
+    <listitem>
+     <simpara>
+      <literal>PDO::ATTR_CURSOR_NAME</literal>
       (spécificité de Firebird et d'ODBC) :
       Définit le nom du curseur pour <literal>UPDATE ... WHERE CURRENT OF</literal>.
-     </para></listitem>
+     </simpara>
+    </listitem>
    </itemizedlist>
    Il est à noter que les attributs spécifiques au pilote <emphasis>ne doivent pas</emphasis>
    être utilisés avec d'autres pilotes.

--- a/reference/pgsql/functions/pg-fetch-object.xml
+++ b/reference/pgsql/functions/pg-fetch-object.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 39bb8a868935a56cfce438b0169e13c02c93211c Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: lacatoire Status: ready -->
 <refentry xml:id="function.pg-fetch-object" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>pg_fetch_object</refname>
@@ -92,10 +91,10 @@
 
  <refsect1 role="errors">
   &reftitle.errors;
-  <para>
+  <simpara>
    Une <classname>ValueError</classname> est déclenchée lorsque
    l'argument <parameter>constructor_args</parameter> n'est pas vide et que la classe n'a pas de constructeur.
-  </para>
+  </simpara>
 </refsect1>
 
  <refsect1 role="changelog">

--- a/reference/tidy/tidy/parsefile.xml
+++ b/reference/tidy/tidy/parsefile.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 8bcc6238e8017a8a78c23b7256c55617ada5d385 Maintainer: yannick Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: lacatoire Status: ready -->
 <refentry xml:id="tidy.parsefile" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>tidy::parseFile</refname>

--- a/reference/tidy/tidy/parsestring.xml
+++ b/reference/tidy/tidy/parsestring.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 2b84fa46e30d9611e9b5d3af877a7e9ab5c7411a Maintainer: jpauli Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: lacatoire Status: ready -->
 <refentry xml:id="tidy.parsestring" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>tidy::parseString</refname>


### PR DESCRIPTION
Port of php/doc-en 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc. connect.xml and quote.xml also carry the preceding commits on those files (603435cd84, c62ef37e0d). Where the upstream change only fixed English grammar the French wording is unchanged and only the structure (para to simpara) and the revision follow.

Fixes: #3156