### PR TITLE
[Sync EN] ext/standard: clarify the executable lookup of proc_open() with an array command

### DIFF
--- a/reference/exec/functions/proc-open.xml
+++ b/reference/exec/functions/proc-open.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: f50098447455250c9f92eed119248aaa30920100 Maintainer: lacatoire Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 5600a279c7904a92dca710222de2289613a47aad Maintainer: lacatoire Status: ready -->
 <refentry xml:id="function.proc-open" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>proc_open</refname>
@@ -58,6 +57,16 @@
        Dans ce cas le processus sera ouvert directement (sans passer à travers
        un shell) et PHP se chargera d'échapper les arguments nécessaires.
       </para>
+      <simpara>
+       Lorsque <parameter>command</parameter> est fourni sous forme de tableau et que
+       le premier élément est un simple nom de fichier sans séparateur de dossiers,
+       l'exécutable est recherché en utilisant la variable d'environnement
+       <envar>PATH</envar> courante.
+      </simpara>
+      <simpara>
+       Si <envar>PATH</envar> n'est pas définie, les chemins de recherche par défaut
+       du système sont utilisés, tels que définis par le système d'exploitation.
+      </simpara>
       <note>
        <para>
         Sur Windows, l'échappement des arguments des éléments du &array; suppose


### PR DESCRIPTION
Translates php/doc-en#5220 (commit 5600a27): PATH lookup for an array `command`, and the fallback to the system default search paths. EN-Revision hash updated.

Fixes: #3287