### PR TITLE
[Sync EN] strtr: fix the confusing example, CS (#5754)

### DIFF
--- a/reference/strings/functions/strtr.xml
+++ b/reference/strings/functions/strtr.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 45042fef652f1b4e904e809fcbfcf31f6c60670b Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 1ed119182ad4629064b13301d0e427de47736bfe Maintainer: yannick Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="function.strtr" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -113,15 +113,20 @@
     <programlisting role="php">
 <![CDATA[
 <?php
-$addr = "The river å";
 
-// Ici, strtr() remplace octet par octet, nous supposons
-// donc ici des encodages sur un seul octet:
-$addr = strtr($addr, "äåö", "aao");
-echo $addr, PHP_EOL;
-?>
+$original = "He1Lo, w0rld!";
+
+// Avec trois arguments, strtr() effectue une traduction octet par octet.
+$result = strtr($original, "1L0", "llo");
+echo $result;
 ]]>
     </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+Hello, world!
+]]>
+    </screen>
    </example>
   </para>
   <para>
@@ -135,9 +140,9 @@ echo $addr, PHP_EOL;
     <programlisting role="php">
 <![CDATA[
 <?php
-$trans = array("h" => "-", "hello" => "hi", "hi" => "hello");
-echo strtr("hi all, I said hello", $trans);
-?>
+
+$replace_pairs = ["h" => "-", "hello" => "hi", "hi" => "hello"];
+echo strtr("hi all, I said hello", $replace_pairs);
 ]]>
     </programlisting>
     &example.outputs;
@@ -157,11 +162,22 @@ hello all, I said hi
     <programlisting role="php">
 <![CDATA[
 <?php
-echo strtr("baab", "ab", "01"),"\n";
 
-$trans = array("ab" => "01");
-echo strtr("baab", $trans);
-?>
+// Caractères sur un seul octet
+$singlebyte_string = "baab";
+echo strtr($singlebyte_string, "ab", "01"), "\n"; // Traduction octet par octet
+
+$replace_pairs = ["ab" => "01"];
+echo strtr($singlebyte_string, $replace_pairs), "\n"; // Traduction de sous-chaînes
+
+// Caractères multi-octets
+$multibyte_string = "Ä"; // En UTF-8, encodé sur deux octets : "\xC3\x84"
+
+$result = strtr($multibyte_string, 'Ä', 'A');
+echo bin2hex($result), "\n"; // "4184", où "c3" devient "41" ("A"), tandis que "84" est conservé et casse l'UTF-8
+
+$replace_pairs = ['Ä' => 'A'];
+echo strtr($multibyte_string, $replace_pairs); // Une traduction de sous-chaîne multi-octets correcte
 ]]>
     </programlisting>
     &example.outputs;
@@ -169,6 +185,8 @@ echo strtr("baab", $trans);
 <![CDATA[
 1001
 ba01
+4184
+A
 ]]>
     </screen>
   </example>


### PR DESCRIPTION
Sync of `reference/strings/functions/strtr.xml` with doc-en `1ed119182ad4629064b13301d0e427de47736bfe` (php/doc-en#5754).

- the first example used multibyte characters with the three-argument form (byte per byte), which was confusing: replaced by a single-byte example with its output
- the comparison example now illustrates the multibyte case explicitly (`bin2hex`)
- coding style: short array syntax, no trailing `?>` tag

Closes #3200
