### PR TITLE
[Sync EN] ext/xml: drop the bundled expat paragraph and document the --with-expat rename

### DIFF
--- a/reference/xml/configure.xml
+++ b/reference/xml/configure.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: cdab70215c31e34b90a5f941a33cdf47eeaa12e2 Maintainer: gui Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: c1b9c92d863bd1b4f82b13b4d13b8ab27caa66f0 Maintainer: gui Status: ready -->
 
 <section xml:id="xml.installation" xmlns="http://docbook.org/ns/docbook">
  &reftitle.install;
@@ -9,20 +7,32 @@
   &installation.enabled.disable;
   <option role="configure">--disable-xml</option>
  </para>
- <para>
-  Ces fonctions sont activées par défaut, et utilisent la 
-  bibliothèque expat fournie avec la distribution. Il est possible de
-  désactiver le support de XML en utilisant l'option de
-  compilation <option role="configure">--disable-xml</option>.
-  Lors de la compilation de PHP comme module pour Apache 1.3.9 ou supérieur,
-  PHP va automatiquement utiliser la bibliothèque
-  <productname>expat</productname> fournie par Apache. Pour ne pas
-  utiliser la bibliothèque expat intégrée,
-  il faut compiler PHP avec l'option
-  <option role="configure">--with-expat-dir=DIR</option>, où DIR est le
-  dossier d'installation de la bibliothèque expat.
- </para>
  &windows.builtin;
+ <simplesect role="changelog">
+ &reftitle.changelog;
+  <para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>7.4.0</entry>
+       <entry>
+        L'option <option role="configure">--with-libexpat-dir</option> a été renommée en
+        <option role="configure">--with-expat</option> et n'accepte plus de dossier en argument.
+        La bibliothèque expat fournie avec la distribution a été retirée.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </para>
+ </simplesect>
 </section>
 
 <!-- Keep this comment at the end of the file


### PR DESCRIPTION
Translates php/doc-en#4678 (commit c1b9c92): the outdated bundled-expat paragraph is replaced by a 7.4.0 changelog row about the --with-libexpat-dir to --with-expat rename. EN-Revision hash updated.

Fixes: #3284