### PR TITLE
[Sync EN] ext/filter: version the FILTER_CALLBACK flags note

### DIFF
--- a/reference/filter/constants.xml
+++ b/reference/filter/constants.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 911fe79de766ef4475bf22446903667a0f3a24d3 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 1900175b061e4de78f5ba3e79874e457d7e710a1 Maintainer: lacatoire Status: ready -->
 <appendix xml:id="filter.constants" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.constants;
  &extension.constants;
@@ -713,9 +713,9 @@
     (<type>int</type>)
    </term>
    <listitem>
-    <para>
+    <simpara>
      Valide la valeur en tant qu'adresse IP.
-    </para>
+    </simpara>
     <variablelist xml:id="filter.constants.validation.ip.options">
      <title>Options disponibles</title>
      <varlistentry>
@@ -1225,12 +1225,21 @@ NULL
 ]]>
         </screen>
        </example>
-       <warning>
+       <note>
         <simpara>
-         Ce filtre ne peut pas être utilisé avec d'autres indicateurs de filtre,
-         par exemple <constant>FILTER_NULL_ON_FAILURE</constant>.
+         À partir de PHP 8.1.25 et 8.2.12, les indicateurs structurels
+         <constant>FILTER_REQUIRE_ARRAY</constant>,
+         <constant>FILTER_FORCE_ARRAY</constant> et
+         <constant>FILTER_REQUIRE_SCALAR</constant> s'appliquent à ce filtre, et
+         <constant>FILTER_NULL_ON_FAILURE</constant> modifie la façon dont un tel
+         échec structurel est rapporté. Dans les versions antérieures, tous les
+         indicateurs étaient ignorés. Les indicateurs propres à un filtre sont
+         toujours ignorés et, puisque la valeur de retour de la fonction de rappel
+         constitue le résultat, la fonction de rappel elle-même ne peut pas
+         échouer : aucun indicateur ne transforme un <literal>false</literal>
+         retourné par la fonction de rappel en &null; ou en exception.
         </simpara>
-       </warning>
+       </note>
       </listitem>
      </varlistentry>
     </variablelist>


### PR DESCRIPTION
Translates php/doc-en#5243 (commit 1900175): the warning about FILTER_CALLBACK flags becomes a versioned note (PHP 8.1.25 / 8.2.12, structural flags), plus the para/simpara change on FILTER_VALIDATE_IP. EN-Revision hash updated.

Fixes: #3297