### PR TITLE
[Sync EN] ext/curl: add the POST and JSON POST request examples

### DIFF
--- a/reference/curl/examples.xml
+++ b/reference/curl/examples.xml
@@ -1,12 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: fc9a0a8b29a7a099998bdd71fe5350a10b18fe62 Maintainer: yannick Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: e7c6a2f6847c3a8c9fec6ba588f235ccdcf6f3a5 Maintainer: yannick Status: ready -->
 
 <chapter xml:id="curl.examples" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.examples;
  <section xml:id="curl.examples-basic">
-  <title>Exemple avec curl</title>
-  <para>
+  <title>Exemples de base avec curl</title>
+  <simpara>
    Une fois PHP compilé avec le support cURL, il est possible de commencer
    à utiliser les fonctions cURL. La première des choses à faire est
    d'initialiser une session cURL avec la fonction
@@ -14,9 +13,73 @@
    options pour le transfert avec la fonction <function>curl_setopt</function>,
    et enfin, il est possible d'exécuter la session avec
    <function>curl_exec</function>.
-   Voici un exemple qui utilise les
-   fonctions cURL pour récupérer la page d'accueil du site
-   example.com dans un fichier :
+  </simpara>
+  <para>
+   Voici un exemple simple qui utilise les fonctions cURL pour envoyer
+   une requête POST :
+   <example>
+    <title>Utilisation du module cURL de PHP pour envoyer une requête POST</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+$data = ['foo' => 'bar', 'baz' => 48];
+$url = "http://www.example.com/handler.php";
+
+$ch = curl_init($url);
+
+// demande à CURL de retourner la réponse au lieu de l'envoyer sur la sortie standard
+curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+
+// définit les données POST, la méthode correspondante et les en-têtes
+curl_setopt($ch, CURLOPT_POSTFIELDS, http_build_query($data));
+
+// envoie la requête et récupère la réponse
+$response = curl_exec($ch);
+
+if(curl_error($ch)) {
+    // traite l'erreur, ou simplement
+    throw new RuntimeException(curl_error($ch));
+}
+]]>
+    </programlisting>
+   </example>
+  </para>
+  <para>
+   Un autre exemple qui utilise les fonctions cURL pour envoyer une requête
+   POST avec du JSON brut :
+   <example>
+    <title>Utilisation du module cURL de PHP pour envoyer une requête POST JSON</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+$post_data = ['foo' => 'bar', 'baz' => 48];
+$url = "http://www.example.com/api/endpoint";
+
+$ch = curl_init($url);
+
+// demande à CURL de retourner la réponse au lieu de l'envoyer sur la sortie standard
+curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+
+// définit les données POST et la méthode correspondante
+curl_setopt($ch, CURLOPT_POSTFIELDS, json_encode($post_data));
+
+// définit l'en-tête requis
+curl_setopt($ch, CURLOPT_HTTPHEADER, ['Content-Type: application/json']);
+
+// envoie la requête et récupère la réponse
+$response = curl_exec($ch);
+
+if(curl_error($ch)) {
+    // traite l'erreur, ou simplement
+    throw new RuntimeException(curl_error($ch));
+}
+]]>
+    </programlisting>
+   </example>
+  </para>
+  <para>
+   Voici un autre exemple qui utilise les fonctions cURL pour récupérer
+   la page d'accueil du site example.com dans un fichier :
    <example>
     <title>Utilisation du module cURL pour récupérer la page d'accueil d'example.com</title>
     <programlisting role="php">
@@ -34,7 +97,6 @@ if(curl_error($ch)) {
     fwrite($fp, curl_error($ch));
 }
 fclose($fp);
-?>
 ]]>
     </programlisting>
    </example>


### PR DESCRIPTION
Translates php/doc-en#4612 (commit e7c6a2f): two new examples (form-encoded POST and raw JSON POST), section title and intro reflow, and the trailing `?>` removal in the existing example. EN-Revision hash updated.

Fixes: #3289