### PR TITLE
[Sync EN] ext/pcre: clarify that ^ and the A modifier ignore the offset parameter

### DIFF
--- a/reference/pcre/functions/preg-match.xml
+++ b/reference/pcre/functions/preg-match.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4de6272a1f15efc9e3df21d255965fd890da0d6f Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: aa5a948a110f87b5ca4d2510288e0ad37e21ead0 Maintainer: lacatoire Status: ready -->
 <refentry xml:id="function.preg-match" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>preg_match</refname>
@@ -233,12 +233,12 @@ Array
 )
 ]]>
          </screen>
-         <para>
-          Sinon, pour éviter l'usage de <function>substr</function>, utiliser 
-          l'assertion <literal>\G</literal> plutôt que l'ancre <literal>^</literal>, ou
-          le modificateur <literal>A</literal>, tous les deux fonctionnent avec le
-          paramètre <parameter>offset</parameter>.
-         </para>
+         <simpara>
+          Sinon, pour éviter l'usage de <function>substr</function>, utiliser
+          l'assertion <literal>\G</literal> plutôt que l'ancre <literal>^</literal>
+          ou le modificateur <literal>A</literal>, ces deux derniers ne fonctionnant
+          pas avec le paramètre <parameter>offset</parameter>.
+         </simpara>
         </informalexample>
        </para>
       </note>


### PR DESCRIPTION
Sync of php/doc-en#5652 (commit aa5a948a110f87b5ca4d2510288e0ad37e21ead0).

Fixes: #3249