### PR TITLE
[Sync-En] Revise the Yaconf extension documentation (#5801)

### DIFF
--- a/reference/yaconf/book.xml
+++ b/reference/yaconf/book.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 4a87d61dbfcaddeafeebe5fd9546c5d9c6bc9ea2 Maintainer: girgias Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 3b052562d228be18fa6dce221df7e375469fb7ad Maintainer: girgias Status: ready -->
 
 <book xml:id="book.yaconf" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <?phpdoc extension-membership="pecl" ?>
@@ -10,67 +8,57 @@
 
  <preface xml:id="intro.yaconf">
   &reftitle.intro;
-  <para>
+  <simpara>
    <literal>Yet Another Configurations Container</literal>
-   (<acronym>Yaconf</acronym>) est un conteneur de configuration,
-   il analyse les fichiers <literal>INI</literal>, enregistre le résultat en
-   PHP quand PHP est démarré, le résultat vit tout
-   le long du cycle de vie de PHP.
-  </para>
-  <para>
-   Yaconf enregistre toutes les configurations en tant que
-   chaîne internée ou un tableau immuable, ce qui signifie qu'ils ne sont pas
-   comptabilisés dans les références, ainsi lors de la récupération des
-   configurations depuis <acronym>Yaconf</acronym>, ceci peut être considéré sans copie,
-   très rapide.
-  </para>
-  <para>
-   Yaconf supporte les sections et l'héritage des sections
-   dans les fichiers <literal>INI</literal>. Si PHP est compilé en tant que non-ZTS,
-   Yaconf supporte aussi le rechargement automatique après que les
-   fichiers <literal>INI</literal> sont modifiés.
-  </para>
-  <para>
+   (<acronym>Yaconf</acronym>) est un conteneur de configuration. Il analyse
+   les fichiers <literal>INI</literal> au démarrage de PHP et conserve le
+   résultat en mémoire persistante pour toute la durée du cycle de vie de PHP,
+   de sorte que chaque accès est une simple recherche dans une table de hachage,
+   sans aucune E/S disque ni analyse par requête.
+  </simpara>
+  <simpara>
+   Yaconf enregistre toutes les configurations sous forme de chaînes internées
+   ou de tableaux immuables. Ils ne sont pas comptabilisés dans les références,
+   donc la récupération d'une configuration depuis Yaconf est effectivement
+   sans copie. Depuis Yaconf 1.2.0, l'arbre de configuration analysé est en
+   outre compacté dans un bloc contigu unique, ce qui réduit l'empreinte
+   mémoire et améliore la localité du cache.
+  </simpara>
+  <simpara>
+   La configuration analysée réside en mémoire persistante partagée par tous
+   les workers PHP-FPM via la copie sur écriture : tant qu'un fichier de
+   configuration ne change pas, les workers partagent les mêmes pages mémoire
+   physiques, quel que soit leur nombre.
+  </simpara>
+  <simpara>
+   Yaconf supporte les sections et l'héritage de sections dans les fichiers
+   INI. Sur les compilations non-ZTS, il recharge aussi les fichiers
+   automatiquement lorsqu'ils changent ; sur les compilations ZTS
+   (thread-safe), les configurations sont chargées au démarrage et un
+   redémarrage est nécessaire pour prendre en compte les modifications.
+  </simpara>
+  <simpara>
+   Depuis Yaconf 1.2.0, les sous-répertoires du répertoire configuré sont
+   chargés récursivement (jusqu'à 16 niveaux de profondeur) et adressés avec
+   le nom du répertoire comme niveau de clé : par exemple,
+   <literal>Yaconf::get("users.database.master")</literal> lit la clé
+   <literal>master</literal> depuis le fichier
+   <filename>database.ini</filename> placé dans le sous-répertoire
+   <filename>users/</filename>.
+  </simpara>
+  <simpara>
+   Stocker des configurations sensibles en dehors de l'arborescence web réduit
+   aussi la surface d'attaque. Avec Yaconf, les fichiers
+   <filename>.ini</filename> peuvent être placés dans un répertoire accessible
+   uniquement par root, comme <filename>/etc/yaconf</filename> : le master
+   PHP-FPM charge les configurations au démarrage du service, tandis que les
+   workers forqués — qui s'exécutent sous un utilisateur non privilégié et
+   traitent les requêtes web — n'ont pas besoin, et ne reçoivent pas, l'accès
+   à ce répertoire.
+  </simpara>
+  <simpara>
    Yaconf nécessite PHP 7.0 ou supérieur.
-  </para>
-  <example>
-   <title>Exemple INI</title>
-   <programlisting role="ini">
-<![CDATA[
-;Simple key val
-key=val
-
-;Hash
-hash.a=val
-
-;Array
-arr.0=val
-
-;or
-arr[]=val
-
-;PHP constants
-version=PHP_VERSION
-
-;Environment variable
-env=${PATH}
-]]>
-   </programlisting>
-  </example>
-  <example>
-   <title>Exemple avec les sections INI</title>
-   <programlisting role="ini">
-<![CDATA[
-[SectionA]
-key=val
-hash.a=val
-
-;SectionB inherits SectionA
-[SectionB:SectionA]
-key=new_val                 ;override configuration key in SectionA
-]]>
-   </programlisting>
-  </example>
+  </simpara>
  </preface>
 
  &reference.yaconf.setup;

--- a/reference/yaconf/ini.xml
+++ b/reference/yaconf/ini.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: d4d5216e7a965ca194f6b1c9dee84cecab2674e5 Maintainer: girgias Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 3b052562d228be18fa6dce221df7e375469fb7ad Maintainer: girgias Status: ready -->
 
 <section xml:id="yaconf.configuration" xmlns="http://docbook.org/ns/docbook">
  &reftitle.runtime;
@@ -20,14 +18,14 @@
     </thead>
     <tbody>
      <row>
-      <entry><link linkend="ini.yaconf.check-delay">yaconf.check_delay</link></entry>
-      <entry>300</entry>
+      <entry><link linkend="ini.yaconf.directory">yaconf.directory</link></entry>
+      <entry><literal>""</literal></entry>
       <entry><constant>INI_SYSTEM</constant></entry>
       <entry><!-- leave empty, this will be filled by an automatic script --></entry>
      </row>
      <row>
-      <entry><link linkend="ini.yaconf.directory">yaconf.directory</link></entry>
-      <entry>/tmp/conf/</entry>
+      <entry><link linkend="ini.yaconf.check-delay">yaconf.check_delay</link></entry>
+      <entry><literal>300</literal></entry>
       <entry><constant>INI_SYSTEM</constant></entry>
       <entry><!-- leave empty, this will be filled by an automatic script --></entry>
      </row>
@@ -40,31 +38,87 @@
 
  <para>
   <variablelist>
-   <varlistentry xml:id="ini.yaconf.check-delay">
-     <term>
-      <parameter>yaconf.check_delay</parameter>
-      <type>int</type>
-     </term>
-     <listitem>
-      <para>
-       Intervalle dans lequel Yaconf détectera les modifications de fichier
-       INI (grâce au mtime du dossier), si ceci est défini à zéro, il faut
-       redémarrer PHP pour recharger les configurations.
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="ini.yaconf.directory">
-     <term>
-      <parameter>yaconf.directory</parameter>
-      <type>string</type>
-     </term>
-     <listitem>
-      <para>
-       Chemin vers le dossier où tous les fichiers de configuration INI sont placés.
-      </para>
-     </listitem>
-    </varlistentry>
+   <varlistentry xml:id="ini.yaconf.directory">
+    <term>
+     <parameter>yaconf.directory</parameter>
+     <type>string</type>
+    </term>
+    <listitem>
+     <simpara>
+      Le répertoire où tous les fichiers de configuration INI sont placés.
+      Seuls les fichiers avec l'extension <filename>.ini</filename> sont
+      chargés. Les sous-répertoires sont chargés récursivement (jusqu'à
+      16 niveaux de profondeur) ; chacun agit comme un niveau de clé, de
+      sorte qu'un fichier <filename>database.ini</filename> placé dans le
+      sous-répertoire <filename>users/</filename> est adressé comme
+      <literal>"users.database"</literal>. Disponible depuis Yaconf 1.2.0 ;
+      avant cela, seuls les fichiers directement dans le répertoire étaient
+      chargés.
+     </simpara>
+     <simpara>
+      Les exemples ci-dessous supposent le
+      <filename>database.ini</filename> suivant placé dans le répertoire
+      configuré, à côté d'un <filename>features.ini</filename> contenant
+      des paramètres par fonctionnalité.
+     </simpara>
+     <example>
+      <title>Syntaxe du fichier INI</title>
+      <programlisting role="ini">
+<![CDATA[
+; database.ini
+name=production                        ; valeur scalaire
+version=PHP_VERSION                    ; les constantes PHP sont résolues
+connection_string=${DATABASE_URL}      ; les variables d'environnement sont résolues
+options.max_connections=50             ; clé de hachage imbriquée
+options.timeout=30
 
+; entrées de tableau, les deux notations sont équivalentes
+replicas.0=replica-1.example.com
+replicas[]=replica-2.example.com
+]]>
+      </programlisting>
+     </example>
+     <example>
+      <title>Exemple de sections INI</title>
+      <programlisting role="ini">
+<![CDATA[
+; features.ini
+[default]
+cache_enabled=on
+rate_limit=100
+
+; la section "premium" hérite de toutes les clés de "default" et
+; remplace celles qu'elle redéfinit
+[premium:default]
+rate_limit=1000
+]]>
+      </programlisting>
+     </example>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="ini.yaconf.check-delay">
+    <term>
+     <parameter>yaconf.check_delay</parameter>
+     <type>int</type>
+    </term>
+    <listitem>
+     <simpara>
+      L'intervalle, en secondes, auquel Yaconf vérifie si un fichier INI
+      chargé a changé et recharge les fichiers modifiés (la modification est
+      détectée en comparant les temps de modification du répertoire). Définir
+      cette valeur à <literal>0</literal> fait vérifier Yaconf à chaque
+      requête.
+     </simpara>
+     <note>
+      <simpara>
+       Cette directive n'est enregistrée que sur les compilations non-ZTS.
+       Sur les compilations ZTS (thread-safe), les configurations sont
+       chargées au démarrage et le rechargement automatique n'est pas
+       disponible ; redémarrer PHP pour prendre en compte les modifications.
+      </simpara>
+     </note>
+    </listitem>
+   </varlistentry>
   </variablelist>
  </para>
 </section>

--- a/reference/yaconf/setup.xml
+++ b/reference/yaconf/setup.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: aebf045bfb7f4f2350db5e1e908cf290be334075 Maintainer: girgias Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 3b052562d228be18fa6dce221df7e375469fb7ad Maintainer: girgias Status: ready -->
 
 <chapter xml:id="yaconf.setup" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.setup;
@@ -15,6 +13,10 @@
 
  <section xml:id="yaconf.installation">
   &reftitle.install;
+  <simpara>
+   Yaconf peut être installé de trois façons : via PECL, via PIE, ou en
+   compilant depuis les sources.
+  </simpara>
   <para>
    &pecl.moved;
   </para>
@@ -25,6 +27,43 @@
   <para>
    &pecl.windows.download.avail;
   </para>
+  <example>
+   <title>Installation de Yaconf avec PECL</title>
+   <programlisting role="shell">
+<![CDATA[
+pecl install yaconf
+]]>
+   </programlisting>
+  </example>
+  <simpara>
+   Depuis Yaconf 1.2.0, l'extension peut être installée avec
+   &link.pie;, le PHP Installer for Extensions, en exécutant la commande
+   suivante.
+  </simpara>
+  <example>
+   <title>Installation de Yaconf avec PIE</title>
+   <programlisting role="shell">
+<![CDATA[
+pie install laruence/yaconf
+]]>
+   </programlisting>
+  </example>
+  <simpara>
+   Le code source est hébergé sur
+   <link xlink:href="&url.git.hub;laruence/yaconf">GitHub</link>. Pour
+   compiler l'extension depuis les sources, exécutez les commandes suivantes,
+   en remplaçant les chemins par ceux de l'installation PHP locale.
+  </simpara>
+  <example>
+   <title>Compilation de Yaconf depuis les sources</title>
+   <programlisting role="shell">
+<![CDATA[
+/path/to/phpize
+./configure --with-php-config=/path/to/php-config
+make && make install
+]]>
+   </programlisting>
+  </example>
  </section>
 
  &reference.yaconf.ini;

--- a/reference/yaconf/yaconf/debuginfo.xml
+++ b/reference/yaconf/yaconf/debuginfo.xml
@@ -1,0 +1,143 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 3b052562d228be18fa6dce221df7e375469fb7ad Maintainer: Fan2Shrek Status: ready -->
+
+<refentry xml:id="yaconf.debug-info" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Yaconf::__debug_info</refname>
+  <refpurpose>Inspecte la façon dont une valeur de configuration est stockée</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>public</modifier> <modifier>static</modifier> <type class="union"><type>array</type><type>null</type></type><methodname>Yaconf::__debug_info</methodname>
+   <methodparam><type>string</type><parameter>name</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Retourne des informations de débogage sur la valeur stockée sous
+   <parameter>name</parameter> : l'adresse mémoire de la valeur stockée et
+   si la valeur réside toujours dans le bloc de stockage compacté de Yaconf.
+  </simpara>
+  <warning>
+   <simpara>
+    Cette méthode existe uniquement pour la suite de tests de Yaconf, qui
+    l'utilise pour vérifier que l'extension fonctionne correctement. Ne pas
+    l'utiliser dans du code de production, et ne pas se fier au format de sa
+    sortie : le tableau retourné peut changer à tout moment.
+   </simpara>
+  </warning>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>name</parameter></term>
+    <listitem>
+     <simpara>
+      Le nom de configuration à inspecter, en utilisant la même notation
+      pointée que <methodname>Yaconf::get</methodname>.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Un &array; avec quatre entrées lorsque la configuration existe, &null;
+   sinon :
+  </simpara>
+  <itemizedlist>
+   <listitem>
+    <simpara>
+     <literal>key</literal> — le nom recherché.
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <literal>address</literal> — l'adresse mémoire de la valeur stockée.
+     Les valeurs sont stockées comme des chaînes internées ou des tableaux
+     immuables, donc cette adresse reste constante jusqu'au rechargement de
+     la configuration.
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <literal>val</literal> — la valeur stockée elle-même.
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <literal>changed</literal> — &false; tant que les données de la valeur
+     résident dans le bloc de stockage compacté, ce qui signifie que le
+     système d'exploitation n'a pas eu besoin de copier la page (la
+     copie-sur-écriture s'applique toujours) ; &true; lorsque la valeur a
+     été réallouée en dehors du bloc.
+    </simpara>
+   </listitem>
+  </itemizedlist>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Exemple avec <methodname>Yaconf::__debug_info</methodname></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+// supposant que app.ini contient name="shop"
+var_dump(Yaconf::__debug_info("app.name"));
+/*
+array(4) {
+  ["key"]=>
+  string(8) "app.name"
+  ["address"]=>
+  string(14) "0x7f8b1c0a3d20"
+  ["val"]=>
+  string(4) "shop"
+  ["changed"]=>
+  bool(false)
+}
+*/
+
+var_dump(Yaconf::__debug_info("app.missing")); // NULL
+?>
+]]>
+   </programlisting>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><methodname>Yaconf::get</methodname></member>
+    <member><methodname>Yaconf::has</methodname></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/yaconf/yaconf/get.xml
+++ b/reference/yaconf/yaconf/get.xml
@@ -1,12 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: a464df4c7d82ef16d94fff2582eeb8dd7579b894 Maintainer: girgias Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 3b052562d228be18fa6dce221df7e375469fb7ad Maintainer: girgias Status: ready -->
 
 <refentry xml:id="yaconf.get" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Yaconf::get</refname>
-  <refpurpose>Récupère une entrée</refpurpose>
+  <refpurpose>Récupère une valeur de configuration par son nom</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -14,11 +12,18 @@
   <methodsynopsis>
    <modifier>public</modifier> <modifier>static</modifier> <type>mixed</type><methodname>Yaconf::get</methodname>
    <methodparam><type>string</type><parameter>name</parameter></methodparam>
-   <methodparam choice="opt"><type>mixed</type><parameter>default_value</parameter><initializer>NULL</initializer></methodparam>
+   <methodparam choice="opt"><type>mixed</type><parameter>default</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
-
-  </para>
+  <simpara>
+   Récupère la valeur de configuration stockée sous <parameter>name</parameter>.
+   Les noms utilisent la notation pointée pour traverser les clés imbriquées :
+   <literal>"app"</literal> adresse le fichier <filename>app.ini</filename>
+   entier, <literal>"app.name"</literal> une clé à l'intérieur, et depuis
+   Yaconf 1.2.0 <literal>"users.database.master"</literal> une clé dans le
+   fichier <filename>database.ini</filename> placé dans le sous-répertoire
+   <filename>users/</filename>. La notation pointée supporte jusqu'à 64
+   niveaux d'imbrication.
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -27,18 +32,22 @@
    <varlistentry>
     <term><parameter>name</parameter></term>
     <listitem>
-     <para>
-      Clé de configuration, la clé ressemble à "filename.key",
-      ou "filename.sectionName,key".
-     </para>
+     <simpara>
+      Le nom de configuration à rechercher, en utilisant la notation pointée
+      pour traverser les clés imbriquées, par exemple
+      <literal>"app.name"</literal>, <literal>"app.features.1"</literal>
+      ou, depuis Yaconf 1.2.0, <literal>"users.database.master"</literal>
+      pour les fichiers dans des sous-répertoires.
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term><parameter>default_value</parameter></term>
+    <term><parameter>default</parameter></term>
     <listitem>
-     <para>
-      Si la clé n'existe pas, Yaconf::get retourne ceci comme résultat.
-     </para>
+     <simpara>
+      La valeur à retourner lorsque <parameter>name</parameter> n'est pas
+      trouvé. Lorsqu'omis, &null; est retourné.
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -46,50 +55,69 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
-   Retourne la valeur de configuration (&string; ou &array;) si la clé existe,
-   retourne <parameter>default_value</parameter> sinon.
-  </para>
+  <simpara>
+   La valeur de configuration stockée, une &string; ou un &array;, lorsque
+   <parameter>name</parameter> existe ; sinon la valeur
+   <parameter>default</parameter> (ou &null; lorsqu'aucun défaut n'a été
+   fourni).
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">
   &reftitle.examples;
-  <example>
-   <title>Exemple <function>INI</function></title>
-   <programlisting role="ini">
+  <simpara>
+   Les exemples ci-dessous supposent les deux fichiers suivants placés dans
+   le répertoire configuré avec <literal>yaconf.directory</literal>.
+  </simpara>
+  <programlisting role="ini">
 <![CDATA[
-;filenmame foo.ini, placed in directory which is yaconf.directoy
-[SectionA]
-;key value pair
-key=val
-;hash[a]=val
-hash.a=val
-;arr[0]=val
-arr.0=val
-;or
-arr[]=val
+; app.ini
+name="shop"                     ; valeur scalaire
+debug=0                         ; nombre
+features[]="checkout"           ; entrées de tableau, les deux notations
+features.1="wishlist"
+]]>
+  </programlisting>
+  <programlisting role="ini">
+<![CDATA[
+; users/database.ini, dans un sous-répertoire (Yaconf 1.2.0+)
+master="192.168.0.10"
+replica="192.168.0.20"
+]]>
+  </programlisting>
+  <example>
+   <title>Exemple avec <methodname>Yaconf::get</methodname></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+// récupérer un fichier analysé entier sous forme de tableau
+var_dump(Yaconf::get("app"));
 
-;SectionB inherits SectionA
-[SectionB:SectionA]
-;override configuration key in SectionA
-key=new_val
+// la notation pointée traverse les clés imbriquées
+var_dump(Yaconf::get("app.name"));           // string(4) "shop"
+var_dump(Yaconf::get("app.features.1"));     // string(8) "wishlist"
+
+// depuis 1.2.0 : les fichiers dans les sous-répertoires sont nommés
+// par le nom du répertoire
+var_dump(Yaconf::get("users.database.master")); // string(12) "192.168.0.10"
+
+// lorsque la clé est absente, la valeur par défaut est retournée
+var_dump(Yaconf::get("app.missing"));             // NULL
+var_dump(Yaconf::get("app.missing", "fallback")); // string(8) "fallback"
+?>
 ]]>
    </programlisting>
