### PR TITLE
[Sync EN] remove 11 entities no longer defined in doc-en

### DIFF
--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 7b3094477569cda19b14bf61f244b60d24a5e479 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: de78d65ef7785a167268b3cb5d5268b13bb9f358 Maintainer: lacatoire Status: ready -->
 <!-- Relecture des Notes, Précautions, Avertissements, Astuces, Divers et Retour le 2018-12-29 par girgias -->
 
 <!--
@@ -9,10 +9,6 @@ la version originale. Merci.
 -->
 
 <!ENTITY installation.enabled.disable 'Cette extension est activée par défaut. Elle peut être désactivée en utilisant l&#39;option de configuration : '>
-
-<!-- Not used in EN anymore -->
-<!ENTITY changelog.randomseed '<row xmlns="http://docbook.org/ns/docbook"><entry>4.2.0</entry><entry>Le générateur
-de nombres aléatoires est initialisé automatiquement.</entry></row>'>
 
 <!ENTITY changelog.class-constants-typed '<row xmlns="http://docbook.org/ns/docbook">
  <entry>8.4.0</entry>
@@ -104,11 +100,6 @@ de nombres aléatoires est initialisé automatiquement.</entry></row>'>
  Les noms de fichiers avec un point trainant ne sont également pas supporté.
  Contrairement à certains outils d&apos;extraction, cette méthode ne remplace pas ces caractères
  avec un tiret bas, mais échoue à extraire de tel fichiers.
-</simpara></note>'>
-
-<!ENTITY note.func-callback '<note xmlns="http://docbook.org/ns/docbook"><simpara>
- À la place d&#39;un nom de fonction, un tableau contenant une référence d&#39;objet et un nom de méthode peut aussi
- être utilisé.
 </simpara></note>'>
 
 <!ENTITY note.func-callback-exceptions '<note xmlns="http://docbook.org/ns/docbook"><simpara>
@@ -279,11 +270,6 @@ de nombres aléatoires est initialisé automatiquement.</entry></row>'>
 <!ENTITY deprecated.function 'Cette fonction est obsolète.'>
 <!ENTITY removed.function 'Cette fonction a été supprimée.'>
 
-<!ENTITY warn.deprecated.feature-5-3-0.removed-5-4-0 '<warning xmlns="http://docbook.org/ns/docbook"><simpara>
- Cette fonctionnalité est <emphasis>OBSOLÈTE</emphasis> à partir de PHP 5.3.0 et a été
- <emphasis>SUPPRIMÉE</emphasis> à partir de PHP 5.4.0.
-</simpara></warning>'>
-
 <!ENTITY warn.deprecated.feature-5-6-0 '<warning xmlns="http://docbook.org/ns/docbook"><simpara>
  Cette fonctionnalité est <emphasis>OBSOLÈTE</emphasis> à partir de PHP 5.6.0.
  Dépendre de cette fonctionnalité est fortement déconseillé.
@@ -306,11 +292,6 @@ de nombres aléatoires est initialisé automatiquement.</entry></row>'>
  Dépendre de cette fonction est fortement déconseillé.
 </simpara></warning>'>
 
-<!ENTITY warn.deprecated.feature-7-2-0 '<warning xmlns="http://docbook.org/ns/docbook"><simpara>
- Cette fonctionnalité est <emphasis>OBSOLÈTE</emphasis> à partir de PHP 7.2.0.
- Dépendre de cette fonctionnalité est fortement déconseillé.
-</simpara></warning>'>
-
 <!ENTITY warn.deprecated.feature-7-2-0.removed-8-0-0 '<warning xmlns="http://docbook.org/ns/docbook"><simpara>
  Cette fonctionnalité est <emphasis>OBSOLÈTE</emphasis> à partir de PHP 7.2.0,
  et <emphasis>SUPPRIMÉE</emphasis> à partir de PHP 8.0.0.
@@ -331,11 +312,6 @@ de nombres aléatoires est initialisé automatiquement.</entry></row>'>
 xmlns="http://docbook.org/ns/docbook"><simpara>
  Cette fonction est <emphasis>OBSOLÈTE</emphasis> à partir de PHP 7.3.0,
  et a été <emphasis>SUPPRIMÉE</emphasis> à partir de PHP 8.0.0.
- Dépendre de cette fonction est fortement déconseillé.
-</simpara></warning>'>
-
-<!ENTITY warn.deprecated.function-7-4-0 '<warning xmlns="http://docbook.org/ns/docbook"><simpara>
- Cette fonction est <emphasis>OBSOLÈTE</emphasis> à partir de PHP 7.4.0.
  Dépendre de cette fonction est fortement déconseillé.
 </simpara></warning>'>
 
