### PR TITLE
[Sync EN] ext/standard: document the DEBUG_BACKTRACE_PROVIDE_OBJECT option of debug_print_backtrace()

### DIFF
--- a/reference/errorfunc/functions/debug-print-backtrace.xml
+++ b/reference/errorfunc/functions/debug-print-backtrace.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 1fd69376c6c90066f086c99a32621f0b3fd47ba0 Maintainer: jpauli Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 41911b489877ce67e1a9c47b43b1cc37aa21b6e2 Maintainer: jpauli Status: ready -->
 
 <refentry xml:id="function.debug-print-backtrace" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -43,6 +41,15 @@
            <entry>
             Si l'on doit omettre l'index "args" et ainsi, tous les arguments
             de la méthode/fonction pour préserver la mémoire.
+           </entry>
+          </row>
+          <row>
+           <entry>DEBUG_BACKTRACE_PROVIDE_OBJECT</entry>
+           <entry>
+            Acceptée pour la compatibilité avec
+            <function>debug_backtrace</function>, mais sans effet : la trace
+            générée est rendue sous forme de chaîne de caractères et l'entrée
+            "object" n'est jamais affichée.
            </entry>
           </row>
          </tbody>


### PR DESCRIPTION
Translates php/doc-en#5217 (commit 41911b4): the option row stating it is accepted for compatibility but has no effect. EN-Revision hash updated.

Fixes: #3291