### PR TITLE
[Sync-En] pcre: clarify that delimiters must be single-byte characters

### DIFF
--- a/reference/pcre/pattern.syntax.xml
+++ b/reference/pcre/pattern.syntax.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 3e1cd2462664adb2495cff5887671ba8a9909cf9 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 61d512bfd7098a177b6490e0b478c72ed6fb90d6 Maintainer: yannick Status: ready -->
 
 <chapter xml:id="reference.pcre.pattern.syntax" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Syntaxe des masques</title>
@@ -29,12 +29,21 @@
  </section>
  <section xml:id="regexp.reference.delimiters">
   <title>Délimiteurs</title>
-  <para>
+  <simpara>
    Lors de l'utilisation des fonctions PCRE, il est nécessaire que le motif soit encadré
-   par des <emphasis>délimiteurs</emphasis>. Un délimiteur peut être n'importe quel caractère 
-   non alpha-numérique autre qu'un backslash ou qu'un espace.
+   par des <emphasis>délimiteurs</emphasis>. Un délimiteur peut être n'importe quel caractère
+   sur un seul octet non alpha-numérique autre qu'un backslash ou qu'un espace.
    Les caractères d'espacement blanc avant un délimiteur valide sont silencieusement ignorés.
-  </para>
+  </simpara>
+  <note>
+   <simpara>
+    Les caractères multi-octets (tels que les caractères encodés en UTF-8 comme
+    <literal>§</literal>) ne peuvent pas être utilisés comme délimiteurs.
+    PHP lit exactement un octet comme délimiteur ; utiliser un caractère
+    multi-octets ferait interpréter à tort les octets restants comme des
+    options de motif inconnues.
+   </simpara>
+  </note>
   <para>
    Les délimiteurs les plus courants sont les slashes (<literal>/</literal>), dièses
    (<literal>#</literal>) et les tildes (<literal>~</literal>). Les exemples suivants ont


### PR DESCRIPTION
Syncs the FR page with php/doc-en@61d512bfd7098a177b6490e0b478c72ed6fb90d6.

Fixes: #3367