### PR TITLE
[Sync-En] ext/odbc: document the row default value change to null in fetch_object/array/into (PHP 8.4)

### DIFF
--- a/reference/uodbc/functions/odbc-fetch-array.xml
+++ b/reference/uodbc/functions/odbc-fetch-array.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: ed1aff13602c94f86344bdd7c4fbc31f5a71bf84 Maintainer: yannick Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 5035039fb951eac2330431bf47dc4a50e1ef9ee9 Maintainer: yannick Status: ready -->
 
 <refentry xml:id="function.odbc-fetch-array" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -37,9 +35,12 @@
     <varlistentry>
      <term><parameter>row</parameter></term>
      <listitem>
-      <para>
-       Le numéro de la ligne devant être lue, optionnel.
-      </para>
+      <simpara>
+       Le numéro de la ligne à récupérer, basé sur 1. Si omis ou &null;, la
+       ligne suivante du jeu de résultats est récupérée, comme le fait
+       <function>odbc_fetch_row</function>. Si le pilote ne prend pas en charge
+       la récupération des lignes par numéro, ce paramètre est ignoré.
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -69,7 +70,9 @@
      <row>
       <entry>8.4.0</entry>
       <entry>
-       <parameter>row</parameter> est désormais nullable.
+       <parameter>row</parameter> est désormais nullable, et sa valeur par défaut
+       est passée de <literal>-1</literal> à &null;, de façon cohérente avec
+       <function>odbc_fetch_row</function>.
       </entry>
      </row>
     </tbody>

--- a/reference/uodbc/functions/odbc-fetch-into.xml
+++ b/reference/uodbc/functions/odbc-fetch-into.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: ed1aff13602c94f86344bdd7c4fbc31f5a71bf84 Maintainer: yannick Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 5035039fb951eac2330431bf47dc4a50e1ef9ee9 Maintainer: yannick Status: ready -->
 
 <refentry xml:id="function.odbc-fetch-into" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -47,9 +45,12 @@
     <varlistentry>
      <term><parameter>row</parameter></term>
      <listitem>
-      <para>
-       Le numéro de la ligne.
-      </para>
+      <simpara>
+       Le numéro de la ligne à récupérer, basé sur 1. Si omis ou &null;, la
+       ligne suivante du jeu de résultats est récupérée, comme le fait
+       <function>odbc_fetch_row</function>. Si le pilote ne prend pas en charge
+       la récupération des lignes par numéro, ce paramètre est ignoré.
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -78,7 +79,9 @@
      <row>
       <entry>8.4.0</entry>
       <entry>
-       <parameter>row</parameter> est désormais nullable.
+       <parameter>row</parameter> est désormais nullable, et sa valeur par défaut
+       est passée de <literal>0</literal> à &null;, de façon cohérente avec
+       <function>odbc_fetch_row</function>.
       </entry>
      </row>
     </tbody>

--- a/reference/uodbc/functions/odbc-fetch-object.xml
+++ b/reference/uodbc/functions/odbc-fetch-object.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: ed1aff13602c94f86344bdd7c4fbc31f5a71bf84 Maintainer: yannick Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 5035039fb951eac2330431bf47dc4a50e1ef9ee9 Maintainer: yannick Status: ready -->
 
 <refentry xml:id="function.odbc-fetch-object" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -37,9 +35,12 @@
     <varlistentry>
      <term><parameter>row</parameter></term>
      <listitem>
-      <para>
-       Le numéro de ligne à récupérer, en option.
-      </para>
+      <simpara>
+       Le numéro de la ligne à récupérer, basé sur 1. Si omis ou &null;, la
+       ligne suivante du jeu de résultats est récupérée, comme le fait
+       <function>odbc_fetch_row</function>. Si le pilote ne prend pas en charge
+       la récupération des lignes par numéro, ce paramètre est ignoré.
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -69,7 +70,9 @@
      <row>
       <entry>8.4.0</entry>
       <entry>
-       <parameter>row</parameter> est désormais nullable.
+       <parameter>row</parameter> est désormais nullable, et sa valeur par défaut
+       est passée de <literal>-1</literal> à &null;, de façon cohérente avec
+       <function>odbc_fetch_row</function>.
       </entry>
      </row>
     </tbody>


### PR DESCRIPTION
Fixes #3237

Translates EN commit 5035039fb951eac2330431bf47dc4a50e1ef9ee9.

Changes in `odbc_fetch_array`, `odbc_fetch_into`, `odbc_fetch_object`:
- Expand the `row` parameter description (1-based, null fetches next row, ignored if driver doesn't support positional fetch)
- Changelog 8.4.0: document the actual default value that changed (-1 or 0 → null)