### PR TITLE
[Sync EN] ext/var: document bool support for the allowed_classes option

### DIFF
--- a/appendices/migration84/incompatible.xml
+++ b/appendices/migration84/incompatible.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 64dc79d6c9710dddf196aa28e3c5f63b562e7aef Maintainer: lacatoire Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: b2acdf5697fa3c189f24c3b0147bef57cb8a6c32 Maintainer: lacatoire Status: ready -->
 <sect1 xml:id="migration84.incompatible" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Changements non rétrocompatibles</title>
 
@@ -410,10 +409,10 @@
 
    <simpara>
     L'option <literal>"allowed_classes"</literal> pour
-    <function>unserialize</function> lance désormais des
-    <exceptionname>TypeError</exceptionname> et
-    <exceptionname>ValueError</exceptionname> si ce n'est pas un
-    <type>array</type> de noms de classe.
+    <function>unserialize</function> lance désormais une
+    <exceptionname>TypeError</exceptionname> et une
+    <exceptionname>ValueError</exceptionname> si ce n'est ni un
+    <type>array</type> de noms de classe, ni un <type>bool</type>.
    </simpara>
   </sect3>
 

--- a/reference/var/functions/unserialize.xml
+++ b/reference/var/functions/unserialize.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 8af3521cb43f54c652baaf8dbbcb786b79a5d04e Maintainer: lacatoire Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: b2acdf5697fa3c189f24c3b0147bef57cb8a6c32 Maintainer: lacatoire Status: ready -->
 <refentry xml:id="function.unserialize" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>unserialize</refname>
@@ -150,9 +149,9 @@
   </simpara>
   <simpara>
    À partir de PHP 8.4.0, si l'élément <literal>allowed_classes</literal> de
-   <parameter>options</parameter> n'est pas un <type>array</type> de noms de classes,
-   <function>unserialize</function> lève des <exceptionname>TypeError</exceptionname>
-   et <exceptionname>ValueError</exceptionname>.
+   <parameter>options</parameter> n'est ni un <type>array</type> de noms de classes,
+   ni un <type>bool</type>, <function>unserialize</function> lève une
+   <exceptionname>TypeError</exceptionname> et une <exceptionname>ValueError</exceptionname>.
   </simpara>
  </refsect1>
 
@@ -171,9 +170,10 @@
       <row>
        <entry>8.4.0</entry>
        <entry>
-        Lève désormais des <exceptionname>TypeError</exceptionname> et
+        Lève désormais une <exceptionname>TypeError</exceptionname> et une
         <exceptionname>ValueError</exceptionname> si l'élément <literal>allowed_classes</literal>
-        de <parameter>options</parameter> n'est pas un <type>array</type> de noms de classes.
+        de <parameter>options</parameter> n'est ni un <type>array</type> de noms de classes,
+        ni un <type>bool</type>.
        </entry>
       </row>
       <row>


### PR DESCRIPTION
Sync of php/doc-en#4768 (commit b2acdf5697fa3c189f24c3b0147bef57cb8a6c32).

Fixes: #3246