### PR TITLE
[Sync EN] install/unix: fix naming and paths and add php-fpm in dnf.xml

### DIFF
--- a/install/unix/dnf.xml
+++ b/install/unix/dnf.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: ee1ce6a0e1875b6851274f8c373ca2bd48630fa0 Maintainer: lacatoire Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 88d5409cd9668b28ecb879522750807322a816dd Maintainer: lacatoire Status: ready -->
 <sect1 xml:id="install.unix.dnf" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Installation depuis les paquets sur les distributions GNU/Linux qui utilisent DNF</title>
  <simpara>
@@ -29,7 +28,7 @@
    <title>Exemple d'installation DNF</title>
    <programlisting role="shell">
 <![CDATA[
-# dnf install php php-common
+# dnf install php php-common php-fpm
 ]]>
    </programlisting>
   </example>
@@ -39,7 +38,7 @@
    Par exemple :
   </simpara>
   <example xml:id="install.unix.dnf.example2">
-   <title>Redémarrage d'Apache une fois PHP installé</title>
+   <title>Redémarrage d'Apache httpd une fois PHP installé</title>
    <programlisting role="shell">
 <![CDATA[
 # sudo systemctl restart httpd
@@ -87,10 +86,10 @@
   <simpara>
    DNF va automatiquement ajouter les lignes appropriées aux différents fichiers
    liés à &php.ini;, comme
-   <filename>/etc/php/8.3/php.ini</filename>,
-   <filename>/etc/php/8.3/conf.d/*.ini</filename>, etc. et en fonction de
+   <filename>/etc/php.ini</filename>,
+   <filename>/etc/php.d/*.ini</filename>, etc. et en fonction de
    l'extension ajoutera des entrées similaires à <literal>extension=foo.so</literal>.
-   Cependant il est nécessaire de redémarrer le serveur web (comme Apache) avant que
+   Cependant il est nécessaire de redémarrer le serveur web et PHP-FPM avant que
    ces changements prennent effet.
   </simpara>
  </sect2>


### PR DESCRIPTION
Translates php/doc-en#5745 (commit 88d5409): php-fpm added to the install example, "Apache httpd" naming, the actual DNF layout paths, and the PHP-FPM restart mention. EN-Revision hash updated.

Fixes: #3294