### PR TITLE
[Sync-En] filesystem: add deprecation notice for auto_detect_line_endings

### DIFF
--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4c85baa92d7c99df238876d20d77ecb952472f11 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 9e5166dc6a5ff650b649298470d19eb7c3637a63 Maintainer: lacatoire Status: ready -->
 <!-- Relecture des Notes, Précautions, Avertissements, Astuces, Divers et Retour le 2018-12-29 par girgias -->
 
 <!--
@@ -124,9 +124,12 @@ la version originale. Merci.
 </simpara></note>'>
 
 <!ENTITY note.line-endings '<note xmlns="http://docbook.org/ns/docbook"><simpara>
- Si PHP ne reconnaît pas correctement les fins de lignes lors de la lecture de fichiers qui ont été créés ou lus sur
- un Macintosh, l&apos;activation de l&apos;option de configuration
- <link linkend="ini.auto-detect-line-endings">auto_detect_line_endings</link> peut régler le problème.
+ Avant PHP 8.1.0, l&apos;option de configuration
+ <link linkend="ini.auto-detect-line-endings">auto_detect_line_endings</link>
+ pouvait être activée pour aider PHP à reconnaître correctement les fins de ligne lors
+ de la lecture de fichiers créés sur des systèmes Macintosh. Cette option est obsolète
+ à partir de PHP 8.1.0. Si nécessaire, il faut traiter manuellement les sauts de ligne
+ <literal>"\r"</literal>.
 </simpara></note>'>
 
 <!ENTITY note.no-remote '<note xmlns="http://docbook.org/ns/docbook"><simpara>

--- a/reference/filesystem/ini.xml
+++ b/reference/filesystem/ini.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: d4d5216e7a965ca194f6b1c9dee84cecab2674e5 Maintainer: yannick Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 9e5166dc6a5ff650b649298470d19eb7c3637a63 Maintainer: yannick Status: ready -->
 <section xml:id="filesystem.configuration" xmlns="http://docbook.org/ns/docbook">
  &reftitle.runtime;
  &extension.runtime;
@@ -152,19 +150,24 @@
      <type>bool</type>
     </term>
     <listitem>
-     <para>
+     <simpara>
       Lorsque cette option est activée, PHP va examiner les données lues
       par <function>fgets</function> et <function>file</function> pour voir
       si le fichier utilise les conventions de ligne de Unix, MS-Dos ou
       Macintosh.
-     </para>
-     <para>
+     </simpara>
+     <simpara>
       Cela permet à PHP de fonctionner avec des systèmes Macintosh, mais
       par défaut, cette option est désactivée, car cette détection
       impose une légère pénalité en temps de traitement, mais aussi
       parce que ceux qui utilisent les retours chariots comme séparateurs
       auront des soucis de compatibilité.
-     </para>
+     </simpara>
+     <warning>
+      <simpara>
+       Cette option est obsolète à partir de PHP 8.1.0.
+      </simpara>
+     </warning>
     </listitem>
    </varlistentry>
    


### PR DESCRIPTION
Sync with EN commit 9e5166dc6a5ff650b649298470d19eb7c3637a63.

Retranslates the `note.line-endings` entity (deprecation of `auto_detect_line_endings` in 8.1.0, manual handling of `"\\r"`) and adds the deprecation `<warning>` to the INI directive; the two inline-only paragraphs become `<simpara>`.

Removes the obsolete `<!-- Reviewed -->` and `<!-- $Revision$ -->` markers.

Fixes: #3386