### PR TITLE
[Sync-En] sodium: document the 8.4 aarch64 support for AES-256-GCM

### DIFF
--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: fd1f9d85122cd85854f4afdf5a57ab7da38ff69c Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 4c85baa92d7c99df238876d20d77ecb952472f11 Maintainer: lacatoire Status: ready -->
 <!-- Relecture des Notes, Précautions, Avertissements, Astuces, Divers et Retour le 2018-12-29 par girgias -->
 
 <!--

--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -4764,6 +4764,29 @@ anglais. On devrait penser à leur utilité :
 <!-- Widely used -->
 <!ENTITY class.theclass 'La classe'>
 
+<!-- Sodium -->
+<!ENTITY sodium.changelog.aes256gcm-aarch64 '
+  <informaltable xmlns="http://docbook.org/ns/docbook">
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.4.0</entry>
+      <entry>
+       Cette fonction est désormais également définie sur aarch64.
+       Auparavant, elle était définie uniquement sur x86 et x86_64.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+'>
+
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/sodium/constants.xml
+++ b/reference/sodium/constants.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 2214cd3277cf065a3abf395e9bbde73ed61d7d12 Maintainer: girgias Status: ready -->
+<!-- EN-Revision: 4c85baa92d7c99df238876d20d77ecb952472f11 Maintainer: girgias Status: ready -->
 <!-- Reviewed: yes -->
 <appendix xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="sodium.constants">
  &reftitle.constants;
@@ -171,6 +170,9 @@
    </term>
    <listitem>
     <simpara>
+     Défini uniquement sur les plateformes où le support d'AES-256-GCM est
+     compilé.
+     Défini sur aarch64 à partir de PHP 8.4.0.
     </simpara>
    </listitem>
   </varlistentry>
@@ -181,6 +183,9 @@
    </term>
    <listitem>
     <simpara>
+     Défini uniquement sur les plateformes où le support d'AES-256-GCM est
+     compilé.
+     Défini sur aarch64 à partir de PHP 8.4.0.
     </simpara>
    </listitem>
   </varlistentry>
@@ -191,6 +196,9 @@
    </term>
    <listitem>
     <simpara>
+     Défini uniquement sur les plateformes où le support d'AES-256-GCM est
+     compilé.
+     Défini sur aarch64 à partir de PHP 8.4.0.
     </simpara>
    </listitem>
   </varlistentry>
@@ -201,6 +209,9 @@
    </term>
    <listitem>
     <simpara>
+     Défini uniquement sur les plateformes où le support d'AES-256-GCM est
+     compilé.
+     Défini sur aarch64 à partir de PHP 8.4.0.
     </simpara>
    </listitem>
   </varlistentry>

--- a/reference/sodium/constants.xml
+++ b/reference/sodium/constants.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: 4c85baa92d7c99df238876d20d77ecb952472f11 Maintainer: girgias Status: ready -->
-<!-- Reviewed: yes -->
 <appendix xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="sodium.constants">
  &reftitle.constants;
  &extension.constants;

--- a/reference/sodium/functions/sodium-crypto-aead-aes256gcm-decrypt.xml
+++ b/reference/sodium/functions/sodium-crypto-aead-aes256gcm-decrypt.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 96a8863cc0403bb23a99caff9a113b64f3524671 Maintainer: Fan2Shrek Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 4c85baa92d7c99df238876d20d77ecb952472f11 Maintainer: Fan2Shrek Status: ready -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.sodium-crypto-aead-aes256gcm-decrypt">
  <refnamediv>
   <refname>sodium_crypto_aead_aes256gcm_decrypt</refname>
@@ -68,6 +67,11 @@
   <simpara>
    Renvoie le texte en clair en cas de succès, &return.falseforfailure;.
   </simpara>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  &sodium.changelog.aes256gcm-aarch64;
  </refsect1>
 
 

--- a/reference/sodium/functions/sodium-crypto-aead-aes256gcm-encrypt.xml
+++ b/reference/sodium/functions/sodium-crypto-aead-aes256gcm-encrypt.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 96a8863cc0403bb23a99caff9a113b64f3524671 Maintainer: Fan2Shrek Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 4c85baa92d7c99df238876d20d77ecb952472f11 Maintainer: Fan2Shrek Status: ready -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.sodium-crypto-aead-aes256gcm-encrypt">
  <refnamediv>
   <refname>sodium_crypto_aead_aes256gcm_encrypt</refname>
@@ -67,6 +66,11 @@
   <simpara>
    Renvoie le texte chiffré et l'étiquette d'authentification sous forme de chaîne de bytes binaires bruts. (Format : texte chiffré, puis étiquette.)
   </simpara>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  &sodium.changelog.aes256gcm-aarch64;
  </refsect1>
 
 

--- a/reference/sodium/functions/sodium-crypto-aead-aes256gcm-is-available.xml
+++ b/reference/sodium/functions/sodium-crypto-aead-aes256gcm-is-available.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 96a8863cc0403bb23a99caff9a113b64f3524671 Maintainer: Fan2Shrek Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 4c85baa92d7c99df238876d20d77ecb952472f11 Maintainer: Fan2Shrek Status: ready -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.sodium-crypto-aead-aes256gcm-is-available">
  <refnamediv>
   <refname>sodium_crypto_aead_aes256gcm_is_available</refname>
@@ -29,6 +28,32 @@
   <simpara>
    Renvoie &true; s'il est sûr de chiffrer avec AES-256-GCM, et &false; sinon.
   </simpara>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.4.0</entry>
+      <entry>
+       Cette fonction peut désormais retourner &true; sur les processeurs
+       aarch64 disposant des extensions cryptographiques ARM.
+       Auparavant, l'AES-256-GCM accéléré matériellement était détecté
+       uniquement sur x86 et x86_64, et cette fonction retournait toujours
+       &false; sur aarch64.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
 

--- a/reference/sodium/functions/sodium-crypto-aead-aes256gcm-keygen.xml
+++ b/reference/sodium/functions/sodium-crypto-aead-aes256gcm-keygen.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 96a8863cc0403bb23a99caff9a113b64f3524671 Maintainer: Fan2Shrek Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 4c85baa92d7c99df238876d20d77ecb952472f11 Maintainer: Fan2Shrek Status: ready -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.sodium-crypto-aead-aes256gcm-keygen">
  <refnamediv>
   <refname>sodium_crypto_aead_aes256gcm_keygen</refname>
@@ -30,6 +29,11 @@
   <simpara>
    Renvoie une clé aléatoire de 256 bits.
   </simpara>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  &sodium.changelog.aes256gcm-aarch64;
  </refsect1>
 
 


### PR DESCRIPTION
Syncs the FR pages with php/doc-en@4c85baa92d7c99df238876d20d77ecb952472f11.

- new sodium.changelog.aes256gcm-aarch64 entity in language-snippets.ent
- changelog section on the four AES-256-GCM function pages
- the four SODIUM_CRYPTO_AEAD_AES256GCM_* constants now state where they are defined
- bumps EN-Revision, drops the obsolete $Revision$ and Reviewed markers

Fixes: #3357