### PR TITLE
[Sync EN] install/pecl: clarify the PECL deprecation (#5622)

### DIFF
--- a/install/pecl.xml
+++ b/install/pecl.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: d1fa3096926b6cbaf9da1f831b6fe3302ae2e490 Maintainer: yannick Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 7b3094477569cda19b14bf61f244b60d24a5e479 Maintainer: yannick Status: ready -->
 <chapter xml:id="install.pecl" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Installation d'extensions PECL</title>
- 
+ &pecl.moving.to.pie;
+
  <sect1 xml:id="install.pecl.intro">
   <title>Introduction aux installations PECL</title>
   &pecl.moving.to.pie;
@@ -114,6 +114,7 @@ $ svn checkout https://svn.php.net/repository/pecl/extname/trunk extname
  
  <sect1 xml:id="install.pecl.windows">
   <title>Installer une extension PHP sous Windows</title>
+  &pecl.moving.to.pie;
   <para>
    Il existe deux moyens de charger une extension PHP sous Windows : 
    soit la compiler dans PHP, soit charger une DLL. Charger une
@@ -309,6 +310,7 @@ Loaded Configuration File   C:\Program Files\PHP\8.2\php.ini
  
  <sect1 xml:id="install.pecl.pear">
   <title>Compilation d'extensions PECL partagées avec la commande pecl</title>
+  &pecl.moving.to.pie;
   <simpara>
    PECL facilite la création d'extensions PHP partagées. En utilisant la
    <link xlink:href="&url.php.pear.cli;">commande pecl</link>, procéder comme suit :
@@ -353,6 +355,7 @@ $ pecl install extname-0.1
  
  <sect1 xml:id="install.pecl.phpize">
   <title>Compilation des extensions partagées avec phpize</title>
+  &pecl.moving.to.pie;
   <simpara>
    Parfois, l'utilisation de l'installeur <command>pecl</command> n'est pas une option.
    Cela peut être dû à la présence d'un pare-feu ou au fait que l'extension en cours
@@ -400,7 +403,7 @@ $ make
   <title>
    <command>php-config</command>
   </title>
-  
+  &pecl.moving.to.pie;
   <para>
    <command>php-config</command> est un petit script shell pour obtenir des informations
    sur la configuration installée de PHP.
@@ -501,6 +504,7 @@ Options:
  
  <sect1 xml:id="install.pecl.static">
   <title>Compilation des extensions PECL statiquement dans PHP</title>
+  &pecl.moving.to.pie;
   <simpara>
    Il peut être nécessaire de construire une extension PECL statiquement dans le binaire PHP.
    Pour ce faire, les sources de l'extension doivent être placées dans le répertoire

--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 6a2ad3ecf9b77855446019ed2d74aa6f734d35a8 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 7b3094477569cda19b14bf61f244b60d24a5e479 Maintainer: lacatoire Status: ready -->
 <!-- Relecture des Notes, Précautions, Avertissements, Astuces, Divers et Retour le 2018-12-29 par girgias -->
 
 <!--
@@ -2165,13 +2165,13 @@ des extensions PECL</link>. D&#39;autres informations comme les notes sur les no
 
 <!ENTITY pecl.moved-ver 'Cette extension a été déplacée dans le module &link.pecl; et ne sera plus intégrée dans PHP à partir de PHP '>
 
-<!ENTITY pecl.moving.to.pie '<note xmlns="http://docbook.org/ns/docbook">
+<!ENTITY pecl.moving.to.pie '<warning xmlns="http://docbook.org/ns/docbook">
  <simpara>
-  L&#39;installeur d&#39;Extensions pour PHP (PHP Installer for Extensions - <acronym>PIE</acronym>) est un nouvel outil qui remplacera PECL.
-  Nous recommandons d&#39;utiliser PIE pour installer les extensions.
+  PECL est obsolète.
+  L&#39;installeur d&#39;extensions pour PHP (PHP Installer for Extensions - <acronym>PIE</acronym>) remplace PECL et est recommandé pour installer les extensions.
   Plus d&#39;informations sur <link xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="https://github.com/php/pie">https://github.com/php/pie</link>
  </simpara>
-</note>'>
+</warning>'>
 
 <!ENTITY warn.pecl.unmaintained '<warning xmlns="http://docbook.org/ns/docbook">
  <simpara>Cette extension est <emphasis>non maintenue</emphasis>.</simpara>


### PR DESCRIPTION
Sync of `install/pecl.xml` and `language-snippets.ent` with doc-en `7b3094477569cda19b14bf61f244b60d24a5e479` (php/doc-en#5622).

- `pecl.moving.to.pie` becomes a `<warning>`: PECL is deprecated, PIE replaces it
- the entity is repeated at the top of the chapter and in the Windows, `pecl`, `phpize`, `php-config` and static sections, as in the English chapter
- drop the obsolete `Reviewed` marker
- `EN-Revision` bumped

Note: `language-snippets.ent` is also touched by #3217, which carries the other pending English change on that file (`6a2ad3ec`). Whichever merges first, the other needs a trivial rebase on the `EN-Revision` line.

Closes #3206
