### PR TITLE
[Sync-En] install: note apache2handler requires Apache 2.4 as of PHP 8.4.0

### DIFF
--- a/install/unix/apache2.xml
+++ b/install/unix/apache2.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: fd1f9d85122cd85854f4afdf5a57ab7da38ff69c Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: ee7185a089f266a9475b069aa199314811fad8a8 Maintainer: lacatoire Status: ready -->
 
 <sect1 xml:id="install.unix.apache2" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Apache httpd 2.x sur les systèmes Unix</title>
@@ -60,6 +60,14 @@
   de version supportée d'Apache httpd. Les versions antérieures (2.2 et inférieures)
   sont en fin de vie et ne doivent pas être utilisées.
  </simpara>
+
+ <note>
+  <simpara>
+   À partir de PHP 8.4.0, la SAPI apache2handler nécessite au minimum
+   Apache 2.4 ; la prise en charge d'Apache 2.0 et 2.2, en fin de vie, a été
+   retirée.
+  </simpara>
+ </note>
 
  <orderedlist>
   <listitem>


### PR DESCRIPTION
Syncs the FR page with php/doc-en@ee7185a089f266a9475b069aa199314811fad8a8.

Fixes: #3363