-   &example.outputs.similar;
-   <screen>
-<![CDATA[
-php7 -r 'var_dump(Yaconf::get("foo.SectionA.key"));'
-//string(3) "val"
-
-php7 -r 'var_dump(Yaconf::get("foo.SectionB.key"));'
-//string(7) "new_val"
-
-php7 -r 'var_dump(Yaconf::get("foo")["SectionA"]["hash"]);'
-//array(1)
-
-]]>
-   </screen>
   </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><methodname>Yaconf::has</methodname></member>
+    <member><methodname>Yaconf::__debug_info</methodname></member>
+   </simplelist>
+  </para>
  </refsect1>
 
 </refentry>

--- a/reference/yaconf/yaconf/has.xml
+++ b/reference/yaconf/yaconf/has.xml
@@ -1,12 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 9cfadc46e7d5a27ae5cc17430f3aa5fc5dc27a04 Maintainer: girgias Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 3b052562d228be18fa6dce221df7e375469fb7ad Maintainer: girgias Status: ready -->
 
 <refentry xml:id="yaconf.has" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Yaconf::has</refname>
-  <refpurpose>Détermine si une entrée existe</refpurpose>
+  <refpurpose>Vérifie si une valeur de configuration existe</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -15,9 +13,14 @@
    <modifier>public</modifier> <modifier>static</modifier> <type>bool</type><methodname>Yaconf::has</methodname>
    <methodparam><type>string</type><parameter>name</parameter></methodparam>
   </methodsynopsis>
