### PR TITLE
[Sync-En] flock: document Windows deadlock; modernize Apache httpd install guide

### DIFF
--- a/install/unix/apache2.xml
+++ b/install/unix/apache2.xml
@@ -1,49 +1,72 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: a38e360ae1ce4169b331013958c519d17f19114e Maintainer: lacatoire Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: fd1f9d85122cd85854f4afdf5a57ab7da38ff69c Maintainer: lacatoire Status: ready -->
 
 <sect1 xml:id="install.unix.apache2" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
- <title>Apache 2.x sur les systèmes Unix</title>
- <para>
+ <title>Apache httpd 2.x sur les systèmes Unix</title>
+
+ <simpara>
   Cette section contient les notes et conseils d'installation de PHP avec le serveur
-  Apache 2.x sur les systèmes Unix.
- </para>
- 
- &warn.apache2.compat;
- 
- <para>
+  HTTP Apache 2.x sur les systèmes Linux et de type Unix.
+ </simpara>
+
+ <warning>
+  <title>Utiliser PHP-FPM à la place</title>
+  <simpara>
+   <emphasis role="strong">Ne pas utiliser <literal>mod_php</literal> pour les nouvelles
+   installations.</emphasis> Les instructions de cette page sont conservées
+   à titre de référence historique et pour les rares cas où l'intégration de PHP
+   directement dans le processus Apache httpd est spécifiquement requise.
+  </simpara>
+  <simpara>
+   Pour tous les déploiements modernes, utiliser
+   <link linkend="install.fpm">PHP-FPM</link> (FastCGI Process Manager)
+   avec le module <literal>mod_proxy_fcgi</literal> d'Apache httpd. PHP-FPM
+   offre une meilleure gestion des ressources, l'isolation des processus, le redémarrage
+   indépendant de PHP sans redémarrer Apache httpd, et la compatibilité avec le MPM
+   <literal>event</literal> d'Apache httpd (le MPM par défaut depuis Apache httpd 2.4).
+   Les principales distributions Linux utilisent cette configuration par défaut.
+  </simpara>
+  <simpara>
+   L'approche <literal>mod_php</literal> intègre PHP directement dans chaque processus
+   worker d'Apache httpd. Sauf si PHP est compilé avec la sécurité des threads
+   (<literal>--enable-zts</literal>), <literal>mod_php</literal> requiert
+   le MPM <literal>prefork</literal>, ce qui limite significativement la
+   simultanéité. L'utilisation de <literal>mod_php</literal> implique
+   de bien comprendre les implications en termes de performances et de sécurité.
+  </simpara>
+ </warning>
+
+ <simpara>
   La <link xlink:href="&url.apache2.docs;">Documentation Apache</link>
-  est la meilleure source d'informations sur le serveur Apache 2.x.
-  La plupart des informations sur les options d'installation d'Apache
+  est la meilleure source d'informations sur le serveur Apache httpd 2.x.
+  La plupart des informations sur les options d'installation d'Apache httpd
   peut y être trouvée.
- </para>
- 
- <para>
-  La version la plus récente du serveur HTTP Apache peut être obtenue
+ </simpara>
+
+ <simpara>
+  La version la plus récente d'Apache httpd peut être obtenue
   depuis la <link xlink:href="&url.apache;">page de téléchargement d'Apache</link>,
   et une version adaptée de PHP depuis les liens ci-dessus.
-  Ce guide couvre uniquement les bases de fonctionnement d'Apache 2.x avec PHP.     
+  Ce guide couvre uniquement les bases de fonctionnement d'Apache httpd 2.x avec PHP.
   Pour plus d'informations, lire la
   <link xlink:href="&url.apache2.docs;">documentation Apache</link>.
   Les numéros de version sont omis ici, pour s'assurer que les instructions ne soient
   pas incorrectes. Dans les exemples ci-dessous, 'NN' devra être remplacé
