### PR TITLE
[Sync-En] pcntl: fix reference pages and document 8.4 failure return

### DIFF
--- a/reference/pcntl/constants.xml
+++ b/reference/pcntl/constants.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 71fa455c5670ea4a3a3a0c60e34d906d1061a6c8 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 253f4bdd29fc3938030dce22882611ceefa9f74a Maintainer: yannick Status: ready -->
 <appendix xml:id="pcntl.constants" xmlns="http://docbook.org/ns/docbook">
  &reftitle.constants;
  <para>
@@ -626,16 +626,6 @@
   <varlistentry xml:id="constant.si-timer">
    <term>
     <constant>SI_TIMER</constant> 
-    (<type>int</type>)
-   </term>
-   <listitem>
-    <simpara>
-    </simpara>
-   </listitem>
-  </varlistentry>
-  <varlistentry xml:id="constant.si-msggq">
-   <term>
-    <constant>SI_MSGGQ</constant> 
     (<type>int</type>)
    </term>
    <listitem>

--- a/reference/pcntl/functions/pcntl-exec.xml
+++ b/reference/pcntl/functions/pcntl-exec.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: fcd9214294f88b05862a538c6dd94c7872420139 Maintainer: lacatoire Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 253f4bdd29fc3938030dce22882611ceefa9f74a Maintainer: lacatoire Status: ready -->
 <refentry xml:id="function.pcntl-exec" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>pcntl_exec</refname>
@@ -31,7 +29,7 @@
       <para>
        <parameter>path</parameter> doit être le chemin vers un binaire exécutable
        ou un script avec un chemin valide pointant vers un exécutable à la première ligne
