### PR TITLE
Fix accented filename in imagick/functionimage figure reference

### DIFF
--- a/reference/imagick/imagick/functionimage.xml
+++ b/reference/imagick/imagick/functionimage.xml
@@ -90,7 +90,7 @@ echo $imagick->getImageBlob();
     <mediaobject>
      <alt>Résultat de la création d'un gradient sinusoïdal</alt>
      <imageobject>
-      <imagedata fileref="en/reference/imagick/figures/functionImage_sinusoïdal.png"/>
+      <imagedata fileref="en/reference/imagick/figures/functionImage_sinusoidal.png"/>
      </imageobject>
     </mediaobject>
    </example>


### PR DESCRIPTION
Fixes #3315

The figure references  (with diaeresis) but the actual file in doc-en is named .