### PR TITLE
[Sync-En] json: move JSON_ERROR_NON_BACKED_ENUM availability to a changelog section

### DIFF
--- a/reference/json/functions/json-last-error.xml
+++ b/reference/json/functions/json-last-error.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 058ea1e8420b9c1b24402af52545e8313428e1d1 Maintainer: lacatoire Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 3733e082ad183251e0b63d08b52c448a243f9710 Maintainer: lacatoire Status: ready -->
 
 <refentry xml:id="function.json-last-error" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -28,91 +27,115 @@
  
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
+  <simpara>
+   Retourne un entier, la valeur peut être une des constantes
+   suivantes :
+  </simpara>
   <para>
-   Retourne un entier, la valeur peut être une des constantes suivantes :
+   <variablelist>
+   <varlistentry>
+    <term><constant>JSON_ERROR_NONE</constant></term>
+    <listitem>
+     <simpara>Aucune erreur n'est survenue</simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><constant>JSON_ERROR_DEPTH</constant></term>
+    <listitem>
+     <simpara>La profondeur maximale de la pile a été atteinte</simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><constant>JSON_ERROR_STATE_MISMATCH</constant></term>
+    <listitem>
+     <simpara>JSON invalide ou mal formé</simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><constant>JSON_ERROR_CTRL_CHAR</constant></term>
+    <listitem>
+     <simpara>Erreur de caractère de contrôle, probablement mal encodé</simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><constant>JSON_ERROR_SYNTAX</constant></term>
+    <listitem>
+     <simpara>Erreur de syntaxe</simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><constant>JSON_ERROR_UTF8</constant></term>
+    <listitem>
+     <simpara>Caractères UTF-8 mal formés, probablement mal encodés</simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><constant>JSON_ERROR_RECURSION</constant></term>
+    <listitem>
+     <simpara>Une ou plusieurs références récursives dans la valeur à encoder</simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><constant>JSON_ERROR_INF_OR_NAN</constant></term>
+    <listitem>
+     <simpara>
+      Une ou plusieurs valeurs
+      <link linkend="language.types.float.nan"><constant>NAN</constant></link>
+      ou <link linkend="function.is-infinite"><constant>INF</constant></link>
+      dans la valeur à encoder
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><constant>JSON_ERROR_UNSUPPORTED_TYPE</constant></term>
+    <listitem>
+     <simpara>Une valeur d'un type qui ne peut pas être encodé a été fournie</simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><constant>JSON_ERROR_INVALID_PROPERTY_NAME</constant></term>
+    <listitem>
+     <simpara>Un nom de propriété qui ne peut pas être encodé a été fourni</simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><constant>JSON_ERROR_UTF16</constant></term>
+    <listitem>
+     <simpara>Caractères UTF-16 mal formés, probablement mal encodés</simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><constant>JSON_ERROR_NON_BACKED_ENUM</constant></term>
+    <listitem>
+     <simpara>La valeur contient une énumération non adossée qui ne peut pas être sérialisée</simpara>
+    </listitem>
+   </varlistentry>
+   </variablelist>
   </para>
-  <table>
-   <title>Codes d'erreur JSON</title>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
    <tgroup cols="2">
     <thead>
      <row>
-      <entry>Constante</entry>
-      <entry>Signification</entry>
-      <entry>Disponibilité</entry>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
      </row>
     </thead>
     <tbody>
      <row>
-      <entry><constant>JSON_ERROR_NONE</constant></entry>
-      <entry>Aucune erreur n'est survenue</entry>
-      <entry></entry>
-     </row>
-     <row>
-      <entry><constant>JSON_ERROR_DEPTH</constant></entry>
-      <entry>La profondeur maximale de la pile a été atteinte</entry>
-      <entry></entry>
-     </row>
-     <row>
-      <entry><constant>JSON_ERROR_STATE_MISMATCH</constant></entry>
-      <entry>JSON invalide ou mal formé</entry>
-      <entry></entry>
-     </row>
-     <row>
-      <entry><constant>JSON_ERROR_CTRL_CHAR</constant></entry>
-      <entry>Erreur lors du contrôle des caractères ; probablement un encodage incorrect</entry>
-      <entry></entry>
-     </row>
-     <row>
-      <entry><constant>JSON_ERROR_SYNTAX</constant></entry>
-      <entry>Erreur de syntaxe</entry>
-      <entry></entry>
-     </row>
-     <row>
-      <entry><constant>JSON_ERROR_UTF8</constant></entry>
-      <entry>Caractères UTF-8 malformés, possiblement mal encodés</entry>
-      <entry></entry>
-     </row>
-     <row>
-      <entry><constant>JSON_ERROR_RECURSION</constant></entry>
-      <entry>Une ou plusieurs références récursives sont présentes dans
-       la valeur à encoder</entry>
-      <entry></entry>
-     </row>
-     <row>
-      <entry><constant>JSON_ERROR_INF_OR_NAN</constant></entry>
+      <entry>8.1.0</entry>
       <entry>
-       Une ou plusieurs valeurs
-       <link linkend="language.types.float.nan"><constant>NAN</constant></link>
-       ou <link linkend="function.is-infinite"><constant>INF</constant></link>
-       sont présentes dans la valeur à encoder.
+       La constante <constant>JSON_ERROR_NON_BACKED_ENUM</constant> a été ajoutée.
       </entry>
-      <entry></entry>
-     </row>
-     <row>
-      <entry><constant>JSON_ERROR_UNSUPPORTED_TYPE</constant></entry>
-      <entry>Une valeur d'un type qui ne peut être encodée a été fournie</entry>
-      <entry></entry>
-     </row>
-     <row>
-      <entry><constant>JSON_ERROR_INVALID_PROPERTY_NAME</constant></entry>
-      <entry>Un nom de propriété qui ne peut pas être encodé a été donné</entry>
-      <entry></entry>
-     </row>
-     <row>
-      <entry><constant>JSON_ERROR_UTF16</constant></entry>
-      <entry>Caractères UTF-16 mal formés, probablement mal encodés</entry>
-      <entry></entry>
-     </row>
-     <row>
-      <entry><constant>JSON_ERROR_NON_BACKED_ENUM</constant></entry>
-      <entry>La valeur contient un enum non adossé qui ne peut pas être sérialisé. Disponible à partir de PHP 8.1.0.</entry>
-      <entry></entry>
      </row>
     </tbody>
    </tgroup>
-  </table>
+  </informaltable>
  </refsect1>
- 
+
  <refsect1 role="examples">
   &reftitle.examples;
   <para>


### PR DESCRIPTION
Sync with EN commit 3733e082ad183251e0b63d08b52c448a243f9710.

Replaces the JSON error codes table with a `<variablelist>` matching EN, and moves the `JSON_ERROR_NON_BACKED_ENUM` availability information into a dedicated changelog section.

Removes the obsolete `<!-- Reviewed -->` marker.

Fixes: #3385