### PR TITLE
[Sync EN] ext/soap: document the PHP 8.4 changes (#5735)

### DIFF
--- a/reference/soap/soapclient.xml
+++ b/reference/soap/soapclient.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 89205c88a79fcaad39fd043ed5ef695cd7bf813e Maintainer: dams Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: d20d66d9c76ff98dceb853aeb86794fe9d657669 Maintainer: dams Status: ready -->
 <reference xml:id="class.soapclient" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>La classe <classname>SoapClient</classname></title>
@@ -74,7 +73,7 @@
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>private</modifier>
-     <type class="union"><type>resource</type><type>null</type></type>
+     <type class="union"><type>array</type><type>null</type></type>
      <varname linkend="soapclient.props.typemap">typemap</varname>
      <initializer>null</initializer>
     </fieldsynopsis>
@@ -246,12 +245,8 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.soapclient')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='SoapClient'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.soapclient')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SoapClient'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.soapclient')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='SoapClient'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.soapclient')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SoapClient'])"/>
    </classsynopsis>
    <!-- }}} -->
   </section>
@@ -493,8 +488,15 @@
     <varlistentry xml:id="soapclient.props.typemap">
      <term><varname>typemap</varname></term>
      <listitem>
-      <para>
-      </para>
+      <simpara>
+       Un tableau de correspondances de types utilisé pour les conversions
+       personnalisées entre XML et types PHP, ou &null; si aucune
+       correspondance de type n'est configurée.
+       À partir de PHP 8.4.0, cette propriété est de type <type>array</type> ;
+       auparavant, elle était de type <type>resource</type>.
+       Le code utilisant <function>is_resource</function> pour tester cette
+       propriété doit être adapté en conséquence.
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry xml:id="soapclient.props.uri">

--- a/reference/soap/soapclient/construct.xml
+++ b/reference/soap/soapclient/construct.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: f309e78f9439ae5d063a284cefb4b375233aa785 Maintainer: yannick Status: ready -->
-<!-- Reviewed: yes Maintainer: yannick -->
+<!-- EN-Revision: d20d66d9c76ff98dceb853aeb86794fe9d657669 Maintainer: yannick Status: ready -->
 <refentry xml:id="soapclient.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>SoapClient::__construct</refname>
@@ -367,6 +366,14 @@
            mais les méthodes magiques <link linkend="object.set">__set()</link> et
            <link linkend="object.get">__get()</link> pour les propriétés individuelles le seront.
           </para>
+          <simpara>
+           À partir de PHP 8.4.0, les clés peuvent également être indiquées en
+           notation de Clark, sous la forme <literal>{namespace}type</literal>,
+           afin de faire correspondre un type d'un espace de noms XML
+           particulier, par exemple <literal>'{http://example.com}foo'</literal>.
+           Ceci est utile lorsque le même nom de type est défini dans plusieurs
+           espaces de noms.
+          </simpara>
          </listitem>
         </varlistentry>
         <varlistentry xml:id="soapclient.construct.options.typemap">

--- a/reference/soap/soapserver/construct.xml
+++ b/reference/soap/soapserver/construct.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: fe4e8b87d18f17394e7177917c498774b062448c Maintainer: jpauli Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: d20d66d9c76ff98dceb853aeb86794fe9d657669 Maintainer: jpauli Status: ready -->
 <refentry xml:id="soapserver.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>SoapServer::__construct</refname>
@@ -42,12 +41,16 @@
        un jeu de caractères d'encodage interne (<literal>encoding</literal>)
        et un URI acteur (<literal>actor</literal>).
       </para>
-      <para>
+      <simpara>
        L'option <literal>classmap</literal> peut être utilisée pour lier
        quelques types WSDL à des classes PHP. Cette option doit être un
        tableau avec les types WSDL en tant que clés et les noms des classes PHP
        en tant que valeurs.
-      </para>
+       À partir de PHP 8.4.0, les clés peuvent également être indiquées en
+       notation de Clark, sous la forme <literal>{namespace}type</literal>,
+       afin de faire correspondre un type d'un espace de noms XML
+       particulier, par exemple <literal>'{http://example.com}foo'</literal>.
+      </simpara>
       <para>
        L'option <literal>typemap</literal> est un tableau dont les clés sont
        <literal>type_name</literal>, <literal>type_ns</literal> (URI du namespace),

--- a/reference/soap/soapserver/setpersistence.xml
+++ b/reference/soap/soapserver/setpersistence.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 89ae180a851621c308f0ea4604ff2e919aa57a7f Maintainer: yannick Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: d20d66d9c76ff98dceb853aeb86794fe9d657669 Maintainer: yannick Status: ready -->
 <refentry xml:id="soapserver.setpersistence" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>SoapServer::setPersistence</refname>
@@ -72,7 +71,35 @@
    &return.void;
   </para>
  </refsect1>
- 
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.4.0</entry>
+      <entry>
+       <constant>SOAP_PERSISTENCE_SESSION</constant> fonctionne désormais
+       lorsque l'extension session est compilée en module partagé ;
+       auparavant, l'échec était silencieux.
+       <methodname>SoapServer::setPersistence</methodname> lève désormais
+       aussi une <exceptionname>Error</exceptionname> lorsque
+       <constant>SOAP_PERSISTENCE_SESSION</constant> est demandé alors que
+       l'extension session n'est pas disponible.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+
  <refsect1 role="examples">
   &reftitle.examples;
   <para>

--- a/reference/soap/soapvar/construct.xml
+++ b/reference/soap/soapvar/construct.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: fe4e8b87d18f17394e7177917c498774b062448c Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: d20d66d9c76ff98dceb853aeb86794fe9d657669 Maintainer: yannick Status: ready -->
 <refentry xml:id="soapvar.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>SoapVar::__construct</refname>
@@ -90,6 +89,15 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.4.0</entry>
+      <entry>
+       Une instance de <classname>DateTimeInterface</classname> utilisée comme
+       valeur d'un élément <literal>xsd:dateTime</literal>, ou d'un type de
+       date et heure similaire, est désormais sérialisée sous sa représentation
+       ISO 8601, au lieu d'être sérialisée en une chaîne vide.
+      </entry>
+     </row>
      <row>
       <entry>8.0.3</entry>
       <entry>


### PR DESCRIPTION
Sync of `reference/soap` with doc-en `d20d66d9c76ff98dceb853aeb86794fe9d657669` (php/doc-en#5735).

- `SoapClient::$typemap` is an `array` as of PHP 8.4.0, no longer a `resource`; its description was empty
- `SoapClient::__construct()` / `SoapServer::__construct()`: `classmap` keys accept the Clark notation `{namespace}type` as of PHP 8.4.0
- `SoapServer::setPersistence()`: changelog for the shared session module support and the new `Error`
- `SoapVar::__construct()`: changelog for the ISO 8601 serialization of `DateTimeInterface` values
- also drop the empty `<xi:fallback/>` elements in `soapclient.xml` (php/doc-en#5699)
- obsolete `Reviewed` markers dropped, `EN-Revision` bumped on the 5 files

Closes #3210
