### PR TITLE
[Sync EN] ext/opcache: document the JIT default change and the startup fatal error (#5738)

### DIFF
--- a/reference/opcache/ini.xml
+++ b/reference/opcache/ini.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: f2cdcd5af4558c22db95463b6ccdd25e4cea3cf5 Maintainer: lacatoire Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 36d18e7d4a32ecfdacc1eb086276ffb1baf0393c Maintainer: lacatoire Status: ready -->
 <sect1 xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="opcache.configuration">
  &reftitle.runtime;
  &extension.runtime;
@@ -1176,7 +1175,9 @@ function getA() { return A; }
      <member><literal>off</literal>: Désactivé, mais peut être activé lors du runtime.</member>
      <member>
       <literal>tracing</literal>/<literal>on</literal>: Utilise le tracing JIT.
-      Activé par défaut et recommandé pour la plupart des utilisateurs.
+      Recommandé pour la plupart des utilisateurs. Avant PHP 8.4.0, c'était la
+      valeur par défaut ; à partir de PHP 8.4.0, la valeur par défaut est
+      <literal>disable</literal>.
      </member>
      <member><literal>function</literal>: Utilise le function JIT.</member>
     </simplelist>
@@ -1239,6 +1240,12 @@ function getA() { return A; }
      Le mode <literal>"tracing"</literal> correspond à <code>CRTO = 1254</code>,
      le mode <literal>"function"</literal> correspond à <code>CRTO = 1205</code>.
     </para>
+    <note>
+     <simpara>
+      À partir de PHP 8.4.0, si le JIT est activé, PHP s'arrête sur une erreur
+      fatale au démarrage lorsque l'initialisation du JIT échoue.
+     </simpara>
+    </note>
    </listitem>
   </varlistentry>
   <varlistentry xml:id="ini.opcache.jit-buffer-size">


### PR DESCRIPTION
Sync of `reference/opcache/ini.xml` with doc-en `36d18e7d4a32ecfdacc1eb086276ffb1baf0393c` (php/doc-en#5738).

- the tracing JIT is no longer the default as of PHP 8.4.0 (`disable` is)
- PHP exits with a fatal error during startup when JIT initialization fails
- drop the obsolete `Reviewed` marker, `EN-Revision` bumped

Closes #3212
