### PR TITLE
[Sync EN] ext/intl: sync the book preface with doc-en (#5759)

### DIFF
--- a/reference/intl/book.xml
+++ b/reference/intl/book.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e1b9f588815a51682acf68f9b8929f49ad612488 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: a03f9eda2d45b725f75b4d6a1a22e8aec63e157a Maintainer: lacatoire Status: ready -->
 
 <book xml:id="book.intl" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <?phpdoc extension-membership="bundled" ?>
@@ -10,12 +10,12 @@
  <preface xml:id="intro.intl">
   &reftitle.intro;
   <simpara>
-   L'extension d'Internationalization (qui est aussi appelée Intl) est une 
-   interface pour la bibliothèque <link xlink:href="&url.icu.home;">ICU</link>,
+   L'extension d'internationalisation (appelée par la suite Intl) est une
+   enveloppe pour la bibliothèque <link xlink:href="&url.icu.home;">ICU</link>,
    qui permet aux développeurs PHP d'effectuer des opérations
    compatibles avec les paramètres régionaux incluant, mais
    non limitées à cette liste, le formatage, la translitération, la conversion
-   d'encodage, les opérations de calendrier, la collation 
+   d'encodage, les opérations de calendrier, la collation
    <link xlink:href="&url.icu.uca;">UCA</link>-conforme, la
    localisation des limites du texte et l'utilisation des identificateurs
    de paramètres régionaux, des fuseaux horaires et des graphèmes.
@@ -23,7 +23,7 @@
 
   <simpara>
    Cette extension tend à suivre de près l'API ICU, ce qui fait que ceux
-   qui ont l'expérience de cette bibliothèque en C, C++ ou Java pourront 
+   qui ont l'expérience de cette bibliothèque en C, C++ ou Java pourront
    facilement s'y retrouver dans l'API PHP. De plus, la documentation ICU
    peut être très utile pour comprendre les fonctions ICU.
   </simpara>
@@ -35,14 +35,14 @@
   <itemizedlist>
    <listitem>
     <simpara>
-     Collator : fournit des outils de comparaison de chaînes, qui 
+     Collator : fournit des outils de comparaison de chaînes, qui
      supportent les tris en fonction des conventions locales.
     </simpara>
    </listitem>
    <listitem>
     <simpara>
      Number Formatter : permet d'afficher des nombres en fonction des conventions
-     locales, ou de modèles particuliers, ou encore de règles d'affichage.
+     locales, ou de modèles particuliers, ou encore de règles d'affichage,
      et d'analyser des chaînes pour en extraire des nombres.
     </simpara>
    </listitem>
@@ -50,27 +50,29 @@
     <simpara>
      Message Formatter : permet de créer des messages en incorporant des
      données (comme des dates ou des nombres) formatées en fonction des conventions
-     locales ou particulières; permet aussi d'analyser des textes pour extraire
-     ces informations. Il peut gérer les pluriels, les nombres, les devises,
-     les conditions et bien plus encore.
+     locales ou particulières ; permet aussi d'analyser des textes pour extraire
+     ces informations. Il peut gérer les pluriels, les nombres adaptés à la
+     locale, les devises, les conditions et bien plus encore.
     </simpara>
    </listitem>
    <listitem>
     <simpara>
-     Normalizer : fournit une fonction pour normaliser un texte dans 
+     Normalizer : fournit une fonction pour normaliser un texte dans
      l'une des normalisations Unicode, et des méthodes pour tester si une
      chaîne est déjà normalisée.
     </simpara>
    </listitem>
    <listitem>
     <simpara>
-     Locale : fournit des outils d'interaction avec les identifiants de locale :
-     analyse, compose, recherche et filtre des identifiants de locale.
+     Locale : fournit une interaction avec les identifiants de locale sous la
+     forme de fonctions pour obtenir les sous-balises d'un identifiant de
+     locale ; analyser, composer et faire correspondre (recherche et filtrage)
+     des identifiants de locale.
     </simpara>
    </listitem>
    <listitem>
     <simpara>
-     Calendar: fournit une classe qui peut être utilisée pour
+     Calendar : fournit une classe qui peut être utilisée pour
      les opérations de régionalisation du calendrier, et
      obtenir des informations variées telles que le fuseau horaire pour
      la locale choisie, le premier jour de la semaine, ou si le
@@ -79,21 +81,22 @@
    </listitem>
    <listitem>
     <simpara>
-     Timezone: fournit une surcouche autour de <link xlink:href="&url.icu.tzdatabase;">la base de données "Olson"</link>
+     Timezone : fournit une enveloppe autour de <link xlink:href="&url.icu.tzdatabase;">la base de données "Olson"</link>
      qui contient des informations sur tous les fuseaux horaires du monde.
     </simpara>
    </listitem>
    <listitem>
     <simpara>
-     Date formatter: permet d'afficher la date et l'heure en
+     Date formatter : permet d'afficher la date et l'heure en
      rapport avec le format localisé, ou le schéma donné ou
-     les règles définies, et de transformer une chaîne de caractères en date et heure.    
+     les règles définies, et de transformer une chaîne de caractères en date et heure.
     </simpara>
    </listitem>
    <listitem>
     <simpara>
-     Transliterator: permet d'obtenir une représentation
-     latine d'une chaîne de caractères dans différents langages.     </simpara>
+     Transliterator : permet d'obtenir une représentation
+     latine d'une chaîne de caractères dans différentes langues.
+    </simpara>
    </listitem>
   </itemizedlist>
 


### PR DESCRIPTION
Sync of `reference/intl/book.xml` with doc-en `a03f9eda2d45b725f75b4d6a1a22e8aec63e157a` (php/doc-en#5759).

The English fix only added a missing space, which has no counterpart in the French wording. The preface is fixed while touching the file:

- restore the missing "get subtags" part of the `Locale` item
- fix a stray full stop in the `Number Formatter` item
- French spacing before `:` and `;`, `wrapper` -> `enveloppe`, `languages` -> `langues`
- remove the trailing whitespace
- `EN-Revision` bumped

Closes #3211
