### PR TITLE
[Sync-En] Yac: sync with EN revision 1a42637 (EN PR #5794)

### DIFF
--- a/reference/yac/book.xml
+++ b/reference/yac/book.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 68c2c871505aadf983f16113c5b077b335ce8d76 Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 1a42637cd40d0f75af1435ff051c7caa9b1c83e0 Maintainer: lacatoire Status: ready -->
 
 <book xml:id="book.yac" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <?phpdoc extension-membership="pecl" ?>
@@ -10,10 +9,34 @@
 
  <preface xml:id="intro.yac">
   &reftitle.intro;
-  <para>
-   Yac (Yet Another cache), est un cache de données utilisateur
-   en mémoire partagée, sans verrou, pouvant être utilisé pour remplacer APC.
-  </para>
+  <simpara>
+   Yac (Yet Another Cache) est un cache de données utilisateur en mémoire
+   partagée, sans verrou, pouvant être utilisé pour remplacer APC ou un
+   memcached local.
+  </simpara>
+  <simpara>
+   Yac stocke les données en mémoire partagée, ce qui les rend visibles par
+   chaque worker PHP de la même machine sans aucune communication
+   inter-processus. Au lieu de verrous, Yac repose sur des mises à jour
+   atomiques de slots et quelques sondes de collision, ce qui signifie qu'un
+   défaut de cache ne bloque jamais une requête, et qu'une écriture
+   concurrente peut au pire provoquer un échec de stockage ou une lecture
+   ratée que l'appelant peut simplement réessayer.
+  </simpara>
+  <simpara>
+   Parce que Yac échange des garanties de cohérence contre vitesse et
+   débit, il convient mieux aux données coûteuses à produire mais faciles à
+   recréer : fragments de page, instantanés de configuration, petites
+   réponses de service et autres caches locaux. Il ne doit pas être utilisé
+   comme stockage faisant autorité pour des données irremplaçables.
+  </simpara>
+  <note>
+   <simpara>
+    La mémoire partagée n'est visible qu'au sein d'une seule machine. Pour
+    partager un cache entre plusieurs serveurs, utiliser un cache réseau tel
+    que Memcached ou Redis.
+   </simpara>
+  </note>
  </preface>
 
  &reference.yac.setup;

--- a/reference/yac/book.xml
+++ b/reference/yac/book.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
 <!-- EN-Revision: 1a42637cd40d0f75af1435ff051c7caa9b1c83e0 Maintainer: lacatoire Status: ready -->
 
 <book xml:id="book.yac" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/reference/yac/configure.xml
+++ b/reference/yac/configure.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
 <!-- EN-Revision: 1a42637cd40d0f75af1435ff051c7caa9b1c83e0 Maintainer: lacatoire Status: ready -->
 
 <section xml:id="yac.installation" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/reference/yac/configure.xml
+++ b/reference/yac/configure.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: b8be4b126c545a0b452be29b6b5ce185471814a1 Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 1a42637cd40d0f75af1435ff051c7caa9b1c83e0 Maintainer: lacatoire Status: ready -->
 
 <section xml:id="yac.installation" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.install;

--- a/reference/yac/constants.xml
+++ b/reference/yac/constants.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 86e6094e86b84a51d00ab217ac50ce8dde33d82a Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 1a42637cd40d0f75af1435ff051c7caa9b1c83e0 Maintainer: lacatoire Status: ready -->
 
 <appendix xml:id="yac.constants" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.constants;

--- a/reference/yac/constants.xml
+++ b/reference/yac/constants.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
 <!-- EN-Revision: 1a42637cd40d0f75af1435ff051c7caa9b1c83e0 Maintainer: lacatoire Status: ready -->
 
 <appendix xml:id="yac.constants" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/reference/yac/ini.xml
+++ b/reference/yac/ini.xml
@@ -1,14 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: d4d5216e7a965ca194f6b1c9dee84cecab2674e5 Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 1a42637cd40d0f75af1435ff051c7caa9b1c83e0 Maintainer: lacatoire Status: ready -->
 
 <section xml:id="yac.configuration" xmlns="http://docbook.org/ns/docbook">
  &reftitle.runtime;
  &extension.runtime;
  <para>
   <table>
-   <title>&ConfigureOptions; Yac</title>
+   <title>Yac &ConfigureOptions;</title>
    <tgroup cols="4">
     <thead>
      <row>
@@ -76,9 +75,14 @@
       <type>int</type>
      </term>
      <listitem>
-      <para>
-       
-      </para>
+      <simpara>
+       Les valeurs sérialisées plus grandes que ce nombre d'octets sont
+       compressées avant d'être stockées (actuellement avec LZ4). Mettre à
+       <literal>-1</literal> (la valeur par défaut) pour désactiver
+       entièrement la compression. Compresser les grandes valeurs économise
+       de la mémoire partagée au coût de quelques cycles CPU lors du
+       stockage et de la récupération.
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry xml:id="ini.yac.debug">
@@ -87,9 +91,10 @@
       <type>int</type>
      </term>
      <listitem>
-      <para>
-       
-      </para>
+      <simpara>
+       Réservé au débogage. À partir de Yac 2.4.0, cette directive est
+       enregistrée mais n'a aucun effet.
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry xml:id="ini.yac.enable">
@@ -98,9 +103,10 @@
       <type>int</type>
      </term>
      <listitem>
-      <para>
-       
-      </para>
+      <simpara>
+       Si Yac est activé. Si désactivé, créer une instance de
+       <classname>Yac</classname> lance une exception.
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry xml:id="ini.yac.enable-cli">
@@ -109,9 +115,12 @@
       <type>int</type>
      </term>
      <listitem>
-      <para>
-       
-      </para>
+      <simpara>
+       Si Yac est activé lors de l'exécution sous le SAPI
+       <literal>CLI</literal>. Désactivé par défaut car les scripts en
+       ligne de commande démarrent et s'arrêtent immédiatement, et le
+       segment de mémoire partagée serait créé inutilement.
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry xml:id="ini.yac.keys-memory-size">
@@ -120,9 +129,15 @@
       <type>string</type>
      </term>
      <listitem>
-      <para>
-       
-      </para>
+      <simpara>
+       Quantité de mémoire partagée utilisée pour la table de hachage qui
+       contient les clés et les informations de gestion. Chaque slot est une
+       structure de taille fixe, donc cette valeur détermine combien
+       d'éléments peuvent être suivis simultanément. La valeur par défaut
+       est <literal>4M</literal>. Yac divise cette zone en segments ; la
+       taille de segment est de 4M, donc cette valeur doit être un multiple
+       de <literal>4M</literal>.
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry xml:id="ini.yac.serializer">
@@ -131,9 +146,17 @@
       <type>string</type>
      </term>
      <listitem>
-      <para>
-       
-      </para>
+      <simpara>
+       Sérialisateur utilisé pour transformer les valeurs PHP arbitraires
+       en octets avant de les stocker. Les valeurs autorisées sont
+       <literal>php</literal> (la valeur par défaut),
+       <literal>json</literal>, <literal>igbinary</literal> et
+       <literal>msgpack</literal>. Les trois derniers nécessitent que
+       l'extension soit compilée avec le support correspondant. Les
+       sérialisateurs binaires tels que <literal>igbinary</literal> et
+       <literal>msgpack</literal> sont généralement plus rapides et
+       produisent des données plus compactes que <literal>php</literal>.
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry xml:id="ini.yac.values-memory-size">
@@ -142,9 +165,14 @@
       <type>string</type>
      </term>
      <listitem>
-      <para>
-       
-      </para>
+      <simpara>
+       Quantité de mémoire partagée utilisée pour stocker les valeurs
+       réelles. La valeur par défaut est <literal>64M</literal>. Yac alloue
+       cette zone en segments de 4M chacun, donc cette valeur doit être un
+       multiple de <literal>4M</literal>. Lorsque la zone est pleine, les
+       entrées les moins récemment utilisées sont expulsées pour faire de la
+       place aux nouvelles.
+      </simpara>
      </listitem>
     </varlistentry>
 

--- a/reference/yac/ini.xml
+++ b/reference/yac/ini.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
 <!-- EN-Revision: 1a42637cd40d0f75af1435ff051c7caa9b1c83e0 Maintainer: lacatoire Status: ready -->
 
 <section xml:id="yac.configuration" xmlns="http://docbook.org/ns/docbook">

--- a/reference/yac/setup.xml
+++ b/reference/yac/setup.xml
@@ -1,31 +1,65 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 9dbf3a558f49ddc5b2e0097abd3f06cf5413f25d Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 1a42637cd40d0f75af1435ff051c7caa9b1c83e0 Maintainer: lacatoire Status: ready -->
 
 <chapter xml:id="yac.setup" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.setup;
 
  <section xml:id="yac.requirements">
   &reftitle.required;
-  <para>
-
-  </para>
+  <simpara>
+   Aucune bibliothèque externe n'est requise.
+  </simpara>
  </section>
 
  <!-- {{{ Installation -->
  <section xml:id="yac.installation">
   &reftitle.install;
-  <para>
+  <simpara>
    &pecl.moved;
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    &pecl.info;
    <link xlink:href="&url.pecl.package;yac">&url.pecl.package;yac</link>.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    &pecl.windows.download.avail;
+  </simpara>
+  <para>
+   Le code source est hébergé sur
+   <link xlink:href="&url.git.hub;laruence/yac">GitHub</link>. Pour compiler
+   l'extension depuis les sources :
+   <screen>
+<![CDATA[
+$ git clone https://github.com/laruence/yac.git
+$ cd yac
+$ phpize
+$ ./configure
+$ make
+$ sudo make install
+]]>
+   </screen>
   </para>
+  <simpara>
+   Les options <literal>configure</literal> suivantes sont disponibles :
+  </simpara>
+  <simpara>
+   Les valeurs sont compressées avec LZ4 avant d'être stockées. Par défaut,
+   Yac utilise la copie de LZ4 fournie avec l'extension ; aucun indicateur
+   supplémentaire n'est nécessaire. Pour lier l'extension contre la
+   bibliothèque LZ4 système, utiliser le commutateur
+   <option role="configure">--with-system-lz4</option>, qui nécessite que
+   l'en-tête <literal>lz4.h</literal> et <literal>liblz4</literal> soient
+   installés.
+  </simpara>
+  <simpara>
+   Des sérialisateurs alternatifs peuvent être compilés avec
+   <option role="configure">--enable-json</option>,
+   <option role="configure">--enable-msgpack</option> ou
+   <option role="configure">--enable-igbinary</option>, qui enregistrent
+   l'extension correspondante comme dépendance optionnelle. Le sérialisateur
+   utilisé à l'exécution est sélectionné avec la directive ini
+   <link linkend="ini.yac.serializer">yac.serializer</link>.
+  </simpara>
  </section>
  <!-- }}} -->
 
@@ -35,9 +69,9 @@
 
  <section xml:id="yac.resources">
   &reftitle.resources;
-  <para>
-
-  </para>
+  <simpara>
+   Cette extension ne définit aucune ressource.
+  </simpara>
  </section>
 
 </chapter>

--- a/reference/yac/versions.xml
+++ b/reference/yac/versions.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8"?>
+<?do-not-translate?>
+
+<versions>
+  <!-- Classes and Methods -->
+
+ <function name='yac' from='PECL yac &gt;= 1.0.0'/>
+ <function name='yac::__construct' from='PECL yac &gt;= 1.0.0'/>
+ <function name='yac::add' from='PECL yac &gt;= 1.0.0'/>
+ <function name='yac::add key' from='PECL yac &gt;= 1.0.0'/>
+ <function name='yac::add value' from='PECL yac &gt;= 1.0.0'/>
+ <function name='yac::add ttl' from='PECL yac &gt;= 1.0.0'/>
+ <function name='yac::set' from='PECL yac &gt;= 1.0.0'/>
+ <function name='yac::set key' from='PECL yac &gt;= 1.0.0'/>
+ <function name='yac::set value' from='PECL yac &gt;= 1.0.0'/>
+ <function name='yac::set ttl' from='PECL yac &gt;= 1.0.0'/>
+ <function name='yac::__set' from='PECL yac &gt;= 1.0.0'/>
+ <function name='yac::get' from='PECL yac &gt;= 1.0.0'/>
+ <function name='yac::get key' from='PECL yac &gt;= 1.0.0'/>
+ <function name='yac::get cas' from='PECL yac &gt;= 1.0.0, &lt;= 2.3.1'/>
+ <function name='yac::get default' from='PECL yac &gt;= 2.4.0'/>
+ <function name='yac::__get' from='PECL yac &gt;= 1.0.0'/>
+ <function name='yac::delete' from='PECL yac &gt;= 1.0.0'/>
+ <function name='yac::delete key' from='PECL yac &gt;= 1.0.0'/>
+ <function name='yac::delete delay' from='PECL yac &gt;= 1.0.0'/>
+ <function name='yac::flush' from='PECL yac &gt;= 1.0.0'/>
+ <function name='yac::info' from='PECL yac &gt;= 1.0.0'/>
+ <function name='yac::dump' from='PECL yac &gt;= 1.0.0'/>
+ <function name='yac::dump limit' from='PECL yac &gt;= 1.0.0'/>
+ <function name='yac::dump offset' from='PECL yac &gt;= 2.4.0'/>
+</versions>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/yac/yac.xml
+++ b/reference/yac/yac.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
 <!-- EN-Revision: 1a42637cd40d0f75af1435ff051c7caa9b1c83e0 Maintainer: lacatoire Status: ready -->
 
 <reference xml:id="class.yac" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">

--- a/reference/yac/yac.xml
+++ b/reference/yac/yac.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 1a42637cd40d0f75af1435ff051c7caa9b1c83e0 Maintainer: lacatoire Status: ready -->
 
 <reference xml:id="class.yac" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 

--- a/reference/yac/yac/add.xml
+++ b/reference/yac/yac/add.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
 <!-- EN-Revision: 1a42637cd40d0f75af1435ff051c7caa9b1c83e0 Maintainer: lacatoire Status: ready -->
 
 <refentry xml:id="yac.add" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/reference/yac/yac/add.xml
+++ b/reference/yac/yac/add.xml
@@ -1,29 +1,31 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 8e2cfbdce0cd028a6521c6e073f148e0f7efac7c Maintainer: lacatoire Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 1a42637cd40d0f75af1435ff051c7caa9b1c83e0 Maintainer: lacatoire Status: ready -->
 
 <refentry xml:id="yac.add" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Yac::add</refname>
-  <refpurpose>Stocke un élément dans le cache</refpurpose>
+  <refpurpose>Stocke une valeur sans écraser une valeur existante</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
    <modifier>public</modifier> <type>bool</type><methodname>Yac::add</methodname>
-   <methodparam><type>string</type><parameter>keys</parameter></methodparam>
+   <methodparam><type class="union"><type>string</type><type>array</type></type><parameter>keys</parameter></methodparam>
    <methodparam><type>mixed</type><parameter>value</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>ttl</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
   <methodsynopsis>
    <modifier>public</modifier> <type>bool</type><methodname>Yac::add</methodname>
-   <methodparam><type>array</type><parameter>key_vals</parameter></methodparam>
+   <methodparam><type>array</type><parameter>values</parameter></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>ttl</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
-  <para>
-   Ajoute un élément dans le cache.
-  </para>
+  <simpara>
+   Stocke une valeur dans le cache. Contrairement à
+   <methodname>Yac::set</methodname>, cette méthode n'écrase pas une entrée
+   existante encore valide ; le stockage est rejeté dans ce cas.
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -32,25 +34,30 @@
    <varlistentry>
     <term><parameter>keys</parameter></term>
     <listitem>
-     <para>
-       &string; ; la clé
-     </para>
+     <simpara>
+      Une clé <type>string</type>, ou un <type>array</type> de paires
+      <literal>clé =&gt; valeur</literal> à stocker en un seul appel.
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>value</parameter></term>
     <listitem>
-     <para>
-      Tout type de valeur PHP peut être stocké, à l'exception d'une &resource;.
-     </para>
+     <simpara>
+      La valeur à stocker. Tout type PHP sauf <type>resource</type> peut
+      être stocké. Utilisé uniquement dans la forme à clé unique ; quand
+      <parameter>keys</parameter> est un tableau, cet argument est le
+      <parameter>ttl</parameter> optionnel.
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>ttl</parameter></term>
     <listitem>
-     <para>
-      Délai d'expiration.
-     </para>
+     <simpara>
+      Durée de vie en secondes. <literal>0</literal> signifie que l'entrée
+      n'expire jamais dans le temps.
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -58,26 +65,64 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
-   &boolean;, &true; en cas de succès, &false; si une erreur survient.
-   <note>
-    <para>
-     La méthode <methodname>Yac::add</methodname> peut échouer si le verrou
-     ne peut être obtenu, aussi, pour que l'élément soit stocké
-     proprement, il est recommandé d'écrire le code comme ceci :
-     <example>
-      <title>Permet de s'assurer que l'élément est stocké</title>
-      <programlisting role="php">
-       <![CDATA[
-       while(!$yac->set("key", "value"));
-       ]]>
-      </programlisting> 
-     </example>
-    </para>
-   </note>
-  </para>
+  <simpara>
+   Retourne &true; en cas de succès, &false; en cas d'échec. Un stockage
+   est également rejeté (retournant &false;) quand la clé existe déjà et
+   n'a pas expiré.
+  </simpara>
+  <note>
+   <para>
+    Yac stocke les entrées sans verrou. Sous forte contention, un stockage
+    peut échouer de façon transitoire ; si la valeur doit finalement être
+    stockée, réessayer :
+    <programlisting role="php">
+<![CDATA[
+<?php
+while (!$yac->add("key", "value")) {
+    // réessayer en cas d'échec transitoire
+}
+?>
+]]>
+    </programlisting>
+   </para>
+  </note>
  </refsect1>
 
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Exemple avec <methodname>Yac::add</methodname></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$yac = new Yac();
+
+var_dump($yac->add("foo", "bar"));          // bool(true)
+var_dump($yac->add("foo", "baz"));          // bool(false): "foo" existe déjà
+
+// ttl en secondes ; 0 (la valeur par défaut) signifie que l'entrée n'expire jamais
+$yac->add("short-lived", "value", 5);
+sleep(6);
+var_dump($yac->get("short-lived"));        // bool(false): expiré
+
+// stocker plusieurs paires clé => valeur en un appel, avec un ttl
+$yac->add(array("a" => 1, "b" => 2), 60);
+?>
+]]>
+   </programlisting>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><methodname>Yac::set</methodname></member>
+    <member><methodname>Yac::get</methodname></member>
+    <member><methodname>Yac::delete</methodname></member>
+   </simplelist>
+  </para>
+ </refsect1>
 
 </refentry>
 

