### PR TITLE
[Sync EN] basic-syntax: example emitting an unrelated warning (#5747)

### DIFF
--- a/language/basic-syntax.xml
+++ b/language/basic-syntax.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: fa67e21421448a20fe701a20897c30f93072e64b Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: e7ec2928daf49d50796dfe74d106eb1068a1c72b Maintainer: lacatoire Status: ready -->
 <!-- CREDITS: DavidA -->
 
 <chapter xml:id="language.basic-syntax" xmlns="http://docbook.org/ns/docbook" annotations="interactive">
@@ -120,7 +120,7 @@ echo "Dernière instruction\n";
     <title>Échappement avancé en utilisant des conditions</title>
     <programlisting role="php">
 <![CDATA[
-<?php if ($expression == true): ?>
+<?php if (true): ?>
   Ceci sera affiché si l'expression est vraie.
 <?php else: ?>
   Sinon, ceci sera affiché.


### PR DESCRIPTION
Sync of `language/basic-syntax.xml` with doc-en `e7ec2928daf49d50796dfe74d106eb1068a1c72b` (php/doc-en#5747).

The advanced escaping example used `$expression`, an undefined variable that emitted a warning unrelated to the point of the example.

Closes #3195
