### PR TITLE
[Sync EN] language/generators: correct the range() memory usage estimate

### DIFF
--- a/language/generators.xml
+++ b/language/generators.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 50e6f42c83ac3f6de5e1086b649e06adedd562ff Maintainer: lacatoire Status: ready -->
-<!-- Reviewed: no -->
-<!-- CREDITS: DAnnebicque -->
+<!-- EN-Revision: a8c1fc582e4917898980533b90fab4a598aede0f Maintainer: lacatoire Status: ready -->
 
 <chapter xml:id="language.generators" xmlns="http://docbook.org/ns/docbook" annotations="interactive">
  <title>Les générateurs</title>
@@ -31,15 +29,15 @@
    Comme avec les itérateurs, l'accès aléatoire aux données n'est pas possible.
   </para>
   
-  <para>
+  <simpara>
    Un exemple simple de ce mécanisme est la ré-implémentation
    de la fonction <function>range</function> sous la forme d'un générateur.
    La fonction standard <function>range</function> doit générer un tableau
    contenant chaque valeur, et le retourner, ce qui peut conduire
    à des tableaux de taille importante : par exemple, l'appel du code
    <command>range(0, 1000000)</command> peut consommer nettement plus de
-   100 Mo de mémoire.
-  </para>
+   10 Mo de mémoire.
+  </simpara>
   
   <para>
    Comme alternative, nous pouvons implémenter un générateur


### PR DESCRIPTION
Sync of php/doc-en#4680 (commit a8c1fc582e4917898980533b90fab4a598aede0f).

Fixes: #3245