--- a/reference/yac/yac/construct.xml
+++ b/reference/yac/yac/construct.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 74155fb94bef0d0e0c6edd5994fc33ab40781701 Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 1a42637cd40d0f75af1435ff051c7caa9b1c83e0 Maintainer: lacatoire Status: ready -->
 
 <refentry xml:id="yac.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -15,11 +14,13 @@
    <modifier>public</modifier> <methodname>Yac::__construct</methodname>
    <methodparam choice="opt"><type>string</type><parameter>prefix</parameter><initializer>""</initializer></methodparam>
   </constructorsynopsis>
-  <para>
-   Le préfixe est utilisé pour préfixer les clés ; cela permet d'éviter les
-   conflits entre plusieurs applications.
-  </para>
-
+  <simpara>
+   Crée une nouvelle instance de <classname>Yac</classname>. Le
+   <parameter>prefix</parameter> optionnel est ajouté au début de chaque
+   clé stockée par cette instance, ce qui permet à plusieurs applications
+   ou caches sur la même machine d'utiliser des noms de clés chevauchants
+   sans collision.
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -28,32 +29,49 @@
    <varlistentry>
     <term><parameter>prefix</parameter></term>
     <listitem>
-     <para>
-       &string; ; le préfixe
-     </para>
+     <simpara>
+      Un préfixe de clé, jusqu'à 48 octets (<constant>YAC_MAX_KEY_LEN</constant>).
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
  </refsect1>
 