-       (par exemple, <literal>#!/usr/local/bin/perl</literal>). 
+       (par exemple, <literal>#!/usr/local/bin/perl</literal>).
        Voir les pages d'aide du système concernant <literal>execve(2)</literal>
        pour plus d'informations.
       </para>
@@ -63,9 +61,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
-   Retourne &false;.
-  </para>
+  <simpara>
+   Retourne &false; en cas d'échec. En cas de succès, la fonction ne retourne pas,
+   car l'image du processus courant est remplacée par le programme exécuté.
+  </simpara>
  </refsect1>
 
 </refentry>

--- a/reference/pcntl/functions/pcntl-sigprocmask.xml
+++ b/reference/pcntl/functions/pcntl-sigprocmask.xml
@@ -1,13 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 7bc131d65540e2a0f706cf4d99b5a3235c965fdb Maintainer: dams Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 253f4bdd29fc3938030dce22882611ceefa9f74a Maintainer: dams Status: ready -->
 <refentry xml:id="function.pcntl-sigprocmask" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>pcntl_sigprocmask</refname>
   <refpurpose>Liste et configure les signaux bloqués</refpurpose>
  </refnamediv>
- 
+
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
@@ -31,7 +29,7 @@
      <listitem>
       <para>
        Configure le comportement de <function>pcntl_sigprocmask</function>. Les valeurs
-       possibles sont : 
+       possibles sont :
        <simplelist>
         <member><constant>SIG_BLOCK</constant> : ajoute les signaux à la liste
         des signaux bloqués.</member>
@@ -85,28 +83,28 @@
      <row>
       <entry>8.4.0</entry>
       <entry>
-       Une exception <classname>ValueError</classname> est levée si le <parameter>signal</parameter>
-       est vide.
+       Une exception <exceptionname>ValueError</exceptionname> est levée si le <parameter>signals</parameter>
+       est vide, sauf si le <parameter>mode</parameter> est <constant>SIG_SETMASK</constant>.
       </entry>
      </row>
      <row>
       <entry>8.4.0</entry>
       <entry>
-       Une exception <classname>TypeError</classname> est levée si la valeur de <parameter>signal</parameter>
+       Une exception <exceptionname>TypeError</exceptionname> est levée si la valeur de <parameter>signals</parameter>
        n'est pas un <type>int</type>.
       </entry>
      </row>
      <row>
       <entry>8.4.0</entry>
       <entry>
-       Une exception <classname>ValueError</classname> est levée si la valeur de <parameter>signal</parameter>
+       Une exception <exceptionname>ValueError</exceptionname> est levée si la valeur de <parameter>signals</parameter>
        est invalide.
       </entry>
      </row>
      <row>
       <entry>8.4.0</entry>
       <entry>
-       Une exception <classname>ValueError</classname> est levée si la valeur de <parameter>mode</parameter>
+       Une exception <exceptionname>ValueError</exceptionname> est levée si la valeur de <parameter>mode</parameter>
        n'est pas <constant>SIG_BLOCK</constant>, <constant>SIG_UNBLOCK</constant> ou
        <constant>SIG_SETMASK</constant>.
       </entry>
@@ -136,12 +134,10 @@ pcntl_sigprocmask(SIG_UNBLOCK, array(SIGHUP), $oldset);
 
  <refsect1 role="seealso">
   &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><function>pcntl_sigwaitinfo</function></member>
-    <member><function>pcntl_sigtimedwait</function></member>
-   </simplelist>
-  </para>
+  <simplelist>
+   <member><function>pcntl_sigwaitinfo</function></member>
+   <member><function>pcntl_sigtimedwait</function></member>
+  </simplelist>
  </refsect1>
 
 </refentry>

--- a/reference/pcntl/functions/pcntl-sigtimedwait.xml
+++ b/reference/pcntl/functions/pcntl-sigtimedwait.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 7bc131d65540e2a0f706cf4d99b5a3235c965fdb Maintainer: dams Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 253f4bdd29fc3938030dce22882611ceefa9f74a Maintainer: dams Status: ready -->
 <refentry xml:id="function.pcntl-sigtimedwait" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>pcntl_sigtimedwait</refname>
@@ -43,7 +41,7 @@
      <listitem>
       <para>
        Le paramètre <parameter>info</parameter> reçoit les informations
-       du signal, sous forme de tableau. Voir 
+       du signal, sous forme de tableau. Voir
        <function>pcntl_sigwaitinfo</function>.
       </para>
      </listitem>
@@ -90,42 +88,49 @@
      <row>
       <entry>8.4.0</entry>
       <entry>
-       Une exception <classname>ValueError</classname> est levée si le <parameter>signal</parameter>
+       En cas d'échec, &false; est désormais retourné ; auparavant,
+       <literal>-1</literal> pouvait être retourné dans certains cas.
+      </entry>
+     </row>
+     <row>
+      <entry>8.4.0</entry>
+      <entry>
+       Une exception <exceptionname>ValueError</exceptionname> est levée si le <parameter>signals</parameter>
        est vide.
       </entry>
      </row>
      <row>
       <entry>8.4.0</entry>
       <entry>
-       Une exception <classname>TypeError</classname> est levée si la valeur de <parameter>signal</parameter>
+       Une exception <exceptionname>TypeError</exceptionname> est levée si la valeur de <parameter>signals</parameter>
        n'est pas un <type>int</type>.
       </entry>
      </row>
      <row>
       <entry>8.4.0</entry>
       <entry>
-       Une exception <classname>ValueError</classname> est levée si la valeur de <parameter>signal</parameter>
+       Une exception <exceptionname>ValueError</exceptionname> est levée si la valeur de <parameter>signals</parameter>
        est invalide.
       </entry>
      </row>
      <row>
       <entry>8.4.0</entry>
       <entry>
-       Une exception <classname>ValueError</classname> est levée si la valeur de <parameter>seconds</parameter>
+       Une exception <exceptionname>ValueError</exceptionname> est levée si la valeur de <parameter>seconds</parameter>
        est inférieure à <literal>0</literal>.
       </entry>
      </row>
      <row>
       <entry>8.4.0</entry>
       <entry>
-       Une exception <classname>ValueError</classname> est levée si la valeur de <parameter>nanoseconds</parameter>
-       est inférieure à <literal>0</literal>.
+       Une exception <exceptionname>ValueError</exceptionname> est levée si la valeur de <parameter>nanoseconds</parameter>
+       n'est pas comprise entre <literal>0</literal> et <literal>1e9</literal>.
       </entry>
      </row>
      <row>
       <entry>8.4.0</entry>
       <entry>
-       Une exception <classname>ValueError</classname> est levée si les valeurs de <parameter>seconds</parameter> et
+       Une exception <exceptionname>ValueError</exceptionname> est levée si les valeurs de <parameter>seconds</parameter> et
        de <parameter>nanoseconds</parameter> sont toutes deux égales à <literal>0</literal>.
       </entry>
      </row>
@@ -136,12 +141,10 @@
 
  <refsect1 role="seealso">
   &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><function>pcntl_sigprocmask</function></member>
-    <member><function>pcntl_sigwaitinfo</function></member>
-   </simplelist>
-  </para>
+  <simplelist>
+   <member><function>pcntl_sigprocmask</function></member>
+   <member><function>pcntl_sigwaitinfo</function></member>
+  </simplelist>
  </refsect1>
 
 </refentry>

--- a/reference/pcntl/functions/pcntl-sigwaitinfo.xml
+++ b/reference/pcntl/functions/pcntl-sigwaitinfo.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 7bc131d65540e2a0f706cf4d99b5a3235c965fdb Maintainer: dams Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 253f4bdd29fc3938030dce22882611ceefa9f74a Maintainer: dams Status: ready -->
 <refentry xml:id="function.pcntl-sigwaitinfo" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>pcntl_sigwaitinfo</refname>
@@ -106,21 +104,28 @@
      <row>
       <entry>8.4.0</entry>
       <entry>
-       Une exception <classname>ValueError</classname> est levée si le <parameter>signal</parameter>
+       En cas d'échec, &false; est désormais retourné ; auparavant,
+       <literal>-1</literal> pouvait être retourné dans certains cas.
+      </entry>
+     </row>
+     <row>
+      <entry>8.4.0</entry>
+      <entry>
+       Une exception <exceptionname>ValueError</exceptionname> est levée si le <parameter>signals</parameter>
        est vide.
       </entry>
      </row>
      <row>
       <entry>8.4.0</entry>
       <entry>
-       Une exception <classname>TypeError</classname> est levée si la valeur de <parameter>signal</parameter>
+       Une exception <exceptionname>TypeError</exceptionname> est levée si la valeur de <parameter>signals</parameter>
        n'est pas un <type>int</type>.
       </entry>
      </row>
      <row>
       <entry>8.4.0</entry>
       <entry>
-       Une exception <classname>ValueError</classname> est levée si la valeur de <parameter>signal</parameter>
+       Une exception <exceptionname>ValueError</exceptionname> est levée si la valeur de <parameter>signals</parameter>
        est invalide.
       </entry>
      </row>
@@ -155,12 +160,10 @@ pcntl_sigwaitinfo(array(SIGHUP), $info);
 
  <refsect1 role="seealso">
   &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><function>pcntl_sigprocmask</function></member>
-    <member><function>pcntl_sigtimedwait</function></member>
-   </simplelist>
-  </para>
+  <simplelist>
+   <member><function>pcntl_sigprocmask</function></member>
+   <member><function>pcntl_sigtimedwait</function></member>
+  </simplelist>
  </refsect1>
 
 </refentry>

--- a/reference/pcntl/functions/pcntl-unshare.xml
+++ b/reference/pcntl/functions/pcntl-unshare.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: d7c1097cca089f4571977b41855e63d3c3638433 Maintainer: Fan2Shrek Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 253f4bdd29fc3938030dce22882611ceefa9f74a Maintainer: Fan2Shrek Status: ready -->
 <refentry xml:id='function.pcntl-unshare' xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>pcntl_unshare</refname>
@@ -49,20 +48,18 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
-   Renvoie <literal>0</literal> en cas de succès, <literal>-1</literal> sinon.
+  <simpara>
+   Retourne &true; en cas de succès ou &false; en cas d'échec.
    En cas d'échec, il définit un code d'erreur, qui peut être récupéré avec <function>pcntl_get_last_error</function>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="seealso">
   &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><link linkend="pcntl.constants.clone">Constante PCNTL</link></member>
-    <member><function>pcntl_get_last_error</function></member>
-   </simplelist>
-  </para>
+  <simplelist>
+   <member><link linkend="pcntl.constants.clone">Constante PCNTL</link></member>
+   <member><function>pcntl_get_last_error</function></member>
+  </simplelist>
  </refsect1>
 
 </refentry>


### PR DESCRIPTION
Fixes #3333

- constants.xml: remove SI_MSGGQ (the constant is SI_MESGQ and is already documented)
- pcntl_exec(): clarify that on success the function does not return, because the process image is replaced
- pcntl_unshare(): returns bool, not 0 or -1
- pcntl_sigprocmask(), pcntl_sigtimedwait(), pcntl_sigwaitinfo(): classname→exceptionname, signal→signals parameter name
- pcntl_sigtimedwait(), pcntl_sigwaitinfo(): document that failure now returns false since 8.4.0
- pcntl_sigprocmask(): empty signals array is accepted when mode is SIG_SETMASK
- pcntl_sigtimedwait(): nanoseconds must be between 0 and 1e9, not merely non-negative
- seealso: move simplelist out of their para