### PR TITLE
CI: check the EN-Revision of the PR head, not of the merge commit

### DIFF
--- a/.github/workflows/check-en-revision.yml
+++ b/.github/workflows/check-en-revision.yml
@@ -18,9 +18,15 @@ jobs:
     name: "Check EN-Revision"
     runs-on: ubuntu-latest
     steps:
+      # Le ref explicite prend la tête réelle de la PR, et non le commit de
+      # fusion que actions/checkout construit par défaut : ce dernier a master
+      # pour deuxième parent, donc le diff plus bas y verrait aussi tous les
+      # fichiers arrivés sur master depuis le dernier push de la PR.
+
       - name: "Checkout php/doc-fr"
         uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 
       - name: "Checkout php/doc-en"


### PR DESCRIPTION
On a `pull_request` event, `actions/checkout` defaults to `refs/pull/N/merge`, whose second parent is master. The `BASE...HEAD` diff therefore also lists every file landed on master since the last push to the pull request, so a translation PR can fail on EN-Revision drift it did not introduce.

Checking out the head sha restores the diff to the commits of the pull request.

Same change as #3193, which fixed `check-xml.yml`.
