### PR TITLE
[Sync EN] language/types: fix grammar (#5746)

### DIFF
--- a/language/types/array.xml
+++ b/language/types/array.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 17c238517825dfb7ec3edfef5972acd944ffbc1e Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 7132d8833a86604aa2d10c16c0470d0ef1a0fdfb Maintainer: lacatoire Status: ready -->
 <sect1 xml:id="language.types.array">
  <title>Les tableaux</title>
 
@@ -488,7 +488,7 @@ $arr[] = <replaceable>valeur</replaceable>;
 // <replaceable>clé</replaceable> peut être un &integer; ou une &string;
 // <replaceable>valeur</replaceable> peut être n'importe quel type</synopsis>
 
-   <para>
+   <simpara>
     Si lors de l'assignation <varname>$arr</varname> n'existe pas ou est défini
     à &null; ou &false;, il sera créé ; c'est ainsi une façon détournée de créer un tableau.
     Cette pratique est cependant découragée car si <varname>$arr</varname>
@@ -497,7 +497,7 @@ $arr[] = <replaceable>valeur</replaceable>;
     un <link linkend="language.types.string.substr">opérateur d'accès
     sur une chaîne</link>. C'est toujours un meilleur choix que d'initialiser
     une variable par affectation directe.
-   </para>
+   </simpara>
    <note>
     <simpara>
      À partir de PHP 7.1.0, l'application de l'opérateur d'index vide sur une 
@@ -1067,7 +1067,7 @@ $error_descriptions[8] = "This is just an informal notice";
    même chose que <literal>array($scalarValue)</literal>.
   </para>
 
-  <para>
+  <simpara>
    Si un objet est converti en un tableau, le résultat sera un tableau dont les
    éléments sont les propriétés de l'objet. Les clés sont les noms des membres,
    avec une légère exception : les variables ayant un nom sous forme d'entier sont
@@ -1077,7 +1077,7 @@ $error_descriptions[8] = "This is just an informal notice";
    Ces valeurs préfixées ont des octets <literal>NUL</literal> des deux côtés.
    Les <link linkend="language.oop5.properties.typed-properties">propriétés typées</link>
    non-initialisées sont silencieusement écartées.
-  </para>
+  </simpara>
 
   <example>
    <title>Conversion en tableau</title>

--- a/language/types/callable.xml
+++ b/language/types/callable.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 17c238517825dfb7ec3edfef5972acd944ffbc1e Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 7132d8833a86604aa2d10c16c0470d0ef1a0fdfb Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes Maintainer: girgias -->
 <!-- CREDITS: DavidA -->
 <sect1 xml:id="language.types.callable">
@@ -198,7 +198,7 @@ print implode(' ', $new_numbers);
 
   <example>
    <title>
-    Appel de différents types de callables avec <function>call_user_function</function>
+    Appel de différents types de callables avec <function>call_user_func</function>
    </title>
    <programlisting role="php">
 <![CDATA[

--- a/language/types/declarations.xml
+++ b/language/types/declarations.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 911fe79de766ef4475bf22446903667a0f3a24d3 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 7132d8833a86604aa2d10c16c0470d0ef1a0fdfb Maintainer: lacatoire Status: ready -->
 <sect1 xml:id="language.types.declarations">
  <title>Déclarations de type</title>
 
@@ -11,14 +11,14 @@
   sinon une <classname>TypeError</classname> est lancée.
  </para>
 
- <para>
+ <simpara>
   Chaque type pris en charge par PHP, à l'exception du type
   <type>resource</type>, peut être utilisé dans une déclaration de type
   par l'utilisateur.
   Cette page contient un journal des modifications de la disponibilité des
   différents types et de la documentation sur leur utilisation dans les
   déclarations de type.
- </para>
+ </simpara>
 
  <note>
   <para>

--- a/language/types/float.xml
+++ b/language/types/float.xml
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e587d0655e426f97b3fcb431453da5030e743b23 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 7132d8833a86604aa2d10c16c0470d0ef1a0fdfb Maintainer: yannick Status: ready -->
 <!-- Reviewed: yes Maintainer: girgias -->
 <!-- CREDITS: DavidA -->
 
 <sect1 xml:id="language.types.float" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Nombres à virgule flottante</title>
  
- <para>
+ <simpara>
   Les nombres à virgule flottante (aussi connus comme <literal>"floats"</literal>,
   <literal>"doubles"</literal>, ou <literal>"nombres réels"</literal>)
   peuvent être spécifiés en utilisant les syntaxes suivantes :
- </para>
+ </simpara>
  
  <informalexample>
   <programlisting role="php">
@@ -49,16 +49,16 @@ EXPONENT_DNUM (({LNUM} | {DNUM}) [eE][+-]? {LNUM})
  <warning xml:id="warn.float-precision">
   <title>Précision des nombres flottants</title>
   
-  <para>
+  <simpara>
    Les nombres flottants ont une précision limitée. Même s'ils dépendent du système,
    PHP utilise le format de double précision IEEE 754, qui donnera une erreur
    maximale relative de l'ordre de 1.11e-16 (due aux arrondis). Les opérations
    arithmétiques non-élémentaires peuvent donner des erreurs plus importantes et
    bien sûr les erreurs doivent être prises en compte lorsque plusieurs opérations
    sont liées.
-  </para>
+  </simpara>
   
-  <para>
+  <simpara>
    Aussi, les nombres rationnels exactement représentables sous forme de nombre à virgule
    flottante en base 10, comme <literal>0.1</literal> ou <literal>0.7</literal>, n'ont pas
    de représentation exacte comme nombres à virgule flottante en base 2, utilisée en
@@ -67,15 +67,15 @@ EXPONENT_DNUM (({LNUM} | {DNUM}) [eE][+-]? {LNUM})
    confus : par exemple, <literal>floor((0.1+0.7)*10)</literal> retournera normalement
    <literal>7</literal> au lieu de <literal>8</literal> attendu, car la représentation
    interne sera quelque chose comme <literal>7.9999999999999991118...</literal>.
-  </para>
+  </simpara>
   
-  <para>
+  <simpara>
    Ainsi, il ne faut jamais faire confiance aux derniers chiffres d'un nombre
    flottant, et il ne faut pas non plus comparer l'égalité de 2 nombres flottants
    directement. Si une plus grande précision est nécessaire, les
    <link linkend="ref.bc">fonctions mathématiques de précision arbitraire</link>
    et les fonctions <link linkend="ref.gmp">gmp</link> sont disponibles.
-  </para>
+  </simpara>
   
   <para>
    Pour une explication "simple", voir le
@@ -123,19 +123,19 @@ EXPONENT_DNUM (({LNUM} | {DNUM}) [eE][+-]? {LNUM})
  <sect2 xml:id="language.types.float.comparison">
   <title>Comparaison de nombres flottants</title>
   
-  <para>
+  <simpara>
    Comme dit dans la note ci-dessus, le test d'égalité des valeurs de
    nombres flottants est problématique, en raison de la façon dont ils
    sont représentés en interne. Cependant, il existe des façons de
    réaliser cette comparaison.
-  </para>
+  </simpara>
   
-  <para>
+  <simpara>
    Pour tester l'égalité de valeurs de nombres flottants, une borne supérieure
    de l'erreur relative à l'arrondi est utilisée. Cette valeur est connue
    comme étant l'epsilon de la machine, ou le <literal>unit roundoff</literal>,
    et est la différence la plus petite acceptable dans les calculs.
-  </para>
+  </simpara>
 
   <para>
    <varname>$a</varname> et <varname>$b</varname> sont égaux sur 5 nombres

--- a/language/types/integer.xml
+++ b/language/types/integer.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 78a11d3ca004ee937549d932e77a79c51b9777cd Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 7132d8833a86604aa2d10c16c0470d0ef1a0fdfb Maintainer: yannick Status: ready -->
 <!-- Reviewed: yes Maintainer: girgias -->
 <!-- CREDITS: DavidA -->
 
@@ -32,12 +32,12 @@
    peut être utilisé pour désigner un &integer; négatif.
   </simpara>
 
-  <para>
+  <simpara>
    Pour utiliser la notation octale, il faut précéder le nombre d'un <literal>0</literal> (zéro).
    À partir de PHP 8.1.0, la notation octale peut également être précédée de <literal>0o</literal> ou <literal>0O</literal>.
    Pour utiliser la notation hexadécimale, il faut précéder le nombre de <literal>0x</literal>.
    Pour utiliser la notation binaire, il faut précéder le nombre de <literal>0b</literal>.
-  </para>
+  </simpara>
 
   <para>
    À partir de PHP 7.4.0, les entiers littéraux peuvent contenir des underscores
@@ -129,14 +129,14 @@ var_dump(PHP_INT_MAX + 1);       // 32-bit system: float(2147483648)
  <sect2 xml:id="language.types.integer.division">
   <title>Division d'entier</title>
 
-  <para>
-   Il n'y a pas d'opérateur de division d'&integer; en PHP, pour accomplir ceci,
+  <simpara>
+   Il n'y a pas d'opérateur de division d'&integer; en PHP. Pour accomplir ceci,
    utiliser la fonction <function>intdiv</function>.
    <literal>1/2</literal> produit le &float; (<literal>0.5</literal>).
    La valeur peut être transtypée en un &integer; pour l'arrondir vers zéro, ou
    en utilisant la fonction <function>round</function> pour avoir un contrôle
    plus fin sur la façon dont l'arrondi est exécuté.
-  </para>
+  </simpara>
 
   <example>
    <title>Division</title>

--- a/language/types/iterable.xml
+++ b/language/types/iterable.xml
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e587d0655e426f97b3fcb431453da5030e743b23 Maintainer: jbnahan Status: ready -->
+<!-- EN-Revision: 7132d8833a86604aa2d10c16c0470d0ef1a0fdfb Maintainer: jbnahan Status: ready -->
 <!-- Reviewed: yes Maintainer: girgias -->
 <sect1 xml:id="language.types.iterable">
  <title>Itérables</title>
 
- <para>
+ <simpara>
   Un <type>Iterable</type> est un alias de type intégré au moment de la compilation pour
   <!-- Besoin d'améliorer le rendu des éléments de type autonomes dans PhD <type class="union"><type>array</type><type>Traversable</type></type>. -->
   <literal>array|Traversable</literal>.
   Depuis son introduction dans PHP 7.1.0 et avant PHP 8.2.0,
   <type>iterable</type> était un pseudo-type intégré qui agissait comme
-  l'alias de type susmentionné et peut être utilisé comme une déclaration de type.
+  l'alias de type susmentionné et pouvait être utilisé comme une déclaration de type.
   <type>iterable</type> peut être utilisé dans une boucle &foreach; et avec
   <command>yield from</command> dans un <link linkend="language.generators">générateur</link>.
- </para>
+ </simpara>
 
  <note>
   <para>

--- a/language/types/mixed.xml
+++ b/language/types/mixed.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 161dde4fe721309398dd324edbf02aec409f127b Maintainer: pierrick Status: ready -->
+<!-- EN-Revision: 7132d8833a86604aa2d10c16c0470d0ef1a0fdfb Maintainer: pierrick Status: ready -->
 <!-- Reviewed: no -->
 <sect1 xml:id="language.types.mixed">
  <title>Mixed</title>
@@ -17,10 +17,10 @@
   Disponible à partir de PHP 8.0.0.
  </para>
 
- <para>
-  <type>mixed</type> est, dans le langage de la théorie des types, le type supérieur.
-  Cela signifie que tous les autres types sont des sous-types de ce type.
- </para>
+ <simpara>
+  <type>mixed</type> est, dans le langage de la théorie des types, le type supérieur,
+  ce qui signifie que tous les autres types sont des sous-types de ce type.
+ </simpara>
 
 </sect1>
 <!-- Keep this comment at the end of the file

--- a/language/types/never.xml
+++ b/language/types/never.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 161dde4fe721309398dd324edbf02aec409f127b Maintainer: pierrick Status: ready -->
+<!-- EN-Revision: 7132d8833a86604aa2d10c16c0470d0ef1a0fdfb Maintainer: pierrick Status: ready -->
 <!-- Reviewed: no -->
 <sect1 xml:id="language.types.never">
  <title>Never</title>
@@ -12,11 +12,11 @@
   <link linkend="language.types.type-system.composite.union">type union</link>.
   Disponible à partir de PHP 8.1.0.
  </para>
- <para>
-  <type>never</type> est, dans le langage de la théorie des types, le type vide.
-  Cela signifie qu'il est le sous-type de tous les autres types et qu'il peut remplacer n'importe quel autre
+ <simpara>
+  <type>never</type> est, dans le langage de la théorie des types, le type vide,
+  ce qui signifie qu'il est le sous-type de tous les autres types et qu'il peut remplacer n'importe quel autre
   type de retour lors de l'héritage.
- </para>
+ </simpara>
 
 </sect1>
 <!-- Keep this comment at the end of the file

--- a/language/types/null.xml
+++ b/language/types/null.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 3f1dbc451b313fb1ec8058f24c1beccf55fce316 Maintainer: jpauli Status: ready -->
+<!-- EN-Revision: 7132d8833a86604aa2d10c16c0470d0ef1a0fdfb Maintainer: jpauli Status: ready -->
 <!-- Reviewed: yes Maintainer: girgias -->
 <sect1 xml:id="language.types.null">
  <title>NULL</title>
@@ -10,9 +10,9 @@
   &null;.
  </para>
 
- <para>
-  Les variables non définies et les variables <function>unset</function> auront la valeur &null;.
- </para>
+ <simpara>
+  Les variables non définies et les variables <function>unset</function> ont la valeur &null;.
+ </simpara>
 
  <sect2 xml:id="language.types.null.syntax">
   <title>Syntaxe</title>

--- a/language/types/numeric-strings.xml
+++ b/language/types/numeric-strings.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e587d0655e426f97b3fcb431453da5030e743b23 Maintainer: pierrick Status: ready -->
+<!-- EN-Revision: 7132d8833a86604aa2d10c16c0470d0ef1a0fdfb Maintainer: pierrick Status: ready -->
 <!-- Reviewed: no -->
 <sect1 xml:id="language.types.numeric-strings" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Chaînes numériques</title>
@@ -91,11 +91,12 @@ var_dump("2E1" == "020"); // true, "2E1" est 2 * (10 ^ 1), soit 20
 
  <sect2 xml:id="language.types.numeric-string.prior">
   <title>Comportement antérieur à PHP 8.0.0</title>
-  <para>
-   Avant PHP 8.0.0, une <type>string</type> était considérée comme numérique seulement si elle
-   avait des espaces blancs en <emphasis>début</emphasis> de chaîne, si elle avait des espaces blancs
-   en <emphasis>fin</emphasis> de chaîne, la chaîne était considérée comme une chaîne débutant numériquement.
-  </para>
+  <simpara>
+   Avant PHP 8.0.0, une <type>string</type> était considérée comme numérique si elle
+   avait uniquement des espaces blancs en <emphasis>début</emphasis> de chaîne. Si elle avait
+   des espaces blancs en <emphasis>fin</emphasis> de chaîne, la chaîne était considérée
+   comme une chaîne débutant numériquement.
+  </simpara>
 
   <para>
    Avant PHP 8.0.0, lorsqu'une chaîne de caractères était utilisée dans un contexte numérique,

--- a/language/types/object.xml
+++ b/language/types/object.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e587d0655e426f97b3fcb431453da5030e743b23 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 7132d8833a86604aa2d10c16c0470d0ef1a0fdfb Maintainer: yannick Status: ready -->
 <!-- Reviewed: yes -->
 
 <sect1 xml:id="language.types.object">
@@ -42,16 +42,15 @@ $bar->do_foo();
 
  <sect2 xml:id="language.types.object.casting">
   <title>Conversion en un objet</title>
-  <para>
+  <simpara>
    Si un objet est converti en un objet, il ne sera pas modifié.
    Si une valeur de n'importe quel type est convertie en un objet,
    une nouvelle instance de la classe interne <classname>stdClass</classname>
    sera créée. Si la valeur est &null;, la nouvelle instance sera vide.
    Un <type>array</type> se convertit en <type>object</type> avec les propriétés
-   nommées au regard des clés avec leurs valeurs correspondantes. Il est à noter que
-   dans ce cas, avant PHP 7.2.0 les clés numériques ont été inaccessibles à
-   moins d'être itérées.
-  </para>
+   nommées au regard des clés avec leurs valeurs correspondantes.
+   Avant PHP 7.2.0, les clés numériques étaient inaccessibles à moins d'être itérées.
+  </simpara>
 
   <example>
    <title>Conversion en un objet</title>

--- a/language/types/relative-class-types.xml
+++ b/language/types/relative-class-types.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 339ba3f0f4440af1f8d83e73b2c3be06b3cb2315 Maintainer: pierrick Status: ready -->
+<!-- EN-Revision: 7132d8833a86604aa2d10c16c0470d0ef1a0fdfb Maintainer: pierrick Status: ready -->
 <sect1 xml:id="language.types.relative-class-types">
  <title>Types de classes relatives</title>
 
- <para>
+ <simpara>
   Ces déclarations de types ne peuvent être utilisées qu'à l'intérieur des classes.
- </para>
+ </simpara>
 
  <sect2 xml:id="language.types.relative-class-types.self">
   <title><type>self</type></title>

--- a/language/types/resource.xml
+++ b/language/types/resource.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 95bdd6883b5dde9504701777ba81b3c5f15df52b Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 7132d8833a86604aa2d10c16c0470d0ef1a0fdfb Maintainer: yannick Status: ready -->
 <!-- Reviewed: yes Maintainer: girgias -->
 <!-- CREDITS: DavidA -->
 
@@ -31,12 +31,12 @@
  <sect2 xml:id="language.types.resource.self-destruct">
   <title>Libération des ressources</title>
 
-  <para>
+  <simpara>
    Grâce au système de compteur de référence qui fait partie du Zend Engine,
    une &resource; qui n'a plus aucune référence est détectée automatiquement
    et est libérée par le ramasse-miettes. Pour cette raison, il est rarement
    nécessaire de libérer la mémoire manuellement.
-  </para>
+  </simpara>
 
   <note>
    <simpara>

--- a/language/types/singleton.xml
+++ b/language/types/singleton.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 828980b619bb4300e196924598b6a5d398f630e4 Maintainer: Fan2Shrek Status: ready -->
+<!-- $Revision$ -->
+<!-- EN-Revision: 7132d8833a86604aa2d10c16c0470d0ef1a0fdfb Maintainer: Fan2Shrek Status: ready -->
 <!-- Reviewed: yes -->
 <sect1 xml:id="language.types.singleton">
  <title>Type singleton</title>

--- a/language/types/string.xml
+++ b/language/types/string.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: ddc2a2d0966f746b67292b6c0987ef288747e409 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 7132d8833a86604aa2d10c16c0470d0ef1a0fdfb Maintainer: yannick Status: ready -->
 <!-- Reviewed: no Maintainer: girgias -->
 <sect1 xml:id="language.types.string">
  <title>Chaînes</title>
@@ -13,8 +13,8 @@
 
  <note>
   <simpara>
-   Sur les versions 32 bits, une <type>chaîne</type> peut être aussi grande que 2 Go
-   (2147483647 octets maximum)
+   Sur les versions 32 bits, une <type>chaîne</type> peut faire jusqu'à 2 Go
+   (2147483647 octets) de long.
   </simpara>
  </note>
 
@@ -263,7 +263,8 @@ c
    </example>
 
    <simpara>
-    Si l'identifiant de fermeture est indenté plus que n'importe quelle ligne du corps, alors une <classname>ParseError</classname> sera levée :
+    Si l'identifiant de fermeture est indenté plus que n'importe quelle ligne du corps,
+    alors une <exceptionname>ParseError</exceptionname> sera levée :
    </simpara>
 
    <example>
@@ -287,22 +288,23 @@ Parse error: Invalid body indentation level (expecting an indentation level of a
    </example>
 
    <simpara>
-    Si l'identifiant de fermeture est indenté, des tabulations peuvent également être utilisées, cependant,
-    les tabulations et les espaces <emphasis>ne doivent pas</emphasis> être mélangés concernant
-    l'indentation de l'identifiant de fermeture et l'indentation du corps
-    (jusqu'à l'identifiant de fermeture). Dans l'un de ces cas, une <classname>ParseError</classname> sera levée.
+    Si l'identifiant de fermeture est indenté, des tabulations peuvent également être
+    utilisées. Cependant, les tabulations et les espaces <emphasis>ne doivent pas</emphasis>
+    être mélangés. L'indentation du corps et celle de l'identifiant de fermeture doivent
+    utiliser l'un ou l'autre de manière cohérente. Si des tabulations et des espaces sont
+    mélangés, alors une <exceptionname>ParseError</exceptionname> sera levée.
 
     Ces contraintes d'espace ont été incluses car le mélange d'espaces et de tabulations pour l'indentation nuit à la lisibilité.
    </simpara>
 
    <example>
-    <title>Indentation différente pour le corps (espaces) identifiant de fermeture</title>
+    <title>Indentation différente pour le corps et l'identifiant de fermeture</title>
     <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
 // Tout le code suivant ne fonctionne pas.
 
-// indentation différente pour le corps (espaces) marqueur de fin (tabulations)
+// indentation différente pour le corps (espaces) et marqueur de fin (tabulations)
 {
 	echo <<<END
 	 a
@@ -368,13 +370,13 @@ array(2) {
 
    <warning>
     <simpara>
-     Si l'identifiant de fermeture a été trouvé au début d'une ligne, alors
-     peu importe s'il faisait partie d'un autre mot, il peut être considéré
-     comme l'identifiant de fermeture et provoquer une <classname>ParseError</classname>.
+     Si l'identifiant de fermeture est trouvé au début d'une ligne, alors
+     peu importe qu'il fasse partie d'un autre mot, il est considéré
+     comme l'identifiant de fermeture et provoque une <exceptionname>ParseError</exceptionname>.
     </simpara>
 
     <example>
-     <title>L'identifiant de fermeture dans le corps de la chaîne tend à provoquer une ParseError</title>
+     <title>L'identifiant de fermeture dans le corps de la chaîne tend à provoquer une <exceptionname>ParseError</exceptionname></title>
      <programlisting role="php">
 <![CDATA[
 <?php
@@ -582,11 +584,11 @@ FOOBAR;
   <sect3 xml:id="language.types.string.syntax.nowdoc">
    <title>Nowdoc</title>
 
-   <para>
+   <simpara>
     Les nowdocs sont aux chaînes entre guillemets simples ce que les heredocs sont aux chaînes entre guillemets doubles. Un nowdoc est spécifié de manière similaire à un heredoc, mais <emphasis>aucune interpolation de chaîne n'est effectuée</emphasis> à l'intérieur d'un nowdoc. La construction est idéale pour intégrer du code PHP ou d'autres blocs de texte volumineux sans avoir besoin d'échapper. Il partage certaines caractéristiques avec la construction SGML
     <literal>&lt;![CDATA[ ]]&gt;</literal>, en ce sens qu'elle déclare un
     bloc de texte qui n'est pas destiné à être analysé.
-   </para>
+   </simpara>
 
    <para>
     Un nowdoc est identifié par la même séquence <literal>&lt;&lt;&lt;</literal>
@@ -1188,12 +1190,12 @@ string(1) "b"
    les valeurs <type>bool</type> et <type>chaîne</type>.
   </para>
 
-  <para>
+  <simpara>
    Un <type>int</type> ou <type>float</type> est converti en une
    <type>chaîne</type> représentant le nombre textuellement (y compris la
    partie exponentielle pour les <type>float</type>). Les nombres à virgule flottante peuvent être
    convertis à l'aide de la notation exponentielle (<literal>4.1E+6</literal>).
-  </para>
+  </simpara>
 
   <note>
    <para>
@@ -1252,23 +1254,23 @@ string(1) "b"
 
   <title>Détails du type chaîne</title>
 
-  <para>
+  <simpara>
    La <type>chaîne</type> en PHP est implémentée comme un tableau d'octets et un
    entier indiquant la longueur du tampon. Elle n'a aucune information sur la façon
    dont ces octets se traduisent en caractères, laissant cette tâche au programmeur.
    Il n'y a pas de limitations sur les valeurs que la chaîne peut être composée ; en
    particulier, les octets de valeur <literal>0</literal> (« octets NUL ») sont autorisés
-   partout dans la chaîne (cependant, quelques fonctions, dites dans ce manuel de ne
+   partout dans la chaîne. Cependant, quelques fonctions, dites dans ce manuel de ne
    pas être « sûres pour les binaires », peuvent transmettre les chaînes à des bibliothèques
-   qui ignorent les données après un octet NUL.)
-  </para>
+   qui ignorent les données après un octet NUL.
+  </simpara>
   <para>
    Cette nature du type chaîne explique pourquoi il n'y a pas de type « octet » distinct
    en PHP – les chaînes prennent ce rôle. Les fonctions qui ne renvoient pas de données
    textuelles – par exemple, des données arbitraires lues à partir d'une socket réseau –
    renverront tout de même des chaînes.
   </para>
-  <para>
+  <simpara>
    Étant donné que PHP ne dicte pas un encodage spécifique pour les chaînes, on pourrait
    se demander comment les littéraux de chaînes sont encodés. Par exemple, la chaîne
    <literal>"á"</literal> est-elle équivalente à <literal>"\xE1"</literal> (ISO-8859-1),
@@ -1287,7 +1289,7 @@ string(1) "b"
    Il est cependant à noter que les encodages dépendants de l'état où les mêmes valeurs d'octets
    peuvent être utilisées dans des états de décalage initiaux et non initiaux peuvent
    poser problème.
-  </para>
+  </simpara>
   <para>
    Bien sûr, afin d'être utiles, les fonctions qui opèrent sur du texte peuvent devoir
    faire certaines hypothèses sur la façon dont la chaîne est encodée. Malheureusement,
@@ -1307,8 +1309,8 @@ string(1) "b"
    </listitem>
    <listitem>
     <simpara>
-     D'autres fonctions reçoivent l'encodage de la chaîne, supposant éventuellement un
-     défaut si aucune information de ce type n'est donnée. C'est le cas de
+     D'autres fonctions reçoivent l'encodage de la chaîne en paramètre ou supposent
+     une valeur par défaut lorsqu'il n'est pas fourni. C'est le cas de
      <function>htmlentities</function> et de la majorité des fonctions dans
      l'<link linkend="book.mbstring">extension mbstring</link>.
     </simpara>

--- a/language/types/type-juggling.xml
+++ b/language/types/type-juggling.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 50f76f26914c5a9e61aa26f2e36c4acb362a48fd Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 7132d8833a86604aa2d10c16c0470d0ef1a0fdfb Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <sect1 xml:id="language.types.type-juggling">
  <title>Jonglage de type</title>
@@ -60,13 +60,13 @@
   </simpara>
 
   <simpara>
-   Dans ce contexte si un des opérandes est un <type>float</type> (ou pas
+   Dans ce contexte, si un des opérandes est un <type>float</type> (ou pas
    interprétable comme <type>int</type>), les deux opérandes sont interprétés
    comme des <type>float</type>s, et le résultat sera un <type>float</type>.
    Sinon, les opérandes sont interprétés comme des <type>int</type>s,
    et le résultat sera aussi un <type>int</type>.
    À partir de PHP 8.0.0, si un des opérandes ne peut être interprété, une
-   <classname>TypeError</classname> est lancée.
+   <exceptionname>TypeError</exceptionname> est lancée.
   </simpara>
  </sect2>
 
@@ -81,9 +81,9 @@
   </simpara>
 
   <simpara>
-   Dans ce contexte la valeur sera interprétée comme une <type>string</type>.
+   Dans ce contexte, la valeur sera interprétée comme une <type>string</type>.
    Si la valeur ne peut pas être interprétée, une
-   <classname>TypeError</classname> est levée.
+   <exceptionname>TypeError</exceptionname> est levée.
    Avant PHP 7.4.0, une <constant>E_RECOVERABLE_ERROR</constant> était soulevée.
   </simpara>
  </sect2>
@@ -98,7 +98,7 @@
   </simpara>
 
   <simpara>
-   Dans ce contexte la valeur sera interprétée comme un <type>bool</type>.
+   Dans ce contexte, la valeur sera interprétée comme un <type>bool</type>.
   </simpara>
  </sect2>
 
@@ -111,12 +111,12 @@
   </simpara>
 
   <simpara>
-   Dans ce contexte si tous les opérandes sont de type <type>string</type>
+   Dans ce contexte, si tous les opérandes sont de type <type>string</type>,
    alors le résultat sera aussi une <type>string</type>.
    Sinon, les opérandes seront interprétés comme des <type>int</type>s,
    et le résultat sera aussi un <type>int</type>.
    À partir de PHP 8.0.0, si un des opérandes ne peut être interprété, une
-   <classname>TypeError</classname> est lancée.
+   <exceptionname>TypeError</exceptionname> est lancée.
   </simpara>
  </sect2>
 
@@ -143,9 +143,9 @@
    typée ou retournée depuis une fonction qui déclare un type de retour.
   </simpara>
 
-  <para>
+  <simpara>
    Dans ce contexte, la valeur doit être une valeur du type.
-   Il existe deux exceptions, la première est la suivante : si la valeur est de
+   Il existe deux exceptions. La première est la suivante : si la valeur est de
    type <type>int</type> et que le type déclaré est <type>float</type>, alors
    l'entier est converti en nombre à virgule flottante.
    La seconde est : si le type déclaré est un type <emphasis>scalaire</emphasis>
@@ -153,13 +153,13 @@
    , la valeur est convertible en un type scalaire, et le mode de typage coercitif
    est actif (par défaut), la valeur peut être convertie en une valeur scalaire acceptée.
    Voir ci-dessous pour une description de ce comportement.
-  </para>
+  </simpara>
 
   <warning>
    <simpara>
     <link linkend="functions.internal">Les fonctions internes</link>
-    contraignent automatiquement &null; aux types scalaires,
-    ce comportement est <emphasis>OBSOLÈTE</emphasis> à partir de PHP 8.1.0.
+    contraignent automatiquement &null; aux types scalaires.
+    Ce comportement est <emphasis>OBSOLÈTE</emphasis> à partir de PHP 8.1.0.
    </simpara>
   </warning>
 
@@ -241,12 +241,12 @@
    </caution>
 
    <note>
-    <para>
+    <simpara>
      Les types qui ne font pas partie de la liste de préférences ci-dessus ne
      sont pas des cibles admissibles à la coercition implicite. En particulier,
      aucune contrainte implicite aux types <type>null</type>,
      <type>false</type>, et <type>true</type> ne se produit.
-    </para>
+    </simpara>
    </note>
 
    <example>

--- a/language/types/type-system.xml
+++ b/language/types/type-system.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: dfd68fd22aef25658bc9348176b55b504d26ab11 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 7132d8833a86604aa2d10c16c0470d0ef1a0fdfb Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <sect1 xml:id="language.types.type-system">
  <title>Système de type</title>
@@ -18,10 +18,10 @@
 
  <sect2 xml:id="language.types.type-system.atomic">
   <title>Types atomiques</title>
-  <para>
+  <simpara>
    Certains types atomiques sont des types qui sont étroitement intégrés au langage
    et ne peuvent être reproduits avec des types définis par l'utilisateur.
-  </para>
+  </simpara>
 
   <para>
    La liste des types de base est la suivante :
@@ -161,14 +161,14 @@
 
   <sect3 xml:id="language.types.type-system.composite.intersection">
    <title>Intersection de types</title>
-   <para>
+   <simpara>
     Un type d'intersection accepte des valeurs qui satisfont plusieurs
     déclarations de type de classe, plutôt qu'une seule.
     Les types individuels qui forment le type d'intersection sont reliés par le symbole
     <literal>&amp;</literal>. Par conséquent, un type d'intersection composé
     des types <literal>T</literal>, <literal>U</literal> et
     <literal>V</literal> s'écrit <literal>T&amp;U&amp;V</literal>.
-   </para>
+   </simpara>
   </sect3>
 
   <sect3 xml:id="language.types.type-system.composite.union">
@@ -190,13 +190,13 @@
  <sect2 xml:id="language.types.type-system.alias">
   <title>Alias de type</title>
 
-  <para>
+  <simpara>
    PHP supporte deux alias de type : <type>mixed</type> et
    <type>iterable</type> qui correspondent au
    <link linkend="language.types.type-system.composite.union">type d'union</link>
    de <literal>object|resource|array|string|float|int|bool|null</literal>
    et <literal>Traversable|array</literal> respectivement.
-  </para>
+  </simpara>
 
   <note>
    <simpara>

--- a/language/types/void.xml
+++ b/language/types/void.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 50f76f26914c5a9e61aa26f2e36c4acb362a48fd Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 7132d8833a86604aa2d10c16c0470d0ef1a0fdfb Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <sect1 xml:id="language.types.void">
  <title>Void</title>
@@ -15,7 +15,7 @@
  <note>
   <simpara>
    Même si une fonction a un type de retour <type>void</type>, elle
-   retournera toujours une valeur, cette valeur est toujours &null;.
+   retournera toujours une valeur. Cette valeur est toujours &null;.
   </simpara>
  </note>
 


### PR DESCRIPTION
Sync of `language/types` with doc-en `7132d8833a86604aa2d10c16c0470d0ef1a0fdfb` (php/doc-en#5746).

- convert the affected `<para>` elements to `<simpara>` (18 files)
- `<classname>TypeError</classname>` / `ParseError` → `<exceptionname>`
- add the missing `$Revision$` marker in `singleton.xml`
- reword the French text where the English meaning changed (iterable, mixed, never, null, numeric-strings, object, string, type-juggling, void)
- `EN-Revision` bumped on all 18 files

Closes #3194
