### PR TITLE
[Sync EN] ext/spl, ext/sqlite3: typed class constants (PHP 8.4) (#5736)

### DIFF
--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9eb61e3573bc9af825caa0aba34932850aa1b666 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 6a2ad3ecf9b77855446019ed2d74aa6f734d35a8 Maintainer: lacatoire Status: ready -->
 <!-- Relecture des Notes, Précautions, Avertissements, Astuces, Divers et Retour le 2018-12-29 par girgias -->
 
 <!--
@@ -13,6 +13,14 @@ la version originale. Merci.
 <!-- Not used in EN anymore -->
 <!ENTITY changelog.randomseed '<row xmlns="http://docbook.org/ns/docbook"><entry>4.2.0</entry><entry>Le générateur
 de nombres aléatoires est initialisé automatiquement.</entry></row>'>
+
+<!ENTITY changelog.class-constants-typed '<row xmlns="http://docbook.org/ns/docbook">
+ <entry>8.4.0</entry>
+ <entry>
+  Les constantes de classe sont désormais typées.
+ </entry>
+</row>'>
+
 
 <!-- Cautions / Précautions -->
 <!ENTITY caution.cryptographically-insecure '<caution xmlns="http://docbook.org/ns/docbook">

--- a/reference/spl/arrayiterator.xml
+++ b/reference/spl/arrayiterator.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 077aab2687db07bcf71c2c7e26f677ea61f5916a Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 6a2ad3ecf9b77855446019ed2d74aa6f734d35a8 Maintainer: yannick Status: ready -->
 <!-- Reviewed: yes -->
 <reference xml:id="class.arrayiterator" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>&class.theclass; <classname>ArrayIterator</classname></title>
@@ -65,12 +65,8 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.arrayiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='ArrayIterator'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.arrayiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ArrayIterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.arrayiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='ArrayIterator'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.arrayiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ArrayIterator'])"/>
    </classsynopsis>
  
   </section>
@@ -103,6 +99,23 @@
    </section>
   </section>
  
+  <section role="changelog">
+   &reftitle.changelog;
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      &changelog.class-constants-typed;
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </section>
+
  </partintro>
  
  &reference.spl.entities.arrayiterator;

--- a/reference/spl/arrayobject.xml
+++ b/reference/spl/arrayobject.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: eff22719b03a83400103686b87d5b470c1d5c785 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 6a2ad3ecf9b77855446019ed2d74aa6f734d35a8 Maintainer: yannick Status: ready -->
 <!-- Reviewed: yes -->
 <reference xml:id="class.arrayobject" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>&class.theclass; <classname>ArrayObject</classname></title>
@@ -63,12 +63,8 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.arrayobject')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='ArrayObject'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.arrayobject')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ArrayObject'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.arrayobject')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='ArrayObject'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.arrayobject')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ArrayObject'])"/>
    </classsynopsis>
  
   </section>
@@ -102,6 +98,23 @@
      </varlistentry>
     </variablelist>
    </section>
+  </section>
+
+  <section role="changelog">
+   &reftitle.changelog;
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      &changelog.class-constants-typed;
+     </tbody>
+    </tgroup>
+   </informaltable>
   </section>
 
  </partintro>

--- a/reference/spl/cachingiterator.xml
+++ b/reference/spl/cachingiterator.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 6a2ad3ecf9b77855446019ed2d74aa6f734d35a8 Maintainer: yannick Status: ready -->
 <!-- Reviewed: yes Maintainer: yannick -->
 <reference xml:id="class.cachingiterator" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>&class.theclass; CachingIterator</title>
@@ -83,17 +83,11 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.cachingiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='CachingIterator'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.cachingiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='CachingIterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.cachingiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='CachingIterator'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.cachingiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='CachingIterator'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.iteratoriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='IteratorIterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.iteratoriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='IteratorIterator'])"/>
    </classsynopsis>
 <!-- }}} -->
    
@@ -177,6 +171,23 @@
    </informaltable>
   </section>
   
+  <section role="changelog">
+   &reftitle.changelog;
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      &changelog.class-constants-typed;
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </section>
+
  </partintro>
  
  &reference.spl.entities.cachingiterator;

--- a/reference/spl/filesystemiterator.xml
+++ b/reference/spl/filesystemiterator.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 6a2ad3ecf9b77855446019ed2d74aa6f734d35a8 Maintainer: yannick Status: ready -->
 <!-- Reviewed: yes -->
 <reference xml:id="class.filesystemiterator" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -107,20 +107,12 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.filesystemiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='FilesystemIterator'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.filesystemiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='FilesystemIterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.filesystemiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='FilesystemIterator'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.filesystemiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='FilesystemIterator'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.directoryiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DirectoryIterator'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.splfileinfo')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SplFileInfo'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.directoryiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DirectoryIterator'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.splfileinfo')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SplFileInfo'])"/>
    </classsynopsis>
 <!-- }}} -->
 
@@ -236,6 +228,23 @@
    </variablelist>
   </section>
   <!-- }}} -->
