### PR TITLE
[Sync EN] Fix grammar in oop5 (#5728)

### DIFF
--- a/language/oop5/anonymous.xml
+++ b/language/oop5/anonymous.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: d6f54016d62904cfd8200604aadd5e3f0d9bad97 Maintainer: jeanseb Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: dff848b17dafaabfb7662ffb5fecfcb04e3b771d Maintainer: lacatoire Status: ready -->
 <sect1 xml:id="language.oop5.anonymous" xmlns="http://docbook.org/ns/docbook">
  <title>Classes anonymes</title>
 
@@ -155,11 +154,11 @@ même classe
  </informalexample>
 
  <note>
-  <para>
+  <simpara>
    Il est à noter que les classes anonymes sont affectées d'un nom par le moteur, comme
    l'illustre l'exemple suivant. Ce nom doit être considéré comme un détail
-   de mise en œuvre, qui ne doit pas être invoqué.
-  </para>
+   d'implémentation, sur lequel il ne faut pas se reposer.
+  </simpara>
   <informalexample>
    <programlisting role="php">
 <![CDATA[

--- a/language/oop5/autoload.xml
+++ b/language/oop5/autoload.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: c1f37a6c270aadbbb3da56a3973ffd62197adf2b Maintainer: jpauli Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: dff848b17dafaabfb7662ffb5fecfcb04e3b771d Maintainer: lacatoire Status: ready -->
 <sect1 xml:id="language.oop5.autoload" xmlns="http://docbook.org/ns/docbook">
  <title>Auto-chargement de classes</title>
  <para>
@@ -9,25 +8,25 @@
   de cette méthode est d'avoir à écrire une longue liste d'inclusions de
   fichier de classes au début de chaque script : une inclusion par classe.
  </para>
- <para>
+ <simpara>
   La fonction <function>spl_autoload_register</function> enregistre un nombre quelconque de
   chargeurs automatiques, ce qui permet aux classes et aux interfaces d'être
   automatiquement chargées si elles ne sont pas définies actuellement.
   En enregistrant des autochargeurs, PHP a une dernière chance de charger
   la classe ou l'interface avant d'échouer avec une erreur.
- </para>
+ </simpara>
  <para>
   Toute construction similaire à une classe peut être autochargée de la
   même manière. Cela inclut les classes, interfaces, traits et énumérations.
  </para>
  <caution>
-  <para>
+  <simpara>
    Avant PHP 8.0.0, il était possible d'utiliser <function>__autoload</function>
    pour autocharger les classes et interfaces. Cependant, c'est une alternative
    moins flexible à <function>spl_autoload_register</function> et
    <function>__autoload</function> est obsolète à partir de PHP 7.2.0,
    et supprimée à partir de PHP 8.0.0.
-  </para>
+  </simpara>
  </caution>
  <note>
   <para>
@@ -107,7 +106,7 @@ echo "Nouvel UUID généré -> ", $uuid->toString(), "\n";
    </programlisting>
   </example>
  </para>
- 
+
  <simplesect role="seealso">
   &reftitle.seealso;
   <para>

--- a/language/oop5/changelog.xml
+++ b/language/oop5/changelog.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 525aa5f198d482c0d03be54ddee5af13b376ab99 Maintainer: lacatoire Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: dff848b17dafaabfb7662ffb5fecfcb04e3b771d Maintainer: lacatoire Status: ready -->
 <sect1 xml:id="language.oop5.changelog" xmlns="http://docbook.org/ns/docbook">
  <title>Modifications en POO (Programmation orientée objet)</title>
  <para>
@@ -46,7 +45,7 @@
      <row>
       <entry>7.4.0</entry>
       <entry>
-       Changement : Il est désormais possible de lancer des exceptions au sein
+       Changement : Il est désormais possible de lancer une exception au sein
        de <function>__toString</function>.
       </entry>
      </row>
@@ -69,7 +68,7 @@
      <row>
       <entry>7.3.0</entry>
       <entry>
-       Incompatibilité : Le déballage d'argument de 
+       Incompatibilité : Le déballage d'argument de
        <classname>Traversable</classname>s avec des clés non-&integer;es n'est
        plus supporté. Ce comportement n'était pas prévu et par conséquent
        supprimé.
@@ -131,7 +130,7 @@
       <entry>7.1.0</entry>
       <entry>
        Changement : Les noms suivants ne peuvent pas être utilisés pour nommer
-       des classes, interfaces ou traits : <literal>void</literal> 
+       des classes, interfaces ou traits : <literal>void</literal>
        et <literal>iterable</literal>.
       </entry>
      </row>
@@ -205,7 +204,7 @@
      <row>
       <entry>5.5.0</entry>
       <entry>
-       Ajout : <link linkend="language.exceptions">finally</link> pour gérer 
+       Ajout : <link linkend="language.exceptions">finally</link> pour gérer
        les exceptions.
       </entry>
      </row>
@@ -315,8 +314,8 @@
        <function>print</function>.
        Désormais, elle est appelée dans n'importe quel contexte de &string;
        (e.g. dans <function>printf</function> avec le modificateur
-       <literal>%s</literal>) mais pas dans les autres contextes (e.g. avec
-       le modificateur <literal>%d</literal>).
+       <literal>%s</literal>) mais pas dans les contextes d'autres types
+       (e.g. avec le modificateur <literal>%d</literal>).
        À partir de PHP 5.2.0, convertir un &object; sans méthode
        <link linkend="object.tostring">__toString</link> en &string;
        émet une erreur <constant>E_RECOVERABLE_ERROR</constant>.
@@ -350,7 +349,7 @@
   </informaltable>
  </para>
 </sect1>
- 
+
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/language/oop5/cloning.xml
+++ b/language/oop5/cloning.xml
@@ -1,12 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 28529d3539b850e870e3aa97570f4db0e53daa03 Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: dff848b17dafaabfb7662ffb5fecfcb04e3b771d Maintainer: lacatoire Status: ready -->
  <sect1 xml:id="language.oop5.cloning" xmlns="http://docbook.org/ns/docbook">
   <title>Clonage d'objets</title>
 
-  <para>
+  <simpara>
    Le fait de créer une copie d'un objet possédant exactement les mêmes
-   propriétés n'est pas toujours le comportement que l'on souhaite. 
+   propriétés n'est pas toujours le comportement que l'on souhaite.
    Un bon exemple pour illustrer le besoin d'un constructeur de copie :
    dans le cas d'un objet qui représente une fenêtre GTK et qui
    contient la ressource représentant cette fenêtre GTK, lors de la
@@ -17,7 +16,7 @@
    lors de la réplication de l'objet parent, il est souhaitable de créer
    une nouvelle instance de cet autre objet afin que la réplique possède
    sa propre copie séparée.
-  </para>
+  </simpara>
 
   <para>
    Une copie d'objet est créée en utilisant le mot-clé <literal>clone</literal>
@@ -35,7 +34,7 @@ $copy_of_object = clone $object;
 
   <para>
    Lorsqu'un objet est cloné, PHP effectue une copie superficielle de toutes
-   les propriétés de l'objet. Toutes les propriétés qui sont des références à d'autres 
+   les propriétés de l'objet. Toutes les propriétés qui sont des références à d'autres
    variables demeureront des références.
   </para>
 
@@ -43,12 +42,13 @@ $copy_of_object = clone $object;
    <type>void</type><methodname>__clone</methodname>
    <void/>
   </methodsynopsis>
-  
-  <para>
+
+  <simpara>
    Une fois le clonage effectué, si une méthode <link linkend="object.clone">__clone()</link>
    est définie, la méthode <link linkend="object.clone">__clone()</link>
-   du nouvel objet sera appelée, pour permettre à chaque propriété qui doit l'être d'être modifiée.
-  </para>
+   du nouvel objet sera appelée, afin de permettre la modification
+   des propriétés nécessaires.
+  </simpara>
 
   <example>
    <title>Exemple de duplication d'objets</title>
@@ -137,8 +137,8 @@ MyCloneable Object
   </example>
 
   <para>
-   Il est possible d'accéder à un membre d'un objet 
-   fraîchement cloné dans une seule expression:
+   Il est possible d'accéder à un membre d'un objet
+   fraîchement cloné dans une seule expression :
   </para>
   <example>
    <title>Accès à un membre d'un objet fraîchement cloné</title>

--- a/language/oop5/constants.xml
+++ b/language/oop5/constants.xml
@@ -1,13 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 922b4b5aeb327d78ea1bb4b932e5db2e9a03ffc5 Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: dff848b17dafaabfb7662ffb5fecfcb04e3b771d Maintainer: lacatoire Status: ready -->
 <sect1 xml:id="language.oop5.constants" xmlns="http://docbook.org/ns/docbook">
  <title>Constantes de classe</title>
- <para>
+ <simpara>
   Il est possible de définir des <link linkend="language.constants">constantes</link>
-  par classes qui restent identiques et non modifiables.
+  par classes.
   La visibilité par défaut des constantes de classe est <literal>public</literal>.
- </para>
+ </simpara>
  <note>
   <para>
    Les constantes de classes peuvent être redéfinies par une classe enfant.

--- a/language/oop5/decon.xml
+++ b/language/oop5/decon.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 82fc6a1c8670b96f1bd2b40932b6eb19929f4f6f Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: dff848b17dafaabfb7662ffb5fecfcb04e3b771d Maintainer: lacatoire Status: ready -->
  <sect1 xml:id="language.oop5.decon" xmlns="http://docbook.org/ns/docbook">
   <title>Constructeurs et destructeurs</title>
 
@@ -164,12 +163,12 @@ class Point {
      </para>
     </note>
     <note>
-     <para>
+     <simpara>
       Les propriétés d'objet ne peuvent être typées <type>callable</type> à cause des ambiguïtés du moteur
       que ceci introduirait. Ainsi, les arguments promus ne peuvent pas non plus être typés
       <type>callable</type>. Cependant, toute autre
       <link linkend="language.types.declarations">déclaration de type</link> est permise.
-     </para>
+     </simpara>
     </note>
     <note>
      <para>
@@ -374,7 +373,7 @@ $obj = new MyDestructableClass();
     appelé une seconde fois lorsque le compteur de références atteint de
     nouveau zéro ou durant la séquence d'arrêt.
    </para>
-   <para>
+   <simpara>
     À partir de PHP 8.4.0, lorsque la
     <link linkend="features.gc.collecting-cycles">collecte des cycles</link>
     se produit pendant l'exécution d'une
@@ -389,7 +388,7 @@ $obj = new MyDestructableClass();
     Les objets dont le destructeur est suspendu ne seront pas collectés tant
     que le destructeur n'a pas terminé ou que la fibre elle-même n'est pas
     collectée.
-   </para>
+   </simpara>
    <note>
     <para>
      Les destructeurs appelés durant l'arrêt du script sont dans une situation

--- a/language/oop5/inheritance.xml
+++ b/language/oop5/inheritance.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: df78bd1d232f2cd8df673accf5ba0e280695639b Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: dff848b17dafaabfb7662ffb5fecfcb04e3b771d Maintainer: lacatoire Status: ready -->
 <sect1 xml:id="language.oop5.inheritance" xmlns="http://docbook.org/ns/docbook">
  <title>Héritage</title>
  <para>
@@ -30,16 +30,16 @@
   manière courante pour "désactiver" le constructeur lors de l'utilisation
   de méthodes factory statiques à la place.
  </para>
- <para>
+ <simpara>
   La <link linkend="language.oop5.visibility">visibilité</link>
   des méthodes, propriétés et constantes peut être relaxée, c.-à-d. une
   méthode <literal>protected</literal> peut être marquée comme
   <literal>public</literal>, mais elles ne peuvent pas être restreintes, e.g.
   marquer une propriété <literal>public</literal> comme <literal>private</literal>.
-  Une exception sont les constructeurs, pour lesquels la visibilité peut être restreinte,
+  Une exception concerne les constructeurs, pour lesquels la visibilité peut être restreinte,
   par exemple un constructeur <literal>public</literal> peut être annoté
   en tant que <literal>private</literal> dans la classe enfant.
- </para>
+ </simpara>
 
  <note>
   <para>

--- a/language/oop5/interfaces.xml
+++ b/language/oop5/interfaces.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 565bd8b6cf2cae44ae2bc54ef6dbe6ee70ddfefd Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: dff848b17dafaabfb7662ffb5fecfcb04e3b771d Maintainer: lacatoire Status: ready -->
  <sect1 xml:id="language.oop5.interfaces" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
   <title>Interfaces</title>
   <para>
@@ -10,9 +9,9 @@
    pas utiliser le même nom.
   </para>
   <para>
-   Les interfaces sont définies de la même façon que pour une classe, mais en 
-   utilisant le mot-clé <literal>interface</literal> à la place de 
-   <literal>class</literal>, et sans qu'aucune des méthodes n'ait son contenu 
+   Les interfaces sont définies de la même façon que pour une classe, mais en
+   utilisant le mot-clé <literal>interface</literal> à la place de
+   <literal>class</literal>, et sans qu'aucune des méthodes n'ait son contenu
    de spécifié.
   </para>
   <para>

--- a/language/oop5/iterations.xml
+++ b/language/oop5/iterations.xml
@@ -1,16 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 1fb0ef23d7be0d8ecd9604fce16ee1e0842c6ef6 Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: dff848b17dafaabfb7662ffb5fecfcb04e3b771d Maintainer: lacatoire Status: ready -->
  <sect1 xml:id="language.oop5.iterations" xmlns="http://docbook.org/ns/docbook">
   <title>Parcours d'objets</title>
-  <para>
+  <simpara>
    PHP fournit une manière de définir les objets de manière à ce qu'on puisse
-   parcourir une liste de membres, par exemple avec une structure
+   parcourir une liste de membres avec, par exemple, une structure
    &foreach;. Par défaut, toutes
-   les propriétés <link linkend="language.oop5.visibility">visibles</link> 
+   les propriétés <link linkend="language.oop5.visibility">visibles</link>
    seront utilisées pour le parcours.
-  </para>
+  </simpara>
 
   <example>
    <title>Parcours d'objet simple</title>

--- a/language/oop5/late-static-bindings.xml
+++ b/language/oop5/late-static-bindings.xml
@@ -1,16 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 009f215fc983eeded6161676bcffdd8cf3b6b080 Maintainer: jpauli Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: dff848b17dafaabfb7662ffb5fecfcb04e3b771d Maintainer: lacatoire Status: ready -->
  <sect1 xml:id="language.oop5.late-static-bindings" xmlns="http://docbook.org/ns/docbook">
   <title>Late Static Bindings (Résolution statique à la volée)</title>
-  <para>
-   PHP implémente une fonctionnalité appelée 
+  <simpara>
+   PHP implémente une fonctionnalité appelée
    <literal>late static binding</literal>, en français la résolution
    statique à la volée, qui peut être utilisée pour référencer la classe appelée
-   dans un contexte d'héritage statique.
-  </para>
-  
+   dans le contexte de l'héritage statique.
+  </simpara>
+
   <para>
    Plus précisément, les résolutions statiques à la volée fonctionnent en enregistrant
    le nom de la classe dans le dernier "appel non transmis". Dans le cas des appels de

--- a/language/oop5/magic.xml
+++ b/language/oop5/magic.xml
@@ -1,12 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 8f51247cb4631b29686f867bd904dfe5b2678074 Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: dff848b17dafaabfb7662ffb5fecfcb04e3b771d Maintainer: lacatoire Status: ready -->
  <sect1 xml:id="language.oop5.magic" xmlns="http://docbook.org/ns/docbook">
   <title>Méthodes magiques</title>
-  <para>
+  <simpara>
    Les méthodes magiques sont des méthodes spéciales qui écrasent l'action
    par défaut de PHP quand certaines actions sont réalisées sur un objet.
-  </para>
+  </simpara>
   <caution>
    <simpara>
     Toutes les méthodes commençant par <literal>__</literal> sont réservées par PHP.
@@ -567,7 +566,9 @@ object(A)#2 (2) {
      En particulier, cela affecte certaines classes internes.
     </simpara>
     <simpara>
-     Il est de la responsabilité du programmeur de vérifier que seuls les objets dont la classe implémente __set_state() seront ré-importés.
+     Il est de la responsabilité du programmeur de vérifier que seuls les objets
+     dont la classe implémente <methodname>__set_state</methodname> seront
+     ré-importés.
     </simpara>
    </note>
   </sect2>

--- a/language/oop5/object-comparison.xml
+++ b/language/oop5/object-comparison.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: a9edd62d087ab1eb6292c795b7256e14ff9f1234 Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: dff848b17dafaabfb7662ffb5fecfcb04e3b771d Maintainer: lacatoire Status: ready -->
   <sect1 xml:id="language.oop5.object-comparison" xmlns="http://docbook.org/ns/docbook">
    <title>Comparaison d'objets</title>
    <para>
@@ -99,10 +97,10 @@ o1 !== o2 : TRUE
     </example>
    </para>
    <note>
-    <para>
-     Les extensions peuvent définir leurs propres règles pour leurs
-     comparaisons d'objets (<literal>==</literal>).
-    </para>
+    <simpara>
+     Les extensions peuvent définir leurs propres règles pour la comparaison
+     de leurs objets (<literal>==</literal>).
+    </simpara>
    </note>
   </sect1>
 <!-- Keep this comment at the end of the file

--- a/language/oop5/paamayim-nekudotayim.xml
+++ b/language/oop5/paamayim-nekudotayim.xml
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e2f2172bf114599926878017ab2dce356956fa9e Maintainer: lacatoire Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: dff848b17dafaabfb7662ffb5fecfcb04e3b771d Maintainer: lacatoire Status: ready -->
 <sect1 xml:id="language.oop5.paamayim-nekudotayim" xmlns="http://docbook.org/ns/docbook">
  <title>L'opérateur de résolution de portée (::)</title>
- 
+
  <para>
   L'opérateur de résolution de portée (aussi appelé Paamayim Nekudotayim) ou,
   en termes plus simples, le symbole &quot;double deux-points&quot; (::),
@@ -16,18 +15,18 @@
   la <link linkend="language.oop5.late-static-bindings">liaison statique tardive</link>.
 
  </para>
- 
+
  <para>
   Lorsque l'on référence ces éléments en dehors de la définition de la
   classe, il faut utiliser le nom de la classe.
  </para>
- 
+
  <para>
   Il est possible de référencer une classe en utilisant
   une variable. La valeur de la variable ne peut être un mot-clé (e.g. <literal>self</literal>,
   <literal>parent</literal> et <literal>static</literal>).
  </para>
- 
+
  <para>
   Paamayim Nekudotayim pourrait au premier abord sembler être un choix étrange
   pour nommer un double deux-points.
@@ -35,7 +34,7 @@
   (qui faisait fonctionner PHP 3), c'est le nom qui a été choisi par l'équipe Zend.
   En fait, cela signifie un double deux-points... en hébreu !
  </para>
- 
+
  <example>
   <title>:: en dehors de la définition de la classe</title>
   <programlisting role="php">
@@ -53,13 +52,13 @@ echo MyClass::CONST_VALUE;
 ]]>
   </programlisting>
  </example>
- 
+
  <para>
   Trois mots-clés spéciaux, <varname>self</varname>, <varname>parent</varname>,
   et <varname>static</varname> sont utilisés pour accéder aux propriétés ou aux
   méthodes depuis la définition de la classe.
  </para>
- 
+
  <example>
   <title>:: depuis la définition de la classe</title>
   <programlisting role="php">
@@ -87,17 +86,17 @@ OtherClass::doubleColon();
 ]]>
   </programlisting>
  </example>
