### PR TITLE
[Sync-En] outcontrol: clarify ob_get_status buffer_size and ob_start chunk_size

### DIFF
--- a/reference/outcontrol/functions/ob-get-status.xml
+++ b/reference/outcontrol/functions/ob-get-status.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: af7044e82ac0abe745ce3dfe2169e69a7e8e342f Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 1ebafd8a44786824396f95102576426462835869 Maintainer: yannick Status: ready -->
 <refentry xml:id="function.ob-get-status" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>ob_get_status</refname>
@@ -108,7 +107,15 @@
     <seglistitem>
      <seg>buffer_size</seg>
      <seg>
-      Taille du tampon de sortie en octets
+      Taille actuellement allouée du tampon de sortie en octets.
+      Elle démarre à <literal>16384</literal> octets avec le
+      <parameter>chunk_size</parameter> par défaut, ou à
+      <parameter>chunk_size</parameter> arrondi au prochain multiple de
+      <literal>4096</literal> lorsqu'une valeur est fournie, et croît par
+      multiples de <literal>4096</literal> au fur et à mesure que des données
+      sont mises en tampon.
+      Ce n'est pas la quantité de données dans le tampon (voir
+      <literal>buffer_used</literal>).
      </seg>
     </seglistitem>
     <seglistitem>

--- a/reference/outcontrol/functions/ob-start.xml
+++ b/reference/outcontrol/functions/ob-start.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e58094c4537a9ac89a6a0a7e64a4256d63e05514 Maintainer: yannick Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 1ebafd8a44786824396f95102576426462835869 Maintainer: yannick Status: ready -->
 <refentry xml:id="function.ob-start" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>ob_start</refname>
@@ -111,15 +110,22 @@
     <varlistentry>
      <term><parameter>chunk_size</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Si le paramètre optionnel <parameter>chunk_size</parameter> est passé,
        la mémoire tampon sera vidée après tout bloc de code résultant en une sortie
        qui fait que la longueur de la mémoire tampon égale ou dépasse
        <parameter>chunk_size</parameter>.
        La valeur par défaut <literal>0</literal> signifie
        que toute la sortie est mise en mémoire tampon jusqu'à ce que la mémoire tampon soit désactivée.
+       Une valeur de <literal>1</literal> signifie que la mémoire tampon sera vidée
+       après chaque opération de sortie, désactivant ainsi effectivement la mise en mémoire tampon.
+       <parameter>chunk_size</parameter> détermine également la taille initiale du tampon
+       rapportée par <function>ob_get_status</function> :
+       <literal>16384</literal> octets lorsqu'il vaut <literal>0</literal>, et
+       <parameter>chunk_size</parameter> arrondi au prochain multiple de
+       <literal>4096</literal> sinon.
        Consulter <xref linkend="outcontrol.buffer-size"/> pour plus de détails.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>


### PR DESCRIPTION
Closes #3338

Sync with https://github.com/php/doc-en/commit/1ebafd8a44786824396f95102576426462835869

- `ob_get_status`: expand `buffer_size` description to clarify it is the allocated buffer size, not data size
- `ob_start`: change `<para>` to `<simpara>` for `chunk_size`, document the `1` behavior and how chunk_size affects initial buffer size