-  par la version spécifique d'Apache à utiliser.
- </para>
- 
- <para>
-  Il y a actuellement 2 versions d'Apache 2.x - 2.4 et 2.2.
-  Il y a plusieurs raisons de choisir l'une plutôt que l'autre ; néanmoins, la version
-  2.4 est actuellement la dernière version disponible et c'est aussi celle
-  qui est recommandée. Cependant, les instructions contenues
-  dans ce guide devraient fonctionner pour la version 2.4 comme pour la version 2.2. Note : Apache httpd 2.2 est officiellement en fin de vie, il n'y aura plus de développement ni de correctif pour cette version.
- </para>
- 
+  par la version spécifique d'Apache httpd à utiliser.
+ </simpara>
+
+ <simpara>
+  Ces instructions s'appliquent à Apache httpd 2.4, qui est la seule branche
+  de version supportée d'Apache httpd. Les versions antérieures (2.2 et inférieures)
+  sont en fin de vie et ne doivent pas être utilisées.
+ </simpara>
+
  <orderedlist>
   <listitem>
-   <para>
-    Télécharger le serveur HTTP Apache depuis le site ci-dessus et le décompresser :
-   </para>
-   
+   <simpara>
+    Télécharger Apache httpd depuis le site ci-dessus et le décompresser :
+   </simpara>
+
    <informalexample>
     <screen>
 <![CDATA[
@@ -52,12 +75,12 @@ tar -xzf httpd-2.x.NN.tar.gz
     </screen>
    </informalexample>
   </listitem>
-  
+
   <listitem>
-   <para>
+   <simpara>
     De la même façon, télécharger et décompresser les sources de PHP :
-   </para>
-   
+   </simpara>
+
    <informalexample>
     <screen>
 <![CDATA[
@@ -66,31 +89,36 @@ tar -xzf php-NN.tar.gz
     </screen>
    </informalexample>
   </listitem>
-  
+
   <listitem>
-   <para>
-    Compiler et installer Apache. Consulter la documentation sur l'installation
-    d'Apache pour plus de détails quant à la compilation de ce logiciel.
-   </para>
-   
+   <simpara>
+    Compiler et installer Apache httpd. Consulter la documentation sur l'installation
+    d'Apache httpd pour plus de détails. Il est à noter que <literal>mod_php</literal>
+    requiert le MPM <literal>prefork</literal>, sauf si PHP a été compilé
+    avec la sécurité des threads (<literal>--enable-zts</literal>). Pour
+    utiliser PHP-FPM à la place (recommandé), il est possible d'utiliser le MPM
+    <literal>event</literal> par défaut et passer directement aux
+    <link linkend="install.fpm">instructions d'installation de PHP-FPM</link>.
+   </simpara>
+
    <informalexample>
     <screen>
 <![CDATA[
 cd httpd-2_x_NN
-./configure --enable-so
+./configure --enable-so --with-mpm=prefork
 make
 make install
 ]]>
     </screen>
    </informalexample>
   </listitem>
-  
+
   <listitem>
    <para>
-    Maintenant qu'Apache 2.x.NN est disponible sous /usr/local/apache2,
-    le configurer avec le support pour le chargement de modules, ainsi que le
-    MPM prefork standard. Pour tester l'installation, utiliser la procédure
-    normale pour démarrer le serveur Apache, c.-à-d. :
+    Maintenant qu'Apache httpd 2.x.NN est disponible sous /usr/local/apache2,
+    configuré avec le support du chargement de modules et le MPM prefork.
+    Pour tester l'installation, utiliser la procédure normale pour démarrer
+    le serveur Apache httpd, c.-à-d. :
 
     <informalexample>
      <screen>
@@ -99,8 +127,9 @@ make install
 ]]>
      </screen>
     </informalexample>
+
     et l'arrêter pour continuer la configuration de PHP :
-    
+
     <informalexample>
      <screen>
 <![CDATA[
@@ -110,24 +139,24 @@ make install
     </informalexample>
    </para>
   </listitem>
-  
+
   <listitem>
-   
-   <para>
+   <simpara>
     Maintenant, configurer et compiler PHP. Ce sera à ce moment-là
     où il est possible de personnaliser PHP avec les diverses options disponibles,
     comme la liste des extensions à activer. Exécuter
     <command>./configure --help</command> pour la liste des options disponibles. Dans notre exemple, nous effectuerons
-    une configuration simple, avec Apache 2 et le support MySQL.
-   </para>
-   
-   <para>
-    Si Apache a été construit depuis les sources, tel que décrit ci-dessus,
+    une configuration simple, avec Apache httpd et le support MySQL.
+   </simpara>
+
+   <simpara>
+    Si Apache httpd a été construit depuis les sources, tel que décrit ci-dessus,
     l'exemple suivant devrait être correct concernant les chemins vers <command>apxs</command>, mais si
-    Apache a été installé d'une autre façon, il faut prendre en compte les
+    Apache httpd a été installé d'une autre façon, il faut prendre en compte les
     spécificités et ajuster les chemins <command>apxs</command> en conséquence. Il est à noter que suivant
     les distributions, il peut être nécessaire de renommer <command>apxs</command> en <command>apxs2</command>.
-   </para>
+   </simpara>
+
    <informalexample>
     <screen>
 <![CDATA[
@@ -138,27 +167,28 @@ make install
 ]]>
     </screen>
    </informalexample>
-   
-   <para>
+
+   <simpara>
     En cas de modification des options de configuration après l'installation,
-    il faut exécuter de nouveau les étapes <command>configure</command>, <command>make</command> et <command>make install</command>.
+    il faut exécuter de nouveau les étapes <command>configure</command>, <command>make</command>
+    et <command>make install</command>.
     Il suffit alors de redémarrer Apache pour que le nouveau module prenne effet.
-    Une re-compilation d'Apache n'est pas nécessaire.
-   </para>
-   
+    Une re-compilation d'Apache httpd n'est pas nécessaire.
+   </simpara>
+
    <para>
-    Il est à noter que, sauf indications contraires, l'étape "make install" installera
-    également <link xlink:href="&url.php.pear;">PEAR</link>, mais aussi divers outils PHP comme <link linkend="install.pecl.phpize">phpize</link>, PHP CLI et
-    bien plus encore.
+    Il est à noter que, sauf indications contraires, l'étape <command>make install</command>
+    installera également <link xlink:href="&url.php.pear;">PEAR</link>,
+    divers outils PHP comme <link linkend="install.pecl.phpize">phpize</link>,
+    PHP CLI et bien plus encore.
    </para>
-   
   </listitem>
-  
+
   <listitem>
-   <para>
+   <simpara>
     Configurer le fichier <filename>php.ini</filename>.
-   </para>
-   
+   </simpara>
+
    <informalexample>
     <screen>
 <![CDATA[
@@ -166,68 +196,50 @@ cp php.ini-development /usr/local/lib/php.ini
 ]]>
     </screen>
    </informalexample>
-   
-   <para>
-    Il faut éditer le fichier .ini pour définir les options PHP.
+
+   <simpara>
+    Il faut éditer le fichier <literal>.ini</literal> pour définir les options PHP.
     Pour placer ce fichier dans un autre répertoire, utiliser
     l'option <literal>--with-config-file-path=/some/path</literal> à l'étape 5.
-   </para>
-   
-   <para>
-    En cas d'utilisation du fichier php.ini-production, il faut s'assurer de lire la liste
-    des modifications correspondante car il peut affecter considérablement la façon
-    dont PHP fonctionnera.
-   </para>
-   
+   </simpara>
+
+   <simpara>
+    En cas d'utilisation du fichier <filename>php.ini-production</filename>, il faut s'assurer
+    de lire la liste des modifications correspondante car il peut affecter considérablement
+    la façon dont PHP fonctionnera.
+   </simpara>
   </listitem>
-  
+
   <listitem>
-   
-   <para>
+   <simpara>
     Éditer le fichier <filename>httpd.conf</filename> pour charger le module PHP. Le chemin spécifié
-    à droite de la chaîne LoadModule, doit correspondre au chemin système du module
-    PHP. L'étape "make install" ci-dessus devrait avoir réalisé cette opération
-    automatiquement, mais une simple vérification permettra de s'en assurer.
-   </para>
+    à droite de l'instruction <literal>LoadModule</literal> doit correspondre au chemin système
+    du module PHP. L'étape <command>make install</command> ci-dessus devrait avoir réalisé
+    cette opération automatiquement, mais une simple vérification permettra de s'en assurer.
+   </simpara>
 
    <informalexample>
-    <para>
-     Pour PHP 8:
-    </para>
     <programlisting role="apache-conf">
 <![CDATA[
 LoadModule php_module modules/libphp.so
 ]]>
     </programlisting>
    </informalexample>
-   
-   <informalexample>
-    <para>
-     Pour PHP 7:
-    </para>
-    <programlisting role="apache-conf">
-<![CDATA[
-LoadModule php7_module modules/libphp7.so
-]]>
-    </programlisting>
-   </informalexample>
-   
   </listitem>
-  
+
   <listitem>
-   
-   <para>
-    Configurer Apache pour analyser certaines extensions comme étant des scripts PHP.
-    Par exemple, laisser Apache passer à PHP les fichiers dont l'extension est
+   <simpara>
+    Configurer Apache httpd pour analyser certaines extensions comme étant des scripts PHP.
+    Par exemple, laisser Apache httpd passer à PHP les fichiers dont l'extension est
     <literal>.php</literal>.
-    Au lieu d'utiliser seulement la directive <literal>AddType</literal> d'Apache,
-    nous souhaitons éviter tout risque potentiellement dangereux, lors
-    d'un téléchargement et de la création de fichier comme <filename>exploit.php.jpg</filename>,
+    Au lieu d'utiliser seulement la directive <literal>AddType</literal>,
+    nous souhaitons éviter tout risque potentiellement dangereux lors
+    d'un téléchargement et de la création de fichiers comme <filename>exploit.php.jpg</filename>,
     d'être exécutés par PHP. En utilisant cet exemple, il est possible d'avoir n'importe
-    quelle extension analysée par PHP. Nous avons ajouté <literal>.php</literal> pour l'exemple.
-   </para>
-   
-   
+    quelle extension analysée par PHP, simplement en les ajoutant. Nous avons ajouté
+    <literal>.php</literal> pour l'exemple.
+   </simpara>
+
    <informalexample>
     <programlisting role="apache-conf">
 <![CDATA[
@@ -237,30 +249,30 @@ LoadModule php7_module modules/libphp7.so
 ]]>
     </programlisting>
    </informalexample>
-   
+
    <para>
     Ou, pour autoriser les fichiers <literal>.php</literal>, <literal>.php2</literal>,
     <literal>.php3</literal>, <literal>.php4</literal>, <literal>.php5</literal>,
     <literal>.php6</literal>, et <literal>.phtml</literal> à être
     analysés par PHP, mais rien d'autre, nous utiliserons ceci :
    </para>
-   
+
    <informalexample>
     <programlisting role="apache-conf">
 <![CDATA[
-<FilesMatch "\.ph(p[2-6]?|tml)$">
+<FilesMatch "\.(php[2-6]?|phtml)$">
     SetHandler application/x-httpd-php
 </FilesMatch>
 ]]>
     </programlisting>
    </informalexample>
-   
+
    <para>
     Et pour autoriser les fichiers <literal>.phps</literal> à être gérés par le filtre du code
-    source de PHP, et ainsi, être affichés comme code source avec la coloration
+    source de PHP, et ainsi être affichés comme code source avec la coloration
     syntaxique, utiliser ceci :
    </para>
-   
+
    <informalexample>
     <programlisting role="apache-conf">
 <![CDATA[
@@ -275,7 +287,6 @@ LoadModule php7_module modules/libphp7.so
     Pour permettre l'utilisation d'un fichier PHP comme gestionnaire par défaut lorsqu'aucun
     autre gestionnaire n'est trouvé, par exemple lors de l'utilisation d'un moteur de routage,
     la directive <literal>FallbackResource</literal> peut être utilisée.
-    Elle est disponible à partir d'Apache 2.4.4.
    </simpara>
 
    <simpara>
@@ -305,7 +316,7 @@ FallbackResource /index.php
     d'être affiché comme code source avec coloration syntaxique, sans pour autant
     avoir besoin de le renommer ou de le copier avec une extension <literal>.phps</literal> :
    </para>
-   
+
    <informalexample>
     <programlisting role="apache-conf">
 <![CDATA[
@@ -314,20 +325,19 @@ RewriteRule (.*\.php)s$ $1 [H=application/x-httpd-php-source]
 ]]>
     </programlisting>
    </informalexample>
-   
-   <para>
+
+   <simpara>
     Le filtre de code source PHP ne devrait pas être actif sur des systèmes de
     production, car il peut exposer du code confidentiel ou des informations
     sensibles contenues dans le code source.
-   </para>
-   
+   </simpara>
   </listitem>
-  
+
   <listitem>
-   <para>
-    Utiliser la procédure normale pour démarrer le serveur Apache, c.-à-d. :
-   </para>
-   
+   <simpara>
+    Utiliser la procédure normale pour démarrer Apache httpd, c.-à-d. :
+   </simpara>
+
    <informalexample>
     <screen>
 <![CDATA[
@@ -335,9 +345,9 @@ RewriteRule (.*\.php)s$ $1 [H=application/x-httpd-php-source]
 ]]>
     </screen>
    </informalexample>
-   
+
    <para>Ou</para>
-   
+
    <informalexample>
     <screen>
 <![CDATA[
@@ -345,52 +355,44 @@ service httpd restart
 ]]>
     </screen>
    </informalexample>
-   
+
   </listitem>
  </orderedlist>
- 
- <para>
-  En ayant suivi les étapes précédentes, le serveur web est maintenant un
-  Apache2 fonctionnel avec le support PHP comme module <literal>SAPI</literal>.
-  Bien sûr, il y a une multitude d'autres options de configuration de disponibles
-  avec Apache et PHP. Pour plus d'informations, entrer la commande
+
+ <simpara>
+  En ayant suivi les étapes précédentes, le serveur web Apache httpd est maintenant
+  fonctionnel avec le support PHP comme module <literal>SAPI</literal>.
+  Il y a une multitude d'autres options de configuration disponibles
+  avec Apache httpd et PHP. Pour plus d'informations, entrer la commande
   <command>./configure --help</command> dans l'arbre source correspondant.
- </para>
- <para>
-  Apache peut être compilé en mode multithreadé, en sélectionnant
-  le MPM <filename>worker</filename>, plutôt que le standard
-  MPM <filename>prefork</filename>. Ceci est fait en ajoutant l'option
-  suivante à l'argument de la commande "./configure", à l'étape 3 ci-dessus :
- </para>
- <informalexample>
-  <screen>
-<![CDATA[
---with-mpm=worker
-]]>
-  </screen>
- </informalexample>
- <para>
-  Cela ne devrait pas être entrepris sans être conscients des conséquences,
-  et ayant au moins une juste compréhension de ce que cela implique.
-  La documentation Apache concernant
-  <link xlink:href="&url.apache2.mpm;">MPM-Modules</link>
-  apportera d'importantes informations qui permettront de prendre
-  une décision.
- </para>
+ </simpara>
+
  <note>
-  <para>
+  <title>Compatibilité MPM</title>
+  <simpara>
+   Sauf si PHP a été compilé avec la sécurité des threads Zend
+   (<literal>--enable-zts</literal>), <literal>mod_php</literal> requiert
+   le MPM <literal>prefork</literal>.
+   Pour savoir pourquoi, lire l'entrée de la FAQ correspondante sur l'utilisation
+   d'<link linkend="faq.installation.apache2">Apache httpd avec un MPM
+   threadé</link>.
+  </simpara>
+
+  <simpara>
+   La plupart des paquets de distribution de
+   <literal>mod_php</literal> ne sont pas compilés avec ZTS, donc
+   <literal>prefork</literal> est généralement requis. Si vous avez besoin d'un
+   MPM threadé (recommandé pour de meilleures performances sous charge), utiliser
+   <link linkend="install.fpm">PHP-FPM</link> avec
+   <literal>mod_proxy_fcgi</literal> à la place.
+  </simpara>
+ </note>
+
+ <note>
+  <simpara>
    La <link linkend="faq.installation.apache.multiviews">FAQ Apache
    MultiViews</link> traite de l'utilisation MultiViews avec PHP.
-  </para>
- </note>
- <note>
-  <para>
-   Pour compiler une version multithreadée d'Apache, le système cible
-   doit supporter les threads. Dans ce cas, PHP doit également être construit
-   avec Zend Thread Safety (ZTS). Sous cette configuration, toutes les extensions
-   ne seront pas disponibles. La configuration recommandée est de compiler Apache avec le
-   module MPM <filename>prefork</filename> par défaut.
-  </para>
+  </simpara>
  </note>
 </sect1>
 <!-- Keep this comment at the end of the file

--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: de78d65ef7785a167268b3cb5d5268b13bb9f358 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: fd1f9d85122cd85854f4afdf5a57ab7da38ff69c Maintainer: lacatoire Status: ready -->
 <!-- Relecture des Notes, Précautions, Avertissements, Astuces, Divers et Retour le 2018-12-29 par girgias -->
 
 <!--
@@ -2412,12 +2412,6 @@ défaut, mais vous pouvez changer cela en utilisant l&#39;argument
 <!ENTITY tidy.object 'L&#39;objet <classname xmlns="http://docbook.org/ns/docbook">Tidy</classname>'>
 
 <!-- Snippets for the installation section -->
-<!ENTITY warn.apache2.compat '<warning xmlns="http://docbook.org/ns/docbook"><simpara>Nous ne recommandons pas
-    l&#39;utilisation de PHP dans un environnement threadé MPM, avec Apache 2.
-    Utilisez le mode prefork MPM, qui est le MPM par défaut pour Apache 2.0 et 2.2.
-    Pour savoir pourquoi, lisez
-    l&#39;entrée de la FAQ correspondante à l&#39;<link linkend="faq.installation.apache2">utilisation
-        d&#39;Apache 2 dans un environnement threadé MPM</link>.</simpara></warning>'>
 <!ENTITY warn.install.third-party-support '<warning xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <simpara>
   Les versions provenant de tiers sont considérées comme non officielles et ne

--- a/reference/filesystem/functions/flock.xml
+++ b/reference/filesystem/functions/flock.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 75a76afb61d91f04feebc83931c5412b13682d2b Maintainer: lacatoire Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: f3112c43e303fcd63c0df89798b45bfef9d49e15 Maintainer: lacatoire Status: ready -->
 <refentry xml:id="function.flock" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>flock</refname>
@@ -193,6 +192,23 @@ fclose($fp);
     comme <literal>FAT</literal> et ses dérivés, et retourne forcément
     &false; sous ces environnements.
    </para>
+   <para>
+    Sur Windows, si PHP essaie d'exécuter un fichier source PHP verrouillé par
+    <constant>LOCK_EX</constant>, il va se bloquer jusqu'à ce que le fichier soit
+    déverrouillé. L'exemple suivant provoquera un interblocage :
+    <informalexample>
+     <programlisting role="php">
+<![CDATA[
+<?php
+if ($argv[1] ?? null === 'child') { die(); }
+$fp = fopen(__FILE__, "rb");
+flock($fp, LOCK_EX);
+shell_exec("php " . escapeshellarg(__FILE__) . " child");
+?>
+]]>
+     </programlisting>
+    </informalexample>
+   </para>
   </warning>
   <note>
    <para>
@@ -200,6 +216,11 @@ fclose($fp);
     il ne peut pas accéder au fichier à travers ce gestionnaire jusqu'à ce que
     le fichier soit déverrouillé.
    </para>
+   <simpara>
+    Sur Windows, si vous essayez d'inclure avec <literal>require</literal> un fichier
+    verrouillé par <constant>LOCK_EX</constant>, cela échouera avec l'erreur :
+    ErrorException: require(): Read of X bytes failed with errno=13 Permission denied
+   </simpara>
   </note>
  </refsect1>
  

--- a/reference/outcontrol/functions/ob-get-status.xml
+++ b/reference/outcontrol/functions/ob-get-status.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: af7044e82ac0abe745ce3dfe2169e69a7e8e342f Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 1ebafd8a44786824396f95102576426462835869 Maintainer: yannick Status: ready -->
 <refentry xml:id="function.ob-get-status" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>ob_get_status</refname>
@@ -108,7 +107,15 @@
     <seglistitem>
      <seg>buffer_size</seg>
      <seg>
-      Taille du tampon de sortie en octets
+      Taille actuellement allouée du tampon de sortie en octets.
+      Elle démarre à <literal>16384</literal> octets avec le
+      <parameter>chunk_size</parameter> par défaut, ou à
+      <parameter>chunk_size</parameter> arrondi au prochain multiple de
+      <literal>4096</literal> lorsqu'une valeur est fournie, et croît par
+      multiples de <literal>4096</literal> au fur et à mesure que des données
+      sont mises en tampon.
+      Ce n'est pas la quantité de données dans le tampon (voir
+      <literal>buffer_used</literal>).
      </seg>
     </seglistitem>
     <seglistitem>

--- a/reference/outcontrol/functions/ob-start.xml
+++ b/reference/outcontrol/functions/ob-start.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e58094c4537a9ac89a6a0a7e64a4256d63e05514 Maintainer: yannick Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 1ebafd8a44786824396f95102576426462835869 Maintainer: yannick Status: ready -->
 <refentry xml:id="function.ob-start" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>ob_start</refname>
@@ -111,15 +110,22 @@
     <varlistentry>
      <term><parameter>chunk_size</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Si le paramètre optionnel <parameter>chunk_size</parameter> est passé,
        la mémoire tampon sera vidée après tout bloc de code résultant en une sortie
        qui fait que la longueur de la mémoire tampon égale ou dépasse
        <parameter>chunk_size</parameter>.
        La valeur par défaut <literal>0</literal> signifie
        que toute la sortie est mise en mémoire tampon jusqu'à ce que la mémoire tampon soit désactivée.
+       Une valeur de <literal>1</literal> signifie que la mémoire tampon sera vidée
+       après chaque opération de sortie, désactivant ainsi effectivement la mise en mémoire tampon.
+       <parameter>chunk_size</parameter> détermine également la taille initiale du tampon
+       rapportée par <function>ob_get_status</function> :
+       <literal>16384</literal> octets lorsqu'il vaut <literal>0</literal>, et
+       <parameter>chunk_size</parameter> arrondi au prochain multiple de
+       <literal>4096</literal> sinon.
        Consulter <xref linkend="outcontrol.buffer-size"/> pour plus de détails.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>


### PR DESCRIPTION
Closes #3326
Closes #3327

## flock (Closes #3326)

Sync with https://github.com/php/doc-en/commit/f3112c43e303fcd63c0df89798b45bfef9d49e15

- Add warning paragraph about Windows deadlock when executing a `LOCK_EX`'ed PHP file, with code example
- Add note about `require()` failing with Permission Denied on a `LOCK_EX`'ed file

## Apache httpd install guide + language-snippets.ent (Closes #3327)

Sync with https://github.com/php/doc-en/commit/fd1f9d85122cd85854f4afdf5a57ab7da38ff69c

- Add warning block recommending PHP-FPM instead of mod_php for new installations
- Update title and text to use "Apache httpd" consistently
- Remove Apache 2.2 references (EOL)
- Remove PHP 7 LoadModule example
- Add prefork MPM note to build step
- Add MPM Compatibility note section
- Remove `warn.apache2.compat` entity from `language-snippets.ent`