- 
- <para>
+
+ <simpara>
   Lorsqu'une classe héritant d'une autre redéfinit une méthode de sa classe parente,
-  PHP n'appellera pas la méthode de la classe parente. Il appartient à la méthode dérivée
-  d'appeler la méthode d'origine en cas de besoin. Cela est également valable
+  PHP n'appellera pas la méthode de la classe parente. Il appartient à la classe dérivée
+  de décider si la méthode parente est appelée ou non. Cela est également valable
   pour les définitions des <link
   linkend="language.oop5.decon">constructeurs et destructeurs</link>,
   la <link linkend="language.oop5.overloading">surcharge</link>, et les
   définitions de <link linkend="language.oop5.magic">méthodes magiques</link>.
- </para>
- 
+ </simpara>
+
  <example>
   <title>Appel d'une méthode parente</title>
   <programlisting role="php">
@@ -127,11 +126,11 @@ $class->myFunc();
 ]]>
   </programlisting>
  </example>
-  <para>
-   Voir aussi <link linkend="language.oop5.basic.class.this">quelques
-   exemples d'appels statiques</link>.
-  </para>
- 
+ <para>
+  Voir aussi <link linkend="language.oop5.basic.class.this">quelques
+  exemples d'appels statiques</link>.
+ </para>
+
 </sect1>
 <!-- Keep this comment at the end of the file
 Local variables:

