### PR TITLE
[Sync-En] Iterator::rewind: remove link to wrong rewind function, replace with self reference (#5764)

### DIFF
--- a/language/predefined/iterator/rewind.xml
+++ b/language/predefined/iterator/rewind.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 7fbb16f538011636999459326a55d5f153ef2c61 Maintainer: yannick Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: f0a5e4f7d35f0af1a7e93b383445657bc459914b Maintainer: yannick Status: ready -->
 <refentry xml:id="iterator.rewind" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Iterator::rewind</refname>
@@ -23,7 +22,7 @@
     exécutée <emphasis>après</emphasis> la boucle &foreach;.
    </para>
    <simpara>
-    Comme &foreach; appelle toujours <methodname>rewind</methodname> avant de
+    Comme &foreach; appelle toujours cette méthode avant de
     commencer l'itération, avancer manuellement la position de l'itérateur
     (par exemple via <methodname>SplFileObject::seek</methodname>) sera réinitialisée.
    </simpara>


### PR DESCRIPTION
Sync of php/doc-en#5764 (commit f0a5e4f7d35f0af1a7e93b383445657bc459914b).

Fixes #3269