- <!-- Return values commented out, as constructors generally don't return a
-      value. Uncomment this if you do need a return values section (for
-      example, because there's also a procedural version of the method).
- <refsect1 role="returnvalues">
-  &reftitle.returnvalues;
-  <para>
-   
-  </para>
- </refsect1>
- -->
-
  <refsect1 role="errors">
   &reftitle.errors;
+  <simpara>
+   Lance une <exceptionname>Exception</exceptionname> si le cache est
+   désactivé (<literal>yac.enable=0</literal>), ou si
+   <parameter>prefix</parameter> est plus long que 48 octets.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Exemple avec <methodname>Yac::__construct</methodname></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$yac = new Yac();
+$yac->set("foo", "bar");
+
+$other = new Yac("app2_");
+var_dump($other->get("foo"));    // bool(false): espace de noms différent
+$other->set("foo", "baz");       // stocké sous "app2_foo"
+?>
+]]>
+   </programlisting>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
   <para>
-   Lance une <classname>Exception</classname> si Yac n'est pas activé.
-   Lance une <classname>Exception</classname> si <parameter>prefix</parameter>
-   excède la longueur maximale de clé de 48
-   (<constant>YAC_MAX_KEY_LEN</constant>) octets.
+   <simplelist>
+    <member><methodname>Yac::set</methodname></member>
+    <member><methodname>Yac::get</methodname></member>
+   </simplelist>
   </para>
  </refsect1>
 

