### PR TITLE
[Sync EN] ext/standard: document the multibyte string behavior of escapeshellarg() and escapeshellcmd()

### DIFF
--- a/reference/exec/functions/escapeshellarg.xml
+++ b/reference/exec/functions/escapeshellarg.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 60c391265d2a51003e1ed0952e5a2413f81c7fc2 Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 0600ff7ba94e3f491aeb246d8ddfedd98f0d7276 Maintainer: yannick Status: ready -->
 <refentry xml:id="function.escapeshellarg" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>escapeshellarg</refname>
@@ -14,7 +12,7 @@
    <type>string</type><methodname>escapeshellarg</methodname>
    <methodparam><type>string</type><parameter>arg</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    <function>escapeshellarg</function> ajoute des guillemets simples
    autour des chaînes de caractères, et ajoute des
    guillemets puis échappe les guillemets simples de la
@@ -25,15 +23,20 @@
    provenant des entrées utilisateur à passer au Shell. Les fonctions Shell sont <function>exec</function>,
    <function>system</function> et les opérateurs
    <link linkend="language.operators.execution">guillemets obliques</link>.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Sous Windows, <function>escapeshellarg</function> remplace plutôt les 
    signes de pourcentage, les points d'exclamation (substitution de variables 
    différées) et les guillemets doubles avec des espaces et ajoute des 
    guillemets doubles autour de la chaîne.
    De plus, chaque série de barres obliques inversées consécutives (<literal>\</literal>)
    est échappée par une barre oblique inverse supplémentaire.
-  </para>
+  </simpara>
+  <simpara>
+   Le comportement de cette fonction avec les chaînes de caractères multi-octets
+   dépend du paramètre de locale <constant>LC_CTYPE</constant> courant. Les
+   caractères non reconnus seront écartés. Voir <function>setlocale</function>.
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -43,9 +46,9 @@
     <varlistentry>
      <term><parameter>arg</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        L'argument à échapper.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -54,9 +57,9 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    La chaîne échappée.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">
@@ -79,6 +82,7 @@ system('ls '.escapeshellarg($dir));
   &reftitle.seealso;
   <para>
    <simplelist>
+    <member><function>setlocale</function></member>
     <member><function>escapeshellcmd</function></member>
     <member><function>exec</function></member>
     <member><function>popen</function></member>

--- a/reference/exec/functions/escapeshellcmd.xml
+++ b/reference/exec/functions/escapeshellcmd.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 62126c55f1c6ed444043e7272c4f9e233818a44b Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 0600ff7ba94e3f491aeb246d8ddfedd98f0d7276 Maintainer: yannick Status: ready -->
 
 <refentry xml:id="function.escapeshellcmd" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -15,7 +13,7 @@
    <type>string</type><methodname>escapeshellcmd</methodname>
    <methodparam><type>string</type><parameter>command</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    <function>escapeshellcmd</function> échappe tous les
    caractères de la chaîne <parameter>command</parameter>
    qui pourraient avoir une signification spéciale dans une
@@ -23,15 +21,20 @@
    donnée provenant des entrées utilisateur est échappée avant d'être passée aux fonctions
    <function>exec</function> et <function>system</function>, ou encore
    à <link linkend="language.operators.execution">guillemets obliques</link>.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Les caractères suivants sont précédés d'un antislash :
    <literal>&amp;#;`|*?~&lt;&gt;^()[]{}$\</literal>, <literal>\x0A</literal>
    et <literal>\xFF</literal>. <literal>'</literal> et <literal>"</literal>
    ne sont échappés que s'ils ne sont pas par paire. Sous Windows, tous ces caractères
    ainsi que <literal>%</literal> et <literal>!</literal> sont précédés d'un
    accent circonflexe (<literal>^</literal>).
-  </para>
+  </simpara>
+  <simpara>
+   Le comportement de cette fonction avec les chaînes de caractères multi-octets
+   dépend du paramètre de locale <constant>LC_CTYPE</constant> courant. Les
+   caractères non reconnus seront écartés. Voir <function>setlocale</function>.
+  </simpara>
  </refsect1>
  
  <refsect1 role="parameters">
@@ -41,9 +44,9 @@
     <varlistentry>
      <term><parameter>command</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        La commande à échapper.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -52,9 +55,9 @@
  
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    La chaîne échappée.
-  </para>
+  </simpara>
  </refsect1>
  
  <refsect1 role="examples">
@@ -69,7 +72,7 @@
 $command = './configure '.$_POST['configure_options'];
 
 $escaped_command = escapeshellcmd($command);
- 
+
 system($escaped_command);
 ?>
 ]]>
@@ -81,13 +84,13 @@ system($escaped_command);
  <refsect1 role="notes">
   &reftitle.notes;
    <warning xmlns="http://docbook.org/ns/docbook">
-    <para>
+    <simpara>
      La fonction <function>escapeshellcmd</function> devrait être utilisée
      sur toute la chaîne de commande, mais elle autorise tout de même
      un attaquant à passer un nombre arbitraire d'arguments.
      Pour échapper un seul argument, la fonction
      <function>escapeshellarg</function> devrait être utilisée à la place.
-    </para>
+    </simpara>
    </warning>
   <warning xmlns="http://docbook.org/ns/docbook">
    <para>
@@ -109,6 +112,7 @@ $cmd = preg_replace('`(?<!^) `', '^ ', escapeshellcmd($cmd));
   &reftitle.seealso;
   <para>
    <simplelist>
+    <member><function>setlocale</function></member>
     <member><function>escapeshellarg</function></member>
     <member><function>exec</function></member>
     <member><function>popen</function></member>


### PR DESCRIPTION
Translates php/doc-en#4924 (commit 0600ff7): the LC_CTYPE dependency note, the setlocale() see-also entries, and the para/simpara changes. EN-Revision hashes updated.

Fixes: #3292