### PR TITLE
[Sync-En] yar: sync the Yar extension documentation with EN

### DIFF
--- a/reference/yar/book.xml
+++ b/reference/yar/book.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 28975cb447c4d3e13fdfd2f9c1eb3e8b7c231e3f Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 75d48299ef85693f10eee31af1be88488fb84c6f Maintainer: yannick Status: ready -->
 
 <book xml:id="book.yar" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <?phpdoc extension-membership="pecl" ?>
@@ -8,11 +8,25 @@
 
  <preface xml:id="intro.yar">
   &reftitle.intro;
-  <para>
-   Yar est un framework RPC qui a pour but de fournir une façon simple
-   de communication entre les applications PHP. Il apporte la possibilité
-   d'appeler plusieurs services distants simultanément.
-  </para>
+  <simpara>
+   Yar (Yet another RPC framework) est un framework RPC léger et concurrent
+   qui a pour but de fournir une façon simple et aisée de communiquer entre
+   les applications PHP. Il peut également émettre plusieurs appels vers des
+   services distants simultanément.
+  </simpara>
+  <simpara>
+   Yar est une extension PHP native plutôt qu'une bibliothèque écrite en PHP.
+   Elle utilise un protocole binaire compact au dessus de HTTP, HTTPS ou TCP
+   et est fournie avec trois empaqueteurs intégrés (<literal>php</literal>,
+   <literal>json</literal> et, lorsqu'elle est compilée avec
+   <option role="configure">--enable-msgpack</option>,
+   <literal>msgpack</literal>), si bien qu'aucun paquet supplémentaire ni
+   processus mandataire n'est nécessaire.
+  </simpara>
+  <simpara>
+   Le protocole est indépendant du langage : des implémentations compatibles
+   existent pour C, Java et Lua.
+  </simpara>
  </preface>
 
  &reference.yar.setup;
@@ -22,13 +36,12 @@
  &reference.yar.yar-client;
  &reference.yar.yar-concurrent-client;
  &reference.yar.yar-server-exception;
- &reference.yar.yar-client-exception;
-
  &reference.yar.yar-server-output-exception;
  &reference.yar.yar-server-packager-exception;
  &reference.yar.yar-server-protocol-exception;
  &reference.yar.yar-server-request-exception;
 
+ &reference.yar.yar-client-exception;
  &reference.yar.yar-client-packager-exception;
  &reference.yar.yar-client-protocol-exception;
  &reference.yar.yar-client-transport-exception;

--- a/reference/yar/configure.xml
+++ b/reference/yar/configure.xml
@@ -1,16 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 914b97130aed191518791045b93b6f858ef5a139 Maintainer: yannick Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 75d48299ef85693f10eee31af1be88488fb84c6f Maintainer: yannick Status: ready -->
 
 <section xml:id="yar.installation" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.install;
 
- <para>
+ <simpara>
   &pecl.info;
   <link xlink:href="&url.pecl.package;yar">&url.pecl.package;yar</link>
- </para>
- 
+ </simpara>
+
 </section>
 
 

--- a/reference/yar/constants.xml
+++ b/reference/yar/constants.xml
@@ -1,166 +1,324 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 4966eedcbc8d5ae4dd7043ee14cec170e321406b Maintainer: yannick Status: ready -->
-<!-- CREDITS: DavidA -->
+<!-- EN-Revision: 75d48299ef85693f10eee31af1be88488fb84c6f Maintainer: yannick Status: ready -->
 
 <appendix xml:id="yar.constants" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.constants;
  &extension.constants;
