### PR TITLE
[Sync EN] language/predefined: fix grammar (#5755)

### DIFF
--- a/language/predefined/arrayaccess.xml
+++ b/language/predefined/arrayaccess.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4b06b2d5c3a28a13504972df0f0be6deffabb4c5 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 029f19dbc090e4d249a23c0ab087d47059b37adc Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <reference xml:id="class.arrayaccess" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -8,36 +8,30 @@
 
  <partintro>
 
-<!-- {{{ ArrayAccess intro -->
   <section xml:id="arrayaccess.intro">
    &reftitle.intro;
-   <para>
-    Interface permettant d'accéder aux objets de la même façon que pour les tableaux.
-   </para>
+   <simpara>
+    Interface permettant de fournir un accès aux objets de la même façon que pour les tableaux.
+   </simpara>
   </section>
-<!-- }}} -->
 
   <section xml:id="arrayaccess.synopsis">
    &reftitle.interfacesynopsis;
 
-<!-- {{{ Synopsis -->
    <classsynopsis class="interface">
     <oointerface>
      <interfacename>ArrayAccess</interfacename>
     </oointerface>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.arrayaccess')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ArrayAccess'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.arrayaccess')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='ArrayAccess'])"/>
    </classsynopsis>
-<!-- }}} -->
 
   </section>
 
   <section xml:id="arrayaccess.examples">
    &reftitle.examples;
-   <example xml:id="arrayaccess.example.basic"><!-- {{{ -->
+   <example xml:id="arrayaccess.example.basic">
     <title>Exemple basique</title>
     <programlisting role="php">
 <![CDATA[
@@ -106,7 +100,7 @@ Obj Object
 )
 ]]>
     </screen>
-   </example><!-- }}} -->
+   </example>
   </section>
 
  </partintro>

--- a/language/predefined/iterator.xml
+++ b/language/predefined/iterator.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 029f19dbc090e4d249a23c0ab087d47059b37adc Maintainer: yannick Status: ready -->
 <!-- Reviewed: no -->
 <reference xml:id="class.iterator" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -8,7 +8,6 @@
 
  <partintro>
 
-<!-- {{{ Iterator intro -->
   <section xml:id="iterator.intro">
    &reftitle.intro;
    <para>
@@ -16,12 +15,10 @@
     d'être itérés eux-mêmes en interne.
    </para>
   </section>
-<!-- }}} -->
 
   <section xml:id="iterator.synopsis">
    &reftitle.interfacesynopsis;
 
-<!-- {{{ Synopsis -->
    <classsynopsis class="interface">
     <oointerface>
      <interfacename>Iterator</interfacename>
@@ -33,25 +30,22 @@
     </oointerface>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.iterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Iterator'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.iterator')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Iterator'])"/>
    </classsynopsis>
-<!-- }}} -->
 
   </section>
   
   <section xml:id="iterator.iterators">
    <title>Itérateurs prédéfinis</title>
-   <para>
+   <simpara>
     PHP fournit quelques itérateurs pour certaines tâches.
     Voir les <link linkend="spl.iterators">itérateurs SPL</link> pour une liste complète.
-   </para>
+   </simpara>
   </section>
 
   <section xml:id="iterator.examples">
    &reftitle.examples;
-   <example xml:id="iterator.example.basic"><!-- {{{ -->
+   <example xml:id="iterator.example.basic">
     <title>Exemple simple</title>
     <para>
      Cet exemple montre l'ordre d'appel des méthodes lors d'un appel
@@ -137,7 +131,7 @@ string(16) "myIterator::next"
 string(17) "myIterator::valid"
 ]]>
     </screen>
-   </example><!-- }}} -->
+   </example>
   </section>
 
   <section xml:id="iterator.seealso">

--- a/language/predefined/serializable.xml
+++ b/language/predefined/serializable.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4b06b2d5c3a28a13504972df0f0be6deffabb4c5 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 029f19dbc090e4d249a23c0ab087d47059b37adc Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <reference xml:id="class.serializable" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -8,26 +8,27 @@
 
  <partintro>
 
