### PR TITLE
[Sync EN] ext/funchand: clarify forward_static_call_array() outside a class context

### DIFF
--- a/reference/funchand/functions/forward-static-call-array.xml
+++ b/reference/funchand/functions/forward-static-call-array.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: c6fb604f39a0fa7bf1ae872064b2a3a24f23d855 Maintainer: yannick Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 846dfb87daacac70877c332686d60c7dfd0f15d8 Maintainer: yannick Status: ready -->
 <refentry xml:id="function.forward-static-call-array" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>forward_static_call_array</refname>
@@ -15,14 +14,23 @@
    <methodparam><type>callable</type><parameter>callback</parameter></methodparam>
    <methodparam><type>array</type><parameter>args</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Appelle une fonction ou une méthode utilisateur, nommée <parameter>callback</parameter>,
-   avec les arguments rassemblés dans un tableau. Cette fonction doit être appelée depuis
-   une méthode, et ne peut pas être utilisée hors d'une classe.
-   Elle utilise le <link linkend="language.oop5.late-static-bindings">liage statique</link>.
-   Tous les arguments transmis sont passés par valeur dans un tableau, similairement à 
+   avec les arguments passés dans un tableau, similairement à
    <function>call_user_func_array</function>.
-  </para>
+   Lorsqu'elle est appelée depuis une méthode, elle utilise la
+   <link linkend="language.oop5.late-static-bindings">résolution statique à la volée</link>.
+   Lorsqu'elle est appelée hors du contexte d'une classe, elle se comporte comme
+   <function>call_user_func_array</function>, sans résolution statique à la volée.
+  </simpara>
+  <note>
+   <simpara>
+    Contrairement à <function>forward_static_call</function>, cette fonction ne
+    nécessite pas de portée de classe active : appeler
+    <function>forward_static_call</function> hors d'une classe lève une
+    <exceptionname>Error</exceptionname>, ce que cette fonction ne fait pas.
+   </simpara>
+  </note>
  </refsect1>
 
  <refsect1 role="parameters">

--- a/reference/funchand/functions/forward-static-call-array.xml
+++ b/reference/funchand/functions/forward-static-call-array.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
 <!-- EN-Revision: 846dfb87daacac70877c332686d60c7dfd0f15d8 Maintainer: yannick Status: ready -->
 <refentry xml:id="function.forward-static-call-array" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>


### PR DESCRIPTION
Sync of php/doc-en#5241 (commit 846dfb87daacac70877c332686d60c7dfd0f15d8).

Fixes: #3243