- <para>
-  <variablelist>
-   <varlistentry xml:id="constant.yar-version">
-    <term>
-     <constant>YAR_VERSION</constant>
-     (<type>string</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.yar-client-protocol-http">
-    <term>
-     <constant>YAR_CLIENT_PROTOCOL_HTTP</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.yar-opt-packager">
-    <term>
-     <constant>YAR_OPT_PACKAGER</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.yar-opt-timeout">
-    <term>
-     <constant>YAR_OPT_TIMEOUT</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.yar-opt-connect-timeout">
-    <term>
-     <constant>YAR_OPT_CONNECT_TIMEOUT</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.yar-opt-header">
-    <term>
-     <constant>YAR_OPT_HEADER</constant>
-     (<type>array</type>)
-    </term>
-    <listitem>
-     <simpara>
-      Depuis 2.0.4
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.yar-packager-php">
-    <term>
-     <constant>YAR_PACKAGER_PHP</constant>
-     (<type>string</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.yar-packager-json">
-    <term>
-     <constant>YAR_PACKAGER_JSON</constant>
-     (<type>string</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.yar-err-okey">
-    <term>
-     <constant>YAR_ERR_OKEY</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.yar-err-output">
-    <term>
-     <constant>YAR_ERR_OUTPUT</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.yar-err-transport">
-    <term>
-     <constant>YAR_ERR_TRANSPORT</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.yar-err-request">
-    <term>
-     <constant>YAR_ERR_REQUEST</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.yar-err-protocol">
-    <term>
-     <constant>YAR_ERR_PROTOCOL</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.yar-err-packager">
-    <term>
-     <constant>YAR_ERR_PACKAGER</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="constant.yar-err-exception">
-    <term>
-     <constant>YAR_ERR_EXCEPTION</constant>
-     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
-   </varlistentry>
-  </variablelist>
- </para>
+ <variablelist>
+  <varlistentry xml:id="constant.yar-version">
+   <term>
+    <constant>YAR_VERSION</constant>
+    (<type>string</type>)
+   </term>
+   <listitem>
+    <simpara>
+     La version de l'extension Yar, par exemple
+     <literal>"2.4.0"</literal>.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.yar-has-msgpack">
+   <term>
+    <constant>YAR_HAS_MSGPACK</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     <literal>1</literal> lorsque Yar a été compilé avec
+     <option role="configure">--enable-msgpack</option>, sinon
+     <literal>0</literal>.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.yar-client-protocol-http">
+   <term>
+    <constant>YAR_CLIENT_PROTOCOL_HTTP</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Identifie le protocole HTTP, exposé via la propriété en lecture
+     seule <varname>_protocol</varname> de
+     <classname>Yar_Client</classname>.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.yar-client-protocol-tcp">
+   <term>
+    <constant>YAR_CLIENT_PROTOCOL_TCP</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Identifie le protocole TCP, exposé via la propriété en lecture
+     seule <varname>_protocol</varname> de
+     <classname>Yar_Client</classname>.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.yar-client-protocol-unix">
+   <term>
+    <constant>YAR_CLIENT_PROTOCOL_UNIX</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Identifie le protocole des sockets Unix, exposé via la propriété
+     en lecture seule <varname>_protocol</varname> de
+     <classname>Yar_Client</classname>.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.yar-opt-packager">
+   <term>
+    <constant>YAR_OPT_PACKAGER</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Option de client permettant de surcharger la directive
+     <link linkend="ini.yar.packager">yar.packager</link>
+     pour un seul client. La valeur doit être l'une de
+     <literal>php</literal>, <literal>json</literal> ou
+     <literal>msgpack</literal>.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.yar-opt-persistent">
+   <term>
+    <constant>YAR_OPT_PERSISTENT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Option de client permettant d'activer les connexions
+     persistantes. Lorsqu'elle est définie à une valeur vraie, le
+     keep-alive HTTP est utilisé afin que les appels répétés au même
+     serveur réutilisent la connexion pendant le reste du cycle de vie
+     de la requête PHP.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.yar-opt-timeout">
+   <term>
+    <constant>YAR_OPT_TIMEOUT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Option de client permettant de surcharger la directive
+     <link linkend="ini.yar.timeout">yar.timeout</link>, en
+     millisecondes.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.yar-opt-connect-timeout">
+   <term>
+    <constant>YAR_OPT_CONNECT_TIMEOUT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Option de client permettant de surcharger la directive
+     <link linkend="ini.yar.connect-timeout">yar.connect_timeout</link>,
+     en millisecondes.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.yar-opt-header">
+   <term>
+    <constant>YAR_OPT_HEADER</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Option de client permettant d'ajouter des en-têtes HTTP
+     personnalisés. La valeur doit être un tableau de chaînes de
+     caractères de la forme
+     <literal>"X-Custom: value"</literal>. Effective uniquement avec
+     les protocoles HTTP et HTTPS. Disponible à partir de Yar 2.0.4.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.yar-opt-resolve">
+   <term>
+    <constant>YAR_OPT_RESOLVE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Option de client permettant de surcharger la résolution de nom
+     d'hôte pour les appels HTTP. La valeur doit être un tableau de
+     chaînes de caractères au format
+     <literal>HOST:PORT:ADDRESS</literal>, suivant la syntaxe de
+     <constant>CURLOPT_RESOLVE</constant> de curl. Nécessite libcurl
+     &gt;= 7.21.3. Disponible à partir de Yar 2.1.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.yar-opt-proxy">
+   <term>
+    <constant>YAR_OPT_PROXY</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Option de client permettant de faire transiter les appels HTTP par
+     un proxy HTTP. La valeur doit être une chaîne de caractères telle
+     que <literal>127.0.0.1:8888</literal>.
+     Disponible à partir de Yar 2.2.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.yar-opt-provider">
+   <term>
+    <constant>YAR_OPT_PROVIDER</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Option de client portant l'identité du fournisseur envoyée avec
+     chaque requête. La valeur doit être une chaîne de caractères d'au
+     plus 32 octets, qui est transmise à la méthode magique
+     <literal>__auth</literal> côté serveur.
+     Disponible à partir de Yar 2.3.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.yar-opt-token">
+   <term>
+    <constant>YAR_OPT_TOKEN</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Option de client portant le jeton d'authentification envoyé avec
+     chaque requête. La valeur doit être une chaîne de caractères d'au
+     plus 32 octets, qui est transmise à la méthode magique
+     <literal>__auth</literal> côté serveur.
+     Disponible à partir de Yar 2.3.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.yar-packager-php">
+   <term>
+    <constant>YAR_PACKAGER_PHP</constant>
+    (<type>string</type>)
+   </term>
+   <listitem>
+    <simpara>
+     L'identifiant de l'empaqueteur <literal>php</literal>,
+     <literal>"PHP"</literal>.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.yar-packager-json">
+   <term>
+    <constant>YAR_PACKAGER_JSON</constant>
+    (<type>string</type>)
+   </term>
+   <listitem>
+    <simpara>
+     L'identifiant de l'empaqueteur <literal>json</literal>,
+     <literal>"JSON"</literal>.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.yar-packager-msgpack">
+   <term>
+    <constant>YAR_PACKAGER_MSGPACK</constant>
+    (<type>string</type>)
+   </term>
+   <listitem>
+    <simpara>
+     L'identifiant de l'empaqueteur <literal>msgpack</literal>,
+     <literal>"MSGPACK"</literal>.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.yar-err-okey">
+   <term>
+    <constant>YAR_ERR_OKEY</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Aucune erreur ; la requête a été traitée avec succès.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.yar-err-packager">
+   <term>
+    <constant>YAR_ERR_PACKAGER</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Une erreur d'empaquetage, par exemple un corps qui n'a pas pu être
+     désempaqueté.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.yar-err-protocol">
+   <term>
+    <constant>YAR_ERR_PROTOCOL</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Une erreur de protocole, par exemple un en-tête Yar malformé.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.yar-err-request">
+   <term>
+    <constant>YAR_ERR_REQUEST</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Une erreur de requête, par exemple un appel à une méthode non
+     définie ou non publique.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.yar-err-output">
+   <term>
+    <constant>YAR_ERR_OUTPUT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Une erreur de sortie, par exemple le serveur n'a pas pu démarrer
+     son tampon de sortie.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.yar-err-transport">
+   <term>
+    <constant>YAR_ERR_TRANSPORT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Une erreur de transport, par exemple un échec de connexion ou un
+     dépassement de délai.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.yar-err-exception">
+   <term>
+    <constant>YAR_ERR_EXCEPTION</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Le service distant a levé une exception lors du traitement de la
+     requête.
+    </simpara>
+   </listitem>
+  </varlistentry>
+ </variablelist>
 </appendix>
 
 <!-- Keep this comment at the end of the file

--- a/reference/yar/examples.xml
+++ b/reference/yar/examples.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: df78bd1d232f2cd8df673accf5ba0e280695639b Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 75d48299ef85693f10eee31af1be88488fb84c6f Maintainer: lacatoire Status: ready -->
 
 <chapter xml:id="yar.examples" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.examples;
@@ -9,12 +9,12 @@
 <![CDATA[
 <?php
 
-/* supposons que cette page est accessible via l'URL http://example.com/operator.php */
+/* supposons que cette page soit accessible via http://example.com/operator.php */
 
 class Operator {
 
     /**
-     * Ajout de deux opérandes
+     * Additionne deux opérandes
      * @param integer
      * @return integer
      */
@@ -23,14 +23,14 @@ class Operator {
     }
 
     /**
-     * Sub 
+     * Soustraction
      */
     public function sub($a, $b) {
         return $a - $b;
     }
 
     /**
-     * Mul
+     * Multiplication
      */
     public function mul($a, $b) {
         return $a * $b;
@@ -55,6 +55,13 @@ $server->handle();
 
  <example>
   <title>Accès au serveur depuis un navigateur (requête GET)</title>
+  <simpara>
+   Lorsqu'une requête GET est émise vers l'URI du service, Yar affiche
+   une page d'information listant chaque méthode publique de l'objet
+   exécuteur ainsi que son commentaire de documentation. Ce
+   comportement est contrôlé par la directive
+   <link linkend="ini.yar.expose-info">yar.expose_info</link>.
+  </simpara>
   &example.outputs.similar;
   <mediaobject>
    <alt>Information du serveur Yar</alt>
@@ -69,28 +76,27 @@ $server->handle();
   <programlisting role="php">
 <![CDATA[
 <?php
-$client = new yar_client("http://example.com/operator.php");
+$client = new Yar_Client("http://example.com/operator.php");
 
-/* Appel direct */
+/* appel direct */
 var_dump($client->add(1, 2));
 
-/* Appel via un appel */
+/* appel via call() */
 var_dump($client->call("add", array(3, 2)));
 
-
-/* la méthode _add ne peut être appelée */
+/* _add ne peut pas être appelée : elle n'est pas publique */
 var_dump($client->_add(1, 2));
 ?>
 ]]>
   </programlisting>
   &example.outputs.similar;
-   <screen>
+  <screen>
 <![CDATA[
 int(3)
 int(5)
-PHP Fatal error:  Uncaught exception 'Yar_Server_Exception' with message 'call to api Operator::_add() failed' in *
+PHP Fatal error:  Uncaught Yar_Server_Request_Exception: call to undefined api Operator::_add() in *
 ]]>
-   </screen>
+  </screen>
  </example>
 
  <example>
@@ -99,27 +105,50 @@ PHP Fatal error:  Uncaught exception 'Yar_Server_Exception' with message 'call t
 <![CDATA[
 <?php
 function callback($ret, $callinfo) {
-    echo $callinfo['method'] , " result: ", $ret , "\n";
+    echo $callinfo['method'], " résultat : ", $ret, "\n";
 }
 
-/* enregistre l'appel async aux services distants */
+function error_callback($type, $error, $callinfo) {
+    error_log("[$type] $error");
+}
+
+/* enregistre les appels asynchrones aux services distants */
 Yar_Concurrent_Client::call("http://example.com/operator.php", "add", array(1, 2), "callback");
 Yar_Concurrent_Client::call("http://example.com/operator.php", "sub", array(2, 1), "callback");
 Yar_Concurrent_Client::call("http://example.com/operator.php", "mul", array(2, 2), "callback");
 
 /* envoie toutes les requêtes et attend les réponses */
-Yar_Concurrent_Client::loop();
+Yar_Concurrent_Client::loop("callback", "error_callback");
 ?>
 ]]>
   </programlisting>
   &example.outputs.similar;
   <screen>
 <![CDATA[
-mul result: 4
-sub result: 1
-add result: 3
+mul résultat : 4
+sub résultat : 1
+add résultat : 3
 ]]>
-   </screen>
+  </screen>
+ </example>
+
+ <example>
+  <title>Exemple de client Yar TCP</title>
+  <simpara>
+   Outre HTTP, <classname>Yar_Client</classname> peut dialoguer avec
+   des serveurs compatibles Yar via TCP ou des sockets Unix, par
+   exemple un service implémenté avec le framework Yar en C. Le serveur
+   distant doit implémenter le même protocole binaire Yar.
+  </simpara>
+  <programlisting role="php">
+<![CDATA[
+<?php
+$client = new Yar_Client("tcp://127.0.0.1:8600");
+
+var_dump($client->add(1, 2));
+?>
+]]>
+  </programlisting>
  </example>
 
 </chapter>

--- a/reference/yar/ini.xml
+++ b/reference/yar/ini.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: d4d5216e7a965ca194f6b1c9dee84cecab2674e5 Maintainer: yannick Status: ready -->
-<!-- CREDITS: DavidA -->
+<!-- EN-Revision: 75d48299ef85693f10eee31af1be88488fb84c6f Maintainer: yannick Status: ready -->
 
 <section xml:id="yar.configuration" xmlns="http://docbook.org/ns/docbook">
  &reftitle.runtime;
@@ -20,9 +18,15 @@
     </thead>
     <tbody>
      <row>
-      <entry><link linkend="ini.yar.packager">yar.packager</link></entry>
-      <entry>php</entry>
-      <entry><constant>INI_SYSTEM</constant></entry>
+      <entry><link linkend="ini.yar.connect-timeout">yar.connect_timeout</link></entry>
+      <entry>1000</entry>
+      <entry><constant>INI_ALL</constant></entry>
+      <entry><!-- leave empty, this will be filled by an automatic script --></entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.yar.content-type">yar.content_type</link></entry>
+      <entry>application/octet-stream</entry>
+      <entry><constant>INI_ALL</constant></entry>
       <entry><!-- leave empty, this will be filled by an automatic script --></entry>
      </row>
      <row>
@@ -32,8 +36,20 @@
       <entry><!-- leave empty, this will be filled by an automatic script --></entry>
      </row>
      <row>
-      <entry><link linkend="ini.yar.connect-timeout">yar.connect_timeout</link></entry>
-      <entry>1000</entry>
+      <entry><link linkend="ini.yar.expose-info">yar.expose_info</link></entry>
+      <entry>On</entry>
+      <entry><constant>INI_PERDIR</constant></entry>
+      <entry><!-- leave empty, this will be filled by an automatic script --></entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.yar.packager">yar.packager</link></entry>
+      <entry>php</entry>
+      <entry><constant>INI_PERDIR</constant></entry>
+      <entry><!-- leave empty, this will be filled by an automatic script --></entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.yar.ssl-verify">yar.ssl_verify</link></entry>
+      <entry>Off</entry>
       <entry><constant>INI_ALL</constant></entry>
       <entry><!-- leave empty, this will be filled by an automatic script --></entry>
      </row>
@@ -41,12 +57,6 @@
       <entry><link linkend="ini.yar.timeout">yar.timeout</link></entry>
       <entry>5000</entry>
       <entry><constant>INI_ALL</constant></entry>
-      <entry><!-- leave empty, this will be filled by an automatic script --></entry>
-     </row>
-     <row>
-      <entry><link linkend="ini.yar.expose-info">yar.expose_info</link></entry>
-      <entry>On</entry>
-      <entry><constant>INI_SYSTEM</constant></entry>
       <entry><!-- leave empty, this will be filled by an automatic script --></entry>
      </row>
     </tbody>
@@ -58,49 +68,53 @@
 
  <para>
   <variablelist>
-   <varlistentry xml:id="ini.yar.packager">
-     <term>
-      <parameter>yar.packager</parameter>
-      <type>string</type>
-     </term>
-     <listitem>
-      <para>
-       peut être php, json, et msgpack (nécessite une compilation avec le support
-       msgpack)
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="ini.yar.debug">
-     <term>
-      <parameter>yar.debug</parameter>
-      <type>string</type>
-     </term>
-     <listitem>
-      <para>
-       
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="ini.yar.connect-timeout">
+   <varlistentry xml:id="ini.yar.connect-timeout">
      <term>
       <parameter>yar.connect_timeout</parameter>
       <type>int</type>
      </term>
      <listitem>
-      <para>
-       délai d'attente maximal en ms
-      </para>
+      <simpara>
+       Délai d'attente maximal de connexion, en millisecondes, pour les
+       appels HTTP émis par <classname>Yar_Client</classname> et
+       <classname>Yar_Concurrent_Client</classname>.
+      </simpara>
+      <note>
+       <simpara>
+        Cette valeur est interprétée en millisecondes. Antérieur à
+        Yar 1.2.1, elle était exprimée en secondes (la valeur par défaut
+        était <literal>1</literal>).
+       </simpara>
+      </note>
      </listitem>
     </varlistentry>
-    <varlistentry xml:id="ini.yar.timeout">
+    <varlistentry xml:id="ini.yar.content-type">
      <term>
-      <parameter>yar.timeout</parameter>
-      <type>int</type>
+      <parameter>yar.content_type</parameter>
+      <type>string</type>
      </term>
      <listitem>
-      <para>
-       délai d'attente maximal en ms
-      </para>
+      <simpara>
+       La valeur de l'en-tête de réponse <literal>Content-Type</literal>
+       envoyé par <classname>Yar_Server</classname>. Yar utilise un
+       protocole binaire, la valeur par défaut est donc
+       <literal>application/octet-stream</literal>.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="ini.yar.debug">
+     <term>
+      <parameter>yar.debug</parameter>
+      <type>bool</type>
+     </term>
+     <listitem>
+      <simpara>
+       Active le mode de débogage. Lorsqu'il est actif, Yar émet des
+       messages <constant>E_WARNING</constant> contenant des détails au
+       niveau du protocole pour chaque requête et chaque réponse, préfixés
+       par <literal>[Debug Yar_Server]</literal> ou
+       <literal>[Debug Yar_Client]</literal> et un horodatage.
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry xml:id="ini.yar.expose-info">
@@ -109,10 +123,66 @@
       <type>bool</type>
      </term>
      <listitem>
-      <para>
-       si l'on doit ou non exposer les informations du service
-       (lors de l'accès au serveur via GET)
-      </para>
+      <simpara>
+       Indique si <methodname>Yar_Server::handle</methodname> affiche la
+       page d'informations du service pour les requêtes autres que POST
+       (généralement GET). Lorsque cette directive est désactivée, de
+       telles requêtes lèvent une
+       <exceptionname>Yar_Server_Exception</exceptionname> à la place.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="ini.yar.packager">
+     <term>
+      <parameter>yar.packager</parameter>
+      <type>string</type>
+     </term>
+     <listitem>
+      <simpara>
+       L'empaqueteur utilisé par défaut pour sérialiser le corps des
+       requêtes et des réponses. Les valeurs valides sont
+       <literal>php</literal> (sérialisation PHP), <literal>json</literal>
+       et <literal>msgpack</literal> (uniquement lorsque Yar a été compilée
+       avec <option role="configure">--enable-msgpack</option>).
+      </simpara>
+      <simpara>
+       Lorsque Yar est compilée avec le support de msgpack, la valeur par
+       défaut devient <literal>msgpack</literal>.
+      </simpara>
+      <simpara>
+       Cette valeur peut être surchargée pour chaque client avec l'option
+       <constant>YAR_OPT_PACKAGER</constant>.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="ini.yar.ssl-verify">
+     <term>
+      <parameter>yar.ssl_verify</parameter>
+      <type>bool</type>
+     </term>
+     <listitem>
+      <simpara>
+       Indique s'il faut vérifier le certificat TLS des serveurs HTTPS.
+       Lorsque cette directive est active, le transport curl positionne
+       <constant>CURLOPT_SSL_VERIFYPEER</constant> et
+       <constant>CURLOPT_SSL_VERIFYHOST</constant>, et les requêtes vers
+       des serveurs présentant un certificat invalide échouent. Désactivée
+       par défaut pour des raisons de compatibilité ascendante. Disponible
+       à partir de Yar 2.4.0.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="ini.yar.timeout">
+     <term>
+      <parameter>yar.timeout</parameter>
+      <type>int</type>
+     </term>
+     <listitem>
+      <simpara>
+       Délai d'attente maximal, en millisecondes, pour les appels RPC émis
+       par <classname>Yar_Client</classname> et
+       <classname>Yar_Concurrent_Client</classname>.
+      </simpara>
      </listitem>
     </varlistentry>
 

--- a/reference/yar/setup.xml
+++ b/reference/yar/setup.xml
@@ -1,36 +1,113 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 307e7d78baacfcd228eef8f384e96659b67d9adb Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 75d48299ef85693f10eee31af1be88488fb84c6f Maintainer: yannick Status: ready -->
 
 <chapter xml:id="yar.setup" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.setup;
 
  <section xml:id="yar.requirements">
   &reftitle.required;
-  <para>
-   Pour utiliser msgpack comme packager, il faut compiler
-   Yar soi-même avec l'option de configuration ./configure --enable-msgpack
-  </para>
+  <simpara>
+   La bibliothèque cURL est nécessaire pour les transports HTTP et HTTPS.
+   Le transport TCP est implémenté à l'aide de sockets simples et ne
+   nécessite aucune bibliothèque supplémentaire.
+  </simpara>
+  <simpara>
+   L'extension <link linkend="book.json">JSON</link> est nécessaire ; elle
+   est fournie avec PHP et toujours disponible à partir de PHP 8.0.0.
+  </simpara>
+  <simpara>
+   Pour utiliser l'empaqueteur <literal>msgpack</literal>, l'extension
+   <link xlink:href="&url.pecl.package;msgpack">msgpack</link> doit être
+   installée et Yar doit être compilée avec l'option de configuration
+   <option role="configure">--enable-msgpack</option>.
+  </simpara>
  </section>
 
+ <!-- {{{ Installation -->
  <section xml:id="yar.installation">
   &reftitle.install;
-  <para>
+  <simpara>
    &pecl.moved;
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    &pecl.info;
    <link xlink:href="&url.pecl.package;yar">&url.pecl.package;yar</link>.
+  </simpara>
+  <simpara>
+   &pecl.windows.download.avail;
+  </simpara>
+  <para>
+   Le code source est hébergé sur
+   <link xlink:href="&url.git.hub;laruence/yar">GitHub</link>. Pour compiler
+   l'extension à partir des sources :
+   <screen>
+<![CDATA[
+$ git clone https://github.com/laruence/yar.git
+$ cd yar
+$ phpize
+$ ./configure
+$ make
+$ sudo make install
+]]>
+   </screen>
+  </para>
+  <para>
+   Les options de <literal>configure</literal> suivantes sont disponibles :
+   <variablelist>
+    <varlistentry>
+     <term>
+      <option role="configure">--with-curl</option>
+     </term>
+     <listitem>
+      <simpara>
+       Emplacement de l'installation de cURL, s'il ne se trouve pas dans
+       les chemins d'inclusion par défaut.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term>
+      <option role="configure">--enable-msgpack</option>
+     </term>
+     <listitem>
+      <simpara>
+       Active l'empaqueteur <literal>msgpack</literal> et fait de
+       l'extension <literal>msgpack</literal> une dépendance optionnelle.
+       Lorsque Yar est compilée avec cette option, la valeur par défaut de
+       <link linkend="ini.yar.packager">yar.packager</link> devient
+       <literal>msgpack</literal>.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term>
+      <option role="configure">--enable-epoll</option>
+     </term>
+     <listitem>
+      <simpara>
+       Utilise <literal>epoll</literal> de Linux au lieu de
+       <literal>select()</literal> pour le multiplexage des entrées/sorties,
+       disponible à partir de Yar 2.1.2. Cela peut améliorer les performances
+       de <classname>Yar_Concurrent_Client</classname> en cas de forte
+       concurrence. Cette option ne prend effet que sur Linux ; sur les
+       autres plateformes, elle est ignorée silencieusement.
+      </simpara>
+     </listitem>
+    </varlistentry>
+   </variablelist>
   </para>
  </section>
- 
+ <!-- }}} -->
+
+ <!-- {{{ Configuration -->
  &reference.yar.ini;
+ <!-- }}} -->
 
  <section xml:id="yar.resources">
   &reftitle.resources;
-  <para>
-
-  </para>
+  <simpara>
+   Cette extension ne définit aucune ressource.
+  </simpara>
  </section>
 
 </chapter>

--- a/reference/yar/yar-client-exception.xml
+++ b/reference/yar/yar-client-exception.xml
@@ -1,9 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 75d48299ef85693f10eee31af1be88488fb84c6f Maintainer: yannick Status: ready -->
 
-<reference xml:id="class.yar-client-exception" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+<reference xml:id="class.yar-client-exception" role="exception" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>La classe Yar_Client_Exception</title>
  <titleabbrev>Yar_Client_Exception</titleabbrev>
@@ -13,9 +11,12 @@
 <!-- {{{ Yar_Client_Exception intro -->
   <section xml:id="yar-client-exception.intro">
    &reftitle.intro;
-   <para>
-
-   </para>
+   <simpara>
+    Classe de base des exceptions levées lorsqu'une requête échoue avant,
+    pendant ou après avoir atteint le service distant : une sous-classe est
+    levée selon l'endroit où l'échec s'est produit. Le code de l'exception
+    est l'une des constantes <literal>YAR_ERR_*</literal>.
+   </simpara>
   </section>
 <!-- }}} -->
 
@@ -23,68 +24,29 @@
    &reftitle.classsynopsis;
 
 <!-- {{{ Synopsis -->
-   <classsynopsis>
-    <ooclass><classname>Yar_Client_Exception</classname></ooclass>
+   <classsynopsis class="class">
+    <ooexception>
+     <exceptionname>Yar_Client_Exception</exceptionname>
+    </ooexception>
 
-<!-- {{{ Class synopsis -->
-    <classsynopsisinfo>
-     <ooclass>
-      <classname>Yar_Client_Exception</classname>
-     </ooclass>
-     
-     <ooclass>
-      <modifier>extends</modifier>
-      <classname>Exception</classname>
-     </ooclass>
-    </classsynopsisinfo>
-<!-- }}} -->
-    <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
+    <ooclass>
+     <modifier>extends</modifier>
+     <classname>Exception</classname>
+    </ooclass>
 
-    
+    <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
+
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.yar-client-exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
-    
-    <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.yar-client-exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Yar_Client_Exception'])"/>
 
+    <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])"/>
    </classsynopsis>
 <!-- }}} -->
 
   </section>
-
-  
-<!-- {{{ Yar_Client_Exception properties -->
-  <section xml:id="yar-client-exception.props">
-   &reftitle.properties;
-   <variablelist>
-    <varlistentry xml:id="yar-client-exception.props.message">
-     <term><varname>message</varname></term>
-     <listitem>
-      <para></para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="yar-client-exception.props.code">
-     <term><varname>code</varname></term>
-     <listitem>
-      <para></para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="yar-client-exception.props.file">
-     <term><varname>file</varname></term>
-     <listitem>
-      <para></para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="yar-client-exception.props.line">
-     <term><varname>line</varname></term>
-     <listitem>
-      <para></para>
-     </listitem>
-    </varlistentry>
-   </variablelist>
-  </section>
-<!-- }}} -->
-
 
  </partintro>
 

--- a/reference/yar/yar-client-packager-exception.xml
+++ b/reference/yar/yar-client-packager-exception.xml
@@ -1,89 +1,45 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 28975cb447c4d3e13fdfd2f9c1eb3e8b7c231e3f Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 75d48299ef85693f10eee31af1be88488fb84c6f Maintainer: yannick Status: ready -->
 
-<reference xml:id="class.yar-client-packager-exception" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+<reference xml:id="class.yar-client-packager-exception" role="exception" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>La classe Yar_Client_Packager_Exception</title>
  <titleabbrev>Yar_Client_Packager_Exception</titleabbrev>
 
  <partintro>
 
-<!-- {{{ Yar_Client_Packager_Exception intro -->
   <section xml:id="yar-client-packager-exception.intro">
    &reftitle.intro;
-   <para>
-
-   </para>
+   <simpara>
+    Levée lorsque le corps de la réponse ne peut pas être décodé avec l'empaqueteur demandé (code d'exception <constant>YAR_ERR_PACKAGER</constant>).
+   </simpara>
   </section>
-<!-- }}} -->
 
   <section xml:id="yar-client-packager-exception.synopsis">
    &reftitle.classsynopsis;
 
-<!-- {{{ Synopsis -->
-   <classsynopsis>
-    <ooclass><classname>Yar_Client_Packager_Exception</classname></ooclass>
+   <classsynopsis class="class">
+    <ooexception>
+     <exceptionname>Yar_Client_Packager_Exception</exceptionname>
+    </ooexception>
 
-<!-- {{{ Class synopsis -->
-    <classsynopsisinfo>
-     <ooclass>
-      <classname>Yar_Client_Packager_Exception</classname>
-     </ooclass>
-     
-     <ooclass>
-      <modifier>extends</modifier>
-      <classname>Yar_Client_Exception</classname>
-     </ooclass>
-    </classsynopsisinfo>
-<!-- }}} -->
-    <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
+    <ooclass>
+     <modifier>extends</modifier>
+     <classname>Yar_Client_Exception</classname>
+    </ooclass>
 
-    
+    <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
+
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.yar-client-exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
-
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.yar-client-exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Yar_Client_Exception'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])"/>
    </classsynopsis>
-<!-- }}} -->
 
   </section>
-
-  
-<!-- {{{ Yar_Client_Packager_Exception properties -->
-  <section xml:id="yar-client-packager-exception.props">
-   &reftitle.properties;
-   <variablelist>
-    <varlistentry xml:id="yar-client-packager-exception.props.message">
-     <term><varname>message</varname></term>
-     <listitem>
-      <para></para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="yar-client-packager-exception.props.code">
-     <term><varname>code</varname></term>
-     <listitem>
-      <para></para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="yar-client-packager-exception.props.file">
-     <term><varname>file</varname></term>
-     <listitem>
-      <para></para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="yar-client-packager-exception.props.line">
-     <term><varname>line</varname></term>
-     <listitem>
-      <para></para>
-     </listitem>
-    </varlistentry>
-   </variablelist>
-  </section>
-<!-- }}} -->
-
 
  </partintro>
-
 
 </reference>
 

--- a/reference/yar/yar-client-protocol-exception.xml
+++ b/reference/yar/yar-client-protocol-exception.xml
@@ -1,89 +1,55 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 28975cb447c4d3e13fdfd2f9c1eb3e8b7c231e3f Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 07275f5d03cf34c5a2218e0c103978f8024da153 Maintainer: yannick Status: ready -->
 
-<reference xml:id="class.yar-client-protocol-exception" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+<reference xml:id="class.yar-client-protocol-exception" role="exception" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>La classe Yar_Client_Protocol_Exception</title>
  <titleabbrev>Yar_Client_Protocol_Exception</titleabbrev>
 
  <partintro>
 
-<!-- {{{ Yar_Client_Protocol_Exception intro -->
   <section xml:id="yar-client-protocol-exception.intro">
    &reftitle.intro;
-   <para>
-
-   </para>
+   <simpara>
+    Levée lorsque la réponse du service RPC viole le protocole Yar, par exemple une adresse de protocole non supportée ou un en-tête de réponse malformé (code d'exception <constant>YAR_ERR_PROTOCOL</constant>).
+   </simpara>
+   <simpara>
+    À partir de Yar 2.4.0, cela inclut également une réponse dont
+    l'identifiant de transaction ne correspond pas à celui de la requête à
+    laquelle elle répond. Le client valide le champ <literal>i</literal> de
+    chaque réponse ; une réponse portant un identifiant de transaction
+    différent et non nul (par exemple une réponse mal routée par un
+    mandataire) est rejetée. Les réponses dont l'identifiant de transaction
+    est nul ou absent restent acceptées pour des raisons de compatibilité
+    ascendante avec les serveurs plus anciens.
+   </simpara>
   </section>
-<!-- }}} -->
 
   <section xml:id="yar-client-protocol-exception.synopsis">
    &reftitle.classsynopsis;
 
-<!-- {{{ Synopsis -->
-   <classsynopsis>
-    <ooclass><classname>Yar_Client_Protocol_Exception</classname></ooclass>
+   <classsynopsis class="class">
+    <ooexception>
+     <exceptionname>Yar_Client_Protocol_Exception</exceptionname>
+    </ooexception>
 
-<!-- {{{ Class synopsis -->
-    <classsynopsisinfo>
-     <ooclass>
-      <classname>Yar_Client_Protocol_Exception</classname>
-     </ooclass>
-     
-     <ooclass>
-      <modifier>extends</modifier>
-      <classname>Yar_Client_Exception</classname>
-     </ooclass>
-    </classsynopsisinfo>
-<!-- }}} -->
-    <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
+    <ooclass>
+     <modifier>extends</modifier>
+     <classname>Yar_Client_Exception</classname>
+    </ooclass>
 
-    
+    <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
+
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.yar-client-exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
-
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.yar-client-exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Yar_Client_Exception'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])"/>
    </classsynopsis>
-<!-- }}} -->
 
   </section>
-
-  
-<!-- {{{ Yar_Client_Protocol_Exception properties -->
-  <section xml:id="yar-client-protocol-exception.props">
-   &reftitle.properties;
-   <variablelist>
-    <varlistentry xml:id="yar-client-protocol-exception.props.message">
-     <term><varname>message</varname></term>
-     <listitem>
-      <para></para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="yar-client-protocol-exception.props.code">
-     <term><varname>code</varname></term>
-     <listitem>
-      <para></para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="yar-client-protocol-exception.props.file">
-     <term><varname>file</varname></term>
-     <listitem>
-      <para></para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="yar-client-protocol-exception.props.line">
-     <term><varname>line</varname></term>
-     <listitem>
-      <para></para>
-     </listitem>
-    </varlistentry>
-   </variablelist>
-  </section>
-<!-- }}} -->
-
 
  </partintro>
-
 
 </reference>
 

--- a/reference/yar/yar-client-transport-exception.xml
+++ b/reference/yar/yar-client-transport-exception.xml
@@ -1,89 +1,45 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 28975cb447c4d3e13fdfd2f9c1eb3e8b7c231e3f Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 75d48299ef85693f10eee31af1be88488fb84c6f Maintainer: yannick Status: ready -->
 
-<reference xml:id="class.yar-client-transport-exception" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+<reference xml:id="class.yar-client-transport-exception" role="exception" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>La classe Yar_Client_Transport_Exception</title>
  <titleabbrev>Yar_Client_Transport_Exception</titleabbrev>
 
  <partintro>
 
-<!-- {{{ Yar_Client_Transport_Exception intro -->
   <section xml:id="yar-client-transport-exception.intro">
    &reftitle.intro;
-   <para>
-
-   </para>
+   <simpara>
+    Levée lorsque la connexion au service RPC échoue : connexion refusée, délai d'attente dépassé, ou réponse vide (code d'exception <constant>YAR_ERR_TRANSPORT</constant>).
+   </simpara>
   </section>
-<!-- }}} -->
 
   <section xml:id="yar-client-transport-exception.synopsis">
    &reftitle.classsynopsis;
 
-<!-- {{{ Synopsis -->
-   <classsynopsis>
-    <ooclass><classname>Yar_Client_Transport_Exception</classname></ooclass>
+   <classsynopsis class="class">
+    <ooexception>
+     <exceptionname>Yar_Client_Transport_Exception</exceptionname>
+    </ooexception>
 
-<!-- {{{ Class synopsis -->
-    <classsynopsisinfo>
-     <ooclass>
-      <classname>Yar_Client_Transport_Exception</classname>
-     </ooclass>
-     
-     <ooclass>
-      <modifier>extends</modifier>
-      <classname>Yar_Client_Exception</classname>
-     </ooclass>
-    </classsynopsisinfo>
-<!-- }}} -->
-    <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
+    <ooclass>
+     <modifier>extends</modifier>
+     <classname>Yar_Client_Exception</classname>
+    </ooclass>
 
-    
+    <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
+
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.yar-client-exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
-
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.yar-client-exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Yar_Client_Exception'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])"/>
    </classsynopsis>
-<!-- }}} -->
 
   </section>
-
-  
-<!-- {{{ Yar_Client_Transport_Exception properties -->
-  <section xml:id="yar-client-transport-exception.props">
-   &reftitle.properties;
-   <variablelist>
-    <varlistentry xml:id="yar-client-transport-exception.props.message">
-     <term><varname>message</varname></term>
-     <listitem>
-      <para></para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="yar-client-transport-exception.props.code">
-     <term><varname>code</varname></term>
-     <listitem>
-      <para></para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="yar-client-transport-exception.props.file">
-     <term><varname>file</varname></term>
-     <listitem>
-      <para></para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="yar-client-transport-exception.props.line">
-     <term><varname>line</varname></term>
-     <listitem>
-      <para></para>
-     </listitem>
-    </varlistentry>
-   </variablelist>
-  </section>
-<!-- }}} -->
-
 
  </partintro>
-
 
 </reference>
 

--- a/reference/yar/yar-client.xml
+++ b/reference/yar/yar-client.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 75d48299ef85693f10eee31af1be88488fb84c6f Maintainer: yannick Status: ready -->
 
 <reference xml:id="class.yar-client" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -13,9 +11,12 @@
 <!-- {{{ Yar_Client intro -->
   <section xml:id="yar-client.intro">
    &reftitle.intro;
-   <para>
-
-   </para>
+   <simpara>
+    Le côté client du framework RPC Yar. Un client est lié à une unique
+    adresse de service ; l'appel de n'importe quelle méthode non définie
+    sur celui-ci déclenche un appel distant portant ce nom de méthode et
+    les arguments fournis.
+   </simpara>
   </section>
 <!-- }}} -->
 
@@ -23,43 +24,41 @@
    &reftitle.classsynopsis;
 
 <!-- {{{ Synopsis -->
-   <classsynopsis>
-    <ooclass><classname>Yar_Client</classname></ooclass>
+   <classsynopsis class="class">
+    <ooclass>
+     <classname>Yar_Client</classname>
+    </ooclass>
 
-<!-- {{{ Class synopsis -->
-    <classsynopsisinfo>
-     <ooclass>
-      <classname>Yar_Client</classname>
-     </ooclass>
-    </classsynopsisinfo>
-<!-- }}} -->
     <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
     <fieldsynopsis>
      <modifier>protected</modifier>
+     <type>int</type>
      <varname linkend="yar-client.props.protocol">_protocol</varname>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>protected</modifier>
+     <type>string</type>
      <varname linkend="yar-client.props.uri">_uri</varname>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>protected</modifier>
+     <type class="union"><type>array</type><type>null</type></type>
      <varname linkend="yar-client.props.options">_options</varname>
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>protected</modifier>
+     <type>bool</type>
      <varname linkend="yar-client.props.running">_running</varname>
     </fieldsynopsis>
 
-    
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.yar-client')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.yar-client')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Yar_Client'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.yar-client')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Yar_Client'])"/>
    </classsynopsis>
 <!-- }}} -->
 
   </section>
 
-  
 <!-- {{{ Yar_Client properties -->
   <section xml:id="yar-client.props">
    &reftitle.properties;
@@ -67,31 +66,45 @@
     <varlistentry xml:id="yar-client.props.protocol">
      <term><varname>_protocol</varname></term>
      <listitem>
-      <para></para>
+      <simpara>
+       En lecture seule. Le protocole déduit de l'adresse du service :
+       l'une des valeurs <constant>YAR_CLIENT_PROTOCOL_HTTP</constant>,
+       <constant>YAR_CLIENT_PROTOCOL_TCP</constant> ou
+       <constant>YAR_CLIENT_PROTOCOL_UNIX</constant>.
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry xml:id="yar-client.props.uri">
      <term><varname>_uri</varname></term>
      <listitem>
-      <para></para>
+      <simpara>
+       En lecture seule. L'adresse du service avec laquelle le client a
+       été créé.
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry xml:id="yar-client.props.options">
      <term><varname>_options</varname></term>
      <listitem>
-      <para></para>
+      <simpara>
+       En lecture seule. Un &array; des options définies sur ce client,
+       indexé par les constantes <literal>YAR_OPT_*</literal>, ou &null;
+       si aucune option n'a été définie.
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry xml:id="yar-client.props.running">
      <term><varname>_running</varname></term>
      <listitem>
-      <para></para>
+      <simpara>
+       En lecture seule. Indique si un appel émis par ce client est
+       actuellement en cours.
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
   </section>
 <!-- }}} -->
-
 
  </partintro>
 

--- a/reference/yar/yar-concurrent-client.xml
+++ b/reference/yar/yar-concurrent-client.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 75d48299ef85693f10eee31af1be88488fb84c6f Maintainer: yannick Status: ready -->
 
 <reference xml:id="class.yar-concurrent-client" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -13,9 +11,19 @@
 <!-- {{{ Yar_Concurrent_Client intro -->
   <section xml:id="yar-concurrent-client.intro">
    &reftitle.intro;
-   <para>
-
-   </para>
+   <simpara>
+    Une classe utilitaire statique qui regroupe des appels RPC distants.
+    Les appels enregistrés avec
+    <methodname>Yar_Concurrent_Client::call</methodname> ne sont pas
+    envoyés immédiatement ; ils sont tous émis ensemble, en parallèle, par
+    <methodname>Yar_Concurrent_Client::loop</methodname>.
+   </simpara>
+   <note>
+    <simpara>
+     Seuls les services HTTP(S) sont pris en charge pour les appels
+     concurrents.
+    </simpara>
+   </note>
   </section>
 <!-- }}} -->
 
@@ -23,65 +31,17 @@
    &reftitle.classsynopsis;
 
 <!-- {{{ Synopsis -->
-   <classsynopsis>
-    <ooclass><classname>Yar_Concurrent_Client</classname></ooclass>
+   <classsynopsis class="class">
+    <ooclass>
+     <classname>Yar_Concurrent_Client</classname>
+    </ooclass>
 
-<!-- {{{ Class synopsis -->
-    <classsynopsisinfo>
-     <ooclass>
-      <classname>Yar_Concurrent_Client</classname>
-     </ooclass>
-    </classsynopsisinfo>
-<!-- }}} -->
-    <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
-    <fieldsynopsis>
-     <modifier>static</modifier>
-     <varname linkend="yar-concurrent-client.props.callstack">_callstack</varname>
-    </fieldsynopsis>
-    <fieldsynopsis>
-     <modifier>static</modifier>
-     <varname linkend="yar-concurrent-client.props.callback">_callback</varname>
-    </fieldsynopsis>
-    <fieldsynopsis>
-     <modifier>static</modifier>
-     <varname linkend="yar-concurrent-client.props.error-callback">_error_callback</varname>
-    </fieldsynopsis>
-
-    
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.yar-concurrent-client')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.yar-concurrent-client')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Yar_Concurrent_Client'])"/>
    </classsynopsis>
 <!-- }}} -->
 
   </section>
-
-  
-<!-- {{{ Yar_Concurrent_Client properties -->
-  <section xml:id="yar-concurrent-client.props">
-   &reftitle.properties;
-   <variablelist>
-    <varlistentry xml:id="yar-concurrent-client.props.callstack">
-     <term><varname>_callstack</varname></term>
-     <listitem>
-      <para></para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="yar-concurrent-client.props.callback">
-     <term><varname>_callback</varname></term>
-     <listitem>
-      <para></para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="yar-concurrent-client.props.error-callback">
-     <term><varname>_error_callback</varname></term>
-     <listitem>
-      <para></para>
-     </listitem>
-    </varlistentry>
-   </variablelist>
-  </section>
-<!-- }}} -->
-
 
  </partintro>
 

--- a/reference/yar/yar-server-exception.xml
+++ b/reference/yar/yar-server-exception.xml
@@ -1,9 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 75d48299ef85693f10eee31af1be88488fb84c6f Maintainer: yannick Status: ready -->
 
-<reference xml:id="class.yar-server-exception" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+<reference xml:id="class.yar-server-exception" role="exception" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>La classe Yar_Server_Exception</title>
  <titleabbrev>Yar_Server_Exception</titleabbrev>
@@ -13,10 +11,13 @@
 <!-- {{{ Yar_Server_Exception intro -->
   <section xml:id="yar-server-exception.intro">
    &reftitle.intro;
-   <para>
-     Si le service lance des exceptions, une Yar_Server_Exception sera lancée
-     côté client.
-   </para>
+   <simpara>
+    Lancée côté client lorsque la requête RPC a échoué sur le serveur.
+    Si la méthode du service distant a elle-même lancé une exception, son message,
+    son code, son fichier, sa ligne et son nom de classe sont reportés, et
+    <methodname>Yar_Server_Exception::getType</methodname> retourne le
+    nom de classe de l'exception d'origine.
+   </simpara>
   </section>
 <!-- }}} -->
 
@@ -24,78 +25,56 @@
    &reftitle.classsynopsis;
 
 <!-- {{{ Synopsis -->
-   <classsynopsis>
-    <ooclass><classname>Yar_Server_Exception</classname></ooclass>
+   <classsynopsis class="class">
+    <ooexception>
+     <exceptionname>Yar_Server_Exception</exceptionname>
+    </ooexception>
 
-<!-- {{{ Class synopsis -->
-    <classsynopsisinfo>
-     <ooclass>
-      <classname>Yar_Server_Exception</classname>
-     </ooclass>
-     
-     <ooclass>
-      <modifier>extends</modifier>
-      <classname>Exception</classname>
-     </ooclass>
-    </classsynopsisinfo>
-<!-- }}} -->
+    <ooclass>
+     <modifier>extends</modifier>
+     <classname>Exception</classname>
+    </ooclass>
+
     <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
     <fieldsynopsis>
      <modifier>protected</modifier>
+     <type>string</type>
      <varname linkend="yar-server-exception.props.type">_type</varname>
+     <initializer>"Yar_Exception_Server"</initializer>
     </fieldsynopsis>
 
-    
-    <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.yar-server-exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
-    
-    <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
+    <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
 
+    <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.yar-server-exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Yar_Server_Exception'])"/>
+
+    <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])"/>
    </classsynopsis>
 <!-- }}} -->
 
   </section>
 
