### PR TITLE
[Sync EN] language: document the PHP 8.4 comparison and readonly clone BC breaks

### DIFF
--- a/language/oop5/properties.xml
+++ b/language/oop5/properties.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: dff848b17dafaabfb7662ffb5fecfcb04e3b771d Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 62e61e543c2d2b8519952efa246ed708026cfb16 Maintainer: lacatoire Status: ready -->
 <sect1 xml:id="language.oop5.properties" xmlns="http://docbook.org/ns/docbook">
  <title>Propriétés</title>
 
@@ -377,6 +377,16 @@ var_dump($test2->prop); // NULL
     </programlisting>
    </example>
   </para>
+  <note>
+   <simpara>
+    À partir de PHP 8.4.0, la modification indirecte d'une propriété
+    <literal>readonly</literal> au sein de
+    <link linkend="object.clone">__clone()</link>, comme l'obtention d'une
+    référence vers celle-ci (<code>$ref = &amp;$this->prop</code>), n'est plus
+    autorisée. Cela était déjà interdit lors de l'initialisation d'une
+    propriété <literal>readonly</literal>.
+   </simpara>
+  </note>
  </sect2>
 
  <sect2 xml:id="language.oop5.properties.dynamic-properties">

--- a/language/operators/comparison.xml
+++ b/language/operators/comparison.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 16934048f79c6e117cd16a23c09c1b2ea502e284 Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 62e61e543c2d2b8519952efa246ed708026cfb16 Maintainer: yannick Status: ready -->
 <sect1 xml:id="language.operators.comparison">
  <title>Opérateurs de comparaison</title>
  <titleabbrev>Comparaison</titleabbrev>
@@ -347,6 +346,15 @@ function standard_array_compare($op1, $op2)
    &integer;s à des &string;s. Il est par conséquent généralement recommandé d'utiliser les
    opérateurs de comparaison <literal>===</literal> et <literal>!==</literal> au lieu de
    <literal>==</literal> et <literal>!=</literal> dans la plupart des cas.
+  </simpara>
+ </note>
+
+ <note>
+  <simpara>
+   Rencontrer une récursion lors d'une comparaison, par exemple en comparant
+   un tableau ou un objet qui contient une référence vers lui-même, lève une
+   <exceptionname>Error</exceptionname> à partir de PHP 8.4.0 ; auparavant,
+   cela provoquait une erreur fatale.
   </simpara>
  </note>
 


### PR DESCRIPTION
Translates php/doc-en#5775 (commit 62e61e5): the Error thrown on recursive comparison, and the ban on indirect modification of a readonly property inside `__clone()`. EN-Revision hashes updated.

Fixes: #3290