--- a/language/oop5/properties.xml
+++ b/language/oop5/properties.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 801e7a15e8c9ee2d16966487dc9058d992450b46 Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: dff848b17dafaabfb7662ffb5fecfcb04e3b771d Maintainer: lacatoire Status: ready -->
 <sect1 xml:id="language.oop5.properties" xmlns="http://docbook.org/ns/docbook">
  <title>Propriétés</title>
 
@@ -20,10 +19,10 @@
   être une valeur <link linkend="language.constants">constante</link>.
  </para>
  <note>
-  <para>
+  <simpara>
    Une manière obsolète de déclarer une propriété de classe est d'utiliser
    le mot-clé <literal>var</literal> au lieu d'un modificateur.
-  </para>
+  </simpara>
  </note>
  <note>
   <simpara>
@@ -167,7 +166,7 @@ class Shape
 
 $triangle = new Shape();
 $triangle->setName("triangle");
-$triangle->setNumberofSides(3);
+$triangle->setNumberOfSides(3);
 var_dump($triangle->getName());
 var_dump($triangle->getNumberOfSides());
 
@@ -396,7 +395,7 @@ var_dump($test2->prop); // NULL
     Pour gérer des noms de propriétés arbitraires, la classe devrait implémenter
     les méthodes magiques <link linkend="object.get">__get()</link> et
     <link linkend="object.set">__set()</link>.
