### PR TITLE
[Sync-En] filter: add examples for filter_var_array() and filter_input_array()

### DIFF
--- a/reference/filter/functions/filter-input-array.xml
+++ b/reference/filter/functions/filter-input-array.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 53054bf8decc8648cf2e90a493692a161e2371af Maintainer: lacatoire Status: ready -->
-<!-- Reviewed: no -->
-<!-- CREDITS: DavidA -->
+<!-- EN-Revision: 85264ba268a398c4b90c1948839d54ce688dd5cd Maintainer: lacatoire Status: ready -->
 <refentry xml:id="function.filter-input-array" xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude">
  <refnamediv>
   <refname>filter_input_array</refname>
@@ -41,12 +39,8 @@
      </warning>
     </listitem>
    </varlistentry>
-   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.filter-var-array')/db:refsect1[@role='parameters']//db:varlistentry[db:term[db:parameter[text()='options']]]/.)">
-    <xi:fallback/>
-   </xi:include>
-   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.filter-var-array')/db:refsect1[@role='parameters']//db:varlistentry[db:term[db:parameter[text()='add_empty']]]/.)">
-    <xi:fallback/>
-   </xi:include>
+   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.filter-var-array')/db:refsect1[@role='parameters']//db:varlistentry[db:term[db:parameter[text()='options']]]/.)"/>
+   <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('function.filter-var-array')/db:refsect1[@role='parameters']//db:varlistentry[db:term[db:parameter[text()='add_empty']]]/.)"/>
   </variablelist>
  </refsect1>
 
@@ -57,22 +51,134 @@
   </simpara>
   <simpara>
    En cas d'échec, &false; est retourné.
-   Sauf si l'échec est que le tableau d'entrée désigné par
-   <parameter>type</parameter> n'est pas alimenté, auquel cas &null; est retourné
-   si le drapeau <constant>FILTER_NULL_ON_FAILURE</constant> est utilisé.
+   Si le tableau d'entrée désigné par <parameter>type</parameter> n'est pas
+   alimenté, &null; est retourné à la place.
   </simpara>
   <simpara>
-   Les entrées manquantes du tableau d'entrée seront alimentées dans le &array;
-   retourné si <parameter>add_empty</parameter> est &true;.
-   Auquel cas, les entrées manquantes seront définies à &null;,
-   sauf si le drapeau <constant>FILTER_NULL_ON_FAILURE</constant> est utilisé,
-   auquel cas ce sera &false;.
+   Les entrées manquantes du tableau d'entrée sont ajoutées au &array; retourné
+   avec la valeur &null; si <parameter>add_empty</parameter> vaut &true;,
+   et sont entièrement omises s'il vaut &false;.
+   Contrairement à <function>filter_input</function>,
+   le drapeau <constant>FILTER_NULL_ON_FAILURE</constant> ne change rien à cela :
+   une entrée manquante est toujours &null;.
   </simpara>
   <simpara>
    Une entrée dans le &array; retourné sera &false; si le filtre échoue,
    sauf si le drapeau <constant>FILTER_NULL_ON_FAILURE</constant> est utilisé,
    auquel cas il sera &null;.
+   Avec le drapeau <constant>FILTER_FORCE_ARRAY</constant>,
+   cette valeur d'échec est enveloppée dans un &array; d'un seul élément,
+   comme n'importe quel autre résultat.
   </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Exemple avec <function>filter_input_array</function></title>
