### PR TITLE
[Sync-En] info: fix assert/dl/getrusage return docs and E_ALL value

### DIFF
--- a/reference/info/functions/assert.xml
+++ b/reference/info/functions/assert.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 2916fa4160bdf53bb316a5c7c018fc91df7cd951 Maintainer: yannick Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 5367d2fcdf4b710a81806aba52a71c522f082713 Maintainer: yannick Status: ready -->
 <refentry xml:id="function.assert" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>assert</refname>
@@ -14,32 +13,32 @@
    <methodparam><type>mixed</type><parameter>assertion</parameter></methodparam>
    <methodparam choice="opt"><type class="union"><type>Throwable</type><type>string</type><type>null</type></type><parameter>description</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    <function>assert</function>
    permet de définir des attentes : des assertions qui prennent effet
    dans les environnements de développement et de test, mais qui sont optimisées
    pour ne pas avoir de coût en production.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Les assertions peuvent être utilisées pour aider au débogage.
    Un cas d'utilisation pour les assertions est de servir de vérifications de cohérence
    pour des préconditions qui devraient toujours être &true;, et si elles ne sont pas respectées,
    cela indique des erreurs de programmation.
    Un autre cas d'utilisation est de garantir la présence de certaines fonctionnalités telles que
    des fonctions d'extension ou certaines limites et fonctionnalités du système.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Comme les assertions peuvent être configurées pour être éliminées, elles ne doivent
    <emphasis>pas</emphasis> être utilisées pour des opérations normales en cours d'exécution,
    telles que des vérifications des paramètres d'entrée. En règle générale, le code doit se comporter
    comme prévu même si la vérification des assertions est désactivée.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    <function>assert</function> vérifiera que l'attente donnée dans
    <parameter>assertion</parameter> est satisfaite.
    Si ce n'est pas le cas et donc que le résultat est &false;, elle prendra l'action appropriée
    en fonction de la configuration de <function>assert</function>.
-  </para>
+  </simpara>
   <para>
    Le comportement de <function>assert</function> est dicté par les paramètres INI suivants :
    <table>
@@ -120,7 +119,7 @@
        <entry><link linkend="ini.assert.exception">assert.exception</link></entry>
        <entry>&true;</entry>
        <entry>
-        Si &true;, lancera une <classname>AssertionError</classname> si l'attente n'est pas respectée.
+        Si &true;, lancera une <exceptionname>AssertionError</exceptionname> si l'attente n'est pas respectée.
        </entry>
        <entry>
         Déprécié à partir de PHP 8.3.0.
@@ -162,20 +161,20 @@
     <varlistentry>
      <term><parameter>assertion</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Ceci est une expression quelconque qui retourne une valeur, qui sera exécutée
        et dont le résultat sera utilisé pour indiquer si l'assertion a réussi ou échoué.
-      </para>
+      </simpara>
 
       <warning>
-       <para>
+       <simpara>
         Antérieur à PHP 8.0.0, si <parameter>assertion</parameter> était une
         <type>string</type>, elle était interprétée comme du code PHP et exécutée via
         <function>eval</function>.
         Cette chaîne était transmise à la fonction de rappel en tant que troisième argument.
         Ce comportement était <emphasis>OBSOLÈTE</emphasis> dans PHP 7.2.0,
         et est <emphasis>SUPPRIMÉ</emphasis> à partir de PHP 8.0.0
-       </para>
+       </simpara>
       </warning>
      </listitem>
     </varlistentry>
@@ -184,40 +183,40 @@
      <listitem>
       <para>
        Si <parameter>description</parameter> est une instance de
-       <classname>Throwable</classname>, elle sera lancée uniquement si
+       <exceptionname>Throwable</exceptionname>, elle sera lancée uniquement si
        <parameter>assertion</parameter> est exécutée et échoue.
        <note>
-        <para>
+        <simpara>
          À partir de PHP 8.0.0, cela est fait <emphasis>avant</emphasis> d'appeler
          la fonction de rappel d'assertion éventuellement définie
-        </para>
+        </simpara>
        </note>
        <note>
-        <para>
+        <simpara>
          À partir de PHP 8.0.0, l'objet &object; sera lancé indépendamment de la configuration de
          <link linkend="ini.assert.exception">assert.exception</link>.