+
+  <section role="changelog">
+   &reftitle.changelog;
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      &changelog.class-constants-typed;
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </section>
 
  </partintro>
 

--- a/reference/spl/multipleiterator.xml
+++ b/reference/spl/multipleiterator.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 6a2ad3ecf9b77855446019ed2d74aa6f734d35a8 Maintainer: yannick Status: ready -->
 <!-- Reviewed: yes -->
 <reference xml:id="class.multipleiterator" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  
@@ -59,12 +59,8 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.multipleiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='MultipleIterator'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.multipleiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='MultipleIterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.multipleiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='MultipleIterator'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.multipleiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='MultipleIterator'])"/>
    </classsynopsis>
 <!-- }}} -->
    
@@ -118,6 +114,23 @@
   <!-- }}} -->
   
   
+  <section role="changelog">
+   &reftitle.changelog;
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      &changelog.class-constants-typed;
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </section>
+
  </partintro>
  
  &reference.spl.entities.multipleiterator;

--- a/reference/spl/recursivearrayiterator.xml
+++ b/reference/spl/recursivearrayiterator.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: dams Status: ready -->
+<!-- EN-Revision: 6a2ad3ecf9b77855446019ed2d74aa6f734d35a8 Maintainer: dams Status: ready -->
 <!-- Reviewed: yes -->
 <reference xml:id="class.recursivearrayiterator" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>&class.theclass; <classname>RecursiveArrayIterator</classname></title>
@@ -39,9 +39,7 @@
     </oointerface>
 
     <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.arrayiterator')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.arrayiterator')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))"/>
 
     <classsynopsisinfo role="comment">&Constants;</classsynopsisinfo>
     <fieldsynopsis>
@@ -52,17 +50,11 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.recursivearrayiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='RecursiveArrayIterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.recursivearrayiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='RecursiveArrayIterator'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.arrayiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='ArrayIterator'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.arrayiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ArrayIterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.arrayiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='ArrayIterator'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.arrayiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ArrayIterator'])"/>
    </classsynopsis>
 
   </section>
@@ -80,6 +72,23 @@
      </varlistentry>
     </variablelist>
    </section>
+  </section>
+
+  <section role="changelog">
+   &reftitle.changelog;
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      &changelog.class-constants-typed;
+     </tbody>
+    </tgroup>
+   </informaltable>
   </section>
 
  </partintro>

--- a/reference/spl/recursiveiteratoriterator.xml
+++ b/reference/spl/recursiveiteratoriterator.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 6a2ad3ecf9b77855446019ed2d74aa6f734d35a8 Maintainer: yannick Status: ready -->
 <!-- Reviewed: yes -->
 <reference xml:id="class.recursiveiteratoriterator" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>&class.theclass; <classname>RecursiveIteratorIterator</classname></title>
@@ -58,12 +58,8 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.recursiveiteratoriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='RecursiveIteratorIterator'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.recursiveiteratoriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='RecursiveIteratorIterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.recursiveiteratoriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='RecursiveIteratorIterator'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.recursiveiteratoriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='RecursiveIteratorIterator'])"/>
    </classsynopsis>
 
   </section>
@@ -104,6 +100,23 @@
    </variablelist>
   </section>
 <!-- }}} -->
+
+  <section role="changelog">
+   &reftitle.changelog;
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      &changelog.class-constants-typed;
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </section>
 
  </partintro>
 

--- a/reference/spl/recursivetreeiterator.xml
+++ b/reference/spl/recursivetreeiterator.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 6a2ad3ecf9b77855446019ed2d74aa6f734d35a8 Maintainer: yannick Status: ready -->
 <!-- Reviewed: no -->
 <reference xml:id="class.recursivetreeiterator" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  
@@ -34,9 +34,7 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.recursiveiteratoriterator')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.recursiveiteratoriterator')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))"/>
 
     <classsynopsisinfo role="comment">&Constants;</classsynopsisinfo>
     <fieldsynopsis>
@@ -94,17 +92,11 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.recursivetreeiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='RecursiveTreeIterator'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.recursivetreeiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='RecursiveTreeIterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.recursivetreeiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='RecursiveTreeIterator'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.recursivetreeiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='RecursiveTreeIterator'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.recursiveiteratoriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='RecursiveIteratorIterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.recursiveiteratoriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='RecursiveIteratorIterator'])"/>
    </classsynopsis>
 <!-- }}} -->
    
@@ -176,6 +168,23 @@
   <!-- }}} -->
   
   
+  <section role="changelog">
+   &reftitle.changelog;
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      &changelog.class-constants-typed;
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </section>
+
  </partintro>
  
  &reference.spl.entities.recursivetreeiterator;

--- a/reference/spl/regexiterator.xml
+++ b/reference/spl/regexiterator.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: dams Status: ready -->
+<!-- EN-Revision: 6a2ad3ecf9b77855446019ed2d74aa6f734d35a8 Maintainer: dams Status: ready -->
 <!-- Reviewed: yes -->
 <reference xml:id="class.regexiterator" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>&class.theclass; <classname>RegexIterator</classname></title>
