### PR TITLE
[Sync EN] header_register_callback: warn that callbacks are not stacked (#5760)

### DIFF
--- a/reference/network/functions/header-register-callback.xml
+++ b/reference/network/functions/header-register-callback.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
 <!-- EN-Revision: abdc23836d3f42399028c1174961107e70ada52d Maintainer: jpauli Status: ready -->
 
 <refentry xml:id="function.header-register-callback" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/reference/network/functions/header-register-callback.xml
+++ b/reference/network/functions/header-register-callback.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 5faa7a6747bca628b3bdcc9f93aec5603b65581f Maintainer: jpauli Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: abdc23836d3f42399028c1174961107e70ada52d Maintainer: jpauli Status: ready -->
 
 <refentry xml:id="function.header-register-callback" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -24,6 +23,17 @@
    à envoyer, et avant qu'il ne les envoie. Ceci permet une manipulation fine des en-têtes
    avant leur envoi.
   </para>
+  <warning>
+   <simpara>
+    Les fonctions de rappel ne sont pas empilées. Les appels suivants à
+    <function>header_register_callback</function> désenregistrent
+    silencieusement toute fonction de rappel
+    <parameter>callback</parameter> existante, quel que soit l'endroit où
+    elle a été définie. Il est à noter que les dépendances peuvent écraser
+    la fonction de rappel. Le diagnostic de ce cas de figure peut être
+    difficile.
+   </simpara>
+  </warning>
  </refsect1>
 
  <refsect1 role="parameters">


### PR DESCRIPTION
Sync of `reference/network/functions/header-register-callback.xml` with doc-en `abdc23836d3f42399028c1174961107e70ada52d` (php/doc-en#5760).

- add the warning: a subsequent call silently de-registers the existing callback, wherever it was set
- drop the obsolete `Reviewed` marker
- `EN-Revision` bumped

Closes #3208