-  
 <!-- {{{ Yar_Server_Exception properties -->
   <section xml:id="yar-server-exception.props">
    &reftitle.properties;
    <variablelist>
-    <varlistentry xml:id="yar-server-exception.props.message">
-     <term><varname>message</varname></term>
-     <listitem>
-      <para></para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="yar-server-exception.props.code">
-     <term><varname>code</varname></term>
-     <listitem>
-      <para></para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="yar-server-exception.props.file">
-     <term><varname>file</varname></term>
-     <listitem>
-      <para></para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="yar-server-exception.props.line">
-     <term><varname>line</varname></term>
-     <listitem>
-      <para></para>
-     </listitem>
-    </varlistentry>
     <varlistentry xml:id="yar-server-exception.props.type">
      <term><varname>_type</varname></term>
      <listitem>
-      <para></para>
+      <simpara>
+       Le nom de classe de l'exception lancée par le service distant, ou
+       <literal>"Yar_Exception_Server"</literal> si l'erreur n'a pas été
+       causée par une exception utilisateur. Lu via
+       <methodname>Yar_Server_Exception::getType</methodname>.
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
   </section>
 <!-- }}} -->
-
 
  </partintro>
 

--- a/reference/yar/yar-server-output-exception.xml
+++ b/reference/yar/yar-server-output-exception.xml
@@ -1,89 +1,45 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 28975cb447c4d3e13fdfd2f9c1eb3e8b7c231e3f Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 75d48299ef85693f10eee31af1be88488fb84c6f Maintainer: yannick Status: ready -->
 
