### PR TITLE
[Sync EN] install/ini: add INI_ALL to the .user.ini modes (#4779)

### DIFF
--- a/install/ini.xml
+++ b/install/ini.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9ab074d32484672f93e5d822f42fb94ae9088207 Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 5f0cb2451f24071abbfd5f42d96d9210605966b0 Maintainer: yannick Status: ready -->
 <chapter xml:id="configuration" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink"
 xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>Configuration à l'exécution</title>
@@ -226,11 +225,11 @@ $ PHP_INI_SCAN_DIR=/usr/local/etc/php.d: php
    <varname>$_SERVER['DOCUMENT_ROOT']</varname>). Dans le cas où le fichier PHP
    est hors de la racine web, seul son dossier est scanné.
   </simpara>
-  <simpara>Seules les configurations INI avec les modes <constant>INI_PERDIR</constant>
-   et <constant>INI_USER</constant> seront reconnues dans les fichiers INI
-   .user.ini-style.
+  <simpara>Seules les configurations INI avec les modes <constant>INI_ALL</constant>,
+   <constant>INI_PERDIR</constant> et <constant>INI_USER</constant> seront
+   reconnues dans les fichiers INI .user.ini-style.
   </simpara>
-  
+
   <simpara>
    Deux nouvelles directives INI,
    <link linkend="ini.user-ini.filename">user_ini.filename</link> et
@@ -280,8 +279,7 @@ Replace everything inside the <variablelist> element with an <xi:include>
 once libxml2 gets XInclude 1.1 attribute copying support.
 The below <xi:include> will include the appropriate elements
 but needs all top-level xml:id's removed (see XInclude 1.1 set-xml-id).
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('constant.ini-mode')/*)"><xi:fallback/>
-</xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('constant.ini-mode')/*)"/>
 -->
     <title>Constantes de mode INI</title>
     <varlistentry>


### PR DESCRIPTION
Sync of `install/ini.xml` with doc-en `5f0cb2451f24071abbfd5f42d96d9210605966b0` (php/doc-en#4779).

- `INI_ALL` was missing from the list of modes recognized in .user.ini-style files
- follow the English simplification of the commented-out `<xi:include>`
- drop the obsolete `Reviewed` marker
- `EN-Revision` bumped

Closes #3204
