### PR TITLE
[Sync EN] ext/mbstring: fix the mb_http_input ValueError version (8.0.0)

### DIFF
--- a/reference/mbstring/functions/mb-http-input.xml
+++ b/reference/mbstring/functions/mb-http-input.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: d553fa36940639b0889ec4358fa3bbb92f123b69 Maintainer: yannick Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 2fab26790083c132d6daeb0a0bfa41d5cc0894e0 Maintainer: yannick Status: ready -->
 <refentry xml:id="function.mb-http-input" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>mb_http_input</refname>
@@ -71,16 +70,11 @@
     </thead>
     <tbody>
      <row>
-      <entry>8.4.0</entry>
+      <entry>8.0.0</entry>
       <entry>
        <function>mb_http_input</function> lève désormais une
        exception <exceptionname>ValueError</exceptionname> si <parameter>type</parameter>
        est invalide.
-      </entry>
-     </row>
-     <row>
-      <entry>8.0.0</entry>
-      <entry>
        <parameter>type</parameter> est désormais nullable.
       </entry>
      </row>


### PR DESCRIPTION
Sync of php/doc-en#5252 (commit 2fab26790083c132d6daeb0a0bfa41d5cc0894e0).

Fixes: #3244