### PR TITLE
[Sync EN] ext/pdo: PHP 8.4 changes across PDO, PDO_PGSQL and PDO_Firebird (#5703)

### DIFF
--- a/reference/pdo/pdo/getattribute.xml
+++ b/reference/pdo/pdo/getattribute.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 91183ddf1c54c6ce3051fdf0f5b9987272d51fbe Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 371e92c3d8d9ee92542dfae4dee1d9fd0c940385 Maintainer: lacatoire Status: ready -->
 <refentry xml:id="pdo.getattribute" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>PDO::getAttribute</refname>
@@ -38,18 +38,14 @@
        Une des constantes <literal>PDO::ATTR_*</literal>. Les attributs génériques
        qui sont appliqués aux connexions sont les suivantes :
        <simplelist>
-        <member><literal>PDO::ATTR_AUTOCOMMIT</literal></member>
         <member><literal>PDO::ATTR_CASE</literal></member>
-        <member><literal>PDO::ATTR_CLIENT_VERSION</literal></member>
-        <member><literal>PDO::ATTR_CONNECTION_STATUS</literal></member>
+        <member><literal>PDO::ATTR_DEFAULT_FETCH_MODE</literal></member>
         <member><literal>PDO::ATTR_DRIVER_NAME</literal></member>
         <member><literal>PDO::ATTR_ERRMODE</literal></member>
         <member><literal>PDO::ATTR_ORACLE_NULLS</literal></member>
         <member><literal>PDO::ATTR_PERSISTENT</literal></member>
-        <member><literal>PDO::ATTR_PREFETCH</literal></member>
-        <member><literal>PDO::ATTR_SERVER_INFO</literal></member>
-        <member><literal>PDO::ATTR_SERVER_VERSION</literal></member>
-        <member><literal>PDO::ATTR_TIMEOUT</literal></member>
+        <member><literal>PDO::ATTR_STATEMENT_CLASS</literal></member>
+        <member><literal>PDO::ATTR_STRINGIFY_FETCHES</literal></member>
        </simplelist>
       </para>
       <simpara>

--- a/reference/pdo/pdo/prepare.xml
+++ b/reference/pdo/pdo/prepare.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 371e92c3d8d9ee92542dfae4dee1d9fd0c940385 Maintainer: lacatoire Status: ready -->
 <refentry xml:id="pdo.prepare" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>PDO::prepare</refname>
@@ -60,13 +60,13 @@
   </para>
   <note>
    <simpara>
-    L'analyseur utilisé pour les déclarations préparées
+    Avant PHP 8.4.0, l'analyseur utilisé pour les déclarations préparées
     émulées et pour réécrire les paramètres nommés ou du style point
-    d'interrogation supporte l'échappement antislash non standard pour les
-    guillemets simples et doubles. Cela signifie que les guillemets de fin
-    précédés d'un antislash ne sont pas reconnus comme tels, ce qui
-    peut entraîner une mauvaise détection des paramètres provoquant l'échec de la
-    déclaration préparée lors de son exécution. Un contournement est de ne pas
+    d'interrogation supportait l'échappement antislash non standard pour les
+    guillemets simples et doubles. Cela signifiait que les guillemets de fin
+    précédés d'un antislash n'étaient pas reconnus comme tels, ce qui
+    pouvait entraîner une mauvaise détection des paramètres provoquant l'échec de la
+    déclaration préparée lors de son exécution. Un contournement était de ne pas
     utiliser les requêtes émulées pour de telles requêtes SQL, et d'éviter de
     réécrire les paramètres en utilisant un style de paramètre qui est
     supporté nativement par le pilote.
@@ -77,6 +77,16 @@
    Cela signifie que la chaîne <literal>??</literal> sera traduite en <literal>?</literal>
    lors de l'envoi de la requête à la base de données.
   </para>
+  <simpara>
+   À partir de PHP 8.4.0, PDO utilise des analyseurs SQL spécifiques au pilote pour
+   localiser les marqueurs de paramètres, de sorte que les marqueurs apparaissant à
+   l'intérieur de littéraux de chaîne ou de commentaires ne soient pas confondus avec
+   des espaces réservés. L'analyseur par défaut reconnaît les littéraux de chaîne entre
+   guillemets simples et doubles, ainsi que les commentaires à double tiret et les
+   commentaires de style C non imbriqués. Certains pilotes peuvent fournir un analyseur
+   qui reconnaît une syntaxe supplémentaire ou différente ; se reporter à la
+   documentation spécifique au pilote pour plus de détails.
+  </simpara>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;

--- a/reference/pdo/pdostatement/getattribute.xml
+++ b/reference/pdo/pdostatement/getattribute.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 371e92c3d8d9ee92542dfae4dee1d9fd0c940385 Maintainer: lacatoire Status: ready -->
 <refentry xml:id="pdostatement.getattribute" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>PDOStatement::getAttribute</refname>
@@ -23,6 +23,13 @@
       <literal>PDO::ATTR_CURSOR_NAME</literal>
       (spécificité de Firebird et d'ODBC) :
       Récupère le nom du curseur pour <literal>UPDATE ... WHERE CURRENT OF</literal>.
+     </simpara>
+    </listitem>
+    <listitem>
+     <simpara>
+      <constant>Pdo\Pgsql::ATTR_RESULT_MEMORY_SIZE</constant>
+      (spécificité de PostgreSQL, disponible à partir de PHP 8.4.0) :
+      Récupère la quantité de mémoire, en octets, allouée au résultat de la requête.
      </simpara>
     </listitem>
    </itemizedlist>

--- a/reference/pdo_firebird/configure.xml
+++ b/reference/pdo_firebird/configure.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: c316dd3b8bce869f1c92c760900a29c2ba0a71af Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 371e92c3d8d9ee92542dfae4dee1d9fd0c940385 Maintainer: lacatoire Status: ready -->
 
 <section xml:id="ref.pdo-firebird.installation" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.install;
@@ -17,6 +15,11 @@ $ ./configure --with-pdo-firebird
 ]]>
   </screen>
  </para>
