### PR TITLE
[Sync-En] errorfunc: document the error handler stack

### DIFF
--- a/reference/errorfunc/functions/restore-error-handler.xml
+++ b/reference/errorfunc/functions/restore-error-handler.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 4a6671fe697ead5b27603b56face01a2c4e7ebe5 Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
-
+<!-- EN-Revision: cbfc5d5d55d682c185583561295462a6d5ca0ea1 Maintainer: yannick Status: ready -->
 <refentry xml:id="function.restore-error-handler" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>restore_error_handler</refname>
@@ -15,13 +12,19 @@
    <type>true</type><methodname>restore_error_handler</methodname>
    <void/>
   </methodsynopsis>
-  <para>
-   Utilisée après avoir modifié la fonction de gestion
-   des erreurs, grâce à <function>set_error_handler</function>,
-   <function>restore_error_handler</function> permet de réutiliser
-   l'ancienne version de gestion des erreurs (qui peut être la
-   fonction PHP par défaut, ou une autre fonction utilisateur).
-  </para>
+  <simpara>
+   Dépile de la pile interne des gestionnaires d'erreurs le gestionnaire qui
+   était actif avant le dernier appel à
+   <function>set_error_handler</function> et le réactive, avec le masque
+   <parameter>error_levels</parameter> avec lequel il avait été enregistré.
+   Le gestionnaire restauré peut être le gestionnaire interne de PHP ou une
+   fonction utilisateur.
+  </simpara>
+  <simpara>
+   Appeler cette fonction plus souvent que
+   <function>set_error_handler</function> laisse le gestionnaire d'erreurs
+   interne actif ; aucune erreur n'est levée.
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -72,15 +75,13 @@ Valeur incorrectement sérialisée.
 
  <refsect1 role="seealso">
   &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><function>error_reporting</function></member>
-    <member><function>set_error_handler</function></member>
-    <member><function>get_error_handler</function></member>
-    <member><function>restore_exception_handler</function></member>
-    <member><function>trigger_error</function></member>
-   </simplelist>
-  </para>
+  <simplelist>
+   <member><function>error_reporting</function></member>
+   <member><function>set_error_handler</function></member>
+   <member><function>get_error_handler</function></member>
+   <member><function>restore_exception_handler</function></member>
+   <member><function>trigger_error</function></member>
+  </simplelist>
  </refsect1>
 </refentry>
 <!-- Keep this comment at the end of the file

--- a/reference/errorfunc/functions/set-error-handler.xml
+++ b/reference/errorfunc/functions/set-error-handler.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 21ce7d7f4f9f6f241f3e09e7f0a5be5c504d90d2 Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: cbfc5d5d55d682c185583561295462a6d5ca0ea1 Maintainer: yannick Status: ready -->
 <refentry xml:id="function.set-error-handler" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>set_error_handler</refname>
@@ -15,10 +13,13 @@
    <methodparam><type class="union"><type>callable</type><type>null</type></type><parameter>callback</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>error_levels</parameter><initializer><constant>E_ALL</constant></initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    <function>set_error_handler</function> choisit la fonction utilisateur
    <parameter>callback</parameter> pour gérer les erreurs dans un script.
-  </para>
+   Le gestionnaire actif jusqu'alors est sauvegardé sur une pile interne de
+   gestionnaires d'erreurs, d'où <function>restore_error_handler</function>
+   le dépile.
+  </simpara>
   <para>
    Cette fonction peut être utilisée pour définir des gestionnaires d'erreurs personnalisés pendant l'exécution,
    par exemple dans des applications qui ont besoin de nettoyer des fichiers/données lorsqu'une erreur critique
@@ -66,10 +67,13 @@
     <varlistentry>
      <term><parameter>callback</parameter></term>
      <listitem>
-      <para>
-       Si &null; est fournie le gestionnaire est réinitialisé à son statut par défaut.
+      <simpara>
+       Si &null; est fourni, aucun gestionnaire utilisateur ne reste actif et
+       les erreurs sont traitées par le gestionnaire d'erreurs interne.
+       Le gestionnaire actif jusqu'alors est toujours sauvegardé sur la pile et
+       peut être rétabli avec <function>restore_error_handler</function>.
        Sinon, le gestionnaire est une fonction de rappel avec la signature suivante :