-<!-- {{{ Serializable intro -->
   <section xml:id="serializable.intro">
    &reftitle.intro;
    <para>
     Interface permettant de personnaliser la sérialisation.
    </para>
 
-   <para>
+   <simpara>
     Les classes implémentant cette interface ne supportent plus
     <link linkend="object.sleep">__sleep()</link> et
     <link linkend="object.wakeup">__wakeup()</link>.
-    La méthode de sérialisation est appelée chaque fois qu'une
-    instance doit être sérialisée. Elle n'appelle pas __destruct()
+    La méthode <methodname>serialize</methodname> est appelée chaque fois
+    qu'une instance doit être sérialisée.
+    Elle n'appelle pas <methodname>__destruct</methodname>
     et ne produit aucun autre effet de bord, sauf si cela est codé
     dans la méthode.
     Lorsque les données sont désérialisées, la classe est connue et
-    la méthode unserialize() appropriée est appelée comme constructeur
-    au lieu d'appeler __construct(). S'il est nécessaire d'appeler le constructeur
-    standard, il est possible de le faire dans la méthode.
-   </para>
+    la méthode <methodname>unserialize</methodname> appropriée est appelée
+    comme constructeur au lieu d'appeler <methodname>__construct</methodname>.
+    Le constructeur peut être appelé depuis la méthode
+    <methodname>unserialize</methodname> si besoin.
+   </simpara>
 
    <warning>
     <para>
@@ -38,29 +39,24 @@
     </para>
    </warning>
   </section>
-<!-- }}} -->
 
   <section xml:id="serializable.synopsis">
    &reftitle.interfacesynopsis;
 
-<!-- {{{ Synopsis -->
    <classsynopsis class="interface">
     <oointerface>
      <interfacename>Serializable</interfacename>
     </oointerface>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.serializable')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Serializable'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.serializable')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Serializable'])"/>
    </classsynopsis>
-<!-- }}} -->
 
   </section>
 
   <section xml:id="serializable.examples">
    &reftitle.examples;
-   <example xml:id="serializable.example.basic"><!-- {{{ -->
+   <example xml:id="serializable.example.basic">
     <title>Exemple simple</title>
     <programlisting role="php">
 <![CDATA[
@@ -100,7 +96,7 @@ string(44) "C:3:"obj":29:{s:21:"Mes données privées";}"
 string(21) "Mes données privées"
 ]]>
     </screen>
-   </example><!-- }}} -->
+   </example>
   </section>
 
 

--- a/language/predefined/stdclass.xml
+++ b/language/predefined/stdclass.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 77325b622f91355b118e8f3bc9ff940e8201f55d Maintainer: pierrick Status: ready -->
+<!-- EN-Revision: 029f19dbc090e4d249a23c0ab087d47059b37adc Maintainer: pierrick Status: ready -->
 <!-- Reviewed: no -->
 <reference xml:id="class.stdclass" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -15,14 +15,14 @@
     Une classe générique vide avec des propriétés dynamiques.
    </para>
 
-   <para> 
+   <simpara>
     Les objets de cette classe peuvent être instanciés avec l'opérateur
     <link linkend="language.oop5.basic.new">new</link> ou créés
     en utilisant la <link linkend="language.types.object.casting">conversion en objet</link>.
     Plusieurs fonctions PHP créent également des instances de cette classe, par exemple
     <function>json_decode</function>, <function>mysqli_fetch_object</function>
     ou <methodname>PDOStatement::fetchObject</methodname>.
-   </para>
+   </simpara>
 
    <para>
     Bien que n'implémentant pas
@@ -31,12 +31,12 @@
     <code>#[\AllowDynamicProperties]</code>.
    </para>
 
-   <para>
+   <simpara>
     Ce n'est pas une classe de base car PHP n'a pas de concept de classe de base
     universelle. Cependant, il est possible de créer une classe personnalisée qui étend
     <classname>stdClass</classname> et qui hérite ainsi de la fonctionnalité
     des propriétés dynamiques.
