### PR TITLE
[Sync EN] password: clarify the Argon2 memory_cost and time_cost units (#5219)

### DIFF
--- a/reference/password/constants.xml
+++ b/reference/password/constants.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 66aff414be91c5a0446be585aa6ac78121de1e67 Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 6cc48aed6f887bdabf09c568f854099f9c74e017 Maintainer: yannick Status: ready -->
 <appendix xml:id="password.constants" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.constants;
  &extension.constants.core;
@@ -60,10 +59,14 @@
      (<type>int</type>)
     </term>
     <listitem>
-     <para>
-     </para>
-     <para>
-     </para>
+     <simpara>
+      Coût algorithmique par défaut utilisé par
+      <function>password_hash</function> lors du hachage des mots de passe
+      avec <constant>PASSWORD_BCRYPT</constant>.
+     </simpara>
+     <simpara>
+      &php.version.added; 7.0.0.
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry xml:id="constant.password-argon2i">
@@ -88,11 +91,11 @@
        </para>
       </listitem>
       <listitem>
-       <para>
-        <literal>time_cost</literal> (<type>int</type>) - Durée maximale de 
-        temps qu'il peut prendre pour calculer le hachage Argon2. Par 
+       <simpara>
+        <literal>time_cost</literal> (<type>int</type>) - Nombre d'itérations
+        (passes) utilisées pour calculer le hachage Argon2. Par
         défaut à <constant>PASSWORD_ARGON2_DEFAULT_TIME_COST</constant>.
-       </para>
+       </simpara>
       </listitem>
       <listitem>
        <para>
@@ -131,13 +134,13 @@
      (<type>int</type>)
     </term>
     <listitem>
-     <para>
-      Quantité de mémoire par défaut (en octets) qui sera utilisée en
-      essayant de calculer un hachage.
-     </para>
-     <para>
+     <simpara>
+      Quantité de mémoire par défaut (en kibioctets, KiB) qui sera utilisée
+      pour calculer un hachage.
+     </simpara>
+     <simpara>
       &php.version.added; 7.2.0.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry xml:id="constant.password-argon2-default-time-cost">
@@ -146,13 +149,13 @@
      (<type>int</type>)
     </term>
     <listitem>
-     <para>
-      Durée de temps par défaut qui sera consacrée pour essayer de calculer
-      un hachage.
-     </para>
-     <para>
+     <simpara>
+      Nombre d'itérations (passes) par défaut utilisé pour calculer un
+      hachage.
+     </simpara>
+     <simpara>
       &php.version.added; 7.2.0.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry xml:id="constant.password-argon2-default-threads">

--- a/reference/password/functions/password-hash.xml
+++ b/reference/password/functions/password-hash.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 5003a6ea92eb50ac92121782eedfc5ad3fe9d061 Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 6cc48aed6f887bdabf09c568f854099f9c74e017 Maintainer: yannick Status: ready -->
 <refentry xml:id="function.password-hash" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>password_hash</refname>
@@ -104,11 +103,11 @@
      </para>
     </listitem>
     <listitem>
-     <para>
-      <literal>time_cost</literal> (<type>int</type>) - Durée maximale de 
-      temps qu'il peut prendre pour calculer le hachage Argon2. Par 
+     <simpara>
+      <literal>time_cost</literal> (<type>int</type>) - Nombre d'itérations
+      (passes) utilisées pour calculer le hachage Argon2. Par
       défaut à <constant>PASSWORD_ARGON2_DEFAULT_TIME_COST</constant>.
-     </para>
+     </simpara>
     </listitem>
     <listitem>
      <para>


### PR DESCRIPTION
Sync of `reference/password/constants.xml` and `reference/password/functions/password-hash.xml` with doc-en `6cc48aed6f887bdabf09c568f854099f9c74e017` (php/doc-en#5219).

- `time_cost` is a number of iterations (passes), not a maximum duration
- `PASSWORD_ARGON2_DEFAULT_MEMORY_COST` is expressed in kibibytes (KiB), not in bytes
- fill in the empty `PASSWORD_BCRYPT_DEFAULT_COST` description
- follow the `<para>` to `<simpara>` conversions, drop the obsolete `Reviewed` markers
- `EN-Revision` bumped

Closes #3207