+   <simpara>
+    Cet exemple suppose une requête GET vers
+    <literal>?email=user@example.com&amp;age=twenty&amp;url=https://example.com</literal>.
+    L'entrée <literal>age</literal> échoue car <literal>twenty</literal> n'est
+    pas un entier ; une valeur en dehors de la plage
+    <literal>1</literal> à <literal>120</literal> échouerait de la même façon.
+   </simpara>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$filters = [
+    'email' => FILTER_VALIDATE_EMAIL,
+    'age'   => [
+        'filter'  => FILTER_VALIDATE_INT,
+        'options' => ['min_range' => 1, 'max_range' => 120],
+    ],
+    'url'   => FILTER_VALIDATE_URL,
+];
+
+$result = filter_input_array(INPUT_GET, $filters);
+
+var_dump($result);
+?>
+]]>
+   </programlisting>
+   &example.outputs.similar;
+   <screen>
+<![CDATA[
+array(3) {
+  ["email"]=>
+  string(16) "user@example.com"
+  ["age"]=>
+  bool(false)
+  ["url"]=>
+  string(19) "https://example.com"
+}
+]]>
+   </screen>
+  </example>
+  <example>
+   <title>Filtrage de données POST avec <function>filter_input_array</function></title>
+   <simpara>
+    Cet exemple suppose une requête POST avec les champs
+    <literal>username=&lt;script&gt;alert&lt;/script&gt;</literal> et
+    <literal>comment=Hello World</literal>.
+    Aucun champ <literal>missing</literal> n'est soumis : comme
+    <parameter>add_empty</parameter> vaut &true; par défaut, il est tout de même
+    présent dans le résultat, défini à &null;.
+   </simpara>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$filters = [
+    'username' => FILTER_SANITIZE_SPECIAL_CHARS,
+    'comment'  => FILTER_SANITIZE_SPECIAL_CHARS,
+    'missing'  => FILTER_VALIDATE_INT,
+];
+
+$result = filter_input_array(INPUT_POST, $filters);
+
+var_dump($result);
+?>
+]]>
+   </programlisting>
+   &example.outputs.similar;
+   <screen>
+<![CDATA[
+array(3) {
+  ["username"]=>
+  string(38) "&#60;script&#62;alert&#60;/script&#62;"
+  ["comment"]=>
+  string(11) "Hello World"
+  ["missing"]=>
+  NULL
+}
+]]>
+   </screen>
+  </example>
+  <example>
+   <title>Demande d'un type d'entrée non alimenté</title>
+   <simpara>
+    Cet exemple suppose une requête GET.
+    Comme la requête ne portait aucun champ POST,
+    le tableau d'entrée désigné par <constant>INPUT_POST</constant> n'est pas
+    alimenté et &null; est retourné au lieu d'un &array;.
+    Cela s'applique à tous les types d'entrée :
+    une requête sans chaîne de requête donne également &null; pour
+    <constant>INPUT_GET</constant>.
+   </simpara>
+   <programlisting role="php">
+<![CDATA[
+<?php
+var_dump(filter_input_array(INPUT_POST, ['a' => FILTER_VALIDATE_INT]));
+?>
+]]>
+   </programlisting>
+   &example.outputs.similar;
+   <screen>
+<![CDATA[
+NULL
+]]>
+   </screen>
+  </example>
  </refsect1>
 
  <refsect1 role="notes">

--- a/reference/filter/functions/filter-var-array.xml
+++ b/reference/filter/functions/filter-var-array.xml
@@ -42,7 +42,7 @@
       soit un filtre à appliquer à chaque entrée,
       qui peut être un filtre de validation en utilisant une des constantes
       <constant>FILTER_VALIDATE_<replaceable>*</replaceable></constant>,
-      un filtre de purification en utilisant une des constantes
+      ou un filtre de purification en utilisant une des constantes
       <constant>FILTER_SANITIZE_<replaceable>*</replaceable></constant>.
      </simpara>
      <simpara>

--- a/reference/filter/functions/filter-var-array.xml
+++ b/reference/filter/functions/filter-var-array.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 627f933cfe6a033dccac32982cd68e7c1b86927f Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
-<!-- CREDITS: DavidA -->
+<!-- EN-Revision: 85264ba268a398c4b90c1948839d54ce688dd5cd Maintainer: yannick Status: ready -->
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.filter-var-array">
  <refnamediv>
   <refname>filter_var_array</refname>
@@ -49,7 +47,7 @@
      </simpara>
      <simpara>
       Le tableau d'options est un tableau associatif où les clés correspondent
-      à une clé dans les données <parameter>array</parameter> et la valeur
+      à une clé dans le tableau d'entrée et la valeur
       associée est soit le filtre à appliquer à cette entrée,
       soit un tableau associatif qui décrit comment et quel filtre devrait
       être appliqué à cette entrée.
@@ -63,7 +61,7 @@
       <constant>FILTER_UNSAFE_RAW</constant>, ou
       <constant>FILTER_CALLBACK</constant>.
       Il peut contenir facultativement la clé <literal>'flags'</literal>
