### PR TITLE
[Sync-En] cURL: document multi-handle behavior, update curl-multi-exec purpose, document socket_set_timeout deprecation

### DIFF
--- a/reference/curl/functions/curl-errno.xml
+++ b/reference/curl/functions/curl-errno.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: fc9a0a8b29a7a099998bdd71fe5350a10b18fe62 Maintainer: Fan2Shrek Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: ff7a0054b19ab80290b365d1417550807f82755a Maintainer: Fan2Shrek Status: ready -->
 <refentry xml:id="function.curl-errno" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>curl_errno</refname>
@@ -32,6 +31,15 @@
   <para>
    Retourne le numéro de l'erreur ou <literal>0</literal> si aucune erreur n'est survenue.
   </para>
+  <note>
+   <simpara>
+    Lorsqu'un <type>CurlHandle</type> est exécuté via
+    <function>curl_multi_exec</function>, cette fonction retourne toujours
+    <literal>0</literal>. Le code d'erreur pour chaque handle individuel est
+    disponible via la clé <literal>result</literal> retournée par
+    <function>curl_multi_info_read</function>.
+   </simpara>
+  </note>
  </refsect1>
 
  <refsect1 role="changelog">
@@ -83,6 +91,7 @@ if(curl_errno($ch))
   <para>
    <simplelist>
     <member><function>curl_error</function></member>
+    <member><function>curl_multi_info_read</function></member>
     <member><link xlink:href="&url.curl.error;">les codes erreurs cURL</link></member>
    </simplelist>
   </para>

--- a/reference/curl/functions/curl-error.xml
+++ b/reference/curl/functions/curl-error.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: fc9a0a8b29a7a099998bdd71fe5350a10b18fe62 Maintainer: Fan2Shrek Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: ff7a0054b19ab80290b365d1417550807f82755a Maintainer: Fan2Shrek Status: ready -->
 <refentry xml:id="function.curl-error" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>curl_error</refname>
@@ -33,6 +32,16 @@
    Retourne le message d'erreur ou <literal>''</literal> (chaîne vide) si aucune
    erreur n'est survenue.
   </para>
+  <note>
+   <simpara>
+    Lorsqu'un <type>CurlHandle</type> est exécuté via
+    <function>curl_multi_exec</function>, cette fonction retourne toujours
+    <literal>''</literal> (chaîne vide). Pour récupérer le message d'erreur pour
+    chaque handle individuel, passer la clé <literal>result</literal> retournée par
+    <function>curl_multi_info_read</function> à
+    <function>curl_strerror</function>.
+   </simpara>
+  </note>
  </refsect1>
 
  <refsect1 role="changelog">
@@ -84,6 +93,8 @@ else
   <para>
    <simplelist>
     <member><function>curl_errno</function></member>
+    <member><function>curl_strerror</function></member>
+    <member><function>curl_multi_info_read</function></member>
     <member><link xlink:href="&url.curl.error;">Curl error codes</link></member>
    </simplelist>
   </para>

--- a/reference/curl/functions/curl-multi-exec.xml
+++ b/reference/curl/functions/curl-multi-exec.xml
@@ -1,11 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 2ebb9660d47e648a28007960bf059d1f691c7f21 Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 13682c8c7717db18862829bfc3ce9dc4a006079d Maintainer: yannick Status: ready -->
 <refentry xml:id="function.curl-multi-exec" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>curl_multi_exec</refname>
-  <refpurpose>Exécute les sous-requêtes de la session cURL</refpurpose>
+  <refpurpose>Traite chaque handle dans la file</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -15,10 +14,10 @@
    <methodparam><type>CurlMultiHandle</type><parameter>multi_handle</parameter></methodparam>
    <methodparam><type>int</type><parameter role="reference">still_running</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Exécute chaque gestionnaire de la pile. Cette méthode peut être appelée
    même si un gestionnaire a besoin de lire ou d'écrire des données.
-  </para> 
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -40,10 +39,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Un code cURL, défini dans les <link linkend="curl.constants">constantes prédéfinies</link>
    cURL.
-  </para>
+  </simpara>
   <note>
    <para>
     Cette fonction ne retourne que des erreurs au regard de la pile. Des problèmes

--- a/reference/network/functions/socket-set-timeout.xml
+++ b/reference/network/functions/socket-set-timeout.xml
@@ -1,13 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 96c9d88bad9a7d7d44bfb7f26c226df7ee9ddf26 Maintainer: yannick Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 13682c8c7717db18862829bfc3ce9dc4a006079d Maintainer: yannick Status: ready -->
 
 <refentry xml:id="function.socket-set-timeout" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>socket_set_timeout</refname>
-  <refpurpose>&Alias; <function>stream_set_timeout</function></refpurpose> 
+  <refpurpose>&Alias; <function>stream_set_timeout</function></refpurpose>
  </refnamediv>
+
+ <refsynopsisdiv>
+  &warn.deprecated.function-8-5-0;
+ </refsynopsisdiv>
 
  <refsect1 role="description">
   &reftitle.description;
@@ -16,6 +19,14 @@
    <function>stream_set_timeout</function>.
   </simpara>
  </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>stream_set_timeout</function></member>
+  </simplelist>
+ </refsect1>
+
 </refentry>
 
 <!-- Keep this comment at the end of the file


### PR DESCRIPTION
Closes #3331
Closes #3332
Closes #3337

## curl_errno / curl_error — document behavior with multi handles (Closes #3337)

Sync with https://github.com/php/doc-en/commit/ff7a0054b19ab80290b365d1417550807f82755a

- Add note: `curl_errno()` always returns `0` when handle was executed via `curl_multi_exec()`; use `curl_multi_info_read()` instead
- Add note: `curl_error()` always returns `''` when handle was executed via `curl_multi_exec()`; pass result key from `curl_multi_info_read()` to `curl_strerror()`
- Add `curl_multi_info_read` / `curl_strerror` to seealso

## curl_multi_exec — change function purpose (Closes #3332)

Sync with https://github.com/php/doc-en/commit/d6aa7900b52cdf99998a9367ee06f1155850b92b

- Update `refpurpose` to "Traite chaque handle dans la file"
- Change `<para>` to `<simpara>` for description and return values

## socket_set_timeout — document deprecation in PHP 8.5 (Closes #3331)

Sync with https://github.com/php/doc-en/commit/13682c8c7717db18862829bfc3ce9dc4a006079d

- Add `<refsynopsisdiv>` with `&warn.deprecated.function-8-5-0;`
- Add seealso section with `stream_set_timeout`