-<reference xml:id="class.yar-server-output-exception" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+<reference xml:id="class.yar-server-output-exception" role="exception" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>La classe Yar_Server_Output_Exception</title>
  <titleabbrev>Yar_Server_Output_Exception</titleabbrev>
 
  <partintro>
 
-<!-- {{{ Yar_Server_Output_Exception intro -->
   <section xml:id="yar-server-output-exception.intro">
    &reftitle.intro;
-   <para>
-
-   </para>
+   <simpara>
+    Lancée lorsque le serveur ne parvient pas à capturer les données de sortie de la méthode du service (code d'exception <constant>YAR_ERR_OUTPUT</constant>).
+   </simpara>
   </section>
-<!-- }}} -->
 
   <section xml:id="yar-server-output-exception.synopsis">
    &reftitle.classsynopsis;
 
-<!-- {{{ Synopsis -->
-   <classsynopsis>
-    <ooclass><classname>Yar_Server_Output_Exception</classname></ooclass>
+   <classsynopsis class="class">
+    <ooexception>
+     <exceptionname>Yar_Server_Output_Exception</exceptionname>
+    </ooexception>
 
-<!-- {{{ Class synopsis -->
-    <classsynopsisinfo>
-     <ooclass>
-      <classname>Yar_Server_Output_Exception</classname>
-     </ooclass>
-     
-     <ooclass>
-      <modifier>extends</modifier>
-      <classname>Yar_Server_Exception</classname>
-     </ooclass>
-    </classsynopsisinfo>
-<!-- }}} -->
-    <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
+    <ooclass>
+     <modifier>extends</modifier>
+     <classname>Yar_Server_Exception</classname>
+    </ooclass>
 
-    
+    <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
+
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.yar-server-exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
-
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.yar-server-exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Yar_Server_Exception'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])"/>
    </classsynopsis>
-<!-- }}} -->
 
   </section>
-
-  
-<!-- {{{ Yar_Server_Output_Exception properties -->
-  <section xml:id="yar-server-output-exception.props">
-   &reftitle.properties;
-   <variablelist>
-    <varlistentry xml:id="yar-server-output-exception.props.message">
-     <term><varname>message</varname></term>
-     <listitem>
-      <para></para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="yar-server-output-exception.props.code">
-     <term><varname>code</varname></term>
-     <listitem>
-      <para></para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="yar-server-output-exception.props.file">
-     <term><varname>file</varname></term>
-     <listitem>
-      <para></para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="yar-server-output-exception.props.line">
-     <term><varname>line</varname></term>
-     <listitem>
-      <para></para>
-     </listitem>
-    </varlistentry>
-   </variablelist>
-  </section>
-<!-- }}} -->
-
 
  </partintro>
-
 
 </reference>
 

--- a/reference/yar/yar-server-packager-exception.xml
+++ b/reference/yar/yar-server-packager-exception.xml
@@ -1,89 +1,45 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 28975cb447c4d3e13fdfd2f9c1eb3e8b7c231e3f Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 75d48299ef85693f10eee31af1be88488fb84c6f Maintainer: yannick Status: ready -->
 
-<reference xml:id="class.yar-server-packager-exception" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+<reference xml:id="class.yar-server-packager-exception" role="exception" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>La classe Yar_Server_Packager_Exception</title>
  <titleabbrev>Yar_Server_Packager_Exception</titleabbrev>
 
  <partintro>
 
-<!-- {{{ Yar_Server_Packager_Exception intro -->
   <section xml:id="yar-server-packager-exception.intro">
    &reftitle.intro;
-   <para>
-
-   </para>
+   <simpara>
+    Lancée lorsque le corps de la requête ne peut pas être dépaqueté avec l'empaqueteur annoncé dans la requête (code d'exception <constant>YAR_ERR_PACKAGER</constant>).
+   </simpara>
   </section>
-<!-- }}} -->
 
   <section xml:id="yar-server-packager-exception.synopsis">
    &reftitle.classsynopsis;
 
-<!-- {{{ Synopsis -->
-   <classsynopsis>
-    <ooclass><classname>Yar_Server_Packager_Exception</classname></ooclass>
+   <classsynopsis class="class">
+    <ooexception>
+     <exceptionname>Yar_Server_Packager_Exception</exceptionname>
+    </ooexception>
 
-<!-- {{{ Class synopsis -->
-    <classsynopsisinfo>
-     <ooclass>
-      <classname>Yar_Server_Packager_Exception</classname>
-     </ooclass>
-     
-     <ooclass>
-      <modifier>extends</modifier>
-      <classname>Yar_Server_Exception</classname>
-     </ooclass>
-    </classsynopsisinfo>
-<!-- }}} -->
-    <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
+    <ooclass>
+     <modifier>extends</modifier>
+     <classname>Yar_Server_Exception</classname>
+    </ooclass>
 
-    
+    <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
+
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.yar-server-exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
-
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.yar-server-exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Yar_Server_Exception'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])"/>
    </classsynopsis>
-<!-- }}} -->
 
   </section>
-
-  
-<!-- {{{ Yar_Server_Packager_Exception properties -->
-  <section xml:id="yar-server-packager-exception.props">
-   &reftitle.properties;
-   <variablelist>
-    <varlistentry xml:id="yar-server-packager-exception.props.message">
-     <term><varname>message</varname></term>
-     <listitem>
-      <para></para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="yar-server-packager-exception.props.code">
-     <term><varname>code</varname></term>
-     <listitem>
-      <para></para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="yar-server-packager-exception.props.file">
-     <term><varname>file</varname></term>
-     <listitem>
-      <para></para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="yar-server-packager-exception.props.line">
-     <term><varname>line</varname></term>
-     <listitem>
-      <para></para>
-     </listitem>
-    </varlistentry>
-   </variablelist>
-  </section>
-<!-- }}} -->
-
 
  </partintro>
