### PR TITLE
[Sync EN] ext/simplexml: get methods and string casts no longer implicitly rewind

### DIFF
--- a/reference/simplexml/simplexmlelement.xml
+++ b/reference/simplexml/simplexmlelement.xml
@@ -38,12 +38,8 @@
     </oointerface>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.simplexmlelement')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='SimpleXMLElement'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.simplexmlelement')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SimpleXMLElement'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.simplexmlelement')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='SimpleXMLElement'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.simplexmlelement')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SimpleXMLElement'])"/>
    </classsynopsis>
 <!-- }}} -->
  

--- a/reference/simplexml/simplexmlelement.xml
+++ b/reference/simplexml/simplexmlelement.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: jpauli Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 418ec505128707215c5c99ad4a66a88bfd84a0ff Maintainer: lacatoire Status: ready -->
 <reference xml:id="class.simplexmlelement" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>La classe SimpleXMLElement</title>
  <titleabbrev>SimpleXMLElement</titleabbrev>
@@ -61,6 +60,18 @@
       </row>
      </thead>
      <tbody>
+      <row>
+       <entry>8.4.0</entry>
+       <entry>
+        Les méthodes de lecture (telles que
+        <methodname>SimpleXMLElement::asXML</methodname> ou
+        <methodname>SimpleXMLElement::getName</methodname>) et la conversion d'un
+        <classname>SimpleXMLElement</classname> en &string; ne remettent plus
+        implicitement l'itérateur au début.
+        L'itérateur doit désormais être remis au début explicitement, à l'aide de
+        <methodname>SimpleXMLElement::rewind</methodname>, lorsque cela est nécessaire.
+       </entry>
+      </row>
       <row>
        <entry>8.0.0</entry>
        <entry>

--- a/reference/simplexml/simplexmlelement/rewind.xml
+++ b/reference/simplexml/simplexmlelement/rewind.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: dcb657b7e9e4f7622ce3394ae1fa3c14538721e1 Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 418ec505128707215c5c99ad4a66a88bfd84a0ff Maintainer: lacatoire Status: ready -->
 
 <refentry xml:id="simplexmlelement.rewind" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -23,9 +21,20 @@
   </warning>
 
   <para>
-   Cette méthode remet l'itérateur <classname>SimpleXMLElement</classname> 
+   Cette méthode remet l'itérateur <classname>SimpleXMLElement</classname>
    au premier élément.
   </para>
+
+  <note>
+   <simpara>
+    À partir de PHP 8.4.0, l'appel aux méthodes de lecture (telles que
+    <methodname>SimpleXMLElement::asXML</methodname> ou
+    <methodname>SimpleXMLElement::getName</methodname>) ou la conversion d'un
+    <classname>SimpleXMLElement</classname> en &string; ne remet plus
+    implicitement l'itérateur au début. Lorsque cela est nécessaire, l'itérateur
+    doit être explicitement remis au début en appelant cette méthode.
+   </simpara>
+  </note>
  </refsect1>
 
  <refsect1 role="parameters">


### PR DESCRIPTION
Ports php/doc-en@418ec50 (php/doc-en#5737).

Fixes: #3191