### PR TITLE
[Sync-En] mbstring: factor out encoding-invalid error and changelog entities

### DIFF
--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -1287,6 +1287,22 @@ sera utilisé.</simpara>'>
  </entry>
 </row>'>
 
+<!ENTITY mbstring.errors.encoding-invalid '<para xmlns="http://docbook.org/ns/docbook">
+ À partir de PHP 8.0.0, une <exceptionname>ValueError</exceptionname> est levée si
+ <parameter>encoding</parameter> est un encodage invalide.
+ Avant PHP 8.0.0, un <constant>E_WARNING</constant> était émis à la place.
+</para>'>
+
+<!ENTITY mbstring.changelog.encoding-invalid '<row xmlns="http://docbook.org/ns/docbook">
+ <entry>8.0.0</entry>
+ <entry>
+  Lève désormais une <exceptionname>ValueError</exceptionname> si
+  <parameter>encoding</parameter> est un encodage invalide.
+  Auparavant, un <constant>E_WARNING</constant> était émis
+  et &false; était retourné.
+ </entry>
+</row>'>
+
 <!-- mcrypt notes -->
 
 <!ENTITY mcrypt.parameter.cipher '<simpara xmlns="http://docbook.org/ns/docbook">Une constante parmi les constantes

--- a/reference/mbstring/functions/mb-encoding-aliases.xml
+++ b/reference/mbstring/functions/mb-encoding-aliases.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 96bc008584eaea7d899b13234a88b1d84f82032b Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 8465ca6ec4bbcf79583ecd057860164dd9c7e385 Maintainer: yannick Status: ready -->
 
 <refentry xml:id="function.mb-encoding-aliases" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -43,10 +41,7 @@
 
  <refsect1 role="errors">
   &reftitle.errors;
-  <para>
-   Lève une <classname>ValueError</classname> si
-   <parameter>encoding</parameter> est inconnu.
-  </para>
+  &mbstring.errors.encoding-invalid;
  </refsect1>
 
  <refsect1 role="changelog">
@@ -60,14 +55,7 @@
      </row>
     </thead>
     <tbody>
-     <row>
-      <entry>8.0.0</entry>
-      <entry>
-       Si le paramètre <parameter>encoding</parameter> est inconnu, une <classname>ValueError</classname>
-       est désormais levée ; précédemment, une <constant>E_WARNING</constant> était émise,
-       et la fonction retournait &false;.
-      </entry>
-     </row>
+     &mbstring.changelog.encoding-invalid;
     </tbody>
    </tgroup>
   </informaltable>

--- a/reference/mbstring/functions/mb-internal-encoding.xml
+++ b/reference/mbstring/functions/mb-internal-encoding.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 5b3fc18be040c1d552da1497415b20296163012f Maintainer: yannick Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 8465ca6ec4bbcf79583ecd057860164dd9c7e385 Maintainer: yannick Status: ready -->
 <refentry xml:id="function.mb-internal-encoding" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>mb_internal_encoding</refname>
@@ -53,11 +51,7 @@
 
  <refsect1 role="errors">
   &reftitle.errors;
-  <para>
-   À partir de PHP 8.0.0, une <classname>ValueError</classname> est lancée si la valeur
-   de <parameter>encoding</parameter> est un encodage invalide.
-   Antérieurement à PHP 8.0.0, une <constant>E_WARNING</constant> était émise à la place.
-  </para>
+  &mbstring.errors.encoding-invalid;
  </refsect1>
 
  <refsect1 role="changelog">
@@ -72,14 +66,7 @@
     </thead>
     <tbody>
      &mbstring.changelog.encoding-nullable;
-     <row>
-      <entry>8.0.0</entry>
-      <entry>
-       Lance désormais une <classname>ValueError</classname> si
-       <parameter>encoding</parameter> est un encodage invalide.
-       Auparavant, une <constant>E_WARNING</constant> était émise à la place.
-      </entry>
-     </row>
+     &mbstring.changelog.encoding-invalid;
     </tbody>
    </tgroup>
   </informaltable>

--- a/reference/mbstring/functions/mb-strlen.xml
+++ b/reference/mbstring/functions/mb-strlen.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 92f1b8b177eb5730382abf9f27bae868f1bb636f Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 8465ca6ec4bbcf79583ecd057860164dd9c7e385 Maintainer: yannick Status: ready -->
 <refentry xml:id="function.mb-strlen" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>mb_strlen</refname>
@@ -54,10 +52,7 @@
 
  <refsect1 role="errors">
   &reftitle.errors;
-  <para>
-   Si l'encodage est inconnu, une erreur de niveau
-   <constant>E_WARNING</constant> est générée.
-  </para>
+  &mbstring.errors.encoding-invalid;
  </refsect1>
 
  <refsect1 role="changelog">
@@ -72,6 +67,7 @@
     </thead>
     <tbody>
      &mbstring.changelog.encoding-nullable;
+     &mbstring.changelog.encoding-invalid;
     </tbody>
    </tgroup>
   </informaltable>


### PR DESCRIPTION
Sync with EN commit 8465ca6ec4bbcf79583ecd057860164dd9c7e385 (EN PR php/doc-en#5418).

- Add `mbstring.errors.encoding-invalid` and `mbstring.changelog.encoding-invalid` shared entities to `language-snippets.ent`
- Replace inline `ValueError`/`E_WARNING` blocks in `mb_encoding_aliases`, `mb_internal_encoding` and `mb_strlen` with the new entities
- `mb_strlen` gains the missing 8.0.0 changelog entry

Closes #3400