### PR TITLE
[Sync EN] install/unix: fix typos and stale references in debian.xml (#5744)

### DIFF
--- a/install/unix/debian.xml
+++ b/install/unix/debian.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: ee1ce6a0e1875b6851274f8c373ca2bd48630fa0 Maintainer: lacatoire Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 2d91caad93e275542dfdc1a99a6fc8a0ed030108 Maintainer: lacatoire Status: ready -->
 
 <sect1 xml:id="install.unix.debian" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Installation à partir de paquets sur Debian GNU/Linux et distributions similaires</title>
@@ -20,7 +19,7 @@
   <title>Utilisation de APT</title>
   <simpara>
    Tout d'abord, il est à noter que d'autres paquets peuvent être souhaitables, comme
-   <literal>libapache-mod-php</literal> pour l'intégration avec Apache 2, et
+   <literal>libapache2-mod-php</literal> pour l'intégration avec Apache httpd 2, et
    <literal>php-pear</literal> pour PEAR.
   </simpara>
   <simpara>
@@ -29,7 +28,7 @@
    <command>apt update</command>.
   </simpara>
   <example xml:id="install.unix.debian.apt.example">
-   <title>Exemple d'installation sous Debian avec Apache 2</title>
+   <title>Exemple d'installation sous Debian avec Apache httpd 2</title>
    <programlisting role="shell">
 <![CDATA[
 # apt install php-common libapache2-mod-php php-cli
@@ -37,15 +36,15 @@
    </programlisting>
   </example>
   <simpara>
-   APT installera et activera automatiquement le module PHP pour Apache 2, ainsi que toutes
-   ses dépendances. Apache devra être relancé pour que les changements soient effectifs. Par exemple :
+   APT installera et activera automatiquement le module PHP pour Apache httpd 2, ainsi
+   que toutes ses dépendances. Apache httpd devra être relancé pour que les changements
+   soient effectifs. Par exemple :
   </simpara>
   <example xml:id="install.unix.debian.apt.example2">
-   <title>Stopper et démarrer Apache une fois PHP installé</title>
+   <title>Redémarrer Apache httpd une fois PHP installé</title>
    <programlisting role="shell">
 <![CDATA[
-# /etc/init.d/apache2 stop
-# /etc/init.d/apache2 start
+# systemctl restart apache2
 ]]>
    </programlisting>
   </example>
@@ -87,10 +86,11 @@
   </example>
   <simpara>
    APT ajoutera automatiquement les bonnes lignes aux fichiers connexes à &php.ini;, comme
-   <filename>/etc/php/7.4/php.ini</filename>,
-   <filename>/etc/php/7.4/conf.d/*.ini</filename>, etc. et selon l'extension,
+   <filename>/etc/php/8.x/apache2/php.ini</filename>,
+   <filename>/etc/php/8.x/cli/php.ini</filename>,
+   <filename>/etc/php/8.x/mods-available/*.ini</filename>, etc. et selon l'extension,
    il ajoutera des entrées semblables à <literal>extension=foo.so</literal>.
-   De plus, redémarrer le serveur web (Apache, par exemple) est nécessaire pour que ces changements
+   De plus, redémarrer le serveur web est nécessaire pour que ces changements
    soient effectifs.
   </simpara>
  </sect2>


### PR DESCRIPTION
Sync of `install/unix/debian.xml` with doc-en `2d91caad93e275542dfdc1a99a6fc8a0ed030108` (php/doc-en#5744).

- the package is `libapache2-mod-php`, not `libapache-mod-php`
- the restart example uses `systemctl restart apache2` instead of the obsolete `init.d` calls
- the `php.ini` paths follow the current 8.x layout instead of the EOL 7.4 one
- "Apache" spelled out as "Apache httpd"
- drop the obsolete `Reviewed` marker, `EN-Revision` bumped

Closes #3213