-        </para>
+        </simpara>
        </note>
        <note>
-        <para>
+        <simpara>
          À partir de PHP 8.0.0, le paramètre
          <link linkend="ini.assert.bail">assert.bail</link>
          n'a aucun effet dans ce cas.
-        </para>
+        </simpara>
        </note>
       </para>
-      <para>
+      <simpara>
        Si <parameter>description</parameter> est une &string;, ce message
        sera utilisé si une exception ou un avertissement est émis.
        Une description optionnelle, qui sera incluse dans le message d'échec si
        l'<parameter>assertion</parameter> échoue.
-      </para>
-      <para>
+      </simpara>
+      <simpara>
        Si <parameter>description</parameter> est omis.
        <!-- Cela ne se produit pas si &null; est passé ... -->
        Une description par défaut équivalente au code source de l'appel de
        <function>assert</function> est créée au moment de la compilation.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -226,21 +225,18 @@
  
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    <function>assert</function> renverra toujours &true; si au moins l'une des conditions suivantes est vraie :
-  </para>
+  </simpara>
   <simplelist>
    <member><literal>zend.assertions=0</literal></member>
    <member><literal>zend.assertions=-1</literal></member>
    <member><literal>assert.active=0</literal></member>
-   <member><literal>assert.exception=1</literal></member>
-   <member><literal>assert.bail=1</literal></member>
-   <member>Un objet d'exception personnalisé est passé à <parameter>description</parameter>.</member>
   </simplelist>
-  <para>
+  <simpara>
    Si aucune des conditions n'est vraie, <function>assert</function> renverra &true; si
    <parameter>assertion</parameter> est vrai, et &false; sinon.
-  </para>
+  </simpara>
  </refsect1>
  
  <refsect1 role="changelog">
@@ -275,7 +271,7 @@
        <entry>8.0.0</entry>
        <entry>
         Si <parameter>description</parameter> est une instance de
-        <classname>Throwable</classname>, l'objet est lancé si l'assertion échoue, indépendamment de la valeur de
+        <exceptionname>Throwable</exceptionname>, l'objet est lancé si l'assertion échoue, indépendamment de la valeur de
         <link linkend="ini.assert.exception">assert.exception</link>.
        </entry>
       </row>
@@ -283,7 +279,7 @@
        <entry>8.0.0</entry>
        <entry>
         Si <parameter>description</parameter> est une instance de
-        <classname>Throwable</classname>, aucune fonction de rappel utilisateur
+        <exceptionname>Throwable</exceptionname>, aucune fonction de rappel utilisateur
         n'est appelée même si elle est définie.
        </entry>
       </row>
@@ -332,10 +328,10 @@ echo 'Hi!';
 ?>
 ]]>
     </programlisting>
-    <para>
+    <simpara>
      Si les assertions sont activées (<link linkend="ini.zend.assertions"><literal>zend.assertions=1</literal></link>)
      l'exemple ci-dessus afficherait :
-    </para>
+    </simpara>
     <screen>
 <![CDATA[
 Fatal error: Uncaught AssertionError: assert(1 > 2) in example.php:2
@@ -345,10 +341,10 @@ Stack trace:
   thrown in example.php on line 2
 ]]>
     </screen>
-    <para>
+    <simpara>
      Si les assertions sont désactivées (<literal>zend.assertions=0</literal> ou <literal>zend.assertions=-1</literal>)
      l'exemple ci-dessus afficherait :
-    </para>
+    </simpara>
     <screen>
 <![CDATA[
 Hi!
@@ -365,10 +361,10 @@ echo 'Hi!';
 ?>
 ]]>
     </programlisting>
-    <para>
+    <simpara>
      Si les assertions sont activées,
      l'exemple ci-dessus afficherait :
-    </para>
+    </simpara>
     <screen>
 <![CDATA[
 Fatal error: Uncaught AssertionError: Expected one to be greater than two in example.php:2
@@ -378,10 +374,10 @@ Stack trace:
   thrown in example.php on line 2
 ]]>
     </screen>
-    <para>
+    <simpara>
      Si les assertions sont désactivées,
      l'exemple ci-dessus afficherait :
-    </para>
+    </simpara>
     <screen>
 <![CDATA[
 Hi!
@@ -399,10 +395,10 @@ Hi!
       echo 'Hi!';
       ]]>
      </programlisting>