--- a/reference/yac/yac/construct.xml
+++ b/reference/yac/yac/construct.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
 <!-- EN-Revision: 1a42637cd40d0f75af1435ff051c7caa9b1c83e0 Maintainer: lacatoire Status: ready -->
 
 <refentry xml:id="yac.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/reference/yac/yac/delete.xml
+++ b/reference/yac/yac/delete.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
 <!-- EN-Revision: 1a42637cd40d0f75af1435ff051c7caa9b1c83e0 Maintainer: lacatoire Status: ready -->
 
 <refentry xml:id="yac.delete" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/reference/yac/yac/delete.xml
+++ b/reference/yac/yac/delete.xml
@@ -1,12 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 53242ee6628dc1ae6989fe002231fddfd8f005c6 Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 1a42637cd40d0f75af1435ff051c7caa9b1c83e0 Maintainer: lacatoire Status: ready -->
 
 <refentry xml:id="yac.delete" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Yac::delete</refname>
-  <refpurpose>Supprime un ou plusieurs éléments du cache</refpurpose>
+  <refpurpose>Supprime des éléments du cache</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -14,11 +13,11 @@
   <methodsynopsis>
    <modifier>public</modifier> <type>bool</type><methodname>Yac::delete</methodname>
    <methodparam><type class="union"><type>string</type><type>array</type></type><parameter>keys</parameter></methodparam>
-   <methodparam choice="opt"><type>int</type><parameter>ttl</parameter></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>delay</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Supprime un ou plusieurs éléments du cache.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -27,18 +26,21 @@
    <varlistentry>
     <term><parameter>keys</parameter></term>
     <listitem>
-     <para>
-      La clé ou un tableau de plusieurs clés à supprimer
-     </para>
+     <simpara>
+      Une clé <type>string</type>, ou un <type>array</type> de clés à
+      supprimer.
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term><parameter>ttl</parameter></term>
+    <term><parameter>delay</parameter></term>
     <listitem>
-     <para>
-      Si le délai est défini, l'opération de suppression va marquer les éléments
-      pour qu'ils soient invalides au bout de ttl secondes.
-     </para>
+     <simpara>
+      Nombre de secondes avant que l'élément devienne invalide. Quand omis
+      ou <literal>0</literal>, l'élément est invalidé immédiatement. Une
+      valeur positive garde l'élément lisible pendant ce nombre de secondes
+      avant qu'il expire.
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -46,11 +48,47 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
-   
-  </para>
+  <simpara>
+   Retourne &true; en cas de succès, ou &false; si la clé n'était pas
+   présente dans le cache.
+  </simpara>
  </refsect1>
 
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Exemple avec <methodname>Yac::delete</methodname></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$yac = new Yac();
+$yac->set("foo", "bar");
+
+var_dump($yac->delete("foo"));            // bool(true)
+var_dump($yac->delete("foo"));            // bool(false): déjà supprimé
+
+// suppression différée : garder l'entrée lisible encore 60 secondes,
+// elle disparaît seulement après ce délai
+$yac->set("tmp", "value");
+var_dump($yac->delete("tmp", 60));        // bool(true)
+
+// supprimer plusieurs clés à la fois
+var_dump($yac->delete(array("a", "b")));
+?>
+]]>
+   </programlisting>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><methodname>Yac::set</methodname></member>
+    <member><methodname>Yac::flush</methodname></member>
+   </simplelist>
+  </para>
+ </refsect1>
 
 </refentry>
 

--- a/reference/yac/yac/dump.xml
+++ b/reference/yac/yac/dump.xml
@@ -1,32 +1,45 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4de6272a1f15efc9e3df21d255965fd890da0d6f Maintainer: lacatoire Status: ready -->
+<!-- $Revision$ -->
+<!-- EN-Revision: 1a42637cd40d0f75af1435ff051c7caa9b1c83e0 Maintainer: lacatoire Status: ready -->
 
 <refentry xml:id="yac.dump" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Yac::dump</refname>
-  <refpurpose>Extrait les valeurs du cache</refpurpose>
+  <refpurpose>Vide les entrées du cache pour inspection</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier>public</modifier> <type>mixed</type><methodname>Yac::dump</methodname>
-   <methodparam><type>int</type><parameter>num</parameter></methodparam>
+   <modifier>public</modifier> <type>array</type><methodname>Yac::dump</methodname>
+   <methodparam choice="opt"><type>int</type><parameter>limit</parameter><initializer>100</initializer></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>offset</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
-  <para>
-   Extrait les valeurs stockées dans le cache
-  </para>
+  <simpara>
+   Vide les métadonnées des entrées actuellement stockées dans le cache.
+   Les valeurs elles-mêmes ne sont pas retournées.
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
   &reftitle.parameters;
   <variablelist>
    <varlistentry>
-    <term><parameter>num</parameter></term>
+    <term><parameter>limit</parameter></term>
     <listitem>