-
 
 </reference>
 

--- a/reference/yar/yar-server-protocol-exception.xml
+++ b/reference/yar/yar-server-protocol-exception.xml
@@ -1,89 +1,45 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 28975cb447c4d3e13fdfd2f9c1eb3e8b7c231e3f Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 75d48299ef85693f10eee31af1be88488fb84c6f Maintainer: yannick Status: ready -->
 
-<reference xml:id="class.yar-server-protocol-exception" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+<reference xml:id="class.yar-server-protocol-exception" role="exception" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>La classe Yar_Server_Protocol_Exception</title>
  <titleabbrev>Yar_Server_Protocol_Exception</titleabbrev>
 
  <partintro>
 
-<!-- {{{ Yar_Server_Protocol_Exception intro -->
   <section xml:id="yar-server-protocol-exception.intro">
    &reftitle.intro;
-   <para>
-
-   </para>
+   <simpara>
+    Lancée lorsque la requête entrante viole le protocole Yar, par exemple un en-tête de requête mal formé (code d'exception <constant>YAR_ERR_PROTOCOL</constant>).
+   </simpara>
   </section>
-<!-- }}} -->
 
   <section xml:id="yar-server-protocol-exception.synopsis">
    &reftitle.classsynopsis;
 
-<!-- {{{ Synopsis -->
-   <classsynopsis>
-    <ooclass><classname>Yar_Server_Protocol_Exception</classname></ooclass>
+   <classsynopsis class="class">
+    <ooexception>
+     <exceptionname>Yar_Server_Protocol_Exception</exceptionname>
+    </ooexception>
 
-<!-- {{{ Class synopsis -->
-    <classsynopsisinfo>
-     <ooclass>
-      <classname>Yar_Server_Protocol_Exception</classname>
-     </ooclass>
-     
-     <ooclass>
-      <modifier>extends</modifier>
-      <classname>Yar_Server_Exception</classname>
-     </ooclass>
-    </classsynopsisinfo>
-<!-- }}} -->
-    <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
+    <ooclass>
+     <modifier>extends</modifier>
+     <classname>Yar_Server_Exception</classname>
+    </ooclass>
 
-    
+    <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
+
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.yar-server-exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
-
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.yar-server-exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Yar_Server_Exception'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])"/>
    </classsynopsis>
-<!-- }}} -->
 
   </section>
-
-  
-<!-- {{{ Yar_Server_Protocol_Exception properties -->
-  <section xml:id="yar-server-protocol-exception.props">
-   &reftitle.properties;
-   <variablelist>
-    <varlistentry xml:id="yar-server-protocol-exception.props.message">
-     <term><varname>message</varname></term>
-     <listitem>
-      <para></para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="yar-server-protocol-exception.props.code">
-     <term><varname>code</varname></term>
-     <listitem>
-      <para></para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="yar-server-protocol-exception.props.file">
-     <term><varname>file</varname></term>
-     <listitem>
-      <para></para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="yar-server-protocol-exception.props.line">
-     <term><varname>line</varname></term>
-     <listitem>
-      <para></para>
-     </listitem>
-    </varlistentry>
-   </variablelist>
-  </section>
-<!-- }}} -->
-
 
  </partintro>
-
 
 </reference>
 

--- a/reference/yar/yar-server-request-exception.xml
+++ b/reference/yar/yar-server-request-exception.xml
@@ -1,89 +1,45 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 28975cb447c4d3e13fdfd2f9c1eb3e8b7c231e3f Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 75d48299ef85693f10eee31af1be88488fb84c6f Maintainer: yannick Status: ready -->
 
-<reference xml:id="class.yar-server-request-exception" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+<reference xml:id="class.yar-server-request-exception" role="exception" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>La classe Yar_Server_Request_Exception</title>
  <titleabbrev>Yar_Server_Request_Exception</titleabbrev>
 
  <partintro>
 
-<!-- {{{ Yar_Server_Request_Exception intro -->
   <section xml:id="yar-server-request-exception.intro">
    &reftitle.intro;
-   <para>
-
-   </para>
+   <simpara>
+    Lancée lorsque la méthode distante demandée n'existe pas sur l'objet serveur, ou n'est pas publique (code d'exception <constant>YAR_ERR_REQUEST</constant>).
+   </simpara>
   </section>
-<!-- }}} -->
 
   <section xml:id="yar-server-request-exception.synopsis">
    &reftitle.classsynopsis;
 
-<!-- {{{ Synopsis -->
-   <classsynopsis>
-    <ooclass><classname>Yar_Server_Request_Exception</classname></ooclass>
+   <classsynopsis class="class">
+    <ooexception>
+     <exceptionname>Yar_Server_Request_Exception</exceptionname>
+    </ooexception>
 
-<!-- {{{ Class synopsis -->
-    <classsynopsisinfo>
-     <ooclass>
-      <classname>Yar_Server_Request_Exception</classname>
-     </ooclass>
-     
-     <ooclass>
-      <modifier>extends</modifier>
-      <classname>Yar_Server_Exception</classname>
-     </ooclass>
-    </classsynopsisinfo>
-<!-- }}} -->
-    <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
+    <ooclass>
+     <modifier>extends</modifier>
+     <classname>Yar_Server_Exception</classname>
+    </ooclass>
 
-    
+    <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Properties;']]))"/>
+
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.yar-server-exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
-
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.yar-server-exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Yar_Server_Exception'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Exception'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.exception')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Exception'])"/>
    </classsynopsis>
-<!-- }}} -->
 
   </section>
-
-  
-<!-- {{{ Yar_Server_Request_Exception properties -->
-  <section xml:id="yar-server-request-exception.props">
-   &reftitle.properties;
-   <variablelist>
-    <varlistentry xml:id="yar-server-request-exception.props.message">
-     <term><varname>message</varname></term>
-     <listitem>
-      <para></para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="yar-server-request-exception.props.code">
-     <term><varname>code</varname></term>
-     <listitem>
-      <para></para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="yar-server-request-exception.props.file">
-     <term><varname>file</varname></term>
-     <listitem>
-      <para></para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="yar-server-request-exception.props.line">
-     <term><varname>line</varname></term>
-     <listitem>
-      <para></para>
-     </listitem>
-    </varlistentry>
-   </variablelist>
-  </section>
-<!-- }}} -->
-
 
  </partintro>
-
 
 </reference>
 

--- a/reference/yar/yar-server.xml
+++ b/reference/yar/yar-server.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 75d48299ef85693f10eee31af1be88488fb84c6f Maintainer: yannick Status: ready -->
 
 <reference xml:id="class.yar-server" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -13,9 +11,11 @@
 <!-- {{{ Yar_Server intro -->
   <section xml:id="yar-server.intro">
    &reftitle.intro;
-   <para>
-
-   </para>
+   <simpara>
+    Encapsule un objet et expose toutes ses méthodes publiques sous la
+    forme d'un service distant, servi via HTTP par
+    <methodname>Yar_Server::handle</methodname>.
+   </simpara>
   </section>
 <!-- }}} -->
 
@@ -23,31 +23,27 @@
    &reftitle.classsynopsis;
 
 <!-- {{{ Synopsis -->
-   <classsynopsis>
-    <ooclass><classname>Yar_Server</classname></ooclass>
+   <classsynopsis class="class">
+    <ooclass>
+     <classname>Yar_Server</classname>
+    </ooclass>
 
-<!-- {{{ Class synopsis -->
-    <classsynopsisinfo>
-     <ooclass>
-      <classname>Yar_Server</classname>
-     </ooclass>
-    </classsynopsisinfo>
-<!-- }}} -->
     <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
     <fieldsynopsis>
      <modifier>protected</modifier>
+     <type>object</type>
      <varname linkend="yar-server.props.executor">_executor</varname>
+     <initializer>null</initializer>
     </fieldsynopsis>
 
-    
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.yar-server')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.yar-server')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='Yar_Server'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.yar-server')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Yar_Server'])"/>
    </classsynopsis>
 <!-- }}} -->
 
   </section>
 
-  
 <!-- {{{ Yar_Server properties -->
   <section xml:id="yar-server.props">
    &reftitle.properties;
@@ -55,13 +51,15 @@
     <varlistentry xml:id="yar-server.props.executor">
      <term><varname>_executor</varname></term>
      <listitem>
-      <para></para>
+      <simpara>
+       L'objet dont les méthodes publiques sont exposées comme services
+       RPC.
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
   </section>
 <!-- }}} -->
-
 
  </partintro>
 

--- a/reference/yar/yar_client/call.xml
+++ b/reference/yar/yar_client/call.xml
@@ -1,24 +1,28 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 914b97130aed191518791045b93b6f858ef5a139 Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 75d48299ef85693f10eee31af1be88488fb84c6f Maintainer: yannick Status: ready -->
 
 <refentry xml:id="yar-client.call" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
-  <refname>Yar_Client::__call</refname>
-  <refpurpose>Service d'appel</refpurpose>
+  <refname>Yar_Client::call</refname>
+  <refpurpose>Appelle un service distant</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis>
-   <modifier>public</modifier> <type>void</type><methodname>Yar_Client::__call</methodname>
+  <methodsynopsis role="Yar_Client">
+   <modifier>public</modifier> <type>mixed</type><methodname>Yar_Client::call</methodname>
    <methodparam><type>string</type><parameter>method</parameter></methodparam>
-   <methodparam><type>array</type><parameter>parameters</parameter></methodparam>
+   <methodparam><type>array</type><parameter>arguments</parameter></methodparam>
   </methodsynopsis>
-  <para>
-   Envoie un appel à la méthode RPC distante.
-  </para>
+  <simpara>
+   Émet un appel RPC vers la méthode distante <literal>method</literal>.
+   C'est exactement ce qui se produit lorsqu'une méthode inexistante est
+   invoquée sur un objet <classname>Yar_Client</classname> (voir
+   <methodname>Yar_Client::__call</methodname>) ;
+   <methodname>Yar_Client::call</methodname> n'existe que pour permettre
+   d'atteindre les méthodes distantes littéralement nommées
+   <literal>call</literal> ou <literal>__call</literal>.
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -27,17 +31,17 @@
    <varlistentry>
     <term><parameter>method</parameter></term>
     <listitem>
-     <para>
-      Nom de la méthode RPC distante.
-     </para>
+     <simpara>
+      Le nom de la méthode du service distant.
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term><parameter>parameters</parameter></term>
+    <term><parameter>arguments</parameter></term>
     <listitem>
-     <para>
-      Paramètres.
-     </para>
+     <simpara>
+      La liste des arguments passés à la méthode distante.
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -45,38 +49,26 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
-
-  </para>
+  <simpara>
+   Retourne la valeur de retour de la méthode du service distant.
+  </simpara>
  </refsect1>
 
- <refsect1 role="examples">
-  &reftitle.examples;
-  <example>
-   <title>Exemple avec <function>Yar_Client::__call</function></title>
-   <programlisting role="php">
-<![CDATA[
-<?php
-
-$client = new Yar_Client("http://host/api/");
-
-/* Appel un service distant */
-$result = $client->some_method("parameter");
-?>
-]]>
-   </programlisting>
-   &example.outputs.similar;
-   <screen>
-<![CDATA[
-]]>
-   </screen>
-  </example>
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simpara>
+   Lorsque la méthode <literal>call</literal> n'existe pas du côté du
+   serveur, une exception
+   <exceptionname>Yar_Server_Request_Exception</exceptionname> est lancée.
+   Voir <methodname>Yar_Client::__call</methodname> pour la liste complète
+   des échecs et de leurs classes d'exception.
+  </simpara>
  </refsect1>
-
 
  <refsect1 role="seealso">
   &reftitle.seealso;
   <simplelist>
+   <member><methodname>Yar_Client::__call</methodname></member>
    <member><methodname>Yar_Client::setOpt</methodname></member>
   </simplelist>
  </refsect1>

--- a/reference/yar/yar_client/construct.xml
+++ b/reference/yar/yar_client/construct.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 167c48c1c76f7f29be2f44fd72ea72a43ae5e1e1 Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 75d48299ef85693f10eee31af1be88488fb84c6f Maintainer: yannick Status: ready -->
 
 <refentry xml:id="yar-client.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -11,26 +9,41 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis>
+  <constructorsynopsis role="Yar_Client">
    <modifier>final</modifier> <modifier>public</modifier> <methodname>Yar_Client::__construct</methodname>
-   <methodparam><type>string</type><parameter>url</parameter></methodparam>
-   <methodparam choice="opt"><type>array</type><parameter>options</parameter></methodparam>
-  </methodsynopsis>
-  <para>
-   Crée un <classname>Yar_Client</classname> sur un serveur
-   <classname>Yar_Server</classname>.
-  </para>
+   <methodparam><type>string</type><parameter>uri</parameter></methodparam>
+   <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>options</parameter><initializer>null</initializer></methodparam>
+  </constructorsynopsis>
+  <simpara>
+   Crée un <classname>Yar_Client</classname> pour le service RPC situé à
+   l'adresse <literal>uri</literal>.
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
   &reftitle.parameters;
   <variablelist>
    <varlistentry>
-    <term><parameter>url</parameter></term>
+    <term><parameter>uri</parameter></term>
     <listitem>
-     <para>
-      URL du serveur Yar.
-     </para>
+     <simpara>
+      Adresse du service RPC. Le protocole est déduit du schéma :
+      <literal>http://</literal> et <literal>https://</literal>
+      sélectionnent le transport HTTP, <literal>tcp://</literal>
+      sélectionne le transport TCP, et <literal>unix://</literal>
+      sélectionne le transport par socket Unix.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>options</parameter></term>
+    <listitem>
+     <simpara>
+      Un &array; d'options du client, indexé par les constantes
+      <literal>YAR_OPT_*</literal>, équivalent à un appel à
+      <methodname>Yar_Client::setOpt</methodname> pour chaque entrée. Les
+      options invalides sont ignorées silencieusement.
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -38,30 +51,38 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
-   Une instance <classname>Yar_Client</classname>.
-  </para>
+  <simpara>
+   Une nouvelle instance de <classname>Yar_Client</classname>.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simpara>
+   Si l'URI ne commence pas par un schéma supporté, une exception
+   <exceptionname>Yar_Client_Protocol_Exception</exceptionname> est lancée.
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">
   &reftitle.examples;
   <example>
