### PR TITLE
[Sync-En] Taint: sync with EN revision befe2b9 (EN PR #5802)

### DIFF
--- a/reference/taint/book.xml
+++ b/reference/taint/book.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
 <!-- EN-Revision: befe2b9fbe37b0925498f336632742651386b151 Maintainer: lacatoire Status: ready -->
 
 <book xml:id="book.taint" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/reference/taint/book.xml
+++ b/reference/taint/book.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: cfe2c34143ab17e522b1594ae0902b7245f072d5 Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: befe2b9fbe37b0925498f336632742651386b151 Maintainer: lacatoire Status: ready -->
 
 <book xml:id="book.taint" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <?phpdoc extension-membership="pecl" ?>
@@ -10,49 +9,59 @@
 
  <preface xml:id="intro.taint">
   &reftitle.intro;
-  <para>
-   Taint est une extension dont le but est de détecter les codes XSS (chaîne
-   de caractères corrompue).
-   Cette extension peut être utilisée pour mettre en lumière certaines
-   vulnérabilités concernant des injections SQL, des injections shell, etc.
-  </para>
-  <para>
-   Lorsque taint est actif, si une chaîne corrompue (provenant de <varname>$_GET</varname>,
-   <varname>$_POST</varname> ou <varname>$_COOKIE</varname>) est passée à des fonctions, taint émettra une alerte.
-  </para>
+  <simpara>
+   Taint est une extension permettant de détecter des codes XSS (chaînes
+   corrompues). Elle peut également être utilisée pour repérer des injections
+   SQL, des injections de commandes, des injections de chemins de fichiers et
+   des vulnérabilités similaires.
+  </simpara>
+  <simpara>
+   Lorsque taint est activé, les chaînes reçues de l'entrée utilisateur —
+   <varname>$_GET</varname>, <varname>$_POST</varname> et
+   <varname>$_COOKIE</varname> — sont marquées comme corrompues au démarrage
+   de la requête, et la marque est propagée à travers les opérations sur les
+   chaînes. Lorsqu'une chaîne corrompue atteint un point de sortie dangereux
+   (affichage, requête SQL, commande shell, chemin de fichier...), taint émet
+   un avertissement pointant vers cet endroit. Voir
+   <link linkend="taint.detail">Propagation et vérifications</link> pour les
+   listes complètes.
+  </simpara>
+  <simpara>
+   Taint est un outil de développement et d'audit, non une défense à
+   l'exécution : il ne fait que signaler des problèmes possibles et ne bloque
+   ni n'altère jamais les données. Il est délibérément conservateur et peut
+   sur-rapporter, donc un passage sans erreur signifie uniquement « rien que
+   taint ne pouvait voir », jamais « prouvablement sécurisé ». Ne pas
+   l'activer dans les environnements de production.
+  </simpara>
   <example>
-   <title>Exemple avec <function>Taint</function></title>
+   <title>Exemple avec Taint</title>
    <programlisting role="php">
 <![CDATA[
 <?php
 $a = trim($_GET['a']);
 
-$file_name = '/tmp' .  $a;
+$file_name = '/tmp/' . $a;
 $output    = "Welcome, {$a} !!!";
-$var       = "output";
-$sql       = "Select *  from " . $a;
-$sql      .= "ooxx";
+$sql       = "SELECT * FROM users WHERE name = " . $a;
 
 echo $output;
-
-print $$var;
-
+print $output;
 include $file_name;
-
-mysql_query($sql);
+mysqli_query($link, $sql);
 ?>
 ]]>
    </programlisting>
    &example.outputs.similar;
    <screen>
 <![CDATA[
-Warning: main() [function.echo]: Attempt to echo a string that might be tainted
+Warning: main() [echo]: Attempt to echo a string that might be tainted in /path/to/script.php on line 9
 
-Warning: main() [function.echo]: Attempt to print a string that might be tainted
+Warning: main() [print]: Attempt to print a string that might be tainted in /path/to/script.php on line 10
 
-Warning: include() [function.include]: File path contains data that might be tainted
+Warning: main() [include]: File path contains data that might be tainted in /path/to/script.php on line 11
 
-Warning: mysql_query() [function.mysql-query]: SQL statement contains data that might be tainted
+Warning: main() [mysqli_query]: SQL statement contains data that might be tainted in /path/to/script.php on line 12
 ]]>
    </screen>
   </example>

--- a/reference/taint/configure.xml
+++ b/reference/taint/configure.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
 <!-- EN-Revision: befe2b9fbe37b0925498f336632742651386b151 Maintainer: lacatoire Status: ready -->
 
 <section xml:id="taint.installation" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/reference/taint/configure.xml
+++ b/reference/taint/configure.xml
@@ -1,19 +1,59 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 94497636f2f6956ba6bf1017297d589009fbd040 Maintainer: yannick Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: befe2b9fbe37b0925498f336632742651386b151 Maintainer: lacatoire Status: ready -->
 
 <section xml:id="taint.installation" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.install;
 
- <para>
+ <simpara>
   &pecl.info;
-  <link xlink:href="&url.pecl.package;taint">&url.pecl.package;taint</link>
+  <link xlink:href="&url.pecl.package;taint">&url.pecl.package;taint</link>.
+ </simpara>
+
+ <simpara>
+  Installation via <acronym>PECL</acronym> :
+ </simpara>
+ <para>
+  <screen>
+<![CDATA[
+$ pecl install taint
+]]>
+  </screen>
  </para>
 
- 
-</section>
+ <para>
+  Le code source est hébergé sur
+  <link xlink:href="&url.git.hub;laruence/taint">GitHub</link>. Pour compiler
+  l'extension depuis les sources :
+  <screen>
+<![CDATA[
+$ git clone https://github.com/laruence/taint.git
+$ cd taint
+$ phpize
+$ ./configure
+$ make
+$ sudo make install
+]]>
+  </screen>
+ </para>
 
+ <simpara>
+  Ensuite activer l'extension en ajoutant
+  <literal>extension=taint.so</literal> (ou <literal>extension=php_taint.dll</literal>
+  sous Windows) dans &php.ini;, et mettre
+  <link linkend="ini.taint.enable">taint.enable</link> à
+  <literal>1</literal>.
+ </simpara>
+
+ <warning>
+  <simpara>
+   Taint est un outil de développement et d'audit. Ne pas l'activer dans
+   les environnements de production : l'instrumentation ralentit chaque
+   requête, désactive le JIT d'OPcache, et les avertissements peuvent faire
+   fuiter des données de requête dans les journaux.
+  </simpara>
+ </warning>
+</section>
 
 <!-- Keep this comment at the end of the file
 Local variables:

--- a/reference/taint/detail.xml
+++ b/reference/taint/detail.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
 <!-- EN-Revision: befe2b9fbe37b0925498f336632742651386b151 Maintainer: lacatoire Status: ready -->
 
 <chapter xml:id="taint.detail" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/reference/taint/detail.xml
+++ b/reference/taint/detail.xml
@@ -1,320 +1,280 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 4de6d12569dcee7ac2012400c439eee8a971b813 Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: befe2b9fbe37b0925498f336632742651386b151 Maintainer: lacatoire Status: ready -->
 
 <chapter xml:id="taint.detail" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
- <title>Plus de détails</title>
+ <title>Propagation et vérifications</title>
 
  <section xml:id="taint.detail.basic">
-  <title>Fonctions et requêtes qui seront marquées comme chaînes non propres</title>
+  <title>Comment la marque de corruption se propage</title>
+  <simpara>
+   La marque de corruption est un bit unique stocké sur la chaîne elle-même,
+   pas sur la variable qui la contient. Assigner, passer ou partager une
+   chaîne corrompue conserve la marque. La concaténation et l'interpolation
+   de chaînes la propagent également :
+  </simpara>
   <para>
    <table>
-    <title></title>
-    <tgroup cols="2">
-      <colspec colname="name"/>
-      <colspec colname="version"/>
-     <thead>
-      <row>
-       <entry>Fonction/Requête</entry>
-       <entry>Depuis</entry>
-      </row>
-     </thead>
+    <title>Opérateurs qui propagent la marque de corruption</title>
+    <tgroup cols="1">
      <tbody>
       <row>
-       <entry>= (assignement)</entry>
-       <entry>0.1.0</entry>
+       <entry><literal>=</literal> (assignement, y compris <literal>list()</literal>/<literal>déstructuration de tableau</literal>)</entry>
       </row>
       <row>
-       <entry>. (concat)</entry>
-       <entry>0.1.0</entry>
+       <entry><literal>.</literal> (concaténation)</entry>
       </row>
       <row>
-       <entry>"{$var}" (substitution de variable)</entry>
-       <entry>0.1.0</entry>
+       <entry><literal>.=</literal> (assignement de concaténation)</entry>
       </row>
       <row>
-       <entry>.= (assignement de concaténation)</entry>
-       <entry>0.1.0</entry>
-      </row>
-      <row>
-       <entry>strval</entry>
-       <entry>0.3.0</entry>
-      </row>
-      <row>
-       <entry>explode/split</entry>
-       <entry>0.3.0</entry>
-      </row>
-      <row>
-       <entry>implode/join</entry>
-       <entry>0.3.0</entry>
-      </row>
-      <row>
-       <entry>sprintf</entry>
-       <entry>0.3.0</entry>
-      </row>
-      <row>
-       <entry>vsprintf</entry>
-       <entry>0.3.0</entry>
-      </row>
-      <row>
-       <entry>trim</entry>
-       <entry>0.4.0</entry>
-      </row>
-      <row>
-       <entry>rtrim</entry>
-       <entry>0.4.0</entry>
-      </row>
-      <row>
-       <entry>ltrim</entry>
-       <entry>0.4.0</entry>
-      </row>
-      <row>
-       <entry>strstr</entry>
-       <entry>0.5.0</entry>
-      </row>
-      <row>
-       <entry>str_pad</entry>
-       <entry>0.5.0</entry>
-      </row>
-      <row>
-       <entry>str_replace</entry>
-       <entry>0.5.0</entry>
-      </row>
-      <row>
-       <entry>substr</entry>
-       <entry>0.5.0</entry>
-      </row>
-      <row>
-       <entry>strtolower</entry>
-       <entry>0.5.0</entry>
-      </row>
-      <row>
-       <entry>strtoupper</entry>
-       <entry>0.5.0</entry>
+       <entry><literal>"{$var}"</literal> (interpolation de chaîne, y compris le chemin rapide <literal>ROPE</literal>)</entry>
       </row>
      </tbody>
     </tgroup>
    </table>
   </para>
- </section>
-
- <section xml:id="taint.detail.taint">
-  <title>Fonctions et requêtes qui vérifieront si la chaîne est propre</title>
+  <simpara>
+   De plus, taint comprend un ensemble fixe de fonctions de chaînes : lorsque
+   l'un des arguments de chaîne concernés est corrompu, la chaîne retournée
+   est également marquée comme corrompue. L'appel normal et, sur PHP 8.4+,
+   l'appel rapide sans cadre (frameless) sont tous deux couverts.
+  </simpara>
   <para>
    <table>
-    <title></title>
-    <tgroup cols="2">
-      <colspec colname="name"/>
-      <colspec colname="version"/>
-     <thead>
-      <row>
-       <entry>Fonction/Requêtes</entry>
-       <entry>Depuis</entry>
-      </row>
-     </thead>
+    <title>Fonctions qui propagent la marque de corruption</title>
+    <tgroup cols="1">
      <tbody>
       <row>
-       <entry namest="name" nameend="version">Requêtes basiques</entry>
+       <entry><function>trim</function>, <function>rtrim</function>, <function>ltrim</function></entry>
       </row>
       <row>
-       <entry>eval</entry>
-       <entry>0.1.0</entry>
+       <entry><function>substr</function>, <function>strstr</function></entry>
       </row>
       <row>
-       <entry>include/include_once</entry>
-       <entry>0.1.0</entry>
+       <entry><function>str_replace</function>, <function>str_ireplace</function></entry>
       </row>
       <row>
-       <entry>require/require_once</entry>
-       <entry>0.1.0</entry>
-      </row>
-      <!--end basic -->
-
-      <row>
-       <entry namest="name" nameend="version">Fonctions d'affichage</entry>
+       <entry><function>str_pad</function>, <function>strtolower</function>, <function>strtoupper</function>, <function>strval</function></entry>
       </row>
       <row>
-       <entry>echo</entry>
-       <entry>0.1.0</entry>
+       <entry><function>explode</function> (chaque élément du tableau résultant)</entry>
       </row>
       <row>
-       <entry>print</entry>
-       <entry>0.1.0</entry>
+       <entry><function>implode</function>/<function>join</function> (un séparateur corrompu corrompt également le résultat)</entry>
       </row>
       <row>
-       <entry>printf</entry>
-       <entry>0.1.0</entry>
+       <entry><function>sprintf</function>, <function>vsprintf</function> (seul le spécificateur <literal>%s</literal> transporte la marque ; <literal>sprintf("%d", $t)</literal> retourne une chaîne propre)</entry>
       </row>
       <row>
-       <entry>file_put_contents</entry>
-       <entry>0.1.0</entry>
-      </row>
-      <!-- end outputing -->
-      <row>
-       <entry namest="name" nameend="version">Fonctions du système de fichiers</entry>
-      </row>
-      <row>
-       <entry>fopen</entry>
-       <entry>0.2.0</entry>
-      </row>
-      <row>
-       <entry>opendir</entry>
-       <entry>0.2.0</entry>
-      </row>
-      <row>
-       <entry>basename</entry>
-       <entry>0.2.0</entry>
-      </row>
-      <row>
-       <entry>dirname</entry>
-       <entry>0.2.0</entry>
-      </row>
-      <row>
-       <entry>file</entry>
-       <entry>0.2.0</entry>
-      </row>
-      <row>
-       <entry>pathinfo</entry>
-       <entry>0.2.0</entry>
-      </row>
-      <!-- end file system -->
-      <row>
-       <entry namest="name" nameend="version">Fonctions de base de données</entry>
-      </row>
-      <row>
-       <entry>mysql_query</entry>
-       <entry>0.2.0</entry>
-      </row>
-      <row>
-       <entry>mysqli_query/MySQLi::query</entry>
-       <entry>0.2.0</entry>
-      </row>
-      <row>
-       <entry>sqlite_query/SqliteDataBase::query</entry>
-       <entry>0.3.0</entry>
-      </row>
-      <row>
-       <entry>sqlite_single_query/SqliteDataBase::singleQuery</entry>
-       <entry>0.3.0</entry>
-      </row>
-      <row>
-       <entry>oci_parse</entry>
-       <entry>0.3.0</entry>
-      </row>
-      <row>
-       <entry>PDO::query</entry>
-       <entry>0.3.0</entry>
-      </row>
-      <row>
-       <entry>PDO::prepare</entry>
-       <entry>0.3.0</entry>
-      </row>
-      <row>
-       <entry>SQLite3::query</entry>
-       <entry>2.0.1</entry>
-      </row>
-      <row>
-       <entry>SQLite3::prepare</entry>
-       <entry>2.0.1</entry>
-      </row>
-      <!-- end database -->
-      <row>
-       <entry namest="name" nameend="version">Fonctions de ligne de commande</entry>
-      </row>
-      <row>
-       <entry>system</entry>
-       <entry>0.1.0</entry>
-      </row>
-      <row>
-       <entry>exec</entry>
-       <entry>0.1.0</entry>
-      </row>
-      <row>
-       <entry>proc_open</entry>
-       <entry>0.1.0</entry>
-      </row>
-      <row>
-       <entry>passthru</entry>
-       <entry>0.1.0</entry>
-      </row>
-      <row>
-       <entry>shell_exec</entry>
-       <entry>0.3.0</entry>
-      </row>
-      <!-- end command line -->
-
-     </tbody>
-    </tgroup>
-   </table>
-  </para>
- </section>
-
- <section xml:id="taint.detail.untaint">
-  <title>Fonctions qui ne nettoieront pas une chaîne non propre</title>
-  <para>
-   <table>
-    <title></title>
-    <tgroup cols="2">
-      <colspec colname="name"/>
-      <colspec colname="version"/>
-     <thead>
-      <row>
-       <entry>Fonction</entry>
-       <entry>Depuis</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>addslashes</entry>
-       <entry>0.1.0</entry>
-      </row>
-      <row>
-       <entry>addcslashes</entry>
-       <entry>0.1.0</entry>
-      </row>
-      <row>
-       <entry>htmlspecialchars</entry>
-       <entry>0.1.0</entry>
-      </row>
-      <row>
-       <entry>htmlentities</entry>
-       <entry>0.1.0</entry>
-      </row>
-      <row>
-       <entry>escapeshellcmd</entry>
-       <entry>0.1.0</entry>
-      </row>
-      <row>
-       <entry>mysql_escape_string</entry>
-       <entry>0.1.0</entry>
-      </row>
-      <row>
-       <entry>mysql_real_escape_string</entry>
-       <entry>0.1.0</entry>
-      </row>
-      <row>
-       <entry>mysqli_escape_string/MySQLi::escape_string</entry>
-       <entry>0.1.0</entry>
-      </row>
-      <row>
-       <entry>mysqli_real_escape_string/MySQLi::real_escape_string</entry>
-       <entry>0.1.0</entry>
-      </row>
-      <row>
-       <entry>sqlite_escape_string/SqliteDataBase::escapeString</entry>
-       <entry>0.3.0</entry>
-      </row>
-      <row>
-       <entry>PDO::quote</entry>
-       <entry>0.3.0</entry>
+       <entry><function>dirname</function>, <function>basename</function>, <function>pathinfo</function></entry>
       </row>
      </tbody>
     </tgroup>
    </table>
   </para>
-
+  <simpara>
+   Toute fonction que taint ne comprend pas explicitement retourne une
+   chaîne neuve et non marquée -- y compris les fonctions d'échappement
+   telles que <function>htmlspecialchars</function>,
+   <function>htmlentities</function> ou
+   <function>mysqli_real_escape_string</function>. C'est délibéré : taint
+   sur-rapporte plutôt que d'essayer de décider si une valeur est
+   <quote>sûre</quote> pour un contexte de sortie particulier. Utiliser
+   <function>untaint</function> pour effacer la marque sur des valeurs que
+   l'on a validées soi-même.
+  </simpara>
  </section>
+
+ <section xml:id="taint.detail.sinks">
+  <title>Où taint déclenche des avertissements</title>
+  <simpara>
+   Lorsqu'une chaîne corrompue atteint l'un des points de sortie ci-dessous,
+   taint émet un avertissement (par défaut un
+   <constant>E_USER_WARNING</constant> ; le niveau est configurable via
+   <link linkend="ini.taint.error-level">taint.error_level</link>). Seuls
+   les arguments de chaîne de premier niveau sont inspectés ; vider un
+   tableau qui contient simplement des valeurs corrompues n'émet pas
+   d'avertissement.
+  </simpara>
+  <para>
+   <table>
+    <title>Points de sortie d'affichage</title>
+    <tgroup cols="2">
+     <thead>
+      <row><entry>Point de sortie</entry><entry>Vérifié</entry></row>
+     </thead>
+     <tbody>
+      <row>
+       <entry><literal>echo</literal>, <literal>print</literal></entry>
+       <entry>l'expression affichée</entry>
+      </row>
+      <row>
+       <entry><function>printf</function>, <function>vprintf</function></entry>
+       <entry>la chaîne de format et les valeurs substituées</entry>
+      </row>
+      <row>
+       <entry><function>print_r</function>, <function>var_dump</function>, <function>var_export</function></entry>
+       <entry>la valeur vidée, quand c'est une chaîne</entry>
+      </row>
+      <row>
+       <entry><literal>exit</literal>/<literal>die</literal> avec un message</entry>
+       <entry>le message</entry>
+      </row>
+      <row>
+       <entry><function>file_put_contents</function>, <function>fwrite</function>, <function>fputs</function> vers <literal>php://output</literal></entry>
+       <entry>les données écrites</entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </table>
+  </para>
+  <para>
+   <table>
+    <title>Points de sortie du système de fichiers</title>
+    <tgroup cols="2">
+     <thead>
+      <row><entry>Point de sortie</entry><entry>Vérifié</entry></row>
+     </thead>
+     <tbody>
+      <row>
+       <entry><function>fopen</function>, <function>opendir</function>, <function>unlink</function></entry>
+       <entry>le chemin</entry>
+      </row>
+      <row>
+       <entry><function>file</function>, <function>readfile</function>, <function>file_get_contents</function>, <function>highlight_file</function>/<function>show_source</function></entry>
+       <entry>le chemin</entry>
+      </row>
+      <row>
+       <entry><function>copy</function>, <function>rename</function>, <function>move_uploaded_file</function></entry>
+       <entry>les chemins source et destination</entry>
+      </row>
+      <row>
+       <entry><function>mkdir</function>, <function>rmdir</function>, <function>touch</function></entry>
+       <entry>le chemin</entry>
+      </row>
+      <row>
+       <entry><literal>include</literal>, <literal>include_once</literal>, <literal>require</literal>, <literal>require_once</literal></entry>
+       <entry>le chemin du fichier</entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </table>
+  </para>
+  <para>
+   <table>
+    <title>Points de sortie SQL</title>
+    <tgroup cols="2">
+     <thead>
+      <row><entry>Point de sortie</entry><entry>Vérifié</entry></row>
+     </thead>
+     <tbody>
+      <row>
+       <entry><function>mysqli_query</function>, <function>mysqli_prepare</function>, <function>mysqli_real_query</function>, <function>mysqli_multi_query</function></entry>
+       <entry>la chaîne de requête</entry>
+      </row>
+      <row>
+       <entry><function>mysql_query</function>, <function>sqlite_query</function>, <function>sqlite_single_query</function>, <function>oci_parse</function>, <function>pg_query</function>, <function>pg_send_query</function></entry>
+       <entry>la chaîne de requête</entry>
+      </row>
+      <row>
+       <entry><methodname>mysqli::query</methodname>, <methodname>mysqli::prepare</methodname>, <methodname>mysqli::real_query</methodname>, <methodname>mysqli::multi_query</methodname></entry>
+       <entry>la chaîne de requête</entry>
+      </row>
+      <row>
+       <entry><methodname>PDO::query</methodname>, <methodname>PDO::prepare</methodname>, <methodname>PDO::exec</methodname></entry>
+       <entry>la chaîne de requête</entry>
+      </row>
+      <row>
+       <entry><methodname>SQLite3::query</methodname>, <methodname>SQLite3::prepare</methodname>, <methodname>SQLite3::exec</methodname>, <methodname>SQLiteDatabase::query</methodname>, <methodname>SQLiteDatabase::singleQuery</methodname></entry>
+       <entry>la chaîne de requête</entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </table>
+  </para>
+  <para>
+   <table>
+    <title>Points de sortie d'exécution de commandes</title>
+    <tgroup cols="2">
+     <thead>
+      <row><entry>Point de sortie</entry><entry>Vérifié</entry></row>
+     </thead>
+     <tbody>
+      <row>
+       <entry><function>exec</function>, <function>system</function>, <function>passthru</function>, <function>shell_exec</function> (y compris l'opérateur backtick)</entry>
+       <entry>la chaîne de commande</entry>
+      </row>
+      <row>
+       <entry><function>proc_open</function>, <function>popen</function></entry>
+       <entry>la chaîne de commande</entry>
+      </row>
+      <row>
+       <entry><literal>eval</literal></entry>
+       <entry>le code évalué</entry>
+      </row>
+      <row>
+       <entry>les appels dynamiques tels que <literal>$func()</literal>, <literal>$obj-&gt;$method()</literal>, <function>call_user_func</function>, les callables tableaux</entry>
+       <entry>le nom de fonction/méthode/classe en cours de résolution</entry>
+      </row>
+      <row>
+       <entry><function>preg_match</function>, <function>preg_match_all</function>, <function>preg_replace</function>, <function>preg_split</function>, <function>preg_grep</function>, <function>preg_replace_callback</function></entry>
+       <entry>le motif (et le nom du callback pour <function>preg_replace_callback</function>)</entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </table>
+  </para>
+  <para>
+   <table>
+    <title>Points de sortie d'en-têtes et cookies</title>
+    <tgroup cols="2">
+     <thead>
+      <row><entry>Point de sortie</entry><entry>Vérifié</entry></row>
+     </thead>
+     <tbody>
+      <row>
+       <entry><function>header</function></entry>
+       <entry>la chaîne d'en-tête</entry>
+      </row>
+      <row>
+       <entry><function>setcookie</function>, <function>setrawcookie</function></entry>
+       <entry>le nom et la valeur du cookie</entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </table>
+  </para>
+  <para>
+   <table>
+    <title>Autres points de sortie</title>
+    <tgroup cols="2">
+     <thead>
+      <row><entry>Point de sortie</entry><entry>Vérifié</entry></row>
+     </thead>
+     <tbody>
+      <row>
+       <entry><function>unserialize</function></entry>
+       <entry>la chaîne sérialisée</entry>
+      </row>
+      <row>
+       <entry><function>mail</function></entry>
+       <entry>le destinataire, le sujet, les paramètres supplémentaires et les en-têtes supplémentaires (le corps du message est du contenu et n'est pas vérifié)</entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </table>
+  </para>
+  <simpara>
+   Les avertissements suivent le format
+   <literal>function_name() [sink]: message</literal>, où
+   <literal>sink</literal> identifie l'opération vérifiée (par exemple
+   <literal>echo</literal>, <literal>include</literal> ou le nom de la
+   fonction) et le message décrit ce qui a été trouvé comme potentiellement
+   corrompu.
+  </simpara>
+ </section>
+
 </chapter>
 
 <!-- Keep this comment at the end of the file

--- a/reference/taint/functions/is-tainted.xml
+++ b/reference/taint/functions/is-tainted.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 94497636f2f6956ba6bf1017297d589009fbd040 Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: befe2b9fbe37b0925498f336632742651386b151 Maintainer: lacatoire Status: ready -->
 
 <refentry xml:id="function.is-tainted" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -15,10 +14,10 @@
    <type>bool</type><methodname>is_tainted</methodname>
    <methodparam><type>string</type><parameter>string</parameter></methodparam>
   </methodsynopsis>
-  <para>
-   Vérifie si une chaîne est corrompue.
-  </para>
-
+  <simpara>
+   Vérifie si la valeur donnée porte la marque de corruption. Seules les
+   chaînes peuvent être corrompues ; tout autre type retourne &false;.
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -27,9 +26,9 @@
    <varlistentry>
     <term><parameter>string</parameter></term>
     <listitem>
-     <para>
-      
-     </para>
+     <simpara>
+      La valeur à vérifier.
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -37,11 +36,43 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
-   Retourne &true; si la chaîne est corrompue, &false; sinon.
-  </para>
+  <simpara>
+   Retourne &true; si la valeur est une chaîne corrompue, &false; sinon.
+   Retourne toujours &false; lorsque
+   <link linkend="ini.taint.enable">taint.enable</link> est désactivé.
+  </simpara>
  </refsect1>
 
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Exemple avec <function>is_tainted</function></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$name = $_GET['name'] ?? 'world';
+var_dump(is_tainted($name));
+?>
+]]>
+   </programlisting>
+   &example.outputs.similar;
+   <screen>
+<![CDATA[
+bool(true)
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>taint</function></member>
+    <member><function>untaint</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
 
 </refentry>
 

--- a/reference/taint/functions/is-tainted.xml
+++ b/reference/taint/functions/is-tainted.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
 <!-- EN-Revision: befe2b9fbe37b0925498f336632742651386b151 Maintainer: lacatoire Status: ready -->
 
 <refentry xml:id="function.is-tainted" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/reference/taint/functions/taint.xml
+++ b/reference/taint/functions/taint.xml
@@ -1,12 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 9e0f03ac354d797d1d16c0fcc1663e5e170f2727 Maintainer: itanea Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: befe2b9fbe37b0925498f336632742651386b151 Maintainer: lacatoire Status: ready -->
 
 <refentry xml:id="function.taint" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>taint</refname>
-  <refpurpose>Marque une chaîne comme corrompue</refpurpose>
+  <refpurpose>Marque des chaînes comme corrompues</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -14,11 +13,23 @@
   <methodsynopsis>
    <type>bool</type><methodname>taint</methodname>
    <methodparam><type>string</type><parameter role="reference">string</parameter></methodparam>
-   <methodparam rep="repeat"><type>string</type><parameter>strings</parameter></methodparam>
+   <methodparam rep="repeat"><type>string</type><parameter role="reference">strings</parameter></methodparam>
   </methodsynopsis>
-  <para>
-   Marque une chaîne comme corrompue. Utilisé uniquement dans un but de test.
-  </para>
+  <simpara>
+   Marque manuellement les chaînes données comme corrompues, comme si elles
+   provenaient d'une entrée utilisateur. Les variables sont passées par
+   référence, mais la marque elle-même est stockée sur la chaîne plutôt que
+   sur la variable : chaque variable partageant la même chaîne devient
+   corrompue à la fois.
+  </simpara>
+  <simpara>
+   Ceci est principalement utile pour les tests et pour simuler des entrées
+   utilisateur dans des scripts CLI où les superglobales
+   <link linkend="reserved.variables.get">$_GET</link>,
+   <link linkend="reserved.variables.post">$_POST</link> et
+   <link linkend="reserved.variables.cookies">$_COOKIE</link>
+   ne sont pas peuplées.
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -27,16 +38,17 @@
    <varlistentry>
     <term><parameter>string</parameter></term>
     <listitem>
-     <para>
-      
-     </para>
+     <simpara>
+      Une variable contenant la chaîne à marquer.
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>strings</parameter></term>
     <listitem>
-     <para>
-     </para>
+     <simpara>
+      D'autres variables à marquer.
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -44,11 +56,62 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
+  <simpara>
+   Retourne toujours &true;. Lorsque
+   <link linkend="ini.taint.enable">taint.enable</link> est désactivé, la
+   fonction ne fait rien et retourne quand même &true;.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Exemple avec <function>taint</function></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$name = "world";
+taint($name);
+var_dump(is_tainted($name));
+?>
+]]>
+   </programlisting>
+   &example.outputs.similar;
+   <screen>
+<![CDATA[
+bool(true)
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="notes">
+  &reftitle.notes;
+  <note>
+   <simpara>
+    Seules les chaînes non vides sont marquées ; les variables contenant
+    d'autres types, ou des chaînes vides, sont silencieusement ignorées.
+   </simpara>
+  </note>
+  <note>
+   <simpara>
+    Les chaînes internées, persistantes et permanentes (littéraux de
+    chaînes, chaînes partagées d'opcache) ne peuvent jamais porter la
+    marque et sont silencieusement ignorées.
+   </simpara>
+  </note>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
   <para>
-   Retourne &true; si la transformation a eu lieu, et retournera
-   toujours &true; si l'extension taint n'est pas activée.
+   <simplelist>
+    <member><function>untaint</function></member>
+    <member><function>is_tainted</function></member>
+   </simplelist>
   </para>
  </refsect1>
+
 </refentry>
 
 <!-- Keep this comment at the end of the file

--- a/reference/taint/functions/taint.xml
+++ b/reference/taint/functions/taint.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
 <!-- EN-Revision: befe2b9fbe37b0925498f336632742651386b151 Maintainer: lacatoire Status: ready -->
 
 <refentry xml:id="function.taint" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/reference/taint/functions/untaint.xml
+++ b/reference/taint/functions/untaint.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
 <!-- EN-Revision: befe2b9fbe37b0925498f336632742651386b151 Maintainer: lacatoire Status: ready -->
 
 <refentry xml:id="function.untaint" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/reference/taint/functions/untaint.xml
+++ b/reference/taint/functions/untaint.xml
@@ -1,56 +1,108 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 9e0f03ac354d797d1d16c0fcc1663e5e170f2727 Maintainer: itanea Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: befe2b9fbe37b0925498f336632742651386b151 Maintainer: lacatoire Status: ready -->
 
 <refentry xml:id="function.untaint" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>untaint</refname>
-  <refpurpose>Retire la corruption d'une chaîne</refpurpose>
+  <refpurpose>Retire la marque de corruption des chaînes</refpurpose>
  </refnamediv>
- 
+
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
    <type>bool</type><methodname>untaint</methodname>
    <methodparam><type>string</type><parameter role="reference">string</parameter></methodparam>
-   <methodparam rep="repeat"><type>string</type><parameter>strings</parameter></methodparam>
+   <methodparam rep="repeat"><type>string</type><parameter role="reference">strings</parameter></methodparam>
   </methodsynopsis>
-  <para>
-   Retire la corruption d'une chaîne.
-  </para>
+  <simpara>
+   Efface la marque de corruption sur les chaînes données.
+  </simpara>
+  <simpara>
+   La marque est stockée sur la chaîne elle-même, pas sur la variable, donc
+   cela l'efface pour chaque variable partageant la même chaîne à la fois.
+   Utiliser cette fonction pour autoriser des valeurs que l'on a validées
+   soi-même, par exemple après une vérification stricte par liste blanche.
+  </simpara>
  </refsect1>
- 
+
  <refsect1 role="parameters">
   &reftitle.parameters;
   <variablelist>
    <varlistentry>
     <term><parameter>string</parameter></term>
     <listitem>
-     <para>
-      
-     </para>
+     <simpara>
+      Une variable contenant la chaîne à nettoyer.
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>strings</parameter></term>
     <listitem>
-     <para>
-      
-     </para>
+     <simpara>
+      D'autres variables à nettoyer.
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
  </refsect1>
- 
+
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
+  <simpara>
+   Retourne toujours &true;. Lorsque
+   <link linkend="ini.taint.enable">taint.enable</link> est désactivé, la
+   fonction ne fait rien et retourne quand même &true;.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Exemple avec <function>untaint</function></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$id = "42";
+taint($id);
+if (preg_match('/^\d+$/', $id)) {
+    // validé strictement comme des chiffres : sûr à utiliser
+    untaint($id);
+}
+var_dump(is_tainted($id));
+?>
+]]>
+   </programlisting>
+   &example.outputs.similar;
+   <screen>
+<![CDATA[
+bool(false)
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="notes">
+  &reftitle.notes;
+  <note>
+   <simpara>
+    Seules les valeurs de type chaîne peuvent porter la marque ; passer
+    un type non-chaîne est sans effet.
+   </simpara>
+  </note>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
   <para>
-   
+   <simplelist>
+    <member><function>taint</function></member>
+    <member><function>is_tainted</function></member>
+   </simplelist>
   </para>
  </refsect1>
- 
- 
+
 </refentry>
 
 <!-- Keep this comment at the end of the file

--- a/reference/taint/ini.xml
+++ b/reference/taint/ini.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
 <!-- EN-Revision: befe2b9fbe37b0925498f336632742651386b151 Maintainer: lacatoire Status: ready -->
 
 <section xml:id="taint.configuration" xmlns="http://docbook.org/ns/docbook">

--- a/reference/taint/ini.xml
+++ b/reference/taint/ini.xml
@@ -1,9 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: d4d5216e7a965ca194f6b1c9dee84cecab2674e5 Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: befe2b9fbe37b0925498f336632742651386b151 Maintainer: lacatoire Status: ready -->
 
- 
 <section xml:id="taint.configuration" xmlns="http://docbook.org/ns/docbook">
  &reftitle.runtime;
  &extension.runtime;
@@ -28,7 +26,7 @@
      </row>
      <row>
       <entry><link linkend="ini.taint.error-level">taint.error_level</link></entry>
-      <entry>E_WARNING</entry>
+      <entry>512 (E_USER_WARNING)</entry>
       <entry><constant>INI_ALL</constant></entry>
       <entry><!-- leave empty, this will be filled by an automatic script --></entry>
      </row>
@@ -44,12 +42,28 @@
    <varlistentry xml:id="ini.taint.enable">
      <term>
       <parameter>taint.enable</parameter>
-      <type>int</type>
+      <type>bool</type>
      </term>
      <listitem>
-      <para>
-       Si l'on doit activer taint.
-      </para>
+      <simpara>
+       Interrupteur principal. Lorsqu'il est activé, taint accroche
+       l'exécuteur et marque les chaînes issues de
+       <varname>$_GET</varname>, <varname>$_POST</varname> et
+       <varname>$_COOKIE</varname> comme corrompues au démarrage de la
+       requête.
+      </simpara>
+      <simpara>
+       C'est une directive &php.ini; uniquement : son activation requiert un
+       redémarrage du processus, elle ne peut donc pas être activée ou
+       désactivée par requête ou par répertoire.
+      </simpara>
+      <note>
+       <simpara>
+        Ne pas activer cette directive dans les environnements de production :
+        l'instrumentation ralentit chaque requête et est incompatible avec
+        le JIT d'OPcache.
+       </simpara>
+      </note>
      </listitem>
     </varlistentry>
     <varlistentry xml:id="ini.taint.error-level">
@@ -58,9 +72,24 @@
       <type>int</type>
      </term>
      <listitem>
+      <simpara>
+       Le niveau d'erreur utilisé lorsque taint signale une chaîne
+       potentiellement corrompue. La valeur par défaut est
+       <constant>E_USER_WARNING</constant> (512).
+      </simpara>
+      <simpara>
+       Cette directive étant <constant>INI_ALL</constant>, elle peut être
+       modifiée à l'exécution. Par exemple, pour silencer les avertissements
+       taint pour le script courant :
+      </simpara>
       <para>
-       le type d'erreur que taint va reporter lorsqu'il trouvera
-       une chaîne non propre.
+       <programlisting role="php">
+<![CDATA[
+<?php
+ini_set('taint.error_level', 0);
+?>
+]]>
+       </programlisting>
       </para>
      </listitem>
     </varlistentry>

--- a/reference/taint/reference.xml
+++ b/reference/taint/reference.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
 <!-- EN-Revision: befe2b9fbe37b0925498f336632742651386b151 Maintainer: lacatoire Status: ready -->
 
 <reference xml:id="ref.taint" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/reference/taint/reference.xml
+++ b/reference/taint/reference.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 94497636f2f6956ba6bf1017297d589009fbd040 Maintainer: yannick Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: befe2b9fbe37b0925498f336632742651386b151 Maintainer: lacatoire Status: ready -->
 
 <reference xml:id="ref.taint" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>&Functions; Taint</title>

--- a/reference/taint/setup.xml
+++ b/reference/taint/setup.xml
@@ -1,24 +1,33 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 307e7d78baacfcd228eef8f384e96659b67d9adb Maintainer: yannick Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: befe2b9fbe37b0925498f336632742651386b151 Maintainer: lacatoire Status: ready -->
 
 <chapter xml:id="taint.setup" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.setup;
 
- <section xml:id="taint.installation">
-  &reftitle.install;
-  <para>
-   &pecl.moved;
-  </para>
-  <para>
-   &pecl.info;
-   <link xlink:href="&url.pecl.package;taint">&url.pecl.package;taint</link>.
-  </para>
+ <section xml:id="taint.requirements">
+  &reftitle.required;
+  <simpara>
+   Taint 3.x requiert PHP 8.0 ou supérieur. Pour PHP 7.x utiliser les
+   versions taint 2.1.x, et pour PHP 5.x les versions taint 1.x.
+  </simpara>
  </section>
 
- <!-- {{{ Configuration -->
-  &reference.taint.ini;
+ <!-- {{{ Installation -->
+ &reference.taint.configure;
  <!-- }}} -->
+
+ <!-- {{{ Configuration -->
+ &reference.taint.ini;
+ <!-- }}} -->
+
+ <section xml:id="taint.resources">
+  &reftitle.resources;
+  <simpara>
+   Taint ne définit aucun type de ressource. La marque de corruption est
+   stockée dans la structure interne <literal>zend_string</literal>, pas
+   dans une ressource visible par l'utilisateur.
+  </simpara>
+ </section>
 
 </chapter>
 


### PR DESCRIPTION
Closes #3364

Syncs the French taint extension documentation with EN PR #5802 (merge commit `befe2b9fbe37b0925498f336632742651386b151`).

**Files updated:**
- `reference/taint/book.xml` — rewrite preface (3 simpara, updated mysqli example, production warning)
- `reference/taint/configure.xml` — add PECL install, source build instructions, php.ini note, production warning
- `reference/taint/setup.xml` — restructure: requirements, configure, ini, resources sections
- `reference/taint/detail.xml` — full rewrite: propagation chapter with operators, functions and 6 categorised sink tables
- `reference/taint/ini.xml` — fix default value (512/E_USER_WARNING), expand taint.enable and taint.error_level descriptions
- `reference/taint/functions/is-tainted.xml` — simpara, parameter description, example, seealso
- `reference/taint/functions/taint.xml` — 2 simpara, parameters, example, 2 notes, seealso
- `reference/taint/functions/untaint.xml` — 2 simpara, parameters, example, note, seealso
- `reference/taint/reference.xml` — update EN-Revision, remove Reviewed tag