-     <para>
-      Nombre maximal d'éléments à retourner
-     </para>
+     <simpara>
+      Nombre maximum d'entrées à retourner.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>offset</parameter></term>
+    <listitem>
+     <simpara>
+      Nombre d'entrées à sauter avant de collecter, qui peut être utilisé
+      pour paginer un cache contenant plus d'entrées que
+      <parameter>limit</parameter>.
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -34,11 +47,218 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
-   Les éléments extraits.
-  </para>
+  <simpara>
+   Un <type>array</type> avec un élément par entrée vidée. Chaque élément
+   est lui-même un tableau décrivant l'entrée :
+  </simpara>
+  <variablelist>
+   <varlistentry>
+    <term><literal>index</literal></term>
+    <listitem><simpara>
+     L'index de slot de l'entrée dans la table de hachage.
+    </simpara></listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><literal>hash</literal></term>
+    <listitem><simpara>
+     Le hachage 64 bits de la clé, utilisé pour le sondage de slots.
+    </simpara></listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><literal>crc</literal></term>
+    <listitem><simpara>
+     La somme de contrôle CRC32 de la valeur stockée, utilisée pour
+     détecter les lectures incomplètes. <literal>0</literal> pour les
+     entrées intégrées, qui n'ont pas de bloc de valeur.
+    </simpara></listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><literal>ttl</literal></term>
+    <listitem><simpara>
+     L'horodatage d'expiration (heure Unix). <literal>0</literal> signifie
+     que l'entrée n'expire jamais dans le temps. Notez que
+     <methodname>Yac::delete</methodname> marque seulement une entrée
+     comme expirée, donc les entrées supprimées peuvent encore apparaître
+     dans le vidage ; un <literal>ttl</literal> non nul dans le passé
+     indique une entrée expirée ou supprimée.
+    </simpara></listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><literal>k_len</literal></term>
+    <listitem><simpara>
+     La longueur de la clé, en octets.
+    </simpara></listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><literal>v_len</literal></term>
+    <listitem><simpara>
+     La longueur de la valeur, en octets. Pour les entrées compressées,
+     c'est la longueur de la valeur <emphasis>originale</emphasis> avant
+     compression (à partir de yac 2.4.0 ; les versions antérieures
+     rapportaient la longueur stockée, compressée).
+    </simpara></listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><literal>c_len</literal></term>
+    <listitem><simpara>
+     Présent uniquement pour les entrées compressées (à partir de yac
+     2.4.0) : la longueur du contenu compressé réellement stocké en
+     mémoire partagée, en octets. Comparer <literal>c_len</literal> avec
+     <literal>v_len</literal> montre combien la compression économise par
+     entrée.
+    </simpara></listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><literal>size</literal></term>
+    <listitem><simpara>
+     La taille allouée du bloc de valeur en mémoire partagée, en octets.
+     <literal>0</literal> pour les entrées intégrées.
+    </simpara></listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><literal>atime</literal></term>
+    <listitem><simpara>
+     Le dernier temps d'accès (heure Unix), mis à jour à chaque
+     <methodname>Yac::get</methodname> réussi. Quand le cache est plein,
+     l'entrée avec l'<literal>atime</literal> le plus ancien parmi les
+     slots candidats est expulsée en premier (à partir de yac 2.4.0).
+    </simpara></listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><literal>hits</literal></term>
+    <listitem><simpara>
+     Un compteur de succès par entrée, incrémenté à chaque
+     <methodname>Yac::get</methodname> réussi, remis à zéro quand
+     l'entrée est écrasée, supprimée ou expire (à partir de yac 2.4.0).
+    </simpara></listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><literal>embedded</literal></term>
+    <listitem><simpara>
+     Si la valeur est stockée directement à l'intérieur du slot plutôt que
+     dans un bloc de valeur séparé (à partir de yac 2.4.0). Les petites
+     valeurs — <constant>NULL</constant>, booléens, petits entiers, chaînes
+     jusqu'à 7 octets et tableaux vides — sont intégrées de cette façon et
+     n'allouent aucune mémoire de valeur ; pour elles, <literal>crc</literal>
+     et <literal>size</literal> sont rapportés à <literal>0</literal>.
+    </simpara></listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><literal>key</literal></term>
+    <listitem><simpara>
+     La clé de cache, sans aucun préfixe d'instance.
+    </simpara></listitem>
+   </varlistentry>
+  </variablelist>
  </refsect1>
 
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Exemple avec <methodname>Yac::dump</methodname></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$yac = new Yac();
+$yac->set("foo", "bar");
+$yac->set("baz", "qux");
+
+print_r($yac->dump());
+?>
+]]>
+   </programlisting>
+   &example.outputs.similar;
+   <screen>
+<![CDATA[
+Array
+(
+    [0] => Array
+        (
+            [index] => 12345
+            [hash] => 14463105906481965911
+            [crc] => 0
+            [ttl] => 0
+            [k_len] => 3
+            [v_len] => 3
+            [size] => 0
+            [atime] => 1725955200
+            [hits] => 0
+            [embedded] => 1
+            [key] => foo
+        )
+
+    [1] => Array
+        (
+            [index] => 12987
+            [hash] => 15132029420525657053
+            [crc] => 0
+            [ttl] => 0
+            [k_len] => 3
+            [v_len] => 3
+            [size] => 0
+            [atime] => 1725955200
+            [hits] => 0
+            [embedded] => 1
+            [key] => baz
+        )
+
+)
+]]>
+   </screen>
+   <simpara>
+    Les entrées sont listées dans l'ordre des slots, pas dans l'ordre où
+    elles ont été stockées. Les entrées intégrées (petits scalaires gardés
+    à l'intérieur du slot lui-même) ont <literal>crc</literal> et
+    <literal>size</literal> à zéro ; les entrées stockées dans un bloc de
+    valeur séparé portent leur somme de contrôle et taille de bloc, et les
+    entrées compressées portent additionnellement <literal>c_len</literal>.
+   </simpara>
+  </example>
+  <example>
+   <title>Pagination d'un grand cache</title>
+   <simpara>
+    <parameter>limit</parameter> limite le nombre d'entrées qu'un seul
+    appel retourne, et <parameter>offset</parameter> en saute autant avant
+    de collecter, donc les deux peuvent être combinés pour paginer un cache
+    contenant plus d'entrées qu'un appel peut en retourner.
+   </simpara>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$yac = new Yac();
+
+$page_size = 100;
+$page_num  = 2;
+
+// sauter les 100 premières entrées et retourner les 100 suivantes (page 2)
+$page = $yac->dump($page_size, $page_size * ($page_num - 1));
+
+var_dump(count($page));
+?>
+]]>
+   </programlisting>
+   &example.outputs.similar;
+   <screen>
+<![CDATA[
+int(100)
+]]>
+   </screen>
+   <simpara>
+    Moins d'entrées que demandé sont retournées quand le cache en contient
+    moins que la page demandée ne couvre, et un tableau vide est retourné
+    quand l'offset pointe au-delà du dernier slot occupé.
+   </simpara>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><methodname>Yac::info</methodname></member>
+   </simplelist>
+  </para>
+ </refsect1>
 
 </refentry>
 

--- a/reference/yac/yac/dump.xml
+++ b/reference/yac/yac/dump.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
 <!-- EN-Revision: 1a42637cd40d0f75af1435ff051c7caa9b1c83e0 Maintainer: lacatoire Status: ready -->
 
 <refentry xml:id="yac.dump" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/reference/yac/yac/dump.xml
+++ b/reference/yac/yac/dump.xml
@@ -76,7 +76,7 @@
     <term><literal>ttl</literal></term>
     <listitem><simpara>
      L'horodatage d'expiration (heure Unix). <literal>0</literal> signifie
-     que l'entrée n'expire jamais dans le temps. Notez que
+     que l'entrée n'expire jamais dans le temps. Il est à noter que
      <methodname>Yac::delete</methodname> marque seulement une entrée
      comme expirée, donc les entrées supprimées peuvent encore apparaître
      dans le vidage ; un <literal>ttl</literal> non nul dans le passé

--- a/reference/yac/yac/flush.xml
+++ b/reference/yac/yac/flush.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
 <!-- EN-Revision: 1a42637cd40d0f75af1435ff051c7caa9b1c83e0 Maintainer: lacatoire Status: ready -->
 
 <refentry xml:id="yac.flush" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/reference/yac/yac/flush.xml
+++ b/reference/yac/yac/flush.xml
@@ -1,12 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: b8be4b126c545a0b452be29b6b5ce185471814a1 Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 1a42637cd40d0f75af1435ff051c7caa9b1c83e0 Maintainer: lacatoire Status: ready -->
 
 <refentry xml:id="yac.flush" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Yac::flush</refname>
-  <refpurpose>Supprime toutes les valeurs mises en cache</refpurpose>
+  <refpurpose>Vide le cache</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -15,9 +14,12 @@
    <modifier>public</modifier> <type>bool</type><methodname>Yac::flush</methodname>
    <void />
   </methodsynopsis>
