### PR TITLE
[Sync EN] ext/mysqli: note MYSQLI_TYPE_VECTOR availability (PHP 8.4.0, MySQL 9)

### DIFF
--- a/reference/mysqli/constants.xml
+++ b/reference/mysqli/constants.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 59fd8de0f80a3e4b3d2bc40b91593f70b222a20a Maintainer: lacatoire Status: ready -->
 <appendix xml:id="mysqli.constants" xmlns="http://docbook.org/ns/docbook">
  &reftitle.constants;
  &extension.constants;
@@ -817,9 +817,10 @@
     (<type>int</type>)
    </term>
    <listitem>
-    <para>
+    <simpara>
      Le champ est défini comme <literal>VECTOR</literal>.
-    </para>
+     Disponible à partir de PHP 8.4.0, pour MySQL 9.0 et supérieur.
+    </simpara>
    </listitem>
   </varlistentry>
   <varlistentry xml:id="constant.mysqli-need-data">


### PR DESCRIPTION
Sync of php/doc-en#5770 (commit 59fd8de0f80a3e4b3d2bc40b91593f70b222a20a).

Fixes: #3248