### PR TITLE
[Sync-En] array_unique: add note about SORT_REGULAR with numeric strings

### DIFF
--- a/reference/array/functions/array-unique.xml
+++ b/reference/array/functions/array-unique.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 17c238517825dfb7ec3edfef5972acd944ffbc1e Maintainer: lacatoire Status: ready -->
-<!-- CREDITS: DavidA. -->
+<!-- EN-Revision: 47cbf365f535be1517473eee446e94d096778ca8 Maintainer: lacatoire Status: ready -->
 <refentry xml:id="function.array-unique" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>array_unique</refname>
@@ -58,6 +57,15 @@
         <listitem>
          <simpara><constant>SORT_REGULAR</constant> - compare les éléments normalement
          (ne modifie pas les types)</simpara>
+         <note>
+          <simpara>
+           Lors de la combinaison de <constant>SORT_REGULAR</constant> avec des
+           tableaux mêlant des chaînes numériques et non numériques, l'algorithme
+           de tri puis comparaison peut ne pas placer les éléments égaux côte à
+           côte, ce qui peut laisser des doublons dans le résultat. Utiliser
+           <constant>SORT_STRING</constant> pour éviter cela.
+          </simpara>
+         </note>
         </listitem>
         <listitem>
          <simpara><constant>SORT_NUMERIC</constant> - compare les éléments 


### PR DESCRIPTION
Syncs the FR page with php/doc-en@47cbf365f535be1517473eee446e94d096778ca8.

- adds the note about SORT_REGULAR with arrays mixing numeric and non-numeric strings
- bumps EN-Revision, drops the obsolete CREDITS marker

Fixes: #3355