### PR TITLE
[Sync EN] language/control-structures: fix grammar (#5750)

### DIFF
--- a/language/control-structures/do-while.xml
+++ b/language/control-structures/do-while.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: b8147b7f03506e41f01631c32a907b955593525a Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: e674990649cd2b111b8dd1175a7a1befcc621635 Maintainer: lacatoire Status: ready -->
 
 <sect1 xml:id="control-structures.do.while" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>do-while</title>

--- a/language/control-structures/elseif.xml
+++ b/language/control-structures/elseif.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: b8147b7f03506e41f01631c32a907b955593525a Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: e674990649cd2b111b8dd1175a7a1befcc621635 Maintainer: lacatoire Status: ready -->
 
 <sect1 xml:id="control-structures.elseif" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>elseif/else if</title>

--- a/language/control-structures/for.xml
+++ b/language/control-structures/for.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: b8147b7f03506e41f01631c32a907b955593525a Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: e674990649cd2b111b8dd1175a7a1befcc621635 Maintainer: lacatoire Status: ready -->
 
 <sect1 xml:id="control-structures.for" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>for</title>

--- a/language/control-structures/foreach.xml
+++ b/language/control-structures/foreach.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 17c238517825dfb7ec3edfef5972acd944ffbc1e Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: e674990649cd2b111b8dd1175a7a1befcc621635 Maintainer: lacatoire Status: ready -->
 
 <sect1 xml:id="control-structures.foreach" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>foreach</title>
@@ -144,7 +144,7 @@ Tableaux dynamiques :
     <simpara>
      Il est à noter que
      <link linkend="language.types.array.syntax.destructuring">la déstructuration de tableau</link>
-     via <literal>[]</literal> n'est possible qu'à partir de PHP 7.1.0
+     via <literal>[]</literal> n'est possible qu'à partir de PHP 7.1.0.
     </simpara>
    </note>
   </para>

--- a/language/control-structures/include-once.xml
+++ b/language/control-structures/include-once.xml
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 89d80c92a1154a2903fff371f0d056bf2ac8ba27 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: e674990649cd2b111b8dd1175a7a1befcc621635 Maintainer: yannick Status: ready -->
 <!-- Reviewed: yes -->
 
 <sect1 xml:id="function.include-once" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>include_once</title>
  <?phpdoc print-version-for="include_once"?>
- <para>
+ <simpara>
   L'expression <literal>include_once</literal> inclut et
   évalue le fichier spécifié durant l'exécution du script. 
   Le comportement est similaire à
   <function>include</function>,
   mais la différence est que si le code a déjà été inclus, il ne le sera pas une seconde fois, et include_once retourne &true;. Comme son nom l'indique, le fichier sera inclus une seule fois.
- </para>
+ </simpara>
  <para>
   <literal>include_once</literal> peut être utilisé dans les cas où
   le même fichier pourrait être inclus et évalué plus d'une fois lors

--- a/language/control-structures/include.xml
+++ b/language/control-structures/include.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: b8147b7f03506e41f01631c32a907b955593525a Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: e674990649cd2b111b8dd1175a7a1befcc621635 Maintainer: lacatoire Status: ready -->
 
 <sect1 xml:id="function.include" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>include</title>
@@ -160,7 +160,7 @@ include 'http://www.example.com/file.php?foo=1&bar=2';
  </para>
  <warning>
   <title>Alerte de sécurité</title>
-  <para>
+  <simpara>
    Un fichier distant peut être traité sur le serveur distant
    (dépendamment de l'extension du fichier et si le serveur distant
    exécute PHP ou non) mais il doit toujours produire un script PHP valide
@@ -169,7 +169,7 @@ include 'http://www.example.com/file.php?foo=1&bar=2';
    <function>readfile</function> est une fonction beaucoup plus appropriée.
    Autrement, il est recommandé de bien faire attention à sécuriser le script distant
    afin qu'il produise un code valide et désiré.
-   </para>
+  </simpara>
  </warning>
  <para>
   Voir aussi
@@ -262,16 +262,16 @@ echo $bar; // affiche 1
   Si le fichier ne peut être inclus, &false; est retourné et une erreur
   de niveau <constant>E_WARNING</constant> est envoyée.
  </simpara>
- <para>
+ <simpara>
   S'il y a des fonctions définies dans le fichier inclus, elles peuvent être
-  utilisées dans le fichier principal si elles sont avant le
+  utilisées dans le fichier principal, qu'elles soient avant le
   <function>return</function> ou après.
   Si le fichier est inclus deux fois, PHP émettra une erreur fatale car les
   fonctions ont déjà été déclarées.
   Il est recommandé d'utiliser <function>include_once</function>
   au lieu de vérifier si le fichier a déjà été inclus et donc de retourner
   conditionnellement l'inclusion du fichier.
- </para>
+ </simpara>
  <simpara>
   Une autre façon d'inclure un fichier PHP dans une variable est de capturer
   la sortie en utilisant les fonctions de

--- a/language/control-structures/match.xml
+++ b/language/control-structures/match.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 17c238517825dfb7ec3edfef5972acd944ffbc1e Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: e674990649cd2b111b8dd1175a7a1befcc621635 Maintainer: lacatoire Status: ready -->
 
 <sect1 xml:id="control-structures.match" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>match</title>
@@ -144,11 +144,11 @@ $result = match ($x) {
   </informalexample>
  </para>
 
- <para>
+ <simpara>
   Les bras de l'expression de <literal>match</literal> peuvent contenir plusieurs expressions
   séparées par une virgule. Il s'agit d'un OU logique et d'une abréviation pour plusieurs bras
   qui utilisent la même expression comme résultat.
- </para>
+ </simpara>
  <para>
   <informalexample>
    <programlisting role="php" annotations="non-interactive">
@@ -190,11 +190,11 @@ $expressionResult = match ($condition) {
   </note>
  </para>
 
- <para>
+ <simpara>
   Une expression <literal>match</literal> doit être exhaustive. Si l'expression
   n'est traitée par aucun bras de <literal>match</literal>, une erreur
  <classname>UnhandledMatchError</classname> est lancée.
- </para>
+ </simpara>
 
  <example>
  <title>Exemple d'une expression match non gérée</title>

--- a/language/control-structures/switch.xml
+++ b/language/control-structures/switch.xml
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 17c238517825dfb7ec3edfef5972acd944ffbc1e Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: e674990649cd2b111b8dd1175a7a1befcc621635 Maintainer: lacatoire Status: ready -->
 
 <sect1 xml:id="control-structures.switch" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>switch</title>
  <?phpdoc print-version-for="switch"?>
  <simpara>
   L'instruction <literal>switch</literal> équivaut à une série d'instructions
-  <literal>if</literal>. En de nombreuses occasions, il est nécessaire de
-  comparer la même variable (ou expression) avec un grand nombre de valeurs
+  <literal>if</literal> portant sur la même expression. Lorsqu'il est nécessaire
+  de comparer la même variable ou expression avec un grand nombre de valeurs
   différentes, et d'exécuter différentes parties de code suivant la valeur
-  à laquelle elle est égale. C'est exactement à cela que sert l'instruction
-  <literal>switch</literal>.
+  à laquelle elle est égale, l'instruction <literal>switch</literal> est
+  souvent plus pratique et plus lisible.
  </simpara>
  <note>
   <simpara>
@@ -24,10 +24,10 @@
   </simpara>
  </note>
  <note>
-  <para>
+  <simpara>
    Il est à noter que switch/case provoque une
    <link linkend="types.comparisions-loose">comparaison large</link>.
-  </para>
+  </simpara>
  </note>
 
  <para>
@@ -251,7 +251,8 @@ B
  </para>
  <para>
   Pour des comparaisons plus complexes, la valeur &true; peut être utilisée comme valeur de <literal>switch</literal>.
-  Ou, alternativement, des blocs <literal>if</literal>-<literal>else</literal> au lieu de <literal>switch</literal>.
+  Ou, alternativement, des blocs <literal>if</literal>-<literal>else</literal>
+  peuvent être utilisés au lieu de <literal>switch</literal>.
   <informalexample>
    <programlisting role="php">
 <![CDATA[


### PR DESCRIPTION
Sync of `language/control-structures` with doc-en `e674990649cd2b111b8dd1175a7a1befcc621635` (php/doc-en#5750).

- convert the affected `<para>` elements to `<simpara>` (`include`, `include_once`, `match`, `switch`)
- reword the introduction of `switch` and the mention of the `if`-`else` blocks
- minor fixes in `foreach` and `include`
- `EN-Revision` bumped on the 8 files (`do-while`, `elseif`, `for`: English-only changes)

Closes #3199