-      </para>
+      </simpara>
       <para>
        <methodsynopsis>
         <type>bool</type><methodname><replaceable>handler</replaceable></methodname>
@@ -340,20 +344,80 @@ Arrêt...<br />
     </screen>
    </example>
   </para>
+  <para>
+   <example>
+    <title>Appel du gestionnaire précédent depuis le nouveau</title>
+    <simpara>
+     La valeur de retour de <function>set_error_handler</function> est le
+     gestionnaire qui était actif jusqu'alors. L'appeler depuis le nouveau
+     gestionnaire conserve le comportement existant tout en le complétant.
+     Cela ne fonctionne que si ce gestionnaire est une fonction utilisateur ;
+     &null; est retourné lorsque le gestionnaire interne était actif.
+    </simpara>
+    <programlisting role="php">
+<![CDATA[
+<?php
+function logging_handler(int $errno, string $errstr): bool
+{
+    echo "journalisé : $errstr\n";
+    return true;
+}
+
+set_error_handler('logging_handler');
+
+$previous = set_error_handler(function (int $errno, string $errstr) use (&$previous): bool {
+    echo "compté : $errstr\n";
+    return $previous !== null ? $previous($errno, $errstr) : false;
+});
+
+trigger_error("quelque chose s'est produit", E_USER_WARNING);
+
+restore_error_handler();
+trigger_error("seulement journalisé maintenant", E_USER_WARNING);
+
+restore_error_handler();
+?>
+]]>
+    </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+compté : quelque chose s'est produit
+journalisé : quelque chose s'est produit
+journalisé : seulement journalisé maintenant
+]]>
+    </screen>
+   </example>
+  </para>
+ </refsect1>
+
+ <refsect1 role="notes">
+  &reftitle.notes;
+  <caution>
+   <simpara>
+    Il ne faut pas revenir au gestionnaire précédent en repassant à
+    <function>set_error_handler</function> sa valeur de retour.
+    Cela empile une entrée supplémentaire au lieu d'en retirer une, si bien que
+    la pile croît sans limite dans les boucles et les processus de longue durée,
+    et <parameter>error_levels</parameter> est réinitialisé à
+    <constant>E_ALL</constant>, élargissant silencieusement la plage des erreurs
+    que reçoit le gestionnaire restauré.
+    <function>restore_error_handler</function> est la façon prévue de revenir
+    au gestionnaire précédent.
+   </simpara>
+  </caution>
  </refsect1>
 
  <refsect1 role="seealso">
   &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><classname>ErrorException</classname></member>
-    <member><function>error_reporting</function></member>
-    <member><function>restore_error_handler</function></member>
-    <member><function>get_error_handler</function></member>
-    <member><function>trigger_error</function></member>
-    <member><link linkend="errorfunc.constants">Constantes de niveau d'erreur</link></member>
-   </simplelist>
-  </para>
+  <simplelist>
+   <member><exceptionname>ErrorException</exceptionname></member>
+   <member><function>error_reporting</function></member>
+   <member><function>restore_error_handler</function></member>
+   <member><function>get_error_handler</function></member>
+   <member><function>trigger_error</function></member>
+   <member><link linkend="errorfunc.constants">Constantes de niveau d'erreur</link></member>
+  </simplelist>
  </refsect1>
 </refentry>
 <!-- Keep this comment at the end of the file


### PR DESCRIPTION
Syncs the FR pages with php/doc-en@cbfc5d5d55d682c185583561295462a6d5ca0ea1.

- set_error_handler(): the handler active until then is saved on an internal stack; new example calling the previous handler from the new one; caution against restoring by passing the return value back
- restore_error_handler(): describes the pop, including the error_levels mask
- seealso simplelists unwrapped from their para, matching EN
- bumps EN-Revision, drops the obsolete $Revision$ and Reviewed markers

Fixes: #3356