-    Comme dernier recours la classe peut être marquée avec l'attribut
+    En dernier recours, la classe peut être marquée avec l'attribut
     <code>#[\AllowDynamicProperties]</code>.
    </simpara>
   </warning>

--- a/language/oop5/property-hooks.xml
+++ b/language/oop5/property-hooks.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: dfd68fd22aef25658bc9348176b55b504d26ab11 Maintainer: lacatoire Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: dff848b17dafaabfb7662ffb5fecfcb04e3b771d Maintainer: lacatoire Status: ready -->
 <sect1 xml:id="language.oop5.property-hooks" xmlns="http://docbook.org/ns/docbook">
  <title>Hooks de propriété</title>
 
@@ -203,8 +202,8 @@ class Example
   <simpara>
    Une propriété peut implémenter zéro, un ou les deux hooks selon la situation.
    Toutes les versions abrégées sont mutuellement indépendantes.
-   C'est-à-dire qu'utiliser un raccourci pour obtenir une longue définition,
-   ou un raccourci pour définir un type explicite, etc., est valide.
+   C'est-à-dire qu'utiliser un get abrégé avec un set complet,
+   un set abrégé avec un type explicite, etc., est valide.
   </simpara>
   <simpara>
    Sur une propriété "backed", l'omission d'un hook <literal>get</literal> ou <literal>set</literal>

