### PR TITLE
[Sync EN] ext/pcntl: document the RFTSIGZMB and RFTHREAD flags of pcntl_rfork()

### DIFF
--- a/reference/pcntl/functions/pcntl-rfork.xml
+++ b/reference/pcntl/functions/pcntl-rfork.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 61374bbe228e8e9c55a24aba59a1e2bb2a871148 Maintainer: Fan2Shrek Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: e43fb30acb61e76ef50174ec84c2aa33674a3828 Maintainer: Fan2Shrek Status: ready -->
 <refentry xml:id="function.pcntl-rfork" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>pcntl_rfork</refname>
@@ -50,8 +49,20 @@
          Est mutuellement exclusif avec <constant>RFFDG</constant>.
         </member>
         <member>
-         <constant>RFLINUXTHPN</constant>: Si défini, le noyau renverra SIGUSR1 au lieu de SIGCHILD à la sortie du thread pour l'enfant.
+         <constant>RFLINUXTHPN</constant>: Si défini, le noyau renverra SIGUSR1 au lieu de SIGCHLD à la sortie du thread pour l'enfant.
          Ceci est destiné à faire la notification de sortie du parent de sortie du thread Linux clone.
+        </member>
+        <member>
+         <constant>RFTSIGZMB</constant>: Si défini, le noyau délivrera au parent le signal
+         spécifié par le paramètre <parameter>signal</parameter> à la sortie de l'enfant,
+         au lieu du SIGCHLD par défaut. Spécifier le numéro de signal 0 désactive la
+         délivrance du signal à la sortie de l'enfant.
+        </member>
+        <member>
+         <constant>RFTHREAD</constant>: Si défini, le nouveau processus partage avec son
+         parent la table associant les descripteurs de fichiers aux leaders de processus.
+         Ne s'applique que lorsque ni <constant>RFFDG</constant> ni
+         <constant>RFCFDG</constant> ne sont définis.
         </member>
        </simplelist>
       </para>
@@ -60,9 +71,12 @@
     <varlistentry>
      <term><parameter>signal</parameter></term>
      <listitem>
-      <para>
-       Le numéro du signal.
-      </para>
+      <simpara>
+       Le numéro du signal à délivrer au parent à la sortie de l'enfant.
+       Il n'est utilisé que lorsque l'indicateur <constant>RFTSIGZMB</constant>
+       est défini. Spécifier <literal>0</literal> désactive la délivrance du
+       signal à la sortie de l'enfant.
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>


### PR DESCRIPTION
Translates php/doc-en#5446 (commit e43fb30): the two missing flags, the SIGCHLD typo fix, and the reworked signal parameter description. EN-Revision hash updated.

Fixes: #3298