-   </para>
+   </simpara>
   </section>
 
   <section xml:id="stdclass.synopsis">

--- a/language/predefined/traversable.xml
+++ b/language/predefined/traversable.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 029f19dbc090e4d249a23c0ab087d47059b37adc Maintainer: yannick Status: ready -->
 <!-- Reviewed: yes -->
 <reference xml:id="class.traversable" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  
@@ -8,37 +8,33 @@
  
  <partintro>
   
-  <!-- {{{ Traversable intro -->
   <section xml:id="traversable.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     Interface permettant de détecter si une classe peut
     être parcourue en utilisant &foreach;.
-   </para>
+   </simpara>
    <para>
     L'interface de base est abstraite et ne peut être implémentée seule.
     Elle doit être implémentée par soit <interfacename>IteratorAggregate</interfacename>,
     soit <interfacename>Iterator</interfacename>.
    </para>
   </section>
-  <!-- }}} -->
   
   <section xml:id="traversable.synopsis">
    &reftitle.interfacesynopsis;
    
-<!-- {{{ Synopsis -->
    <classsynopsis class="interface">
     <oointerface>
      <interfacename>Traversable</interfacename>
     </oointerface>
    </classsynopsis>
-<!-- }}} -->
    
-   <para>
+   <simpara>
     Cette interface n'a pas de méthode ; son seul but est d'être
     l'interface de base pour toutes les classes permettant de parcourir
     des objets.
-   </para>
+   </simpara>
    
   </section>
 

--- a/language/predefined/valueerror.xml
+++ b/language/predefined/valueerror.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: pierrick Status: ready -->
+<!-- EN-Revision: 029f19dbc090e4d249a23c0ab087d47059b37adc Maintainer: pierrick Status: ready -->
 <!-- Reviewed: no -->
 <reference xml:id="class.valueerror" role="exception" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>ValueError</title>
@@ -8,23 +8,20 @@
 
  <partintro>
 
-<!-- {{{ Error intro -->
   <section xml:id="valueerror.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     Une <classname>ValueError</classname> est lancée lorsque le type d'un argument est correct
     mais que sa valeur est incorrecte.
     Par exemple, si l'on passe un entier négatif alors que la fonction attend un entier positif,
     ou si l'on passe une chaîne ou un tableau vide alors que la fonction s'attend à ce qu'il ne 
     soit pas vide.
-   </para>
+   </simpara>
   </section>
-<!-- }}} -->
 
   <section xml:id="valueerror.synopsis">
    &reftitle.classsynopsis;
 
-<!-- {{{ Synopsis -->
    <classsynopsis class="class">
     <ooexception>
      <exceptionname>ValueError</exceptionname>
@@ -36,19 +33,12 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Error'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Error'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Error'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.error')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Error'])"/>
    </classsynopsis>
-<!-- }}} -->
   </section>
  </partintro>
 </reference>

--- a/language/predefined/weakmap.xml
+++ b/language/predefined/weakmap.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: pierrick Status: ready -->
+<!-- EN-Revision: 029f19dbc090e4d249a23c0ab087d47059b37adc Maintainer: pierrick Status: ready -->
 <!-- Reviewed: no -->
 <reference xml:id="class.weakmap" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -9,29 +9,26 @@
 
  <partintro>
 
