### PR TITLE
[Sync EN] appendices: document the --enable-zend-max-execution-timers configure option

### DIFF
--- a/appendices/configure/misc.xml
+++ b/appendices/configure/misc.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 4c676dacf58ff5d779eed96739ab4660204cbe7f Maintainer: yannick Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 667093532547bcfe6224765f038c151c61f30f48 Maintainer: yannick Status: ready -->
 
  <sect3 xml:id="configure.options.misc" xmlns="http://docbook.org/ns/docbook">
   <title>Options diverses</title>
@@ -49,6 +47,28 @@
     </listitem>
    </varlistentry>
 
+   <varlistentry xml:id="configure.enable-zend-max-execution-timers">
+    <term>
+     <option role="configure">--enable-zend-max-execution-timers</option>
+    </term>
+    <listitem>
+     <simpara>
+      Utilise les minuteurs POSIX par thread pour le suivi de
+      <link linkend="ini.max-execution-time">max_execution_time</link>
+      au lieu du <literal>setitimer()</literal> appliqué à l'ensemble du
+      processus. Ces minuteurs mesurent le temps écoulé
+      (<literal>CLOCK_BOOTTIME</literal>, ou
+      <literal>CLOCK_MONOTONIC</literal> sur FreeBSD), alors que le
+      <literal>setitimer(ITIMER_PROF)</literal> utilisé par défaut mesure le
+      temps CPU ; ainsi, le temps passé en veille ou en attente d'entrées/sorties
+      est comptabilisé dans la limite.
+      Nécessite le support de <literal>timer_create()</literal> : disponible
+      sous Linux, et sous FreeBSD à partir de PHP 8.4.0.
+      Disponible à partir de PHP 8.1.0. Activé par défaut pour les compilations
+      ZTS à partir de PHP 8.3.0.
+     </simpara>
+    </listitem>
+   </varlistentry>
    <varlistentry xml:id="configure.enable-sigchild">
     <term>
      <option role="configure">--enable-sigchild</option>

--- a/reference/info/ini.xml
+++ b/reference/info/ini.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: b1116af46680f7baf89c46610430a3b63ce9a1f0 Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 667093532547bcfe6224765f038c151c61f30f48 Maintainer: yannick Status: ready -->
 <section xml:id="info.configuration" xmlns="http://docbook.org/ns/docbook">
  &reftitle.runtime;
  &extension.runtime;
@@ -251,6 +249,16 @@
       Se reporter à la fonction <function>set_time_limit</function>
       pour plus de détails.
      </para>
+     <simpara>
+      Lorsque PHP est compilé avec
+      <link linkend="configure.enable-zend-max-execution-timers">--enable-zend-max-execution-timers</link>
+      (le comportement par défaut pour les compilations ZTS à partir de
+      PHP 8.3.0), la limite est suivie à l'aide de minuteurs POSIX par thread
+      qui mesurent le temps écoulé ; ainsi, le temps passé en veille ou en
+      attente d'entrées/sorties y est comptabilisé. Le suivi par défaut, fondé
+      sur <literal>setitimer(ITIMER_PROF)</literal>, mesure quant à lui le
+      temps CPU.
+     </simpara>
      <para>
       Le serveur web peut avoir d'autres configurations de la durée limite
       d'exécution qui peuvent également interrompre PHP. Apache a une directive


### PR DESCRIPTION
Translates php/doc-en#5269 (commit 6670935): the new configure option entry and the max_execution_time note about elapsed-time versus CPU-time tracking. EN-Revision hashes updated.

Fixes: #3295