--- a/language/oop5/references.xml
+++ b/language/oop5/references.xml
@@ -1,14 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: a9edd62d087ab1eb6292c795b7256e14ff9f1234 Maintainer: jpauli Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: dff848b17dafaabfb7662ffb5fecfcb04e3b771d Maintainer: lacatoire Status: ready -->
  <sect1 xml:id="language.oop5.references" xmlns="http://docbook.org/ns/docbook">
   <title>Objets et références</title>
-  <para>
-   Un des piliers de la POO de PHP est le fait que les 
-   "objets sont passés par référence par défaut". Ce n'est pas complètement vrai. 
+  <simpara>
+   Un des piliers de la POO de PHP est le fait que les
+   "objets sont passés par référence par défaut". Ce n'est pas complètement vrai.
    Cette section rectifie cette généralisation avec quelques exemples.
-  </para>
+  </simpara>
 
   <para>
    Une référence PHP est un alias, qui permet à deux variables différentes de

--- a/language/oop5/serialization.xml
+++ b/language/oop5/serialization.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 70f392045a26b176f206013f00fa14b86440efd1 Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: dff848b17dafaabfb7662ffb5fecfcb04e3b771d Maintainer: lacatoire Status: ready -->
 <!-- TODO Rewrite to remove usage of "you" and talk about __serialize/_unserialize -->
 <sect1 xml:id="language.oop5.serialization" xmlns="http://docbook.org/ns/docbook">
  <title>Sérialiser des objets - des objets en session</title>