-  <!-- {{{ WeakMap intro -->
   <section xml:id="weakmap.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     Un <classname>WeakMap</classname> est un tableau associatif (ou dictionnaire) qui accepte des objets comme clés. Cependant, contrairement 
     au par ailleurs similaire <classname>SplObjectStorage</classname>, un objet dans une clé de <classname>WeakMap</classname>
     ne contribue pas au nombre de références de l'objet. En d'autres termes, si, à un moment donné, la seule référence restante
     à un objet est la clé d'un <classname>WeakMap</classname>, l'objet sera ramassé et supprimé du <classname>WeakMap</classname>.
     Son principal cas d'utilisation est la construction de caches de données dérivées d'un objet qui n'ont pas besoin d'être conservées
     plus longtemps que l'objet.
-   </para>
+   </simpara>
    <para>
     <classname>WeakMap</classname> implémente <interfacename>ArrayAccess</interfacename>,
     <interfacename>Traversable</interfacename> (via <interfacename>IteratorAggregate</interfacename>),
     et <interfacename>Countable</interfacename>, de sorte que, dans la plupart des cas, il peut être utilisé de la même manière qu'un tableau associatif.
    </para>
   </section>
-  <!-- }}} -->
 
   <section xml:id="weakmap.synopsis">
    &reftitle.classsynopsis;
 
-   <!-- {{{ Synopsis -->
    <classsynopsis class="class">
     <ooclass>
      <modifier>final</modifier>
@@ -52,19 +49,15 @@
     </oointerface>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.weakmap')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='WeakMap'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.weakmap')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='WeakMap'])"/>
    </classsynopsis>
-   <!-- }}} -->
 
   </section>
-  <!-- {{{ weakmap examples -->
   <section xml:id="weakmap.examples">
    &reftitle.examples;
    <para>
     <example>
-     <title>Exemple d'utilisation d'un <classname>Weakmap</classname></title>
+     <title>Exemple d'utilisation d'un <classname>WeakMap</classname></title>
      <programlisting role="php">
       <![CDATA[
 <?php
@@ -100,7 +93,6 @@ int(0)
     </example>
    </para>
   </section>
-  <!-- }}} -->
 
  </partintro>
 

--- a/language/predefined/weakreference.xml
+++ b/language/predefined/weakreference.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 911fe79de766ef4475bf22446903667a0f3a24d3 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 029f19dbc090e4d249a23c0ab087d47059b37adc Maintainer: lacatoire Status: ready -->
 <reference xml:id="class.weakreference" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>La classe WeakReference</title>
@@ -7,29 +7,26 @@
 
  <partintro>
 
-<!-- {{{ WeakReference intro -->
   <section xml:id="weakreference.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     Les références faibles permettent au programmeur de conserver une
     référence à un objet sans en empêcher sa destruction.
-    Elles sont utiles pour implémenter des structures telles que des caches.
+    Elles sont utiles pour implémenter des structures de type cache.
     Si l'objet d'origine a été détruit, &null; sera retourné
     lors de l'appel de la méthode <methodname>WeakReference::get</methodname>.
     L'objet d'origine sera détruit lorsque le
     <link linkend="features.gc.refcounting-basics">compteur de références</link> atteint zéro ;
     la création de références faibles n'augmente pas le <literal>compteur de références</literal> de l'objet référencé.
-   </para>
+   </simpara>
    <simpara>
     Les <classname>WeakReference</classname>s ne peuvent pas être sérialisées.
    </simpara>
   </section>
-<!-- }}} -->
 
   <section xml:id="weakreference.synopsis">
    &reftitle.classsynopsis;
 
-<!-- {{{ Synopsis -->
    <classsynopsis class="class">
     <ooclass>
      <modifier>final</modifier>
@@ -37,14 +34,9 @@
     </ooclass>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.weakreference')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='WeakReference'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.weakreference')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='WeakReference'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.weakreference')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='WeakReference'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.weakreference')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='WeakReference'])"/>
    </classsynopsis>
-<!-- }}} -->
 
   </section>
 


### PR DESCRIPTION
Sync of `language/predefined` with doc-en `029f19dbc090e4d249a23c0ab087d47059b37adc` (php/doc-en#5755).

- remove the `{{{` / `}}}` folding comments
- simplify the `<xi:include>` elements to an empty `<xi:fallback/>`
- convert the affected `<para>` elements to `<simpara>`
- rewordings: `ArrayAccess`, `Serializable` (methods as `<methodname>`), `WeakMap`, `WeakReference`, `Weakmap` -> `WeakMap` in an example title

Closes #3202
