### PR TITLE
[Sync EN] ext/funchand: clarify the forward_static_call() documentation

### DIFF
--- a/reference/funchand/functions/forward-static-call-array.xml
+++ b/reference/funchand/functions/forward-static-call-array.xml
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 846dfb87daacac70877c332686d60c7dfd0f15d8 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 17ddeefd6592d09dd9abcf185f56b5befc7b2d6d Maintainer: yannick Status: ready -->
 <refentry xml:id="function.forward-static-call-array" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>forward_static_call_array</refname>
-  <refpurpose>Appelle une méthode statique et passe les arguments en tableau</refpurpose>
+  <refpurpose>Appelle une fonction de rappel avec un tableau de paramètres, en
+  préservant la classe appelée courante</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -17,10 +18,13 @@
    Appelle une fonction ou une méthode utilisateur, nommée <parameter>callback</parameter>,
    avec les arguments passés dans un tableau, similairement à
    <function>call_user_func_array</function>.
-   Lorsqu'elle est appelée depuis une méthode, elle utilise la
-   <link linkend="language.oop5.late-static-bindings">résolution statique à la volée</link>.
-   Lorsqu'elle est appelée hors du contexte d'une classe, elle se comporte comme
-   <function>call_user_func_array</function>, sans résolution statique à la volée.
+   Lorsqu'elle est appelée depuis une méthode et que la fonction de rappel est
+   une méthode, elle effectue un
+   <link linkend="language.oop5.late-static-bindings">appel transmis</link>,
+   de sorte que <literal>static::</literal> à l'intérieur de la méthode se
+   résout vers la même classe appelée que dans l'appelant. Cela est utile pour
+   les fonctions de rappel de méthodes statiques qui devraient se comporter
+   comme <literal>self::</literal> ou <literal>parent::</literal>.
   </simpara>
   <note>
    <simpara>
@@ -49,14 +53,14 @@
     <varlistentry>
      <term><parameter>args</parameter></term>
      <listitem>
-      <para>
-       Un paramètre, rassemblant tous les paramètres dans un tableau.
-      </para>
+      <simpara>
+       Les paramètres à passer à la fonction de rappel, sous forme de tableau.
+      </simpara>
       <note>
-       <para>
-        Il est à noter que les paramètres de <function>forward_static_call_array</function> ne sont
-        pas passés par référence.
-       </para>
+       <simpara>
+        Pour passer un paramètre par référence, l'élément correspondant de
+        <parameter>args</parameter> doit être une référence.
+       </simpara>
       </note>
      </listitem>
     </varlistentry>

--- a/reference/funchand/functions/forward-static-call.xml
+++ b/reference/funchand/functions/forward-static-call.xml
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 0c9c2dd669fe9395eaa73d487fbd160f9057429a Maintainer: yannick Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 17ddeefd6592d09dd9abcf185f56b5befc7b2d6d Maintainer: yannick Status: ready -->
 <refentry xml:id="function.forward-static-call" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>forward_static_call</refname>
-  <refpurpose>Appelle une méthode statique</refpurpose>
+  <refpurpose>Appelle une fonction de rappel en préservant la classe appelée courante</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -15,12 +13,17 @@
    <methodparam><type>callable</type><parameter>callback</parameter></methodparam>
    <methodparam rep="repeat"><type>mixed</type><parameter>args</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Appelle une fonction ou une méthode utilisateur, nommée <parameter>callback</parameter>,
    avec les arguments qui suivent. Cette fonction doit être appelée depuis une méthode,
    et ne peut pas être utilisée hors d'une classe.
-   Elle utilise le <link linkend="language.oop5.late-static-bindings">liage statique</link>.
-  </para>
+   Lorsque la fonction de rappel est une méthode, elle effectue un
+   <link linkend="language.oop5.late-static-bindings">appel transmis</link>,
+   de sorte que <literal>static::</literal> à l'intérieur de la méthode se
+   résout vers la même classe appelée que dans l'appelant. Cela est utile pour
+   les fonctions de rappel de méthodes statiques qui devraient se comporter
+   comme <literal>self::</literal> ou <literal>parent::</literal>.
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -40,9 +43,9 @@
     <varlistentry>
      <term><parameter>args</parameter></term>
      <listitem>
-      <para>
-       Zéro ou plusieurs paramètres à passer à la fonction.
-      </para>
+      <simpara>
+       Zéro ou plusieurs paramètres à passer à la fonction de rappel.
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>


### PR DESCRIPTION
Translates php/doc-en#5784 (commit 17ddeef) into `forward_static_call()` and `forward_static_call_array()`: new refpurposes, forwarding-call wording, by-reference note, and the para/simpara changes. EN-Revision hashes updated.

Fixes: #3286