@@ -17,19 +15,18 @@
   seront pas conservées, seul le nom de la classe le sera.
  </para>
  
- <para>
+ <simpara>
   Afin de pouvoir désérialiser (<function>unserialize</function>) un objet,
-  la classe de l'objet doit être définie, pour permettre sa reconstruction.
-  En d'autres termes, pour un objet de la classe A qui est sérialisé,
-  la représentation linéaire obtenue fera référence à la classe A et contiendra toutes
-  ses variables. Pour pouvoir désérialiser cette représentation linéaire dans un
-  endroit où la classe A n'est pas définie (dans un autre fichier par exemple),
-  il faut redéclarer la classe A avant de procéder à la désérialisation
-  de sa représentation linéaire. Cela peut être fait, par exemple, en incluant le
-  fichier de définition de la classe, ou en utilisant la fonction
-  <function>spl_autoload_register</function>.
- </para>  
- 
+  la classe de l'objet doit être définie. En d'autres termes, pour un objet
+  de la classe A qui est sérialisé, la représentation linéaire obtenue fera
+  référence à la classe A et contiendra toutes les valeurs des variables
+  qu'il contient. Pour pouvoir désérialiser un objet de la classe A dans un
+  autre fichier, la définition de la classe A doit d'abord être présente dans
+  ce fichier. Cela peut être fait, par exemple, en stockant la définition de
+  la classe A dans un fichier inclus et en incluant ce fichier, ou en
+  utilisant la fonction <function>spl_autoload_register</function>.
+ </simpara>
+
  <informalexample>
   <programlisting role="php">
 <![CDATA[
@@ -69,15 +66,16 @@
   </programlisting>
  </informalexample>
 
- <para>
-  Si une application sérialise des objets, il est fortement recommandé, pour son usage
-  futur, que l'application inclue les définitions des classes des objets sérialisés
-  à chaque page. Ne pas faire ainsi pourrait aboutir à un objet désérialisé sans sa définition
+ <simpara>
+  Si une application sérialise des objets pour un usage ultérieur dans cette
+  application, il est fortement recommandé que l'application inclue la
+  définition de la classe de ces objets dans toute l'application. Ne pas
+  faire ainsi pourrait aboutir à un objet désérialisé sans sa définition
   de classe. PHP donnerait alors à cet objet une classe de type
   <classname>__PHP_Incomplete_Class_Name</classname>, qui n'a pas de méthode, et
   produirait un objet inutile.
- </para>  
- 
+ </simpara>
+
  <para>
   Ainsi, dans l'exemple ci-dessus, si <varname>$a</varname> était enregistré dans la session
   en ajoutant une clé au tableau superglobal <varname>$_SESSION</varname>, il est recommandé d'inclure le fichier

--- a/language/oop5/traits.xml
+++ b/language/oop5/traits.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: c1f37a6c270aadbbb3da56a3973ffd62197adf2b Maintainer: yannick Status: ready -->
-<!-- Reviewed: no Maintainer: itanea -->
+<!-- EN-Revision: dff848b17dafaabfb7662ffb5fecfcb04e3b771d Maintainer: lacatoire Status: ready -->
 <sect1 xml:id="language.oop5.traits" xmlns="http://docbook.org/ns/docbook">
  <title>Traits</title>
  <para>
@@ -20,7 +19,7 @@
   ajout à l'héritage traditionnel, qui permet la composition horizontale de comportements,
   c'est-à-dire l'application de membres de classe sans nécessiter d'héritage.
  </para>
- 
+
  <example xml:id="language.oop5.traits.basicexample">
   <title>Exemple d'utilisation de Trait</title>
   <programlisting role="php">
@@ -64,7 +63,7 @@ Hello World!
 ]]>
   </screen>
  </example>
