### PR TITLE
[Sync EN] ext/gmp: improve the gmp_export() documentation

### DIFF
--- a/reference/gmp/functions/gmp-export.xml
+++ b/reference/gmp/functions/gmp-export.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 548548299328e56739eb2832a5c22ba2de745038 Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: ba0a95ac9ad601e5ef05a0f3ab937d9749395982 Maintainer: yannick Status: ready -->
 <refentry xml:id="function.gmp-export" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>gmp_export</refname>
@@ -15,9 +14,16 @@
    <methodparam choice="opt"><type>int</type><parameter>word_size</parameter><initializer>1</initializer></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>GMP_MSW_FIRST | GMP_NATIVE_ENDIAN</initializer></methodparam>
   </methodsynopsis>
-  <para>
-   Exporte un nombre GMP vers une chaîne binaire.
-  </para>
+  <simpara>
+   Exporte un nombre GMP vers une chaîne binaire. Cette fonction peut traiter
+   des nombres arbitrairement grands, au-delà de l'intervalle du type entier
+   natif de PHP, avec une taille de mot et un ordre des octets configurables,
+   dans le même esprit que <function>pack</function>.
+  </simpara>
+  <simpara>
+   Le signe du nombre est ignoré ; exporter un nombre négatif produit le même
+   résultat que d'exporter sa valeur absolue.
+  </simpara>
  </refsect1>
  
  <refsect1 role="parameters">
@@ -27,27 +33,36 @@
     <varlistentry>
      <term><parameter>num</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Le nombre GMP à exporter.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>word_size</parameter></term>
      <listitem>
-      <para>
-       La valeur par défaut est 1. Le nombre d'octets dans chaque
-       partie de données binaires. Principalement utilisé avec
-       le paramètre options.
-      </para>
+      <simpara>
+       Le nombre d'octets par mot dans les données de sortie. La longueur
+       totale de la chaîne retournée sera un multiple de cette valeur.
+       Valeur par défaut : <literal>1</literal>.
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>flags</parameter></term>
      <listitem>
-      <para>
-       La valeur par défaut est <constant>GMP_MSW_FIRST</constant> | <constant>GMP_NATIVE_ENDIAN</constant>.
-      </para>
+      <simpara>
+       Un masque de bits contrôlant l'ordre des mots et l'ordre des octets.
+       Ordre des mots : <constant>GMP_MSW_FIRST</constant> (mot le plus
+       significatif en premier, par défaut) ou
+       <constant>GMP_LSW_FIRST</constant> (mot le moins significatif en
+       premier). Ordre des octets au sein de chaque mot :
+       <constant>GMP_NATIVE_ENDIAN</constant> (par défaut),
+       <constant>GMP_BIG_ENDIAN</constant> ou
+       <constant>GMP_LITTLE_ENDIAN</constant>.
+       Valeur par défaut :
+       <constant>GMP_MSW_FIRST</constant> | <constant>GMP_NATIVE_ENDIAN</constant>.
+      </simpara>
      </listitem>
     </varlistentry>   
    </variablelist>
@@ -56,9 +71,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
-   Retourne une chaîne de caractères.
-  </para>
+  <simpara>
+   Retourne une chaîne de caractères contenant la représentation binaire du
+   nombre GMP. La chaîne est vide si le nombre vaut zéro.
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">


### PR DESCRIPTION
Translates php/doc-en#5265 (commit ba0a95a): expanded description, sign handling, `word_size` and `flags` details, and the return value. EN-Revision hash updated.

Fixes: #3288