-  <para>
-    Supprime toutes les valeurs mises en cache.
-  </para>
+  <simpara>
+   Supprime toutes les valeurs mises en cache. Comme le cache est partagé
+   par chaque processus de la même machine, cela vide le cache globalement ;
+   le préfixe de clé donné à <methodname>Yac::__construct</methodname> ne
+   limite pas ce qui est vidé.
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -27,11 +29,45 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
-   Une valeur booléenne, toujours &true;.
-  </para>
+  <simpara>
+   Retourne &true;.
+  </simpara>
  </refsect1>
 
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Exemple avec <methodname>Yac::flush</methodname></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$yac = new Yac();
+$yac->set("foo", "bar");
+
+$other = new Yac("app2_");
+$other->set("baz", "qux");
+
+// flush vide tout le cache : les entrées de chaque instance,
+// quel que soit le préfixe utilisé lors de leur stockage
+$yac->flush();
+
+var_dump($yac->get("foo"));   // bool(false)
+var_dump($other->get("baz")); // bool(false)
+?>
+]]>
+   </programlisting>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><methodname>Yac::delete</methodname></member>
+    <member><methodname>Yac::info</methodname></member>
+   </simplelist>
+  </para>
+ </refsect1>
 
 </refentry>
 

--- a/reference/yac/yac/get.xml
+++ b/reference/yac/yac/get.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
 <!-- EN-Revision: 1a42637cd40d0f75af1435ff051c7caa9b1c83e0 Maintainer: lacatoire Status: ready -->
 
 <refentry xml:id="yac.get" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/reference/yac/yac/get.xml
+++ b/reference/yac/yac/get.xml
@@ -1,43 +1,52 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 53242ee6628dc1ae6989fe002231fddfd8f005c6 Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 1a42637cd40d0f75af1435ff051c7caa9b1c83e0 Maintainer: lacatoire Status: ready -->
 
 <refentry xml:id="yac.get" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Yac::get</refname>
-  <refpurpose>Récupère un élément du cache</refpurpose>
+  <refpurpose>Récupère des valeurs du cache</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
    <modifier>public</modifier> <type>mixed</type><methodname>Yac::get</methodname>
-   <methodparam><type class="union"><type>string</type><type>array</type></type><parameter>key</parameter></methodparam>
-   <methodparam choice="opt"><type>int</type><parameter role="reference">cas</parameter><initializer>&null;</initializer></methodparam>
+   <methodparam><type class="union"><type>string</type><type>array</type></type><parameter>keys</parameter></methodparam>
+   <methodparam choice="opt"><type>mixed</type><parameter>default</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
-    Récupère un élément du cache.
-  </para>
+  <simpara>
+   Récupère des valeurs du cache.
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
   &reftitle.parameters;
   <variablelist>
    <varlistentry>
-    <term><parameter>key</parameter></term>
+    <term><parameter>keys</parameter></term>
     <listitem>
-     <para>
-      &string; ; la clé, ou un &array; de plusieurs clés.
-     </para>
+     <simpara>
+      Une clé <type>string</type>, ou un <type>array</type> de clés.
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term><parameter>cas</parameter></term>
+    <term><parameter>default</parameter></term>
     <listitem>
-     <para>
-      Si différent de &null;, ce devra être le cas de l'élément récupéré.
-     </para>
+     <simpara>
+      La valeur à retourner quand la clé (ou les clés) demandée n'est pas
+      présente dans le cache, disponible à partir de yac 2.4.0. Quand
+      omis, un défaut de cache retourne &false;.
+     </simpara>
+     <note>
+      <simpara>
+       Avant yac 2.4.0, cet emplacement d'argument contenait un jeton
+       <literal>$cas</literal> par référence plutôt qu'une valeur par
+       défaut. Le code qui passait ou se reposait sur ce jeton doit être
+       mis à jour lors d'une montée en version vers 2.4.0.
+      </simpara>
+     </note>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -45,11 +54,60 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
-   Le ou les éléments, &false; si une erreur survient.
-  </para>
+  <simpara>
+   Pour une clé <type>string</type>, retourne la valeur mise en cache en
+   cas de succès, sinon la <parameter>default</parameter> (ou &false; si
+   aucune valeur par défaut n'a été donnée).
+  </simpara>
+  <simpara>
+   Pour un <type>array</type> de clés, retourne un tableau contenant les
+   valeurs trouvées indexées par leurs clés. Les clés absentes du cache
+   sont omises du résultat à partir de yac 2.4.0, ou remplies avec la
+   <parameter>default</parameter> quand une a été fournie ; avant 2.4.0,
+   un placeholder &false; était inséré pour chaque clé manquante.
+  </simpara>
  </refsect1>
 
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Exemple avec <methodname>Yac::get</methodname></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$yac = new Yac();
+
+$yac->set("foo", "bar");
+var_dump($yac->get("foo"));                 // string(3) "bar"
+var_dump($yac->get("missing"));             // bool(false): défaut de cache
+
+// un défaut de cache et un false stocké sont indiscernables sans valeur par défaut ;
+// une valeur sentinelle (disponible à partir de yac 2.4.0) les distingue
+$yac->set("flag", false);
+var_dump($yac->get("flag"));                // bool(false): la valeur stockée
+var_dump($yac->get("missing", false));      // bool(false): un défaut de cache, même forme
+var_dump($yac->get("flag", "__NONE__"));    // bool(false): la valeur stockée
+var_dump($yac->get("missing", "__NONE__")); // string(8) "__NONE__": un défaut de cache
+
+// avec un tableau de clés, seules les clés trouvées sont présentes dans le résultat
+$yac->set("foo2", "bar2");
+var_dump($yac->get(array("foo", "foo2", "missing")));
+// array(2) { ["foo"]=> string(3) "bar" ["foo2"]=> string(4) "bar2" }
+?>
+]]>
+   </programlisting>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><methodname>Yac::set</methodname></member>
+    <member><methodname>Yac::__get</methodname></member>
+   </simplelist>
+  </para>
+ </refsect1>
 
 </refentry>
 

--- a/reference/yac/yac/getter.xml
+++ b/reference/yac/yac/getter.xml
@@ -1,12 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 338bf692d6d24357c4a3b36b098131bc30372378 Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 1a42637cd40d0f75af1435ff051c7caa9b1c83e0 Maintainer: lacatoire Status: ready -->
 
 <refentry xml:id="yac.getter" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Yac::__get</refname>
-  <refpurpose>Récupère un élément du cache</refpurpose>
+  <refpurpose>Récupère une valeur via la syntaxe propriété</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -15,9 +14,11 @@
    <modifier>public</modifier> <type>mixed</type><methodname>Yac::__get</methodname>
    <methodparam><type>string</type><parameter>key</parameter></methodparam>
   </methodsynopsis>
-  <para>
-    Récupère un élément du cache.
-  </para>
+  <simpara>
+   Récupère une valeur du cache, invoqué lors de la lecture d'une propriété
+   d'une instance de <classname>Yac</classname> : <literal>$yac->foo</literal>
+   est équivalent à <literal>$yac->get("foo")</literal>.
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -26,9 +27,9 @@
    <varlistentry>
     <term><parameter>key</parameter></term>
     <listitem>
