### PR TITLE
[Sync-En] Clarify purpose of $data in updateTimestamp() (#4753)

### DIFF
--- a/reference/session/sessionupdatetimestamphandlerinterface/updatetimestamp.xml
+++ b/reference/session/sessionupdatetimestamphandlerinterface/updatetimestamp.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 601f6f4ce5827d441a7e110184708f0abe9fd447 Maintainer: jbnahan Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 8ea3e0884dcec1efce3afac0e3deef0ab4506770 Maintainer: jbnahan Status: ready -->
 <refentry xml:id="sessionupdatetimestamphandlerinterface.updatetimestamp" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>SessionUpdateTimestampHandlerInterface::updateTimestamp</refname>
@@ -35,9 +34,10 @@
    <varlistentry>
     <term><parameter>data</parameter></term>
     <listitem>
-     <para>
-      Les données de session.
-     </para>
+     <simpara>
+      Les données de session. Les données de session sérialisées peuvent être utilisées
+      pour déterminer si les données de session ont changé et doivent donc être mises à jour.
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>


### PR DESCRIPTION
Sync of php/doc-en#4753 (commit 8ea3e0884dcec1efce3afac0e3deef0ab4506770).

Fixes #3268