@@ -85,20 +85,12 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.regexiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='RegexIterator'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.regexiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='RegexIterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.regexiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='RegexIterator'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.regexiterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='RegexIterator'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.filteriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='FilterIterator'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.iteratoriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='IteratorIterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.filteriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='FilterIterator'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.iteratoriterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='IteratorIterator'])"/>
    </classsynopsis>
 
   </section>
@@ -198,6 +190,23 @@
      </listitem>
     </varlistentry>
    </variablelist>
+  </section>
+
+  <section role="changelog">
+   &reftitle.changelog;
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      &changelog.class-constants-typed;
+     </tbody>
+    </tgroup>
+   </informaltable>
   </section>
 
  </partintro>

--- a/reference/spl/spldoublylinkedlist.xml
+++ b/reference/spl/spldoublylinkedlist.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: dams Status: ready -->
+<!-- EN-Revision: 6a2ad3ecf9b77855446019ed2d74aa6f734d35a8 Maintainer: dams Status: ready -->
 <!-- Reviewed: yes -->
 <reference xml:id="class.spldoublylinkedlist" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>&class.theclass; SplDoublyLinkedList</title>
@@ -71,9 +71,7 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.spldoublylinkedlist')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SplDoublyLinkedList'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.spldoublylinkedlist')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SplDoublyLinkedList'])"/>
    </classsynopsis>
  
   </section>
@@ -147,6 +145,23 @@
   </section>
 }}} -->
  
+  <section role="changelog">
+   &reftitle.changelog;
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      &changelog.class-constants-typed;
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </section>
+
  </partintro>
  
  &reference.spl.entities.spldoublylinkedlist;

--- a/reference/spl/splfileobject.xml
+++ b/reference/spl/splfileobject.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 6a2ad3ecf9b77855446019ed2d74aa6f734d35a8 Maintainer: yannick Status: ready -->
 <!-- Reviewed: no -->
 <reference xml:id="class.splfileobject" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -68,17 +68,11 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.splfileobject')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='SplFileObject'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.splfileobject')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SplFileObject'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.splfileobject')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='SplFileObject'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.splfileobject')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SplFileObject'])"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.splfileinfo')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SplFileInfo'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.splfileinfo')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SplFileInfo'])"/>
    </classsynopsis>
 <!-- }}} -->
 
@@ -118,6 +112,23 @@
    </variablelist>
   </section>
 <!-- }}} -->
+
+  <section role="changelog">
+   &reftitle.changelog;
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      &changelog.class-constants-typed;
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </section>
 
  </partintro>
 

--- a/reference/spl/splpriorityqueue.xml
+++ b/reference/spl/splpriorityqueue.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 6a2ad3ecf9b77855446019ed2d74aa6f734d35a8 Maintainer: yannick Status: ready -->
 <!-- Reviewed: yes -->
 <reference xml:id="class.splpriorityqueue" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>&class.theclass; <classname>SplPriorityQueue</classname></title>
@@ -63,9 +63,7 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.splpriorityqueue')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SplPriorityQueue'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.splpriorityqueue')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SplPriorityQueue'])"/>
    </classsynopsis>
  
   </section>
@@ -94,6 +92,23 @@
    </variablelist>
   </section>
  
+  <section role="changelog">
+   &reftitle.changelog;
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      &changelog.class-constants-typed;
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </section>
+
  </partintro>
  
  &reference.spl.entities.splpriorityqueue;

--- a/reference/sqlite3/sqlite3.xml
+++ b/reference/sqlite3/sqlite3.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 6a2ad3ecf9b77855446019ed2d74aa6f734d35a8 Maintainer: yannick Status: ready -->
 <!-- Reviewed: yes -->
 <reference xml:id="class.sqlite3" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>&class.theclass; <classname>SQLite3</classname></title>
@@ -250,12 +250,8 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.sqlite3')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='SQLite3'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.sqlite3')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SQLite3'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.sqlite3')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='SQLite3'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.sqlite3')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SQLite3'])"/>
    </classsynopsis>
 <!-- }}} -->
 
@@ -523,6 +519,23 @@
      </listitem>
     </varlistentry>
    </variablelist>
+  </section>
+
+  <section role="changelog">
+   &reftitle.changelog;
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      &changelog.class-constants-typed;
+     </tbody>
+    </tgroup>
+   </informaltable>
   </section>
 
  </partintro>


### PR DESCRIPTION
Sync with doc-en `6a2ad3ecf9b77855446019ed2d74aa6f734d35a8` (php/doc-en#5736).

- new `changelog.class-constants-typed` entity in `language-snippets.ent`
- 8.4.0 changelog section added on the 13 affected SPL/SQLite3 class pages
- catch up with the simplification of the `<xi:include>` elements to an empty `<xi:fallback/>`
- `EN-Revision` bumped

Closes #3196
