### PR TITLE
CI: check the XML structure of the PR head, not of the merge commit

### DIFF
--- a/.github/workflows/check-xml.yml
+++ b/.github/workflows/check-xml.yml
@@ -19,9 +19,17 @@ jobs:
     name: "Check XML"
     runs-on: ubuntu-22.04
     steps:
+      # doc-fr à la racine, doc-en dans le sous-répertoire en/ : c'est
+      # l'arborescence attendue par check-structure.php. Le ref explicite
+      # prend la tête réelle de la PR, et non le commit de fusion que
+      # actions/checkout construit par défaut : ce dernier a master pour
+      # deuxième parent, donc le diff plus bas y verrait aussi tous les
+      # fichiers arrivés sur master depuis le dernier push de la PR.
+
       - name: "Checkout php/doc-fr"
         uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 
       - name: "Checkout php/doc-en"


### PR DESCRIPTION
On a `pull_request` event, `actions/checkout` defaults to `refs/pull/N/merge`, whose second parent is the tip of `master`. The `BASE...HEAD` diff below it then lists the pull request *plus* everything landed on `master` since `base.sha` was frozen, and hands all of it to `check-structure.php`.

Measured on a pull request of another translation touching a single `.yaml` file:

| diff | files | of which `.xml` |
| --- | --- | --- |
| `base.sha...merge commit` (current) | 300 | 294 |
| `base.sha...head.sha` (this change) | 1 | 0 |

The job failed on structural drift the pull request did not introduce. Checking out the head sha keeps the diff inside the pull request.

The layout the script expects, translation at the root and doc-en under `en/`, is now stated in the workflow too.

Same line present in the check-xml workflow of doc-es, doc-it, doc-pt_br and doc-ru.
