### PR TITLE
[Sync-En] pdo: modernize Windows installation documentation

### DIFF
--- a/reference/pdo/configure.xml
+++ b/reference/pdo/configure.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 6e58d11156926ea75109693d63306092320b63fe Maintainer: lacatoire Status: ready -->
 
 <section xml:id="pdo.installation" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.install;
@@ -50,12 +50,11 @@ extension=pdo
   <step>
    <para>
     PDO est activé par défaut.
-    Il convient de choisir les autres fichiers DLL spécifiques à la base de données
-    et d'utiliser soit la fonction <function>dl</function> pour les charger
-    au moment de l'exécution, soit de les activer dans le fichier &php.ini;.
+    Activez les pilotes spécifiques à la base de données dans &php.ini; selon les besoins.
     Par exemple, ceci charge le pilote
     <link linkend="ref.pdo-sqlite">PDO_SQLITE</link> mais
-    laisse le pilote <link linkend="ref.pdo-odbc">PDO_ODBC</link> commenté:
+    laisse le pilote <link linkend="ref.pdo-odbc">PDO_ODBC</link>
+    commenté :
     <screen>
 <![CDATA[
 ;extension=pdo_odbc
@@ -63,10 +62,10 @@ extension=pdo_sqlite
 ]]>
     </screen>
    </para>
-   <para>
-    Ces bibliothèques DLL doivent exister dans le dossier système
+   <simpara>
+    Les fichiers d'extension correspondants doivent exister dans le dossier
     <link linkend="ini.extension-dir">extension_dir</link>.
-   </para>
+   </simpara>
   </step>
  </procedure>
  <note>


### PR DESCRIPTION
Sync with EN commit 6e58d11156926ea75109693d63306092320b63fe (EN PR php/doc-en#5277).

- Remove outdated references to `dl()` and DLL files
- Replace with simpler instruction to enable drivers in `php.ini`
- `<para>` → `<simpara>` for the `extension_dir` line

Closes #3403