-      qui spécifie les drapeaux à appliquer au filtre,
+      qui spécifie tout drapeau qui s'applique au filtre,
       et la clé <literal>'options'</literal> qui spécifie toute option
       qui s'applique au filtre.
      </simpara>
@@ -82,17 +80,39 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
-   Un tableau contenant les valeurs des variables demandées en cas de succès, ou &false;
-   si une erreur survient. Un tableau de valeurs peut valoir &false; si le filtre échoue, ou &null;
-   si la variable n'est pas définie.
-  </para>
+  <simpara>
+   En cas de succès, un &array; contenant les valeurs des variables demandées.
+  </simpara>
+  <simpara>
+   En cas d'échec, &false; est retourné.
+  </simpara>
+  <simpara>
+   Les entrées manquantes du tableau d'entrée sont ajoutées au &array; retourné
+   avec la valeur &null; si <parameter>add_empty</parameter> vaut &true;,
+   et sont entièrement omises s'il vaut &false;.
+  </simpara>
+  <simpara>
+   Une entrée dans le &array; retourné sera &false; si le filtre échoue,
+   sauf si le drapeau <constant>FILTER_NULL_ON_FAILURE</constant> est utilisé,
+   auquel cas il sera &null;.
+   Avec le drapeau <constant>FILTER_FORCE_ARRAY</constant>,
+   cette valeur d'échec est enveloppée dans un &array; d'un seul élément,
+   comme n'importe quel autre résultat.
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">
   &reftitle.examples;
   <example>
    <title>Exemple avec <function>filter_var_array</function></title>
+   <simpara>
+    Les entrées sont filtrées comme des scalaires à moins que
+    <constant>FILTER_REQUIRE_ARRAY</constant> ou
+    <constant>FILTER_FORCE_ARRAY</constant> ne soit utilisé.
+    Le drapeau <constant>FILTER_REQUIRE_SCALAR</constant> sur
+    <literal>testscalar</literal> ci-dessous ne fait donc qu'expliciter ce
+    comportement par défaut.
+   </simpara>
    <programlisting role="php">
 <![CDATA[
 <?php
@@ -156,6 +176,78 @@ array(6) {
   }
   ["doesnotexist"]=>
   NULL
+}
+]]>
+   </screen>
+  </example>
+  <example>
+   <title>Application d'un filtre unique à toutes les valeurs</title>
+   <simpara>
+    Lorsque <parameter>options</parameter> est un &integer;, le même filtre est
+    appliqué à chaque entrée du tableau.
+   </simpara>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$data = [
+    'name'  => '<b>John</b>',
+    'email' => 'john@example<script>.com',
+    'bio'   => 'Developer & writer',
+];
+
+var_dump(filter_var_array($data, FILTER_SANITIZE_SPECIAL_CHARS));
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+array(3) {
+  ["name"]=>
+  string(27) "&#60;b&#62;John&#60;/b&#62;"
+  ["email"]=>
+  string(32) "john@example&#60;script&#62;.com"
+  ["bio"]=>
+  string(22) "Developer &#38; writer"
+}
+]]>
+   </screen>
+  </example>
+  <example>
+   <title>Utilisation de <constant>FILTER_CALLBACK</constant></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$data = [
+    'name'  => '  John Doe  ',
+    'city'  => '  New York  ',
+];
+
+$options = [
+    'name' => [
+        'filter'  => FILTER_CALLBACK,
+        'options' => 'trim',
+    ],
+    'city' => [
+        'filter'  => FILTER_CALLBACK,
+        'options' => function ($value) {
+            return strtoupper(trim($value));
+        },
+    ],
+];
+
+var_dump(filter_var_array($data, $options));
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+array(2) {
+  ["name"]=>
+  string(8) "John Doe"
+  ["city"]=>
+  string(8) "NEW YORK"
 }
 ]]>
    </screen>


### PR DESCRIPTION
Syncs the FR pages with php/doc-en@85264ba268a398c4b90c1948839d54ce688dd5cd.

- three examples added to filter_input_array(), two to filter_var_array()
- return values rewritten: missing entries, FILTER_NULL_ON_FAILURE and FILTER_FORCE_ARRAY behaviour
- options parameter wording aligned with EN
- also picks up php/doc-en@603435cd84 (empty xi:fallback elements removed)
- bumps EN-Revision, drops the obsolete CREDITS and Reviewed markers

Fixes: #3358