-  <para>
-
-  </para>
+  <simpara>
+   Détermine si une valeur de configuration existe sous
+   <parameter>name</parameter>, qui utilise la même notation pointée que
+   <methodname>Yaconf::get</methodname> : par exemple,
+   <literal>"app.name"</literal> ou, depuis Yaconf 1.2.0,
+   <literal>"users.database.master"</literal> pour les fichiers dans des
+   sous-répertoires.
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -26,9 +29,12 @@
    <varlistentry>
     <term><parameter>name</parameter></term>
     <listitem>
-     <para>
-      
-     </para>
+     <simpara>
+      Le nom de configuration à rechercher, en utilisant la notation pointée
+      pour traverser les clés imbriquées, par exemple
+      <literal>"app.name"</literal> ou
+      <literal>"users.database.master"</literal>.
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -36,11 +42,48 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
-   
-  </para>
+  <simpara>
+   Retourne &true; si une valeur de configuration existe à
+   <parameter>name</parameter>, &false; sinon.
+  </simpara>
  </refsect1>
 
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <simpara>
+   Les exemples ci-dessous supposent un fichier <filename>app.ini</filename>
+   placé dans le répertoire configuré avec <literal>yaconf.directory</literal>,
+   contenant les clés <literal>name="shop"</literal> et
+   <literal>debug=0</literal>.
+  </simpara>
+  <example>
+   <title>Exemple avec <methodname>Yaconf::has</methodname></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+var_dump(Yaconf::has("app.name"));     // bool(true)
+var_dump(Yaconf::has("app.missing"));  // bool(false)
+
+// utile pour distinguer une valeur vide stockée d'une clé absente,
+// où Yaconf::get() retournerait le même défaut dans les deux cas
+if (Yaconf::has("app.debug")) {
+    $debug = (bool) Yaconf::get("app.debug");
+}
+?>
+]]>
+   </programlisting>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><methodname>Yaconf::get</methodname></member>
+    <member><methodname>Yaconf::__debug_info</methodname></member>
+   </simplelist>
+  </para>
+ </refsect1>
 
 </refentry>
 


### PR DESCRIPTION
Closes #3365

Sync with php/doc-en@3b052562d228be18fa6dce221df7e375469fb7ad (PR php/doc-en#5801).

**Changes:**
- `book.xml`: rewrite preface — persistent memory sharing across FPM workers, zero-copy retrieval, compacted storage (1.2.0), recursive sub-directory loading (1.2.0), security notes
- `ini.xml`: swap entry order (`directory` first), rewrite both directive descriptions, add INI syntax and section examples, add ZTS note for `check_delay`
- `setup.xml`: add PIE and from-source installation instructions
- `yaconf/get.xml`: rename `$default_value` → `$default`, rewrite description and examples (sub-directory notation)
- `yaconf/has.xml`: fill previously empty description, parameters, returnvalues; add examples
- `yaconf/debuginfo.xml`: new file documenting `Yaconf::__debug_info()` (PECL yaconf ≥ 1.1.0)