### PR TITLE
[Sync EN] install/fpm: document environment variable expansion in the pool configuration

### DIFF
--- a/install/fpm/configuration.xml
+++ b/install/fpm/configuration.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 1f01e2a8e478c63bd6598cde09235ec027b23dd5 Maintainer: lacatoire Status: ready -->
-<!-- Reviewed: no Maintainer: itanea -->
+<!-- EN-Revision: 7cd12cc82bc0a778241189596022acdda016d857 Maintainer: lacatoire Status: ready -->
 <sect1 xml:id="install.fpm.configuration" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Configuration</title>
  <para>
@@ -1009,6 +1008,22 @@
       </listitem>
      </varlistentry>
   </variablelist>
+  <para>
+   Les valeurs de configuration peuvent être définies en utilisant l'expansion
+   de variables d'environnement. La définition de valeurs par défaut lorsque la
+   variable d'environnement n'est pas définie ou est nulle est également
+   supportée à partir de PHP 8.3.0. Par exemple :
+   <example>
+    <title>Utilisation de l'expansion de variables d'environnement</title>
+    <programlisting role="ini">
+<![CDATA[
+listen = /var/run/php-fpm-${POOL_NAME}.sock
+user = ${USER_NAME:-www-data}
+group = ${USER_NAME:-www-data}
+]]>
+    </programlisting>
+   </example>
+  </para>
   <para>
    Il est possible de passer des variables d'environnement additionnelles et mettre à jour les paramètres
    de PHP d'un pool. Pour ce faire, il faut ajouter les options suivantes au


### PR DESCRIPTION
Translates php/doc-en#5181 (commit 7cd12cc): environment variable expansion in configuration values, the PHP 8.3.0 default-value syntax, and its example. EN-Revision hash updated.

Fixes: #3293