- 
+
  <sect2 xml:id="language.oop5.traits.precedence">
   <title>Précédence</title>
   <para>
@@ -144,7 +143,7 @@ Hello Universe!
    </screen>
   </example>
  </sect2>
- 
+
  <sect2 xml:id="language.oop5.traits.multiple">
   <title>Multiples Traits</title>
   <para>
@@ -190,7 +189,7 @@ Hello World!
    </screen>
   </example>
  </sect2>
- 
+
  <sect2 xml:id="language.oop5.traits.conflict">
   <title>Résolution des conflits</title>
   <para>
@@ -210,17 +209,17 @@ Hello World!
   </para>
   <example xml:id="language.oop5.traits.conflict.ex1">
    <title>Résolution des conflits</title>
-   <para>
+   <simpara>
     Dans cet exemple, la classe Talker utilise les traits A et B.
-    Comme A et B ont des méthodes conflictuelles, on indique que l'on souhaite utiliser
+    Comme A et B ont des méthodes conflictuelles, elle spécifie qu'elle utilise
     la variante de smallTalk depuis le trait B, et la variante de bigTalk depuis le
     trait A.
-   </para>
+   </simpara>
    <para>
     La classe Aliased_Talker utilise l'opérateur <literal>as</literal>
     pour être capable d'utiliser l'implémentation bigTalk de B sous un alias
     supplémentaire <literal>talk</literal>.