-   <title>Exemple avec <function>Yar_Client::__construct</function></title>
+   <title>Exemple avec <methodname>Yar_Client::__construct</methodname></title>
    <programlisting role="php">
 <![CDATA[
 <?php
 $client = new Yar_Client("http://host/api/");
+
+/* avec des options */
+$client = new Yar_Client("http://host/api/", [
+    YAR_OPT_TIMEOUT => 1000,
+    YAR_OPT_PACKAGER => "json",
+]);
 ?>
 ]]>
    </programlisting>
-   &example.outputs.similar;
-   <screen>
-<![CDATA[
-]]>
-   </screen>
   </example>
  </refsect1>
-
 
  <refsect1 role="seealso">
   &reftitle.seealso;

--- a/reference/yar/yar_client/getopt.xml
+++ b/reference/yar/yar_client/getopt.xml
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 75d48299ef85693f10eee31af1be88488fb84c6f Maintainer: yannick Status: ready -->
+
+<refentry xml:id="yar-client.getopt" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Yar_Client::getOpt</refname>
+  <refpurpose>Lit une option du client</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Yar_Client">
+   <modifier>public</modifier> <type>mixed</type><methodname>Yar_Client::getOpt</methodname>
+   <methodparam><type>int</type><parameter>name</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Retourne la valeur précédemment définie avec
+   <methodname>Yar_Client::setOpt</methodname>, ou avec le paramètre
+   <literal>options</literal> de
+   <methodname>Yar_Client::__construct</methodname>.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>name</parameter></term>
+    <listitem>
+     <simpara>
+      L'une des constantes <literal>YAR_OPT_*</literal>, voir
+      <methodname>Yar_Client::setOpt</methodname>.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   La valeur de l'option, ou &false; si l'option n'a pas été définie sur ce
+   client ou si le nom de l'option est inconnu.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Exemple avec <methodname>Yar_Client::getOpt</methodname></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$client = new Yar_Client("http://host/api/");
+$client->setOpt(YAR_OPT_TIMEOUT, 1000);
+
+var_dump($client->getOpt(YAR_OPT_TIMEOUT));
+var_dump($client->getOpt(YAR_OPT_PACKAGER));
+?>
+]]>
+   </programlisting>
+   &example.outputs.similar;
+   <screen>
+<![CDATA[
+int(1000)
+bool(false)
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Yar_Client::setOpt</methodname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/yar/yar_client/setopt.xml
+++ b/reference/yar/yar_client/setopt.xml
@@ -1,104 +1,140 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: fade73b9ec1424cbbfcd5d075a21d30445ce8a23 Maintainer: yannick Status: ready -->
-<!-- CREDITS: DavidA -->
+<!-- EN-Revision: 75d48299ef85693f10eee31af1be88488fb84c6f Maintainer: yannick Status: ready -->
 
 <refentry xml:id="yar-client.setopt" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Yar_Client::setOpt</refname>
-  <refpurpose>Définit le contexte d'appel</refpurpose>
+  <refpurpose>Définit les options du client</refpurpose>
  </refnamediv>
- 
+
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis>
-   <modifier>public</modifier> <type class="union"><type>Yar_Client</type><type>false</type></type><methodname>Yar_Client::setOpt</methodname>
+  <methodsynopsis role="Yar_Client">
+   <modifier>public</modifier> <type class="union"><type>Yar_Client</type><type>bool</type></type><methodname>Yar_Client::setOpt</methodname>
    <methodparam><type>int</type><parameter>name</parameter></methodparam>
    <methodparam><type>mixed</type><parameter>value</parameter></methodparam>
   </methodsynopsis>
-  <para>
-   
-  </para>
+  <simpara>
+   Définit une option sur le client. Les options sont évaluées au moment où
+   un appel est émis, elles peuvent donc être modifiées entre deux appels.
+  </simpara>
  </refsect1>
- 
+
  <refsect1 role="parameters">
   &reftitle.parameters;
   <variablelist>
    <varlistentry>
     <term><parameter>name</parameter></term>
     <listitem>
-     <para>
-      Peut être :
-      <constant>YAR_OPT_PACKAGER</constant>,
-      <constant>YAR_OPT_PERSISTENT</constant> (a besoin du support serveur),
-      <constant>YAR_OPT_TIMEOUT</constant>,
-      <constant>YAR_OPT_CONNECT_TIMEOUT</constant>,
-      <constant>YAR_OPT_HEADER</constant> (depuis 2.0.4),
-      <constant>YAR_OPT_PROXY</constant> (depuis 2.2.0)
-     </para>
+     <simpara>
+      L'une des constantes <literal>YAR_OPT_*</literal> :
+     </simpara>
+     <simplelist>
+      <member><constant>YAR_OPT_PACKAGER</constant> — un nom de packager : <literal>php</literal>, <literal>json</literal> ou, lorsque le support de msgpack est compilé, <literal>msgpack</literal></member>
+      <member><constant>YAR_OPT_PERSISTENT</constant> — un booléen indiquant une connexion persistante (keep-alive HTTP)</member>
+      <member><constant>YAR_OPT_TIMEOUT</constant> — un délai d'expiration en millisecondes, qui surcharge <link linkend="ini.yar.timeout">yar.timeout</link></member>
+      <member><constant>YAR_OPT_CONNECT_TIMEOUT</constant> — un délai d'expiration de connexion en millisecondes, qui surcharge <link linkend="ini.yar.connect-timeout">yar.connect_timeout</link></member>
+      <member><constant>YAR_OPT_HEADER</constant> (à partir de 2.0.4) — un &array; de lignes d'en-tête HTTP supplémentaires</member>
+      <member><constant>YAR_OPT_RESOLVE</constant> (à partir de 2.1.0) — un &array; d'entrées de résolution de noms d'hôtes</member>
+      <member><constant>YAR_OPT_PROXY</constant> (à partir de 2.2.0) — une adresse de proxy HTTP</member>
+      <member><constant>YAR_OPT_PROVIDER</constant> (à partir de 2.3.0) — l'identité du fournisseur, jusqu'à 32 octets</member>
+      <member><constant>YAR_OPT_TOKEN</constant> (à partir de 2.3.0) — le jeton d'authentification, jusqu'à 32 octets</member>
+     </simplelist>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>value</parameter></term>
     <listitem>
-     <para>
-      
-     </para>
+     <simpara>
+      La valeur de l'option. Une valeur invalide émet une alerte et fait
+      retourner &false; à l'appel.
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
  </refsect1>
- 
+
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
-   Retourne <varname>$this</varname> en cas de succès&return.falseforfailure;.
-  </para>
+  <simpara>
+   Retourne l'objet client lui-même, permettant une interface fluide, ou
+   &false; lorsque le nom de l'option est inconnu, que la valeur est
+   invalide, ou que l'option ne s'applique pas au protocole avec lequel le
+   client a été créé.
+  </simpara>
  </refsect1>
- 
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simpara>
+   Les conditions qui font retourner &false; à l'appel émettent également
+   une alerte :
+  </simpara>
+  <itemizedlist>
+   <listitem>
+    <simpara>
+     <constant>YAR_OPT_HEADER</constant>,
+     <constant>YAR_OPT_RESOLVE</constant> et
+     <constant>YAR_OPT_PROXY</constant> ne fonctionnent qu'avec le
+     protocole HTTP ; les utiliser avec un client
+     <literal>tcp://</literal> ou <literal>unix://</literal> émet une
+     alerte.
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <constant>YAR_OPT_RESOLVE</constant> nécessite en outre libcurl
+     &gt;= 7.21.3.
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     Chaque option attend un type de valeur spécifique (chaîne de
+     caractères, booléen, entier ou tableau), décrit sur la page des
+     <link linkend="yar.constants">constantes</link>.
+    </simpara>
+   </listitem>
+  </itemizedlist>
+ </refsect1>
+
  <refsect1 role="examples">
   &reftitle.examples;
   <example>
-   <title>Exemple avec <function>Yar_Client::setOpt</function></title>
+   <title>Exemple avec <methodname>Yar_Client::setOpt</methodname></title>
    <programlisting role="php">
 <![CDATA[
 <?php
 
-$cient = new Yar_Client("http://host/api/");
+$client = new Yar_Client("http://host/api/");
 
-//Définit le délai d'attente maximal à 1s
-$client->SetOpt(YAR_OPT_CONNECT_TIMEOUT, 1000);
+/* Définit le délai d'expiration à 1 s */
+$client->setOpt(YAR_OPT_TIMEOUT, 1000);
 
-//Définit le packager à JSON
-$client->SetOpt(YAR_OPT_PACKAGER, "json");
+/* Définit le packager à JSON */
+$client->setOpt(YAR_OPT_PACKAGER, "json");
 
-//Définit l'en-tête personnalisé
-$client->SetOpt(YAR_OPT_HEADER, array("hr1: val1", "hd2: val2"));
+/* Définit des en-têtes personnalisés */
+$client->setOpt(YAR_OPT_HEADER, ["X-Api-Key: value"]);
 
-// Définit le proxy HTTP
-$client->SetOpt(YAR_OPT_PROXY, "127.0.0.1:8888");
+/* Passe par un proxy HTTP */
+$client->setOpt(YAR_OPT_PROXY, "127.0.0.1:8888");
 
 /* Appelle le service distant */
 $result = $client->some_method("parameter");
 ?>
 ]]>
    </programlisting>
-   &example.outputs.similar;
-   <screen>
-<![CDATA[
-]]>
-   </screen>
   </example>
  </refsect1>
- 
- 
+
  <refsect1 role="seealso">
   &reftitle.seealso;
   <simplelist>
+   <member><methodname>Yar_Client::getOpt</methodname></member>
    <member><methodname>Yar_Client::__call</methodname></member>
   </simplelist>
  </refsect1>
- 
+
 </refentry>
 
 <!-- Keep this comment at the end of the file

--- a/reference/yar/yar_client_exception/gettype.xml
+++ b/reference/yar/yar_client_exception/gettype.xml
@@ -1,24 +1,27 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 167c48c1c76f7f29be2f44fd72ea72a43ae5e1e1 Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 75d48299ef85693f10eee31af1be88488fb84c6f Maintainer: yannick Status: ready -->
 
 <refentry xml:id="yar-client-exception.gettype" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Yar_Client_Exception::getType</refname>
-  <refpurpose>Récupérer le type de l'exception</refpurpose>
+  <refpurpose>Récupère le type de l'exception</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis>
+  <methodsynopsis role="Yar_Client_Exception">
    <modifier>public</modifier> <type>string</type><methodname>Yar_Client_Exception::getType</methodname>
    <void />
   </methodsynopsis>
-  <para>
-
-  </para>
-
+  <simpara>
+   Retourne le type de l'exception. Les exceptions côté client sont levées par
+   le client lui-même (échecs de transport, erreurs de protocole, etc.), aussi
+   le type est toujours la chaîne fixe
+   <literal>"Yar_Exception_Client"</literal>. Il faut utiliser
+   <methodname>Exception::getCode</methodname> pour distinguer l'échec
+   particulier ; le code est l'une des constantes
+   <literal>YAR_ERR_*</literal>.
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -28,38 +31,43 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retourne <literal>"Yar_Exception_Client"</literal>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">
   &reftitle.examples;
   <example>
-   <title>Exemple avec <function>Yar_Client_Exception::getType</function></title>
+   <title>Exemple avec <methodname>Yar_Client_Exception::getType</methodname></title>
    <programlisting role="php">
 <![CDATA[
 <?php
+$client = new Yar_Client("http://host/api/");
 
-/* ... */
-
+try {
+    $client->some_method("parameter");
+} catch (Yar_Client_Exception $e) {
+    var_dump($e->getType());
+    var_dump($e->getCode());
+}
 ?>
 ]]>
    </programlisting>
    &example.outputs.similar;
    <screen>
 <![CDATA[
-...
+string(20) "Yar_Exception_Client"
+int(16)
 ]]>
    </screen>
   </example>
  </refsect1>
 
-
  <refsect1 role="seealso">
   &reftitle.seealso;
   <simplelist>
-   <member><methodname>Yaf_Server_Exception::getType</methodname></member>
+   <member><methodname>Yar_Server_Exception::getType</methodname></member>
   </simplelist>
  </refsect1>
 

--- a/reference/yar/yar_concurrent_client/call.xml
+++ b/reference/yar/yar_concurrent_client/call.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: c50df321d2cccb1044219a98d4c5c7677d4b29cf Maintainer: lacatoire Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 75d48299ef85693f10eee31af1be88488fb84c6f Maintainer: lacatoire Status: ready -->
 
 <refentry xml:id="yar-concurrent-client.call" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -11,20 +9,27 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis>
-   <modifier>public</modifier> <modifier>static</modifier> <type>int</type><methodname>Yar_Concurrent_Client::call</methodname>
+  <methodsynopsis role="Yar_Concurrent_Client">
+   <modifier>public</modifier> <modifier>static</modifier> <type class="union"><type>int</type><type>false</type><type>null</type></type><methodname>Yar_Concurrent_Client::call</methodname>
    <methodparam><type>string</type><parameter>uri</parameter></methodparam>
    <methodparam><type>string</type><parameter>method</parameter></methodparam>
-   <methodparam choice="opt"><type>array</type><parameter>parameters</parameter></methodparam>
-   <methodparam choice="opt"><type>callable</type><parameter>callback</parameter></methodparam>
-   <methodparam choice="opt"><type>callable</type><parameter>error_callback</parameter></methodparam>
-   <methodparam choice="opt"><type>array</type><parameter>options</parameter></methodparam>
+   <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>parameters</parameter><initializer>null</initializer></methodparam>
+   <methodparam choice="opt"><type class="union"><type>callable</type><type>null</type></type><parameter>callback</parameter><initializer>null</initializer></methodparam>
+   <methodparam choice="opt"><type class="union"><type>callable</type><type>null</type></type><parameter>error_callback</parameter><initializer>null</initializer></methodparam>
+   <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>options</parameter><initializer>null</initializer></methodparam>
   </methodsynopsis>
-  <para>
-   Enregistre un appel RPC, mais ne l'envoie pas immédiatement ; il sera
-   envoyé pendant l'appel à la méthode
-   <methodname>Yar_Concurrent_Client::loop</methodname>.
-  </para>
+  <simpara>
+   Enregistre un appel RPC distant. La requête n'est pas envoyée
+   immédiatement ; tous les appels enregistrés sont envoyés ensemble par
+   <methodname>Yar_Concurrent_Client::loop</methodname>, et les réponses
+   sont traitées au fur et à mesure de leur arrivée.
+  </simpara>
+  <note>
+   <simpara>
+    Seules les URI HTTP et HTTPS sont supportées. Les transports TCP et
+    socket Unix ne sont pas disponibles pour les appels concurrents.
+   </simpara>
+  </note>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -33,40 +38,52 @@
    <varlistentry>
     <term><parameter>uri</parameter></term>
     <listitem>
-     <para>
-       L'URI du serveur RPC (HTTP, TCP).
-     </para>
+     <simpara>
+      L'adresse du service RPC, commençant par
+      <literal>http://</literal> ou <literal>https://</literal>.
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>method</parameter></term>
     <listitem>
-     <para>
-      Nom du service (i.e. le nom de la méthode).
-     </para>
+     <simpara>
+      Le nom de la méthode du service distant.
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>parameters</parameter></term>
     <listitem>
-     <para>
-      Paramètres.
-     </para>
+     <simpara>
+      La liste des arguments passés à la méthode distante.
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>callback</parameter></term>
     <listitem>
-     <para>
-      Une fonction de rappel, qui sera appelée par le retour de la réponse.
-     </para>
+     <simpara>
+      Un <type>callable</type> invoqué lorsque la réponse à cet appel
+      arrive, avec deux arguments : la valeur de la réponse, et un
+      &array; <literal>callinfo</literal> contenant les clés
+      <literal>sequence</literal>, <literal>uri</literal> et
+      <literal>method</literal>. S'il est omis, le
+      <literal>callback</literal> de
+      <methodname>Yar_Concurrent_Client::loop</methodname> est utilisé.
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>error_callback</parameter></term>
     <listitem>
      <simpara>
-      Si cette fonction de rappel est définie, alors Yar l'appellera lorsqu'une erreur surviendra.
+      Un <type>callable</type> invoqué lorsque cet appel échoue, avec trois
+      arguments : le type d'erreur (l'un des codes
+      <literal>YAR_ERR_*</literal>), le message d'erreur, et l'&array;
+      <literal>callinfo</literal>. S'il est omis, le
+      <literal>error_callback</literal> de
+      <methodname>Yar_Concurrent_Client::loop</methodname> est utilisé.
      </simpara>
     </listitem>
    </varlistentry>
@@ -74,8 +91,10 @@
     <term><parameter>options</parameter></term>
     <listitem>
      <simpara>
-      Un &array; d'options.
-      Voir la liste des <link linkend="yar.constants">constantes</link>.
+      Un &array; d'options du client, indexé par les constantes
+      <literal>YAR_OPT_*</literal>, voir
+      <methodname>Yar_Client::setOpt</methodname>. Appliqué à cet appel
+      uniquement.
      </simpara>
     </listitem>
    </varlistentry>
@@ -85,7 +104,14 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   Un ID unique ; peut être utilisé pour identifier l'appel.
+   Retourne le numéro de séquence de l'appel enregistré, un identifiant
+   unique commençant à <literal>1</literal> qui identifie l'appel. Retourne
+   &false; lorsque le client concurrent est déjà à l'intérieur de
+   <methodname>Yar_Concurrent_Client::loop</methodname> ou lorsque le
+   maximum de <literal>128</literal> appels enregistrés est atteint ; dans
+   les deux cas, une alerte est émise. Retourne &null; si l'URI ou le nom de
+   la méthode est vide, ou si l'URI n'est pas une adresse HTTP(S), avec une
+   alerte.
   </simpara>
  </refsect1>
 
@@ -108,23 +134,18 @@ function error_callback($type, $error, $callinfo)
 
 Yar_Concurrent_Client::call("http://host/api/", "some_method", array("parameters"), "callback");
 
-// Si la fonction de rappel n'est pas spécifiée, la fonction de rappel de la boucle sera utilisée
+/* Si la fonction de rappel n'est pas spécifiée, celle de loop() sera utilisée */
 Yar_Concurrent_Client::call("http://host/api/", "some_method", array("parameters"));
 
-// Ce serveur accepte le packager JSON
+/* Ce serveur accepte le packager JSON */
 Yar_Concurrent_Client::call("http://host/api/", "some_method", array("parameters"), "callback", NULL, array(YAR_OPT_PACKAGER => "json"));
 
-// Délai d'attente maximal personnalisé
-Yar_Concurrent_Client::call("http://host/api/", "some_method", array("parameters"), "callback", NULL, array(YAR_OPT_TIMEOUT => 1));
+/* Délai d'attente personnalisé */
+Yar_Concurrent_Client::call("http://host/api/", "some_method", array("parameters"), "callback", NULL, array(YAR_OPT_TIMEOUT => 1000));
 
-// Les requêtes ne sont pas envoyées pour le moment
+/* Les requêtes ne sont pas encore envoyées */
 ]]>
    </programlisting>
