### PR TITLE
[Sync-En] reflection: fix setStaticPropertyValue ignores visibility

### DIFF
--- a/reference/reflection/reflectionclass/setstaticpropertyvalue.xml
+++ b/reference/reflection/reflectionclass/setstaticpropertyvalue.xml
@@ -1,10 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: c4aabaa0b97ef1ecc00cf2cd539ea186c6a855ae Maintainer: yannick Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: c74adac363c4ad18bfb648b8962663b26de3828b Maintainer: yannick Status: ready -->
 <refentry xml:id="reflectionclass.setstaticpropertyvalue" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>ReflectionClass::setStaticPropertyValue</refname>
-  <refpurpose>Définit la valeur d'une propriété statique publique</refpurpose>
+  <refpurpose>Définit la valeur d'une propriété statique</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -15,12 +14,12 @@
    <methodparam><type>mixed</type><parameter>value</parameter></methodparam>
   </methodsynopsis>
   <simpara>
-   Définit la valeur d'une propriété statique publique.
-   Si la propriété est privée ou protégée, la méthode échouera.
+   Définit la valeur d'une propriété statique de cette classe, quelle que soit
+   la visibilité de la propriété.
   </simpara>
   <simpara>
-   <methodname>ReflectionProperty::setValue</methodname> permet de définir
-   la valeur des propriétés publiques, privées et protégées.
+   <methodname>ReflectionProperty::setValue</methodname> peut également être
+   utilisée pour définir la valeur des propriétés statiques.
   </simpara>
  </refsect1>
 
@@ -67,11 +66,11 @@
     </thead>
     <tbody>
      <row>
-      <entry>7.4.0</entry>
+      <entry>7.4.9, 8.0.0</entry>
       <entry>
-       L'utilisation de <methodname>ReflectionClass::setStaticPropertyValue</methodname> pour définir
-       une propriété privée ou protégée entraîne désormais une erreur fatale. Auparavant, cela
-       levait une <classname>ReflectionException</classname>.
+       <methodname>ReflectionClass::setStaticPropertyValue</methodname> peut désormais
+       définir des propriétés statiques privées et protégées. Auparavant, une
+       <exceptionname>ReflectionException</exceptionname> était levée.
       </entry>
      </row>
     </tbody>


### PR DESCRIPTION
Sync with EN commit c74adac363c4ad18bfb648b8962663b26de3828b (EN PR php/doc-en#5057).

- Title and description: remove "public" — the method sets any static property regardless of visibility since 7.4.9/8.0.0
- Changelog: correct version from 7.4.0 to 7.4.9, 8.0.0; use `<exceptionname>` for `ReflectionException`; rephrase to match the actual behaviour change

Closes #3408