-    <para>
+    <simpara>
      Si les assertions sont activées,
      l'exemple ci-dessus afficherait :
-    </para>
+    </simpara>
     <screen>
 <![CDATA[
 Fatal error: Uncaught ArithmeticAssertionError: Expected one to be greater than two in example.php:4
@@ -411,9 +407,9 @@ Stack trace:
   thrown in example.php on line 4
 ]]>
     </screen>
-     <para>
+     <simpara>
       Si les assertions sont désactivées, l'exemple ci-dessus affichera :
-     </para>
+     </simpara>
      <screen>
 <![CDATA[
 Hi!

--- a/reference/info/functions/dl.xml
+++ b/reference/info/functions/dl.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: a89c6d71c7b65e3de84f26230fbf72c9b8948adf Maintainer: yannick Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 5367d2fcdf4b710a81806aba52a71c522f082713 Maintainer: yannick Status: ready -->
 <refentry xml:id="function.dl" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>dl</refname>
@@ -95,16 +93,16 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    &return.success; Si la fonctionnalité de chargement de module n'est pas
    disponible, ou a été désactivée (en désactivant la directive
    <link linkend="ini.enable-dl">enable_dl</link>
-   dans le &php.ini;) une <constant>E_ERROR</constant> sera émise et
-   l'exécution du script sera stoppée. Si la fonction
+   dans le &php.ini;) une <constant>E_WARNING</constant> sera émise et
+   &false; sera retourné. Si la fonction
    <function>dl</function> échoue parce que la bibliothèque n'a pu être
-   trouvée, <function>dl</function> retourne &false; et émet un
-   message d'alerte <constant>E_WARNING</constant>.
-  </para>
+   trouvée, en plus de &false; un message d'alerte <constant>E_WARNING</constant>
+   sera émis.
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/info/functions/get-defined-constants.xml
+++ b/reference/info/functions/get-defined-constants.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 525aa5f198d482c0d03be54ddee5af13b376ab99 Maintainer: lacatoire Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 5367d2fcdf4b710a81806aba52a71c522f082713 Maintainer: lacatoire Status: ready -->
 
 <refentry xml:id="function.get-defined-constants" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -60,7 +58,7 @@ Array
             [E_USER_ERROR] => 256
             [E_USER_WARNING] => 512
             [E_USER_NOTICE] => 1024
-            [E_ALL] => 2047
+            [E_ALL] => 30719
             [TRUE] => 1
         )
 
@@ -128,7 +126,7 @@ Array
     [E_USER_ERROR] => 256
     [E_USER_WARNING] => 512
     [E_USER_NOTICE] => 1024
-    [E_ALL] => 2047
+    [E_ALL] => 30719
     [TRUE] => 1
 )
 ]]>

--- a/reference/info/functions/getrusage.xml
+++ b/reference/info/functions/getrusage.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: a277389c9d2d5a940fcd6dbe62da7e109282379d Maintainer: yannick Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 5367d2fcdf4b710a81806aba52a71c522f082713 Maintainer: yannick Status: ready -->
 <refentry xml:id="function.getrusage" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>getrusage</refname>
@@ -105,12 +103,11 @@ echo $dat["ru_stime.tv_sec"]; // temps système utilisé (en secondes)
      </member>
     </simplelist>
    </para>
-   <para>
+   <simpara>
     Si <function>getrusage</function> est appelé avec le paramètre <parameter>mode</parameter>
     valant <literal>1</literal> (<constant>RUSAGE_CHILDREN</constant>), alors l'utilisation
-    de la ressource pour les threads est collectée (ce qui signifie que, en interne,
-    la fonction est appelée avec <constant>RUSAGE_THREAD</constant>).
-   </para>
+    de la ressource pour les processus enfants est collectée.
+   </simpara>
   </note>
   <note>
    <para>


### PR DESCRIPTION
Fixes #3336

- assert.xml: para→simpara throughout, classname→exceptionname for AssertionError/Throwable, update return values section
- dl.xml: E_ERROR→E_WARNING, fix return value wording
- get-defined-constants.xml: E_ALL 2047→30719 in both examples
- getrusage.xml: update RUSAGE_CHILDREN note (child processes, not threads)