@@ -400,11 +376,6 @@ certainement <emphasis xmlns="http://docbook.org/ns/docbook">supprimée</emphasi
 <!ENTITY warn.deprecated.alias-5-4-0 '<warning xmlns="http://docbook.org/ns/docbook"><simpara>
  Cet alias est <emphasis>OBSOLÈTE</emphasis> à partir de PHP 5.4.0.
  Dépendre de cet alias est fortement déconseillé.
-</simpara></warning>'>
-
-<!ENTITY warn.deprecated.alias-5-3-0.removed-7-0-0 '<warning xmlns="http://docbook.org/ns/docbook"><simpara>
- Cet alias est <emphasis>OBSOLÈTE</emphasis> à partir de PHP 5.4.0. et a été
- <emphasis>SUPPRIMÉE</emphasis> à partir de PHP 7.0.0.
 </simpara></warning>'>
 
 <!ENTITY warn.removed.function-7-0-0 '<warning xmlns="http://docbook.org/ns/docbook"><simpara>
@@ -520,10 +491,6 @@ Il est fortement recommandé de les éviter.</simpara></warning>
 <!ENTITY example.outputs '<simpara xmlns="http://docbook.org/ns/docbook">L&#39;exemple ci-dessus va afficher :</simpara>'>
 
 <!ENTITY example.outputs.5 '<simpara xmlns="http://docbook.org/ns/docbook">Résultat de l&#39;exemple ci-dessus en PHP 5 :</simpara>'>
-
-<!ENTITY example.outputs.53 '<simpara xmlns="http://docbook.org/ns/docbook">Résultat de l&#39;exemple ci-dessus en PHP 5.3 :</simpara>'>
-
-<!ENTITY example.outputs.54 '<simpara xmlns="http://docbook.org/ns/docbook">Résultat de l&#39;exemple ci-dessus en PHP 5.4 :</simpara>'>
 
 <!ENTITY example.outputs.55 '<simpara xmlns="http://docbook.org/ns/docbook">Résultat de l&#39;exemple ci-dessus en PHP 5.5 :</simpara>'>
 
@@ -1535,10 +1502,6 @@ Chaque appel à une fonction date/heure générera un diagnostic de type
 <constant>E_WARNING</constant> si le fuseau horaire n&#39;est pas valide.
 Voir aussi <function>date_default_timezone_set</function></simpara>'>
 
-<!ENTITY date.timezone.errors.changelog '<row xmlns="http://docbook.org/ns/docbook"><entry>5.1.0</entry><entry><simpara>
-    Émet un message de type <constant>E_STRICT</constant> et <constant>E_NOTICE</constant>
-    lors d&#39;erreurs de fuseaux horaires.</simpara></entry></row>'>
-
 <!ENTITY date.timestamp.description '
 <varlistentry xmlns="http://docbook.org/ns/docbook"><term><parameter>timestamp</parameter></term><listitem><simpara>
     Le paramètre optionnel <parameter>timestamp</parameter> est un timestamp
@@ -2082,8 +2045,6 @@ Acrobat Distiller™, soit par Ghostview.</simpara>'>
 <!-- Common pieces in partintro-sections -->
 <!ENTITY no.config '<simpara xmlns="http://docbook.org/ns/docbook">Cette extension ne définit aucune directive de
 configuration.</simpara>'>
-<!ENTITY no.resource '<simpara xmlns="http://docbook.org/ns/docbook">Cette extension ne définit aucune ressource.</simpara>'>
-<!ENTITY no.constants '<simpara xmlns="http://docbook.org/ns/docbook">Cette extension ne définit aucune constante.</simpara>'>
 <!ENTITY no.requirement '<simpara xmlns="http://docbook.org/ns/docbook">Aucune bibliothèque externe n&#39;est nécessaire pour compiler cette extension.</simpara>'>
 <!ENTITY no.install '<simpara xmlns="http://docbook.org/ns/docbook">Il n&#39;y pas d&#39;installation nécessaire pour
 utiliser ces fonctions, elles font parties du cœur de PHP.</simpara>'>


### PR DESCRIPTION
Follows php/doc-en#5628 (commit de78d65), which removed 11 unused entities from language-snippets.ent and recorded them as tombstones. None of them is referenced by a French file (checked with a grep for each entity over reference/, language/, appendices/ and the rest of the tree), so the French definitions are dropped as well. EN-Revision hash updated.

Fixes: #3283