+ <simpara>
+  À partir de PHP 8.4.0, cette extension utilise les APIs C++ de Firebird et
+  nécessite donc un compilateur C++, et doit être compilée avec la
+  bibliothèque fbclient 3.0 ou supérieure.
+ </simpara>
 </section>
 
 <!-- Keep this comment at the end of the file

--- a/reference/pdo_pgsql/configure.xml
+++ b/reference/pdo_pgsql/configure.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: c316dd3b8bce869f1c92c760900a29c2ba0a71af Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 371e92c3d8d9ee92542dfae4dee1d9fd0c940385 Maintainer: lacatoire Status: ready -->
 
 <section xml:id="ref.pdo-pgsql.installation" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.install;
@@ -17,6 +15,10 @@ $ ./configure --with-pdo-pgsql
 ]]>
   </screen>
  </para>
+ <simpara>
+  Cette extension nécessite libpq (la bibliothèque cliente C de PostgreSQL).
+  À partir de PHP 8.4.0, libpq 10.0 ou supérieur est requis.
+ </simpara>
 </section>
 
 <!-- Keep this comment at the end of the file

--- a/reference/pdo_pgsql/pdo-pgsql.xml
+++ b/reference/pdo_pgsql/pdo-pgsql.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 205c3b8ad9af665e2b49dcc6020005bb479217a3 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 371e92c3d8d9ee92542dfae4dee1d9fd0c940385 Maintainer: lacatoire Status: ready -->
 <reference xml:id="class.pdo-pgsql" xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" role="class">
  <title>La classe Pdo\Pgsql</title>
  <titleabbrev>Pdo\Pgsql</titleabbrev>
@@ -45,6 +45,16 @@
      </listitem>
     </itemizedlist>
    </para>
+   <note>
+    <simpara>
+     Comme cet analyseur reconnaît les littéraux de chaînes délimitées par
+     des dollars, les points d'interrogation présents à l'intérieur ne sont
+     pas traités comme des marqueurs de paramètre et n'ont pas besoin d'être
+     échappés. À partir de PHP 8.4.0, l'échappement des points d'interrogation
+     sous la forme <literal>??</literal> à l'intérieur d'une chaîne délimitée
+     par des dollars est déprécié.
+    </simpara>
+   </note>
   </section>
   <!-- }}} -->
 
@@ -66,9 +76,7 @@
      </ooclass>
 
      <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))"/>
 
      <classsynopsisinfo role="comment">&Constants;</classsynopsisinfo>
      <fieldsynopsis>
@@ -115,17 +123,11 @@
      </fieldsynopsis>
 
      <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo-pgsql')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Pdo\\Pgsql'])">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo-pgsql')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Pdo\\Pgsql'])"/>
 
      <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='PDO'])">
-      <xi:fallback/>
-     </xi:include>
-     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='PDO'])">
-      <xi:fallback/>
-     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='PDO'])"/>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='PDO'])"/>
     </classsynopsis>
    </packagesynopsis>
    <!-- }}} -->

--- a/reference/pdo_pgsql/reference.xml
+++ b/reference/pdo_pgsql/reference.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 858400b07586b88dcb1e17a95e7a178b54b89d86 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 371e92c3d8d9ee92542dfae4dee1d9fd0c940385 Maintainer: lacatoire Status: ready -->
 <reference xml:id="ref.pdo-pgsql" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
   <?phpdoc extension-membership="bundledexternal" ?>
   <title>Fonctions du pilote PDO PostgreSQL (PDO_PGSQL)</title>
@@ -119,7 +119,15 @@
       </varlistentry>
 
      </variablelist>
-    
+     <note>
+      <simpara>
+       À partir de PHP 8.4.0, les identifiants indiqués dans le DSN
+       (<literal>user</literal> et <literal>password</literal>) sont prioritaires
+       sur les arguments correspondants passés au constructeur de
+       <classname>PDO</classname>. Dans les versions antérieures, les arguments
+       du constructeur PDO avaient la priorité.
+      </simpara>
+     </note>
      <note>
       <simpara>
        Tous les points-virgules dans la chaîne DSN sont remplacés par des espaces,


### PR DESCRIPTION
Ports php/doc-en@371e92c3d8d9ee92542dfae4dee1d9fd0c940385 to the French translation.

Fixes: #3187