### PR TITLE
[Sync-En] cli: document built-in server index lookup for file-like paths (8.4.0)

### DIFF
--- a/features/commandline.xml
+++ b/features/commandline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 07b2f1dcff1d8beb846f5671e5f4bf2ab8d33ebf Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 14f641dc7a2eb3ab1f97062f0a74f7cdb59ae708 Maintainer: lacatoire Status: ready -->
 
 <chapter xml:id="features.commandline" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Utiliser PHP en ligne de commande</title>
@@ -1687,6 +1687,16 @@ php >
    est trouvé, il sera retourné et $_SERVER['PATH_INFO'] sera défini comme la
    dernière partie de l'URI. Sinon, un code réponse 404 sera retourné.
   </para>
+
+  <note>
+   <simpara>
+    À partir de PHP 8.4.0, cette recherche de fichier d'index est effectuée
+    même lorsque le chemin demandé ressemble à un fichier, c'est-à-dire que son
+    dernier composant contient un point, mais ne peut pas être localisé.
+    Auparavant, de telles requêtes ignoraient la recherche et retournaient
+    immédiatement une réponse 404.
+   </simpara>
+  </note>
   
   <para>
    Si un fichier PHP est fourni dans la ligne de commande lorsque le serveur web


### PR DESCRIPTION
Syncs the FR page with php/doc-en@14f641dc7a2eb3ab1f97062f0a74f7cdb59ae708.

Fixes: #3362