### PR TITLE
[Sync-En] pcre: replace inline note with xref for atomic groups

### DIFF
--- a/reference/pcre/pattern.syntax.xml
+++ b/reference/pcre/pattern.syntax.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: c083c88c8e7ed7eb0d14662c0471693dcac42daf Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 3e1cd2462664adb2495cff5887671ba8a9909cf9 Maintainer: yannick Status: ready -->
 
 <chapter xml:id="reference.pcre.pattern.syntax" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Syntaxe des masques</title>
  <titleabbrev>Fonctionnement des expressions régulières</titleabbrev>
 
  <section xml:id="regexp.introduction">
-  &reftitle.intro;
+  <title>Introduction</title>
   <para>
    La syntaxe et la sémantique des expressions régulières
    supportées par PCRE sont décrites dans cette section. Les expressions
@@ -1169,17 +1169,17 @@
    caractère composé, peu importe le nombre de caractères individuels
    nécessaire à l'afficher.
   </para>
-  <para>
+  <simpara>
    Dans les versions PCRE inférieures à 8.32 (ce qui correspond aux
    versions de PHP antérieures à la version 5.4.14 lorsque la
    bibliothèque interne est utilisée), <literal>\X</literal> était
    équivalent à <literal>(?>\PM\pM*)</literal>. Aussi, il matchait
    un caractère sans propriété "mark", suivi par aucun ou plusieurs
    caractères possédant la propriété "mark", et traitait la séquence
-   comme un groupe atomique (voir ci-dessous). Les caractères
-   avec la propriété "mark" sont typiquement les lettres accentuées
-   qui affectent le caractère qui la précède.
-  </para>
+   comme un groupe atomique (voir <xref linkend="regexp.reference.onlyonce"/>).
+   Les caractères avec la propriété "mark" sont typiquement les lettres
+   accentuées qui affectent le caractère qui la précède.
+  </simpara>
   <para>
    La recherche de caractères par les propriétés Unicode n'est pas la méthode
    la plus rapide, car PCRE doit chercher une structure qui contient les données
@@ -2193,6 +2193,9 @@
  
  <section xml:id="regexp.reference.onlyonce">
   <title>Sous-masques uniques</title>
+  <simpara>
+   Les sous-masques uniques sont également connus sous le nom de <emphasis>groupes atomiques</emphasis>.
+  </simpara>
   <para>
    Avec les quantificateurs de répétitions, l'échec
    d'une recherche conduit normalement à une autre recherche, avec


### PR DESCRIPTION
Closes #3334

Sync with https://github.com/php/doc-en/commit/3e1cd2462664adb2495cff5887671ba8a9909cf9

- Change `<para>` to `<simpara>` for the `\X` / atomic group description
- Replace the vague "voir ci-dessous" with an explicit `<xref>` to the "Sous-masques uniques" section
- Add a note in that section that once-only subpatterns are also known as atomic groups