### PR TITLE
[Sync EN] install/unix: sync source.xml with doc-en (#5761)

### DIFF
--- a/install/unix/source.xml
+++ b/install/unix/source.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 1c9fb12650addc936f5a0d5d1edc42cd32e9c765 Maintainer: Fan2Shrek Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: e07f764c8e4234d1195536ffed2eaf19c849ce50 Maintainer: Fan2Shrek Status: ready -->
 <sect1 xml:id="install.unix.source" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Installation depuis les sources sur les systèmes Unix et macOS</title>
  <para>


### PR DESCRIPTION
Sync of `install/unix/source.xml` with doc-en `e07f764c8e4234d1195536ffed2eaf19c849ce50` (php/doc-en#5761).

The English fix corrected the "was been run" typo, which the French sentence never had, so there is nothing to translate here.

- `EN-Revision` bumped
- drop the obsolete `Reviewed` marker

Closes #3214
