### PR TITLE
[Sync-En] Imagick::sigmoidalContrastImage(): amend parameter names

### DIFF
--- a/reference/imagick/imagick/sigmoidalcontrastimage.xml
+++ b/reference/imagick/imagick/sigmoidalcontrastimage.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 6047c10c1f9c7f5f2cc76603807b14b3ac3637b0 Maintainer: yannick Status: ready -->
-<!-- Reviewed: yes -->
-
+<!-- EN-Revision: d9fec5dc8a61c5bbee1d7f70a7bea50c2388e0fd Maintainer: yannick Status: ready -->
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="imagick.sigmoidalcontrastimage" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Imagick::sigmoidalContrastImage</refname>
@@ -18,22 +15,24 @@
    <methodparam><type>float</type><parameter>beta</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>channel</parameter><initializer>Imagick::CHANNEL_DEFAULT</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Ajuste le contraste de l'image avec un algorithme de contraste sigmoïde
-   non linéaire. Augmenter le contraste de l'image en utilisant une fonction
-   de transfert sigmoïde sans saturer les lumières hautes et les ombres.
-   Le contraste indique de combien il faut augmenter le contraste (0 pour
-   ne rien faire, 3 est une valeur typique, 20 est une valeur élevée) ;
-   le point du milieu indique où les tons moyens seront dans l'image
-   résultante (0 correspond à blanc, 50 correspond à gris, 100 correspond
-   à noir). Définir le paramètre <parameter>sharpen</parameter>
-   à &true; pour augmenter le contraste de l'image, sinon, le contraste
-   sera réduit.
-  </para>
-  <para>
+   non linéaire. Augmente le contraste de l'image en utilisant une fonction
+   de transfert sigmoïde sans saturer les hautes lumières ni les ombres.
+   <parameter>alpha</parameter> indique de combien augmenter le contraste :
+   <literal>0.00</literal> pour ne rien faire ; <literal>3.00</literal> est une
+   valeur typique ; <literal>20.00</literal> est une valeur poussée.
+   <parameter>beta</parameter> indique où se situent les tons moyens dans
+   l'image résultante, sous la forme d'une fraction de la plage de quantum :
+   <literal>0.0</literal> correspond au blanc, <literal>0.5</literal> au gris
+   moyen, <literal>1.0</literal> au noir (multiplier par
+   <code>getQuantumRange()['quantumRangeLong']</code> pour obtenir la valeur à
+   passer).
+  </simpara>
+  <simpara>
    Voir aussi les <link xlink:href="&url.imagemagick.usage.color_mods.sigmoidal;">exemples
-   d'ImageMagick V6 - Les transformations d'images - Le contraste non-linéaire</link>
-  </para>
+    d'ImageMagick -- Modifications de couleurs — Le contraste non linéaire sigmoïde</link>.
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -43,18 +42,19 @@
     <varlistentry>
      <term><parameter>sharpen</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Si vaut &true;, le contraste augmentera, sinon, le contraste diminuera.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>alpha</parameter></term>
      <listitem>
-      <para>
-       La quantité de contraste à appliquer. -1 représente une toute petite
-       quantité, 5 représente une quantité significative, et 20 est le maximum.
-      </para>
+      <simpara>
+       La quantité de contraste à appliquer. <literal>1.00</literal> représente
+       une toute petite quantité, <literal>5.00</literal> représente une
+       quantité significative, <literal>20.00</literal> est extrême.
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
@@ -62,16 +62,17 @@
      <listitem>
       <simpara>
        Où doit se situer le milieu du gradient. Cette valeur doit être dans
-       l'intervalle 0-1, multiplié par la valeur du quantum pour ImageMagick.
+       l'intervalle <literal>0.00</literal> à <literal>1.00</literal>,
+       multipliée par la valeur du quantum pour ImageMagick.
       </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>channel</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Canaux de couleurs sur lesquels le contraste doit s'appliquer.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -91,35 +92,32 @@
    &imagick.imagick.throws;
   </para>
  </refsect1>
- 
+
  <refsect1 role="examples">
   &reftitle.examples;
-  <para>
-   <example>
-    <title>
-     Crée un gradient d'image en utilisant la méthode
-     <function>Imagick::sigmoidalContrastImage</function>
-     pour mélanger deux images en douceur, où le mélange est
-     défini par les variables $contrast et $midpoint.
-    </title>
-    <programlisting role="php">
+  <example>
+   <title>
+    Crée un gradient d'image en utilisant la méthode
+    <function>Imagick::sigmoidalContrastImage</function>
+    pour mélanger deux images en douceur, où le mélange est
+    défini par <parameter>alpha</parameter> et <parameter>beta</parameter>
+   </title>
+   <programlisting role="php">
 <![CDATA[
 <?php
 
-function generateBlendImage($width, $height, $contrast = 10, $midpoint = 0.5) {
+function generateBlendImage($width, $height, $alpha = 10, $beta = 0.5)
+{
     $imagick = new Imagick();
     $imagick->newPseudoImage($width, $height, 'gradient:black-white');
     $quanta = $imagick->getQuantumRange();
-    $imagick->sigmoidalContrastImage(true, $contrast, $midpoint * $quanta["quantumRangeLong"]);
+    $imagick->sigmoidalContrastImage(true, $alpha, $beta * $quanta["quantumRangeLong"]);
 
-    return $imagick; 
+    return $imagick;
 }
-
-?>
 ]]>
-    </programlisting>
-   </example>
-  </para>
+   </programlisting>
+  </example>
  </refsect1>
 
 </refentry>


### PR DESCRIPTION
Syncs the FR page with php/doc-en@d9fec5dc8a61c5bbee1d7f70a7bea50c2388e0fd.

- description now names alpha and beta instead of "contrast" and "mid-point", with the quantum-range fraction spelled out
- parameter ranges given as decimal literals; the alpha description said -1 where EN says 1.00
- example renamed its variables to $alpha / $beta
- bumps EN-Revision, drops the obsolete $Revision$ and Reviewed markers

Fixes: #3361