### PR TITLE
[Sync-En] phar: make the OPENSSL signature example runnable

### DIFF
--- a/reference/phar/Phar/setSignatureAlgorithm.xml
+++ b/reference/phar/Phar/setSignatureAlgorithm.xml
@@ -1,6 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<!-- EN-Revision: f03806fcd8fe03a0501bd40b6e3939ff6589a1d2 Maintainer: gui Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 2cbc37d710751c33862709e622d0e928c9015c45 Maintainer: gui Status: ready -->
 <refentry xml:id="phar.setsignaturealgorithm" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Phar::setSignatureAlgorithm</refname>
@@ -53,6 +52,7 @@
        <programlisting role="php">
 <![CDATA[
 <?php
+$p = new Phar('archive.phar');
 $private = openssl_get_privatekey(file_get_contents('private.pem'));
 $pkey = '';
 openssl_pkey_export($private, $pkey);

--- a/reference/phar/PharData/setSignatureAlgorithm.xml
+++ b/reference/phar/PharData/setSignatureAlgorithm.xml
@@ -1,6 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<!-- EN-Revision: f03806fcd8fe03a0501bd40b6e3939ff6589a1d2 Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 2cbc37d710751c33862709e622d0e928c9015c45 Maintainer: yannick Status: ready -->
 <refentry xml:id="phardata.setsignaturealgorithm" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>PharData::setSignatureAlgorithm</refname>
@@ -47,6 +46,7 @@
        <programlisting role="php">
 <![CDATA[
 <?php
+$p = new PharData('archive.tar');
 $private = openssl_get_privatekey(file_get_contents('private.pem'));
 $pkey = '';
 openssl_pkey_export($private, $pkey);


### PR DESCRIPTION
Sync with EN commit 2cbc37d710751c33862709e622d0e928c9015c45.

Adds the missing archive instantiation in the OPENSSL example of both pages so the snippet is runnable. The `privateKey` `<varlistentry>` added upstream on the `PharData` page was already present and translated here, so only the example line was missing.

Removes the obsolete `<!-- Reviewed -->` markers.

Fixes: #3388