### PR TITLE
[Sync-En] DateTime::__(un)serialize Improve the examples, add an Error warning, amend method names in the Example section (#4661)

### DIFF
--- a/reference/datetime/datetimeinterface/serialize.xml
+++ b/reference/datetime/datetimeinterface/serialize.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: Fan2Shrek Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: d0a271b7ed3149b465a364fadd3f1212d01efd22 Maintainer: Fan2Shrek Status: ready -->
 <refentry xml:id="datetime.serialize" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>DateTime::__serialize</refname>
@@ -44,21 +43,48 @@
  <refsect1 role="examples">
   &reftitle.examples;
   <example>
-   <title>Exemple de <function>DateTime::serialize</function></title>
+   <title>Exemple de <methodname>DateTime::__serialize</methodname></title>
    <programlisting role="php">
 <![CDATA[
 <?php
-$date = new DateTime('2025-03-27');
+
+class CustomDateTimeImmutable extends DateTimeImmutable
+{
+    #[\Override]
+    public function __serialize(): array
+    {
+        return [
+            'date' => $this->format(DateTimeInterface::W3C),
+            'timestamp' => $this->getTimestamp(),
+            'timezone' => $this->getTimeZone()->getName(),
+            'to' => 'Drink a cup of coffee',
+        ];
+    }
+}
+
+$date = new CustomDateTimeImmutable('2025-03-27');
 var_dump(serialize($date));
 ]]>
    </programlisting>
    &example.outputs;
    <screen>
 <![CDATA[
-string(114) "O:8:"DateTime":3:{s:4:"date";s:26:"2025-03-27 00:00:00.000000";s:13:"timezone_type";i:3;s:8:"timezone";s:3:"UTC";}"
+string(171) "O:23:"CustomDateTimeImmutable":4:{s:4:"date";s:25:"2025-03-27T00:00:00+00:00";s:9:"timestamp";i:1743033600;s:8:"timezone";s:3:"UTC";s:2:"to";s:21:"Drink a cup of coffee";}"
 ]]>
    </screen>
   </example>
+ </refsect1>
+
+ <refsect1 role="notes">
+  &reftitle.notes;
+  <warning>
+   <simpara>
+    Une <exceptionname>Error</exceptionname> est levée lors de la tentative de
+    désérialisation d'un objet <classname>DateTime</classname> personnalisé si
+    <link linkend="object.serialize">__serialize()</link> est défini mais que
+    <link linkend="object.unserialize">__unserialize()</link> est absent.
+   </simpara>
+  </warning>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/datetime/datetimeinterface/unserialize.xml
+++ b/reference/datetime/datetimeinterface/unserialize.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: Fan2Shrek Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: d0a271b7ed3149b465a364fadd3f1212d01efd22 Maintainer: Fan2Shrek Status: ready -->
 <refentry xml:id="datetime.unserialize" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>DateTime::__unserialize</refname>
@@ -44,36 +43,64 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
-   L'objet <classname>DateTime</classname>.
-  </para>
+  <simpara>
+   &return.void;
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">
   &reftitle.examples;
   <example>
-   <title>Exemple de <function>DateTime::unserialize</function></title>
+   <title>Exemple de <methodname>DateTime::__unserialize</methodname></title>
    <programlisting role="php">
 <![CDATA[
 <?php
-$serializedDate = 'O:8:"DateTime":3:{s:4:"date";s:26:"2025-03-27 00:00:00.000000";s:13:"timezone_type";i:3;s:8:"timezone";s:3:"UTC";}';
-var_dump(unserialize($serializedDate));
+
+class CustomDateTimeImmutable extends DateTimeImmutable
+{
+    #[\Override]
+    public function __unserialize(array $data): void
+    {
+        echo "Time to `{$data['to']}`:\n\n";
+
+        parent::__construct($data['date'], new DateTimeZone($data['timezone']));
+    }
+}
+
+$serializedData = 'O:23:"CustomDateTimeImmutable":4:{s:4:"date";s:25:"2025-03-27T00:00:00+00:00";s:9:"timestamp";i:1743033600;s:8:"timezone";s:3:"UTC";s:2:"to";s:21:"Drink a cup of coffee";}';
+
+var_dump(unserialize($serializedData));
+
 ]]>
    </programlisting>
    &example.outputs;
    <screen>
 <![CDATA[
-object(DateTime)#1 (3) {
+Time to `Drink a cup of coffee`:
+
+object(CustomDateTimeImmutable)#1 (3) {
   ["date"]=>
   string(26) "2025-03-27 00:00:00.000000"
   ["timezone_type"]=>
-  int(3)
+  int(1)
   ["timezone"]=>
-  string(3) "UTC"
+  string(6) "+00:00"
 }
 ]]>
    </screen>
   </example>
+ </refsect1>
+
+ <refsect1 role="notes">
+  &reftitle.notes;
+  <warning>
+   <simpara>
+    Une <exceptionname>Error</exceptionname> est levée lors de la tentative de
+    désérialisation d'un objet <classname>DateTime</classname> personnalisé si
+    <link linkend="object.serialize">__serialize()</link> est défini mais que
+    <link linkend="object.unserialize">__unserialize()</link> est absent.
+   </simpara>
+  </warning>
  </refsect1>
 
  <refsect1 role="seealso">


### PR DESCRIPTION
Sync of php/doc-en#4661 (commit d0a271b7ed3149b465a364fadd3f1212d01efd22).

Fixes #3262