-     <para>
-       &string; ; la clé
-     </para>
+     <simpara>
+      Le nom de la propriété, utilisé comme clé de cache.
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -36,11 +37,46 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
-   L'élément en cas de succès, &null; si une erreur survient.
-  </para>
+  <simpara>
+   La valeur mise en cache en cas de succès, &null; quand la clé n'est pas
+   présente dans le cache.
+  </simpara>
+  <note>
+   <simpara>
+    Contrairement à <methodname>Yac::get</methodname>, la syntaxe propriété
+    ne peut pas distinguer un &null; stocké d'une clé manquante, et ne
+    prend en charge que des clés uniques.
+   </simpara>
+  </note>
  </refsect1>
 
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Exemple avec <methodname>Yac::__get</methodname></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$yac = new Yac();
+$yac->set("foo", "bar");
+
+var_dump($yac->foo);       // string(3) "bar"
+var_dump($yac->missing);   // NULL
+?>
+]]>
+   </programlisting>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><methodname>Yac::get</methodname></member>
+    <member><methodname>Yac::__set</methodname></member>
+   </simplelist>
+  </para>
+ </refsect1>
 
 </refentry>
 

--- a/reference/yac/yac/getter.xml
+++ b/reference/yac/yac/getter.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
 <!-- EN-Revision: 1a42637cd40d0f75af1435ff051c7caa9b1c83e0 Maintainer: lacatoire Status: ready -->
 
 <refentry xml:id="yac.getter" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/reference/yac/yac/info.xml
+++ b/reference/yac/yac/info.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
 <!-- EN-Revision: 1a42637cd40d0f75af1435ff051c7caa9b1c83e0 Maintainer: lacatoire Status: ready -->
 
 <refentry xml:id="yac.info" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/reference/yac/yac/info.xml
+++ b/reference/yac/yac/info.xml
@@ -1,12 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: d286e6182179363c926e03ced71d03f3b2879ad6 Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 1a42637cd40d0f75af1435ff051c7caa9b1c83e0 Maintainer: lacatoire Status: ready -->
 
 <refentry xml:id="yac.info" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Yac::info</refname>
-  <refpurpose>Statut du cache</refpurpose>
+  <refpurpose>État du cache</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -15,9 +14,9 @@
    <modifier>public</modifier> <type>array</type><methodname>Yac::info</methodname>
    <void />
   </methodsynopsis>
-  <para>
-   Récupère le statut du cache système.
-  </para>
+  <simpara>
+   Retourne l'état du système de cache.
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -27,13 +26,149 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
-   Retourne un tableau contenant les éléments suivants :
-   "memory_size", "slots_memory_size", "values_memory_size", "segment_size", "segment_num",
-   "miss", "hits", "fails", "kicks", "recycles", "slots_size", "slots_used"
-  </para>
+  <simpara>
+   Retourne un <type>array</type> avec les clés suivantes :
+  </simpara>
+  <variablelist>
+   <varlistentry>
+    <term><literal>memory_size</literal></term>
+    <listitem><simpara>
+     Mémoire partagée totale utilisée, en octets : la table de slots plus
+     les blocs de valeurs.
+    </simpara></listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><literal>slots_memory_size</literal></term>
+    <listitem><simpara>
+     Mémoire réservée pour la table de hachage de slots, en octets.
+    </simpara></listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><literal>values_memory_size</literal></term>
+    <listitem><simpara>
+     Mémoire réservée pour les valeurs stockées, en octets.
+    </simpara></listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><literal>segment_size</literal></term>
+    <listitem><simpara>
+     Taille d'un segment de mémoire de valeurs, en octets.
+    </simpara></listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><literal>segment_num</literal></term>
+    <listitem><simpara>
+     Nombre de segments de mémoire de valeurs.
+    </simpara></listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><literal>miss</literal></term>
+    <listitem><simpara>
+     Nombre de défauts de cache : recherches n'ayant rien trouvé ou
+     trouvant une entrée expirée.
+    </simpara></listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><literal>hits</literal></term>
+    <listitem><simpara>
+     Nombre de succès de cache : recherches fructueuses.
+    </simpara></listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><literal>fails</literal></term>
+    <listitem><simpara>
+     Nombre de stockages échoués : stockages n'ayant pas pu allouer un
+     bloc de valeur.
+    </simpara></listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><literal>kicks</literal></term>
+    <listitem><simpara>
+     Nombre d'évictions : combien de fois une entrée existante a dû être
+     expulsée parce que le chemin de slot candidat était plein.
+    </simpara></listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><literal>recycles</literal></term>
+    <listitem><simpara>
+     Nombre de fois où l'allocateur a atteint la fin d'un segment et est
+     revenu à son début.
+    </simpara></listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><literal>start_time</literal></term>
+    <listitem><simpara>
+     L'horodatage Unix auquel le cache en mémoire partagée a été
+     initialisé.
+    </simpara></listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><literal>slots_size</literal></term>
+    <listitem><simpara>
+     Nombre total de slots de hachage.
+    </simpara></listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><literal>slots_used</literal></term>
+    <listitem><simpara>
+     Nombre de slots de hachage actuellement occupés.
+    </simpara></listitem>
+   </varlistentry>
+  </variablelist>
  </refsect1>
 
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Exemple avec <methodname>Yac::info</methodname></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$yac = new Yac();
+$yac->set("foo", "bar");
+
+print_r($yac->info());
+?>
+]]>
+   </programlisting>
+   &example.outputs.similar;
+   <screen>
+<![CDATA[
+Array
+(
+    [memory_size] => 46137344
+    [slots_memory_size] => 4194304
+    [values_memory_size] => 41943040
+    [segment_size] => 4194304
+    [segment_num] => 10
+    [miss] => 0
+    [hits] => 0
+    [fails] => 0
+    [kicks] => 0
+    [recycles] => 0
+    [start_time] => 1725955200
+    [slots_size] => 32768
+    [slots_used] => 1
+)
+]]>
+   </screen>
+   <simpara>
+    Le taux de succès peut être calculé comme
+    <literal>hits / (hits + miss)</literal> ; un compteur
+    <literal>kicks</literal> ou <literal>fails</literal> croissant indique
+    que le cache est sous pression mémoire.
+   </simpara>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><methodname>Yac::dump</methodname></member>
+   </simplelist>
+  </para>
+ </refsect1>
 
 </refentry>
 

--- a/reference/yac/yac/set.xml
+++ b/reference/yac/yac/set.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
 <!-- EN-Revision: 1a42637cd40d0f75af1435ff051c7caa9b1c83e0 Maintainer: lacatoire Status: ready -->
 
 <refentry xml:id="yac.set" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/reference/yac/yac/set.xml
+++ b/reference/yac/yac/set.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 338bf692d6d24357c4a3b36b098131bc30372378 Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 1a42637cd40d0f75af1435ff051c7caa9b1c83e0 Maintainer: lacatoire Status: ready -->
 
 <refentry xml:id="yac.set" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,17 +12,19 @@
   &reftitle.description;
   <methodsynopsis>
    <modifier>public</modifier> <type>bool</type><methodname>Yac::set</methodname>
