### PR TITLE
[Sync-En] language/types/string: clarify heredoc closing identifier indentation

### DIFF
--- a/language/types/string.xml
+++ b/language/types/string.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 7132d8833a86604aa2d10c16c0470d0ef1a0fdfb Maintainer: yannick Status: ready -->
-<!-- Reviewed: no Maintainer: girgias -->
+<!-- EN-Revision: 0d964bcaac6618dd80b974eb6fcdf3c67ca07340 Maintainer: yannick Status: ready -->
 <sect1 xml:id="language.types.string">
  <title>Chaînes</title>
 
@@ -215,8 +214,9 @@ echo 'Les variables ne $s\'étendent pas $non plus', PHP_EOL;
    </simpara>
 
    <simpara>
-    L'identifiant de fermeture peut être indenté par des espaces ou des tabulations, auquel cas
-    l'indentation sera supprimée de toutes les lignes dans la chaîne doc.
+    L'identifiant de fermeture peut être indenté avec des espaces ou des tabulations. Les espaces
+    correspondant à l'indentation de l'identifiant de fermeture sont alors supprimés du début de
+    chaque ligne de la chaîne heredoc.
     Avant PHP 7.3.0, l'identifiant de fermeture <emphasis>doit</emphasis>
     commencer dans la première colonne de la ligne.
    </simpara>
@@ -232,7 +232,7 @@ echo 'Les variables ne $s\'étendent pas $non plus', PHP_EOL;
     <programlisting role="php">
 <![CDATA[
 <?php
-// pas d'indentation
+// identifiant de fermeture non indenté
 echo <<<END
       a
      b
@@ -240,12 +240,12 @@ echo <<<END
 \n
 END;
 
-// 4 espaces d'indentation
+// identifiant de fermeture indenté de 3 espaces ; 3 espaces supprimés de chaque ligne
 echo <<<END
       a
      b
     c
-    END;
+   END;
 ]]>
     </programlisting>
     &example.outputs.73;
@@ -255,9 +255,9 @@ echo <<<END
      b
     c
 
-  a
- b
-c
+   a
+  b
+ c
 ]]>
     </screen>
    </example>


### PR DESCRIPTION
Fixes #3239

Translates EN commit 0d964bcaac6618dd80b974eb6fcdf3c67ca07340.

Changes in `language/types/string.xml`:
- Clarify the simpara describing closing identifier indentation: whitespace equal to the indentation is stripped from every line (not just "the indentation is removed")
- Fix example: closing identifier uses 3 spaces (not 4), comments updated accordingly
- Fix `<screen>` output to match the corrected example (3 spaces stripped, not 4)