-   </para> 
+   </para>
    <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
@@ -261,7 +260,7 @@ class Aliased_Talker {
    </programlisting>
   </example>
  </sect2>
- 
+
  <sect2 xml:id="language.oop5.traits.visibility">
   <title>Changer la visibilité des méthodes</title>
   <para>
@@ -294,7 +293,7 @@ class MyClass2 {
    </programlisting>
   </example>
  </sect2>
- 
+
  <sect2 xml:id="language.oop5.traits.composition">
   <title>Traits Composés depuis d'autres Traits</title>
   <para>
@@ -341,7 +340,7 @@ Hello World!
    </screen>
   </example>
  </sect2>
- 
+
  <sect2 xml:id="language.oop5.traits.abstract">
   <title>Méthodes abstraites dans les Traits</title>
   <para>
@@ -385,7 +384,7 @@ class MyHelloWorld {
    </programlisting>
   </example>
  </sect2>
- 
+
  <sect2 xml:id="language.oop5.traits.static">
   <title>Membres statiques dans les Traits</title>
   <para>

--- a/language/oop5/variance.xml
+++ b/language/oop5/variance.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 2e7c00fd314a708ecbd495ef7cc9ae8c8462c33c Maintainer: pierrick Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: dff848b17dafaabfb7662ffb5fecfcb04e3b771d Maintainer: lacatoire Status: ready -->
 <sect1 xml:id="language.oop5.variance" xmlns="http://docbook.org/ns/docbook">
  <title>Covariance et Contravariance</title>
 
@@ -42,17 +40,17 @@
    </listitem>
   </itemizedlist>
 
-  Un type de classe est considéré moins spécifique si l'inverse est vrai.
+  Une déclaration de type est considérée comme moins spécifique si l'inverse est vrai.
  </para>
 
  <sect2 xml:id="language.oop5.variance.covariance">
   <title>Covariance</title>
 
-  <para>
+  <simpara>
    Pour illustrer le fonctionnement de la covariance, une simple classe parente abstraite, <varname>Animal</varname>
    est créée. <varname>Animal</varname> sera étendu par des classes enfants,
-  <varname>Cat</varname> et <varname>Dog</varname>.
-  </para>
+   <varname>Cat</varname> et <varname>Dog</varname>.
+  </simpara>
 
   <informalexample>
    <programlisting role="php">


### PR DESCRIPTION
Ports php/doc-en@dff848b17dafaabfb7662ffb5fecfcb04e3b771d to the French translation.

Fixes: #3188