### PR TITLE
[Sync-En] install: add Arch Linux (pacman) installation page

### DIFF
--- a/install/unix/index.xml
+++ b/install/unix/index.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: f0f5d8646b835280b44b1d95277e3881be931cd9 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 5a5899391ef91a4d42bca9495c8a1d323d38f23a Maintainer: yannick Status: ready -->
 <chapter xml:id="install.unix" xmlns="http://docbook.org/ns/docbook">
  <title>Installation sur les systèmes Unix</title>
  <simpara>
@@ -27,6 +27,7 @@
  <!-- nœuds spécifiques aux distributions -->
  &install.unix.debian;
  &install.unix.dnf;
+ &install.unix.alpine;
  &install.unix.pacman;
  &install.unix.openbsd;
  <!-- instructions générales à partir des sources -->

--- a/install/unix/index.xml
+++ b/install/unix/index.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4cb53ecbd763db2db808e90d7eda63afb380e6df Maintainer: yannick Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: f0f5d8646b835280b44b1d95277e3881be931cd9 Maintainer: yannick Status: ready -->
 <chapter xml:id="install.unix" xmlns="http://docbook.org/ns/docbook">
  <title>Installation sur les systèmes Unix</title>
  <simpara>
@@ -28,6 +27,7 @@
  <!-- nœuds spécifiques aux distributions -->
  &install.unix.debian;
  &install.unix.dnf;
+ &install.unix.pacman;
  &install.unix.openbsd;
  <!-- instructions générales à partir des sources -->
  &install.unix.source;

--- a/install/unix/pacman.xml
+++ b/install/unix/pacman.xml
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: f0f5d8646b835280b44b1d95277e3881be931cd9 Maintainer: none Status: ready -->
+<sect1 xml:id="install.unix.pacman" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <title>Installation depuis les paquets sur Arch Linux</title>
+ <simpara>
+  Tandis que PHP peut être installé depuis les sources, il est également disponible
+  via des paquets sur Arch Linux et les distributions dérivées qui utilisent pacman.
+ </simpara>
+ &warn.install.third-party-support;
+ <simpara>
+  Les paquets peuvent être installés en utilisant la commande <command>pacman</command>.
+ </simpara>
+ <sect2 xml:id="install.unix.pacman.packages">
+  <title>Installation des paquets</title>
+  <simpara>
+   Pour commencer, il est important de noter que d'autres paquets liés peuvent être
+   souhaités, comme <literal>php-apache</literal> pour
+   <link linkend="install.unix.apache2">Apache</link>,
+   ou <literal>php-fpm</literal> pour les configurations FastCGI.
+  </simpara>
+  <simpara>
+   Avant d'installer un paquet, il est recommandé de s'assurer que le système
+   est à jour. Typiquement, cela se fait en exécutant la commande
+   <command>pacman -Syu</command>.
+  </simpara>
+  <example xml:id="install.unix.pacman.example">
+   <title>Exemple d'installation avec pacman et Apache</title>
+   <programlisting role="shell">
+<![CDATA[
+# pacman -S php php-apache
+]]>
+   </programlisting>
+  </example>
+  <simpara>
+   Pacman installera automatiquement toutes les dépendances de PHP.
+   Il peut être nécessaire de redémarrer le serveur web pour que les changements
+   prennent effet. Par exemple :
+  </simpara>
+  <example xml:id="install.unix.pacman.example2">
+   <title>Redémarrage d'Apache une fois PHP installé</title>
+   <programlisting role="shell">
+<![CDATA[
+# systemctl restart httpd
+]]>
+   </programlisting>
+  </example>
+ </sect2>
+ <sect2 xml:id="install.unix.pacman.config">
+  <title>Un meilleur contrôle de la configuration</title>
+  <para>
+   Dans la section précédente, PHP a été installé avec uniquement les modules
+   de base. Il est très probable que des modules additionnels soient souhaités,
+   tels que
+   <simplelist type="inline">
+    <member><link linkend="book.mysql">MySQL</link></member>
+    <member><link linkend="book.curl">cURL</link></member>
+    <member><link linkend="book.image">GD</link></member>
+    <member>etc.</member>
+   </simplelist>
+   Ceux-ci peuvent également être installés via la commande <command>pacman</command>.
+  </para>
+  <example xml:id="install.unix.pacman.config.example">
+   <title>Méthodes pour lister les paquets PHP additionnels</title>
+   <programlisting role="shell">
+<![CDATA[
+# pacman -Ss php
+]]>
+   </programlisting>
+  </example>
+  <simpara>
+   La liste des paquets inclura un certain nombre de paquets contenant des
+   extensions PHP, tels que <literal>php-gd</literal>,
+   <literal>php-intl</literal>, <literal>php-sqlite</literal>, et d'autres.
+   Lorsque des extensions sont installées, des paquets additionnels seront
+   automatiquement installés si nécessaire pour satisfaire les dépendances
+   de ces paquets.
+  </simpara>
+  <example xml:id="install.unix.pacman.config.example2">
+   <title>Installation de PHP avec GD</title>
+   <programlisting role="shell">
+<![CDATA[
+# pacman -S php-gd
+]]>
+   </programlisting>
+  </example>
+  <simpara>
+   Après l'installation d'un paquet d'extension, l'entrée correspondante dans
+   <filename>/etc/php/php.ini</filename> doit être décommentée pour l'activer.
+   Par exemple, après l'installation de <literal>php-gd</literal>, il faut
+   décommenter la ligne <literal>extension=gd</literal> dans
+   <filename>/etc/php/php.ini</filename>. Le redémarrage du serveur web (comme
+   Apache) est nécessaire avant que ces changements ne prennent effet.
+  </simpara>
+ </sect2>
+</sect1>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
Sync with EN commit f0f5d8646b835280b44b1d95277e3881be931cd9.

Translates the new Arch Linux / pacman installation page and references it in the Unix installation index, between `&install.unix.dnf;` and `&install.unix.openbsd;`.

`index.xml` deliberately carries the hash of that commit rather than the latest one (5a58993, Alpine): `install/unix/alpine.xml` is not translated yet and is out of scope here.

Removes the obsolete `<!-- Reviewed -->` marker.

Fixes: #3383