### PR TITLE
[Sync-En] reflection: document named arguments support in ...Args methods

### DIFF
--- a/reference/reflection/reflectionclass/newinstanceargs.xml
+++ b/reference/reflection/reflectionclass/newinstanceargs.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: ec2fe9a592f794978114ef5021db9f1d00c2e05d Maintainer: itanea Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 0f4bc7cf417d6c23a30f1b6e949c272651cf4ab4 Maintainer: itanea Status: ready -->
 <refentry xml:id="reflectionclass.newinstanceargs" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>ReflectionClass::newInstanceArgs</refname>
@@ -27,10 +26,23 @@
     <varlistentry>
      <term><parameter>args</parameter></term>
      <listitem>
-      <para>
-       Accepte un nombre variable d'arguments passés au constructeur,
-       comme pour la fonction <function>call_user_func</function>.
-      </para>
+      <simpara>
+       Les paramètres à passer au constructeur de la classe, sous forme de tableau.
+      </simpara>
+      <simpara>
+       Si toutes les clés de <parameter>args</parameter> sont numériques, les clés sont
+       ignorées et chaque élément est passé au constructeur comme argument positionnel,
+       dans l'ordre.
+      </simpara>
+      <simpara>
+       Si certaines clés de <parameter>args</parameter> sont des chaînes, ces éléments
+       sont passés au constructeur comme arguments nommés, avec le nom donné par la clé.
+      </simpara>
+      <simpara>
+       Une <exceptionname>Error</exceptionname> est levée si une clé numérique de
+       <parameter>args</parameter> apparaît après une clé chaîne, ou si une clé chaîne
+       ne correspond au nom d'aucun paramètre du constructeur.
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -53,6 +65,29 @@
    Une <classname>ReflectionException</classname> si la classe n'a pas de constructeur
    et que le paramètre <parameter>args</parameter> contient au moins une donnée.
   </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.0.0</entry>
+      <entry>
+       Les clés de <parameter>args</parameter> sont désormais interprétées
+       comme les noms des paramètres, au lieu d'être silencieusement ignorées.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/reflection/reflectionfunction/invokeargs.xml
+++ b/reference/reflection/reflectionfunction/invokeargs.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: ec2fe9a592f794978114ef5021db9f1d00c2e05d Maintainer: jpauli Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 0f4bc7cf417d6c23a30f1b6e949c272651cf4ab4 Maintainer: jpauli Status: ready -->
 <refentry xml:id="reflectionfunction.invokeargs" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>ReflectionFunction::invokeArgs</refname>
@@ -26,10 +25,24 @@
     <varlistentry>
      <term><parameter>args</parameter></term>
      <listitem>
-      <para>
-       Les arguments à utiliser lors de l'invocation, tout comme le fonctionnement
-       de <function>call_user_func_array</function>.
-      </para>
+      <simpara>
+       Les paramètres à passer à la fonction, sous forme de tableau, tout comme
+       le fonctionnement de <function>call_user_func_array</function>.
+      </simpara>
+      <simpara>
+       Si toutes les clés de <parameter>args</parameter> sont numériques, les clés sont
+       ignorées et chaque élément est passé à la fonction comme argument positionnel,
+       dans l'ordre.
+      </simpara>
+      <simpara>
+       Si certaines clés de <parameter>args</parameter> sont des chaînes, ces éléments
+       sont passés à la fonction comme arguments nommés, avec le nom donné par la clé.
+      </simpara>
+      <simpara>
+       Une <exceptionname>Error</exceptionname> est levée si une clé numérique de
+       <parameter>args</parameter> apparaît après une clé chaîne, ou si une clé chaîne
+       ne correspond au nom d'aucun paramètre de la fonction.
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>

--- a/reference/reflection/reflectionmethod/invokeargs.xml
+++ b/reference/reflection/reflectionmethod/invokeargs.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: ec2fe9a592f794978114ef5021db9f1d00c2e05d Maintainer: jpauli Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 0f4bc7cf417d6c23a30f1b6e949c272651cf4ab4 Maintainer: jpauli Status: ready -->
 <refentry xml:id="reflectionmethod.invokeargs" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>ReflectionMethod::invokeArgs</refname>
@@ -36,9 +35,23 @@
     <varlistentry>
      <term><parameter>args</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Les paramètres à passer à la méthode, sous forme de tableau.
-      </para>
+      </simpara>
+      <simpara>
+       Si toutes les clés de <parameter>args</parameter> sont numériques, les clés sont
+       ignorées et chaque élément est passé à la méthode comme argument positionnel,
+       dans l'ordre.
+      </simpara>
+      <simpara>
+       Si certaines clés de <parameter>args</parameter> sont des chaînes, ces éléments
+       sont passés à la méthode comme arguments nommés, avec le nom donné par la clé.
+      </simpara>
+      <simpara>
+       Une <exceptionname>Error</exceptionname> est levée si une clé numérique de
+       <parameter>args</parameter> apparaît après une clé chaîne, ou si une clé chaîne
+       ne correspond au nom d'aucun paramètre de la méthode.
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>


### PR DESCRIPTION
Sync with EN commit 0f4bc7cf417d6c23a30f1b6e949c272651cf4ab4 (EN PR php/doc-en#5225).

- Expand the `args` parameter description for `newInstanceArgs`, `ReflectionFunction::invokeArgs` and `ReflectionMethod::invokeArgs`: explain positional vs named key semantics and the `Error` thrown on invalid key order or unknown parameter name
- Add changelog 8.0.0 to `newInstanceArgs` (was already present in the two `invokeArgs`)

Closes #3404