### PR TITLE
[Sync EN] ext/zip: document the deferred write behavior of ZipArchive

### DIFF
--- a/reference/zip/ziparchive/close.xml
+++ b/reference/zip/ziparchive/close.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 5cb356334f35b9ae452e3af47d2d9f0b1cd16b63 Maintainer: lacatoire Status: ready -->
 <refentry xml:id="ziparchive.close" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>ZipArchive::close</refname>
@@ -17,6 +16,16 @@
    les modifications. Cette méthode est appelée automatiquement
    à la fin du script.
   </simpara>
+  <note>
+   <simpara>
+    Toutes les modifications apportées à l'archive (ajout, suppression ou
+    renommage d'entrées) sont effectuées en mémoire et ne sont écrites sur
+    le disque que lorsque cette méthode est appelée. Par conséquent, les
+    erreurs liées aux opérations du système de fichiers (comme une
+    permission refusée ou un dossier manquant) n'apparaîtront qu'à la
+    fermeture, et non lors de l'appel des méthodes de modification.
+   </simpara>
+  </note>
   <simpara>
    Si l'archive ne contient aucun fichier, elle est complètement supprimée par défaut
    (pas d'enregistrement d'une archive vide) en fonction de la valeur de la constante

--- a/reference/zip/ziparchive/open.xml
+++ b/reference/zip/ziparchive/open.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 5cb356334f35b9ae452e3af47d2d9f0b1cd16b63 Maintainer: lacatoire Status: ready -->
 <refentry xml:id="ziparchive.open" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>ZipArchive::open</refname>
@@ -19,6 +18,18 @@
   <simpara>
    À partir de libzip 1.6.0, un fichier vide n'est plus une archive valide.
   </simpara>
+  <note>
+   <simpara>
+    Lors de la création d'une nouvelle archive avec
+    <constant>ZipArchive::CREATE</constant>, le fichier n'est réellement
+    écrit sur le disque qu'au moment de l'appel à
+    <methodname>ZipArchive::close</methodname>. Par conséquent, les erreurs
+    liées au système de fichiers (comme une permission refusée ou un dossier
+    parent inexistant) ne seront signalées que lors de l'appel à
+    <methodname>ZipArchive::close</methodname>, et non lors de l'appel à
+    cette méthode.
+   </simpara>
+  </note>
  </refsect1>
  <refsect1 role="parameters">
   &reftitle.parameters;


### PR DESCRIPTION
Translates the notes added by php/doc-en#5274 (commit 5cb3563) into `ZipArchive::close()` and `ZipArchive::open()`, and updates the EN-Revision hashes.

Fixes: #3285