### PR TITLE
[Sync EN] PDO_MYSQL DSN: document the user and password parameters (#5706)

### DIFF
--- a/reference/pdo_mysql/reference.xml
+++ b/reference/pdo_mysql/reference.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 3c1bec9d700807df36994cf368ba291214cd424d Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 57a2f4c34cc3c74a7040282dcd60b906738a523d Maintainer: yannick Status: ready -->
  <reference xml:id="ref.pdo-mysql" xmlns="http://docbook.org/ns/docbook">
   <?phpdoc extension-membership="bundledexternal" ?>
   <title>Fonctions du pilote PDO MySQL (PDO_MYSQL)</title>
@@ -108,6 +107,26 @@
         <para>
          Le nom de la base de données.
         </para>
+       </listitem>
+      </varlistentry>
+      <varlistentry>
+       <term><literal>user</literal></term>
+       <listitem>
+        <simpara>
+         Le nom de l'utilisateur pour la connexion. Un nom d'utilisateur fourni
+         comme deuxième argument du constructeur de <classname>PDO</classname>
+         a la priorité sur celui indiqué dans le DSN.
+        </simpara>
+       </listitem>
+      </varlistentry>
+      <varlistentry>
+       <term><literal>password</literal></term>
+       <listitem>
+        <simpara>
+         Le mot de passe de l'utilisateur pour la connexion. Un mot de passe
+         fourni comme troisième argument du constructeur de
+         <classname>PDO</classname> a la priorité sur celui indiqué dans le DSN.
+        </simpara>
        </listitem>
       </varlistentry>
       <varlistentry>

--- a/reference/pdo_mysql/reference.xml
+++ b/reference/pdo_mysql/reference.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
 <!-- EN-Revision: 57a2f4c34cc3c74a7040282dcd60b906738a523d Maintainer: yannick Status: ready -->
  <reference xml:id="ref.pdo-mysql" xmlns="http://docbook.org/ns/docbook">
   <?phpdoc extension-membership="bundledexternal" ?>


### PR DESCRIPTION
Sync of `reference/pdo_mysql/reference.xml` with doc-en `57a2f4c34cc3c74a7040282dcd60b906738a523d` (php/doc-en#5706).

- document the `user` and `password` DSN parameters
- drop the obsolete `Reviewed` marker
- `EN-Revision` bumped

Closes #3203