-   <methodparam><type>string</type><parameter>keys</parameter></methodparam>
+   <methodparam><type class="union"><type>string</type><type>array</type></type><parameter>keys</parameter></methodparam>
    <methodparam><type>mixed</type><parameter>value</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>ttl</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
   <methodsynopsis>
-   <modifier>public</modifier> <type>bool</type><methodname>Yac::add</methodname>
-   <methodparam><type>array</type><parameter>key_vals</parameter></methodparam>
+   <modifier>public</modifier> <type>bool</type><methodname>Yac::set</methodname>
+   <methodparam><type>array</type><parameter>values</parameter></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>ttl</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
-  <para>
-   Ajoute un élément dans le cache ; si la clé existe déjà, elle sera écrasée.
-  </para>
+  <simpara>
+   Stocke une valeur dans le cache. Si la clé existe déjà, l'entrée
+   existante est écrasée, qu'elle ait expiré ou non.
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -32,25 +33,30 @@
    <varlistentry>
     <term><parameter>keys</parameter></term>
     <listitem>
-     <para>
-       &string; ; la clé
-     </para>
+     <simpara>
+      Une clé <type>string</type>, ou un <type>array</type> de paires
+      <literal>clé =&gt; valeur</literal> à stocker en un seul appel.
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>value</parameter></term>
     <listitem>
-     <para>
-      Tout type de valeur que PHP peut stocker, à l'exception d'une &resource;.
-     </para>
+     <simpara>
+      La valeur à stocker. Tout type PHP sauf <type>resource</type> peut
+      être stocké. Utilisé uniquement dans la forme à clé unique ; quand
+      <parameter>keys</parameter> est un tableau, cet argument est le
+      <parameter>ttl</parameter> optionnel.
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>ttl</parameter></term>
     <listitem>
-     <para>
-      Durée d'expiration
-     </para>
+     <simpara>
+      Durée de vie en secondes. <literal>0</literal> signifie que l'entrée
+      n'expire jamais dans le temps.
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -58,8 +64,44 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
+  <simpara>
+   Retourne &true; en cas de succès, &false; en cas d'échec.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Exemple avec <methodname>Yac::set</methodname></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$yac = new Yac();
+
+$yac->set("foo", "bar");                    // stocker une valeur unique
+$yac->set("foo", "baz");                    // écraser l'entrée existante
+
+// ttl en secondes : l'entrée expire après 5 secondes
+$yac->set("short-lived", "value", 5);
+sleep(6);
+var_dump($yac->get("short-lived"));        // bool(false): expiré
+
+// stocker plusieurs paires clé => valeur en un appel
+$yac->set(array("a" => 1, "b" => 2));
+?>
+]]>
+   </programlisting>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
   <para>
-   La valeur stockée
+   <simplelist>
+    <member><methodname>Yac::add</methodname></member>
+    <member><methodname>Yac::get</methodname></member>
+    <member><methodname>Yac::__set</methodname></member>
+   </simplelist>
   </para>
  </refsect1>
 

--- a/reference/yac/yac/setter.xml
+++ b/reference/yac/yac/setter.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
 <!-- EN-Revision: 1a42637cd40d0f75af1435ff051c7caa9b1c83e0 Maintainer: lacatoire Status: ready -->
 
 <refentry xml:id="yac.setter" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/reference/yac/yac/setter.xml
+++ b/reference/yac/yac/setter.xml
@@ -1,43 +1,46 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 5733f2023a2aa3112b2e6a560b130523dd8fce03 Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 1a42637cd40d0f75af1435ff051c7caa9b1c83e0 Maintainer: lacatoire Status: ready -->
 
 <refentry xml:id="yac.setter" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Yac::__set</refname>
-  <refpurpose>Stocke un élément dans le cache</refpurpose>
+  <refpurpose>Stocke une valeur via la syntaxe propriété</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
    <modifier>public</modifier> <type>mixed</type><methodname>Yac::__set</methodname>
-   <methodparam><type>string</type><parameter>keys</parameter></methodparam>
+   <methodparam><type>string</type><parameter>key</parameter></methodparam>
    <methodparam><type>mixed</type><parameter>value</parameter></methodparam>
   </methodsynopsis>
-  <para>
-   Stocke un élément dans le cache
-  </para>
+  <simpara>
+   Stocke une valeur dans le cache, invoqué lors de l'écriture d'une
+   propriété d'une instance de <classname>Yac</classname> :
+   <literal>$yac->foo = "bar"</literal> est équivalent à
+   <literal>$yac->set("foo", "bar")</literal>, sans ttl.
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
   &reftitle.parameters;
   <variablelist>
    <varlistentry>
-    <term><parameter>keys</parameter></term>
+    <term><parameter>key</parameter></term>
     <listitem>
-     <para>
-       &string; ; la clé
-     </para>
+     <simpara>
+      Le nom de la propriété, utilisé comme clé de cache.
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>value</parameter></term>
     <listitem>
-     <para>
-      Tout type de valeur PHP peut être stockée, à l'exception d'une &resource;
-     </para>
+     <simpara>
+      La valeur à stocker. Tout type PHP sauf <type>resource</type> peut
+      être stocké.
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -45,8 +48,35 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
+  <simpara>
+   Retourne la valeur stockée.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Exemple avec <methodname>Yac::__set</methodname></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$yac = new Yac();
+
+$yac->foo = "bar";          // stocké sans ttl
+var_dump($yac->get("foo")); // string(3) "bar"
+?>
+]]>
+   </programlisting>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
   <para>
-   La valeur stockée
+   <simplelist>
+    <member><methodname>Yac::set</methodname></member>
+    <member><methodname>Yac::__get</methodname></member>
+   </simplelist>
   </para>
  </refsect1>
 


### PR DESCRIPTION
Closes #3366

Syncs the French yac extension documentation with EN PR #5794 (merge commit `1a42637cd40d0f75af1435ff051c7caa9b1c83e0`).

**Files updated:**
- `reference/yac/book.xml` — rewrite preface (3 simpara + note: lock-free design, use cases, network cache warning)
- `reference/yac/setup.xml` — add requirements, source build instructions, configure options, resources
- `reference/yac/ini.xml` — expand all 7 directive descriptions
- `reference/yac/versions.xml` — new file (was missing in FR)
- `reference/yac/configure.xml`, `constants.xml`, `yac.xml` — update EN-Revision, remove Reviewed tag
- `reference/yac/yac/construct.xml` — simpara, errors section, example, seealso
- `reference/yac/yac/add.xml` — dual methodsynopsis, full params, retry note, example, seealso
- `reference/yac/yac/set.xml` — dual methodsynopsis, full params, example, seealso
- `reference/yac/yac/get.xml` — API change: rename `$cas` → `$default` (yac 2.4.0), migration note, example, seealso
- `reference/yac/yac/delete.xml` — delay param description, example, seealso
- `reference/yac/yac/flush.xml` — global flush note, multi-instance example, seealso
- `reference/yac/yac/info.xml` — 13-key variablelist, example with hit ratio note
- `reference/yac/yac/dump.xml` — new `$offset` param, 12-key variablelist, paging example
- `reference/yac/yac/getter.xml` — null/missing ambiguity note, example, seealso
- `reference/yac/yac/setter.xml` — params, example, seealso