-   &example.outputs.similar;
-   <screen>
-<![CDATA[
-]]>
-   </screen>
   </informalexample>
  </refsect1>
 
@@ -133,8 +154,6 @@ Yar_Concurrent_Client::call("http://host/api/", "some_method", array("parameters
   <simplelist>
    <member><methodname>Yar_Concurrent_Client::loop</methodname></member>
    <member><methodname>Yar_Concurrent_Client::reset</methodname></member>
-   <member><methodname>Yar_Server::__construct</methodname></member>
-   <member><methodname>Yar_Server::handle</methodname></member>
   </simplelist>
  </refsect1>
 

--- a/reference/yar/yar_concurrent_client/loop.xml
+++ b/reference/yar/yar_concurrent_client/loop.xml
@@ -1,23 +1,25 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: dfd68fd22aef25658bc9348176b55b504d26ab11 Maintainer: lacatoire Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 75d48299ef85693f10eee31af1be88488fb84c6f Maintainer: lacatoire Status: ready -->
 
 <refentry xml:id="yar-concurrent-client.loop" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Yar_Concurrent_Client::loop</refname>
-  <refpurpose>Envoie tous les appels</refpurpose>
+  <refpurpose>Envoie tous les appels enregistrés et attend leurs réponses</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis>
-   <modifier>public</modifier> <modifier>static</modifier> <type>bool</type><methodname>Yar_Concurrent_Client::loop</methodname>
-   <methodparam choice="opt"><type>callable</type><parameter>callback</parameter></methodparam>
-   <methodparam choice="opt"><type>callable</type><parameter>error_callback</parameter></methodparam>
+  <methodsynopsis role="Yar_Concurrent_Client">
+   <modifier>public</modifier> <modifier>static</modifier> <type class="union"><type>bool</type><type>null</type></type><methodname>Yar_Concurrent_Client::loop</methodname>
+   <methodparam choice="opt"><type class="union"><type>callable</type><type>null</type></type><parameter>callback</parameter><initializer>null</initializer></methodparam>
+   <methodparam choice="opt"><type class="union"><type>callable</type><type>null</type></type><parameter>error_callback</parameter><initializer>null</initializer></methodparam>
+   <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>options</parameter><initializer>null</initializer></methodparam>
   </methodsynopsis>
   <simpara>
-   Envoie tous les appels distants RPC enregistrés.
+   Envoie en parallèle tous les appels enregistrés avec
+   <methodname>Yar_Concurrent_Client::call</methodname> et bloque jusqu'à ce
+   que chaque réponse soit arrivée et ait été traitée. La liste des appels
+   est vidée lorsque cette méthode retourne.
   </simpara>
  </refsect1>
 
@@ -27,26 +29,34 @@
    <varlistentry>
     <term><parameter>callback</parameter></term>
     <listitem>
-     <para>
-      Si la fonction de rappel est définie, alors Yar appellera cette fonction
-      de rappel après avoir envoyé tous les appels, et avant le retour
-      des réponses, avec $callinfo valant NULL.
-     </para>
-     <para>
-      Alors, si l'utilisateur ne spécifie pas de fonction de rappel lors de
-      l'enregistrement d'appel concurrent, cette fonction de rappel sera
-      utilisée pour gérer les réponses, sinon, la fonction de rappel
-      spécifiée pendant l'enregistrement sera utilisée.
-     </para>
+     <simpara>
+      Un <type>callable</type> utilisé pour traiter les réponses des appels
+      qui ont été enregistrés sans leur propre fonction de rappel. Juste
+      après l'envoi de toutes les requêtes, il est en outre appelé une fois
+      avec deux arguments &null;, avant l'arrivée de toute réponse.
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>error_callback</parameter></term>
     <listitem>
-     <para>
-      Si la fonction de rappel est définie, alors Yar l'appellera
-      lorsqu'une erreur surviendra.
-     </para>
+     <simpara>
+      Un <type>callable</type> utilisé pour traiter les erreurs des appels
+      qui ont été enregistrés sans leur propre fonction de rappel d'erreur.
+      Il reçoit trois arguments : le type d'erreur (l'un des codes
+      <literal>YAR_ERR_*</literal>), le message d'erreur, et l'&array;
+      <literal>callinfo</literal>.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>options</parameter></term>
+    <listitem>
+     <simpara>
+      Un &array; d'options du client, indexé par les constantes
+      <literal>YAR_OPT_*</literal>, appliqué à chaque appel enregistré qui
+      ne les redéfinit pas.
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -54,70 +64,62 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
-
-  </para>
+  <simpara>
+   Retourne &true; lorsque chaque appel enregistré a été traité, ou
+   lorsqu'aucun appel n'a été enregistré. Retourne &false; si le client
+   concurrent est déjà en cours d'exécution dans une autre boucle ; dans ce
+   cas, une alerte est émise.
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">
   &reftitle.examples;
   <example>
-   <title>Exemple avec <function>Yar_Concurrent_Client::loop</function></title>
+   <title>Exemple avec <methodname>Yar_Concurrent_Client::loop</methodname></title>
    <programlisting role="php">
 <![CDATA[
 <?php
 function callback($retval, $callinfo) {
-     if ($callinfo == NULL) {
-        echo "Maintenant, toutes les requêtes ont été émises, et aucune réponse n'est disponible\n";
-     } else {
-        echo "Ceci est une réponse à un appel distant, le nom de la méthode est ", $callinfo["method"], 
-             ". La séquence d'appel est " , $callinfo["sequence"] , "\n";
+    if ($callinfo == NULL) {
+        echo "Maintenant, toutes les requêtes ont été envoyées, et aucune réponse n'est disponible\n";
+    } else {
+        echo "Ceci est une réponse à un appel distant, le nom de la méthode est ", $callinfo["method"],
+             ". Le numéro de séquence de l'appel est ", $callinfo["sequence"], "\n";
         var_dump($retval);
-     }
-} 
+    }
+}
 
 function error_callback($type, $error, $callinfo) {
     error_log($error);
 }
 
 Yar_Concurrent_Client::call("http://host/api/", "some_method", array("parameters"), "callback");
-Yar_Concurrent_Client::call("http://host/api/", "some_method", array("parameters"));   // Si la fonction de rappel n'est pas spécifiée 
-                                                                               // la fonction de rappel de la boucle sera utilisée
-Yar_Concurrent_Client::call("http://host/api/", "some_method", array("parameters"), "callback", NULL, array(YAR_OPT_PACKAGER => "json"));
-                                                                               // ce serveur accepte le packager json 
-Yar_Concurrent_Client::call("http://host/api/", "some_method", array("parameters"), "callback", NULL, array(YAR_OPT_TIMEOUT=>1));
-                                                                               //Délai d'attente maximal personnalisé
 
-Yar_Concurrent_Client::loop("callback", "error_callback"); //Envoie les requêtes,
-                                                           //error_callback est optionnel
+/* Si la fonction de rappel n'est pas spécifiée, celle de loop() sera utilisée */
+Yar_Concurrent_Client::call("http://host/api/", "some_method", array("parameters"));
+
+Yar_Concurrent_Client::loop("callback", "error_callback");
 ?>
 ]]>
    </programlisting>
    &example.outputs.similar;
    <screen>
 <![CDATA[
-Maintenant, toutes les requêtes ont été émises, et aucune réponse n'est disponible
-Ceci est une réponse à un appel distant, le nom de la méthode est some_method. La séquence d'appel est 4
+Maintenant, toutes les requêtes ont été envoyées, et aucune réponse n'est disponible
+Ceci est une réponse à un appel distant, le nom de la méthode est some_method. Le numéro de séquence de l'appel est 2
 string(11) "some_method"
-Ceci est une réponse à un appel distant, le nom de la méthode est some_method. La séquence d'appel est 1
-string(11) "some_method"
-Ceci est une réponse à un appel distant, le nom de la méthode est some_method. La séquence d'appel est 2
-string(11) "some_method"
-Ceci est une réponse à un appel distant, le nom de la méthode est some_method. La séquence d'appel est 3
+Ceci est une réponse à un appel distant, le nom de la méthode est some_method. Le numéro de séquence de l'appel est 1
 string(11) "some_method"
 ]]>
    </screen>
   </example>
  </refsect1>
 
-
  <refsect1 role="seealso">
   &reftitle.seealso;
   <simplelist>
    <member><methodname>Yar_Concurrent_Client::call</methodname></member>
    <member><methodname>Yar_Concurrent_Client::reset</methodname></member>
-   <member><methodname>Yar_Server::__construct</methodname></member>
-   <member><methodname>Yar_Server::handle</methodname></member>
   </simplelist>
  </refsect1>
 

--- a/reference/yar/yar_concurrent_client/reset.xml
+++ b/reference/yar/yar_concurrent_client/reset.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 62126c55f1c6ed444043e7272c4f9e233818a44b Maintainer: girgias Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 75d48299ef85693f10eee31af1be88488fb84c6f Maintainer: girgias Status: ready -->
 
 <refentry xml:id="yar-concurrent-client.reset" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -10,13 +9,23 @@
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis>
+  <methodsynopsis role="Yar_Concurrent_Client">
    <modifier>public</modifier> <modifier>static</modifier> <type>bool</type><methodname>Yar_Concurrent_Client::reset</methodname>
    <void />
   </methodsynopsis>
-  <para>
-   Nettoie tous les appels enregistrés.
-  </para>
+  <simpara>
+   Abandonne tous les appels enregistrés avec
+   <methodname>Yar_Concurrent_Client::call</methodname> qui n'ont pas encore
+   été envoyés.
+  </simpara>
+  <note>
+   <simpara>
+    <methodname>Yar_Concurrent_Client::loop</methodname> vide
+    automatiquement la liste des appels une fois qu'elle a terminé ; reset
+    n'est donc nécessaire que pour abandonner un lot qui n'a jamais été
+    envoyé.
+   </simpara>
+  </note>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -26,8 +35,12 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
-  </para>
+  <simpara>
+   Retourne &true;, ou &false; lorsque le client concurrent est actuellement
+   à l'intérieur de
+   <methodname>Yar_Concurrent_Client::loop</methodname>, auquel cas une
+   erreur de niveau <constant>E_WARNING</constant> est émise.
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">
@@ -36,13 +49,18 @@
    <title>Exemple avec <function>Yar_Concurrent_Client::reset</function></title>
    <programlisting role="php">
 <![CDATA[
+<?php
+function callback($retval, $callinfo) {
+    var_dump($retval);
+}
+
+Yar_Concurrent_Client::call("http://host/api/", "some_method", array("parameters"), "callback");
+
+/* Jamais envoyé : l'appel enregistré est abandonné */
+Yar_Concurrent_Client::reset();
+?>
 ]]>
    </programlisting>
