### PR TITLE
[Sync-En] array: add example on updating values with array_walk_recursive()

### DIFF
--- a/reference/array/functions/array-walk-recursive.xml
+++ b/reference/array/functions/array-walk-recursive.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 63f09f4d816aa29c3f8fba9d12a8c6ce2f1755de Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 0d8ee2131b4da66a4d274c576da9137c2a7963d5 Maintainer: yannick Status: ready -->
 <refentry xml:id="function.array-walk-recursive" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>array_walk_recursive</refname>
@@ -132,6 +132,44 @@ La clé sour contient l'élément lemon
      n'est jamais affichée. Toute clé qui est associée
      à un &array; n'est pas passée à la fonction de rappel.
     </para>
+   </example>
+  </para>
+  <simpara>
+   <function>array_walk_recursive</function> peut aussi être utilisée pour mettre à jour
+   les valeurs sur place, en passant le paramètre de la fonction de rappel par référence.
+  </simpara>
+  <para>
+   <example>
+    <title>Mise à jour des valeurs sur place</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+$sweet = ['a' => 'apple', 'b' => 'banana'];
+$fruits = ['sweet' => $sweet, 'sour' => 'lemon'];
+
+function test_update(&$item)
+{
+    $item = strtoupper($item);
+}
+
+function test_print($item, $key)
+{
+    echo "La clé $key contient l'élément $item\n";
+}
+
+array_walk_recursive($fruits, 'test_update');
+array_walk_recursive($fruits, 'test_print');
+?>
+]]>
+    </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+La clé a contient l'élément APPLE
+La clé b contient l'élément BANANA
+La clé sour contient l'élément LEMON
+]]>
+    </screen>
    </example>
   </para>
  </refsect1>


### PR DESCRIPTION
Sync with EN commit 0d8ee2131b4da66a4d274c576da9137c2a7963d5.

Adds the translated "Updating values in place" example (callback taking the item by reference). The `<screen>` output was checked against php:8.4-cli.

Fixes: #3384