### PR TITLE
[Sync EN] ext/pcre: describe PREG_UNMATCHED_AS_NULL for trailing subpatterns

### DIFF
--- a/reference/pcre/constants.xml
+++ b/reference/pcre/constants.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: e62b1e3989a5049c052bc547bb6bf175ada8e48d Maintainer: lacatoire Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: cdbe6f9826baecd4a6c05f1c95ea47d1d8f32551 Maintainer: lacatoire Status: ready -->
 
 <appendix xml:id="pcre.constants" xmlns="http://docbook.org/ns/docbook">
  &reftitle.constants;
@@ -104,6 +102,11 @@
       d'inclure les sous-masques sans correspondance dans <varname>$matches</varname> avec une valeur à &null;.
       Sans cette constante, les sous-masques sans correspondance sont retournés avec une chaîne vide, comme si la correspondance était vide.
       Définir cette constante permet de distinguer ces deux cas.
+      Avec <function>preg_match</function>, les sous-masques sans correspondance
+      situés en fin de motif sont entièrement omis de <varname>$matches</varname>
+      à moins que cette constante ne soit utilisée ; à partir de PHP 7.4.0, la
+      constante les rapporte avec la valeur &null;, de sorte que
+      <varname>$matches</varname> ait toujours la même taille.
      </entry>
      <entry>7.2.0</entry>
     </row>

--- a/reference/pcre/functions/preg-match.xml
+++ b/reference/pcre/functions/preg-match.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: aa5a948a110f87b5ca4d2510288e0ad37e21ead0 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: cdbe6f9826baecd4a6c05f1c95ea47d1d8f32551 Maintainer: lacatoire Status: ready -->
 <refentry xml:id="function.preg-match" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>preg_match</refname>
@@ -120,8 +120,12 @@ Array
          <term><constant>PREG_UNMATCHED_AS_NULL</constant></term>
          <listitem>
           <para>
-           Si ce drapeau est passé, les sous-masques non satisfaits sont rapportés en tant que &null; ;
-           sinon ils sont rapportés en tant que &string; vide.
+           Si ce drapeau est passé, les sous-masques non satisfaits sont rapportés
+           en tant que &null; et sont toujours inclus dans les résultats (y compris
+           ceux situés en fin de motif). Sans ce drapeau, les sous-masques non
+           satisfaits qui sont suivis d'un sous-masque satisfait sont rapportés en
+           tant que &string; vide, tandis que les sous-masques non satisfaits situés
+           en fin de motif sont entièrement omis des résultats.
            <informalexample>
             <programlisting role="php">
 <![CDATA[
@@ -129,6 +133,12 @@ Array
 preg_match('/(a)(b)*(c)/', 'ac', $matches);
 var_dump($matches);
 preg_match('/(a)(b)*(c)/', 'ac', $matches, PREG_UNMATCHED_AS_NULL);
+var_dump($matches);
+
+// Sous-masques non satisfaits en fin de motif :
+preg_match('/(a)(b)?(c)?/', 'a', $matches);
+var_dump($matches);
+preg_match('/(a)(b)?(c)?/', 'a', $matches, PREG_UNMATCHED_AS_NULL);
 var_dump($matches);
 ?>
 ]]>
@@ -155,6 +165,22 @@ array(4) {
   NULL
   [3]=>
   string(1) "c"
+}
+array(2) {
+  [0]=>
+  string(1) "a"
+  [1]=>
+  string(1) "a"
+}
+array(4) {
+  [0]=>
+  string(1) "a"
+  [1]=>
+  string(1) "a"
+  [2]=>
+  NULL
+  [3]=>
+  NULL
 }
 ]]>
             </screen>
@@ -274,6 +300,18 @@ Array
       </row>
      </thead>
      <tbody>
+      <row>
+       <entry>7.4.0</entry>
+       <entry>
+        Lorsque le drapeau <constant>PREG_UNMATCHED_AS_NULL</constant> est
+        utilisé, les groupes de capture non satisfaits situés en fin de motif
+        sont désormais également inclus dans le résultat avec la valeur &null;
+        (ou <literal>[null, -1]</literal> lorsque
+        <constant>PREG_OFFSET_CAPTURE</constant> est également utilisé), de
+        sorte que <varname>$matches</varname> ait toujours la même taille.
+        Auparavant, ils étaient omis.
+       </entry>
+      </row>
       <row>
        <entry>7.2.0</entry>
        <entry>


### PR DESCRIPTION
Translates php/doc-en#5272 (commit cdbe6f9): trailing unmatched subpatterns in the constant description, the extended preg_match() example and its output, and the 7.4.0 changelog row. The added example output was checked against php:8.4-cli. EN-Revision hashes updated.

Fixes: #3296