-   &example.outputs.similar;
-   <screen>
-<![CDATA[
-]]>
-   </screen>
   </example>
  </refsect1>
 
@@ -51,8 +69,6 @@
   <simplelist>
    <member><methodname>Yar_Concurrent_Client::call</methodname></member>
    <member><methodname>Yar_Concurrent_Client::loop</methodname></member>
-   <member><methodname>Yar_Server::__construct</methodname></member>
-   <member><methodname>Yar_Server::handle</methodname></member>
   </simplelist>
  </refsect1>
 

--- a/reference/yar/yar_server/construct.xml
+++ b/reference/yar/yar_server/construct.xml
@@ -1,36 +1,35 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 914b97130aed191518791045b93b6f858ef5a139 Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 75d48299ef85693f10eee31af1be88488fb84c6f Maintainer: yannick Status: ready -->
 
 <refentry xml:id="yar-server.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Yar_Server::__construct</refname>
-  <refpurpose>Enregistre un serveur</refpurpose>
+  <refpurpose>Crée un serveur RPC</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis>
+  <constructorsynopsis role="Yar_Server">
    <modifier>final</modifier> <modifier>public</modifier> <methodname>Yar_Server::__construct</methodname>
-   <methodparam><type>Object</type><parameter>obj</parameter></methodparam>
-  </methodsynopsis>
-  <para>
-   Configure un serveur Yar HTTP RPC. Toutes les méthodes publiques
-   de l'objet $obj seront enregistrées comme un service RPC.
-  </para>
+   <methodparam><type>object</type><parameter>executor</parameter></methodparam>
+  </constructorsynopsis>
+  <simpara>
+   Crée un serveur Yar HTTP RPC. Toutes les méthodes publiques de
+   <parameter>executor</parameter> sont enregistrées comme services RPC.
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
   &reftitle.parameters;
   <variablelist>
    <varlistentry>
-    <term><parameter>obj</parameter></term>
+    <term><parameter>executor</parameter></term>
     <listitem>
-     <para>
-      Un objet. Toutes les méthodes publiques de cet objet seront enregistrées
-      comme services RPC.
-     </para>
+     <simpara>
+      Tout objet dont les méthodes publiques devraient être exposées comme
+      services RPC. Les méthodes protégées et privées, ainsi que les méthodes
+      dont le nom commence par un tiret bas, ne sont pas exposées.
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -38,23 +37,23 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
-   Une instance de la classe <classname>Yar_Server</classname>.
-  </para>
+  <simpara>
+   Une instance de <classname>Yar_Server</classname>.
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">
   &reftitle.examples;
   <example>
-   <title>Exemple avec <function>Yar_Server::__construct</function></title>
+   <title>Exemple avec <methodname>Yar_Server::__construct</methodname></title>
    <programlisting role="php">
 <![CDATA[
 <?php
 class API {
     /**
-     * les informations seront générées automatiquement sur la page d'information du service.
-     * @params 
-     * @return
+     * Le bloc de documentation est affiché sur la page d'informations du service.
+     * @param string $parameter
+     * @return string
      */
     public function some_method($parameter, $option = "foo") {
          return "some_method";
@@ -69,20 +68,16 @@ $service->handle();
 ?>
 ]]>
    </programlisting>
-   &example.outputs.similar;
-   <screen>
-<![CDATA[
-]]>
-   </screen>
   </example>
  </refsect1>
 
-
  <refsect1 role="seealso">
   &reftitle.seealso;
-  <simplelist>
-   <member><methodname>Yar_Server::handle</methodname></member>
-  </simplelist>
+  <para>
+   <simplelist>
+    <member><methodname>Yar_Server::handle</methodname></member>
+   </simplelist>
+  </para>
  </refsect1>
 
 </refentry>

--- a/reference/yar/yar_server/handle.xml
+++ b/reference/yar/yar_server/handle.xml
@@ -1,30 +1,43 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 331fbfeac522d4ad00de1e043cc11610d66b88f9 Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 07275f5d03cf34c5a2218e0c103978f8024da153 Maintainer: yannick Status: ready -->
 
 <refentry xml:id="yar-server.handle" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Yar_Server::handle</refname>
-  <refpurpose>Démarre un serveur RPC</refpurpose>
+  <refpurpose>Démarre le serveur RPC</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis>
-   <modifier>public</modifier> <type>bool</type> <methodname>Yar_Server::handle</methodname>
-   <void/>
+  <methodsynopsis role="Yar_Server">
+   <modifier>public</modifier> <type>bool</type><methodname>Yar_Server::handle</methodname>
+   <void />
   </methodsynopsis>
-  <para>
-   Démarre un serveur RPC HTTP, et le rend prêt à accepter des requêtes RPC.
-   <note>
-    <para>
-     Les appels RPC sont envoyés par des requêtes HTTP POST.
-     Si une requête HTTP GET est envoyée à l'URI, les informations du service
-     (commenté dans la section ci-dessous) seront affichées sur la page.
-    </para>
-   </note>
-  </para>
+  <simpara>
+   Démarre le traitement de la requête RPC entrante.
+  </simpara>
+  <note>
+   <simpara>
+    Les appels RPC habituels sont émis sous forme de requêtes HTTP POST.
+    Si une requête HTTP GET est émise à la place, la page d'informations du
+    service, générée à partir des méthodes publiques de l'objet exécuteur et
+    de leurs commentaires de documentation, est affichée. Ce comportement peut
+    être désactivé avec la directive
+    <link linkend="ini.yar.expose-info">yar.expose_info</link>,
+    auquel cas une requête GET lève une
+    <exceptionname>Yar_Server_Exception</exceptionname>.
+   </simpara>
+  </note>
+  <note>
+   <simpara>
+    À partir de Yar 2.3.0, la page d'informations du service peut être
+    personnalisée en définissant une méthode <literal>protected</literal>
+    nommée <literal>__info</literal> sur l'objet exécuteur. Lorsqu'une requête
+    GET arrive, Yar appelle cette méthode en lui passant le balisage de la page
+    qu'il aurait sinon produite ; si la méthode retourne une &string;, cette
+    chaîne est envoyée au client à la place de la page par défaut.
+   </simpara>
+  </note>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -34,25 +47,97 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
+  <simpara>
+   Retourne &true;.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
   <para>
-   Un booléen.
+   <table>
+    <title>Erreurs de <methodname>Yar_Server::handle</methodname></title>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>Condition</entry>
+       <entry>Exception</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>
+        La méthode distante a levé une exception.
+       </entry>
+       <entry>
+        <exceptionname>Yar_Server_Exception</exceptionname> (avec le nom de
+        classe d'origine dans sa propriété <literal>_type</literal>).
+       </entry>
+      </row>
+      <row>
+       <entry>
+        La méthode distante est introuvable ou n'est pas publique.
+       </entry>
+       <entry>
+        <exceptionname>Yar_Server_Request_Exception</exceptionname>.
+       </entry>
+      </row>
+      <row>
+       <entry>
+        Le corps de la requête n'a pas pu être décodé.
+       </entry>
+       <entry>
+        <exceptionname>Yar_Server_Packager_Exception</exceptionname>.
+       </entry>
+      </row>
+      <row>
+       <entry>
+        La requête est mal formée au niveau du protocole.
+       </entry>
+       <entry>
+        <exceptionname>Yar_Server_Protocol_Exception</exceptionname>.
+       </entry>
+      </row>
+      <row>
+       <entry>
+        Les données de sortie du serveur n'ont pas pu être capturées.
+       </entry>
+       <entry>
+        <exceptionname>Yar_Server_Output_Exception</exceptionname>.
+       </entry>
+      </row>
+      <row>
+       <entry>
+        L'authentification a échoué, ou la page d'informations a été demandée
+        alors que <link linkend="ini.yar.expose-info">yar.expose_info</link>
+        est désactivée.
+       </entry>
+       <entry>
+        <exceptionname>Yar_Server_Exception</exceptionname> avec le code
+        <constant>YAR_ERR_FORBIDDEN</constant>.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </table>
   </para>
  </refsect1>
 
  <refsect1 role="examples">
   &reftitle.examples;
   <example>
-   <title>Exemple avec <function>Yar_Server::handle</function></title>
+   <title>Exemple avec <methodname>Yar_Server::handle</methodname></title>
    <programlisting role="php">
 <![CDATA[
 <?php
 class API {
     /**
-     * les informations seront générées automatiquement sur la page d'informations du service.
-     * @params 
-     * @return
+     * Le bloc de documentation est affiché sur la page d'informations du service.
+     * @param string $parameter
+     * @return string
      */
     public function some_method($parameter, $option = "foo") {
+        return "some_method";
     }
 
     protected function client_can_not_see() {
@@ -64,20 +149,43 @@ $service->handle();
 ?>
 ]]>
    </programlisting>
-   &example.outputs.similar;
-   <screen>
+  </example>
+  <example>
+   <title>Personnalisation de la page d'informations du service avec
+   <literal>__info</literal> (à partir de Yar 2.3.0)</title>
+   <programlisting role="php">
 <![CDATA[
+<?php
+class API {
+    public function some_method($parameter, $option = "foo") {
+        return "some_method";
+    }
+
+    /*
+     * Doit être protégée. Elle est appelée sur les requêtes GET avec le balisage
+     * de la page que Yar aurait sinon produite, et la chaîne qu'elle retourne est
+     * envoyée au client à la place.
+     */
+    protected function __info($markup) {
+        return "Bonjour le monde";
+    }
+}
+
+$service = new Yar_Server(new API());
+$service->handle();
+?>
 ]]>
-   </screen>
+   </programlisting>
   </example>
  </refsect1>
 
-
  <refsect1 role="seealso">
   &reftitle.seealso;
-  <simplelist>
-   <member><methodname>Yar_Server::__construct</methodname></member>
-  </simplelist>
+  <para>
+   <simplelist>
+    <member><methodname>Yar_Server::__construct</methodname></member>
+   </simplelist>
+  </para>
  </refsect1>
 
 </refentry>

--- a/reference/yar/yar_server_exception/gettype.xml
+++ b/reference/yar/yar_server_exception/gettype.xml
@@ -1,23 +1,24 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 8cc7e649de5889a9029139587962320e2794addd Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 75d48299ef85693f10eee31af1be88488fb84c6f Maintainer: yannick Status: ready -->
 
 <refentry xml:id="yar-server-exception.gettype" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Yar_Server_Exception::getType</refname>
-  <refpurpose>Récupérer le type de l'exception</refpurpose>
+  <refpurpose>Récupère le type de l'exception</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
   &reftitle.description;
-  <methodsynopsis>
-   <modifier>public</modifier> <type>string</type><methodname>Yar_Server_Exception::getType</methodname>
+  <methodsynopsis role="Yar_Server_Exception">
+   <modifier>public</modifier> <type class="union"><type>string</type><type>int</type></type><methodname>Yar_Server_Exception::getType</methodname>
    <void />
   </methodsynopsis>
-  <para>
-   Récupère le type de l'exception émise par le serveur.
-  </para>
+  <simpara>
+   Lorsqu'une méthode distante lève une exception, le serveur intègre
+   l'exception d'origine dans la réponse et le client la relève sous la forme
+   d'une <exceptionname>Yar_Server_Exception</exceptionname>. Cette méthode
+   retourne le nom de classe de cette exception d'origine.
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -27,19 +28,21 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
-   Une chaîne de caractères.
-  </para>
+  <simpara>
+   Le nom de classe de l'exception levée par le service distant, ou
+   <literal>"Yar_Exception_Server"</literal> lorsque l'exception côté serveur
+   ne comportait aucun nom de classe.
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">
   &reftitle.examples;
   <example>
-   <title>Exemple avec <function>Yar_Server_Exception::getType</function></title>
+   <title>Exemple avec <methodname>Yar_Server_Exception::getType</methodname></title>
    <programlisting role="php">
 <![CDATA[
-//Server.php
 <?php
+/* Server.php */
 class Custom_Exception extends Exception {};
 
 class API {
@@ -51,9 +54,12 @@ class API {
 $service = new Yar_Server(new API());
 $service->handle();
 ?>
-
-//Client.php
+]]>
+   </programlisting>
+   <programlisting role="php">
+<![CDATA[
 <?php
+/* Client.php */
 $client = new Yar_Client("http://host/api.php");
 
 try {
@@ -62,6 +68,7 @@ try {
     var_dump($e->getType());
     var_dump($e->getMessage());
 }
+?>
 ]]>
    </programlisting>
    &example.outputs.similar;
@@ -74,11 +81,10 @@ string(6) "client"
   </example>
  </refsect1>
 
-
  <refsect1 role="seealso">
   &reftitle.seealso;
   <simplelist>
-   <member></member>
+   <member><methodname>Yar_Client_Exception::getType</methodname></member>
   </simplelist>
  </refsect1>
 


### PR DESCRIPTION
Two sync issues are handled together because both touch `yar-client-protocol-exception.xml` and `yar_server/handle.xml`.

Sync with EN commits 75d48299ef85693f10eee31af1be88488fb84c6f and 07275f5d03cf34c5a2218e0c103978f8024da153.

- Full revision of the Yar documentation: the nine `YAR_OPT_*` options, the new `Yar_Client::getOpt()` page, the reworked exception hierarchy (`role="exception"`, `<ooexception>`, `_type` property), the INI page with correct defaults, the concurrent client examples and msgpack support, plus markup modernization (`<simpara>`, union types, "See also").
- `yar_server/handle.xml` gains the note and example for the `__info` magic method (Yar 2.3.0) and `yar-client-protocol-exception.xml` the section on response transaction id validation (Yar 2.4.0).

The French pages were far behind EN — several sections were empty or described the wrong method — so they were retranslated in full rather than patched. `versions.xml` is EN-only and stays out of scope.

Fixes: #3360
Fixes: #3389