### PR TITLE
[Sync-En] Add Alpine Linux installation page

### DIFF
--- a/install/unix/alpine.xml
+++ b/install/unix/alpine.xml
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 5a5899391ef91a4d42bca9495c8a1d323d38f23a Maintainer: lacatoire Status: ready -->
+<sect1 xml:id="install.unix.alpine" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <title>Installation via les paquets sur Alpine Linux</title>
+ <simpara>
+  PHP peut être installé depuis les sources, mais il est également disponible
+  via les paquets sur Alpine Linux et ses dérivés qui utilisent le gestionnaire
+  de paquets <command>apk</command>.
+ </simpara>
+ &warn.install.third-party-support;
+ <simpara>
+  Les paquets peuvent être installés à l'aide du gestionnaire de paquets
+  <command>apk</command>.
+ </simpara>
+ <sect2 xml:id="install.unix.alpine.packages">
+  <title>Installation des paquets</title>
+  <simpara>
+   Les paquets PHP dans Alpine Linux incluent le numéro de version majeure dans
+   leur nom (par exemple <literal>php83</literal> pour PHP 8.3). Dans les
+   exemples ci-dessous, remplacez <literal>83</literal> par la version PHP
+   disponible pour la version d'Alpine Linux utilisée.
+  </simpara>
+  <simpara>
+   Avant d'installer un paquet, il faut s'assurer que l'index des paquets est à jour
+   en exécutant <command>apk update</command>.
+  </simpara>
+  <example xml:id="install.unix.alpine.example">
+   <title>Exemple d'installation Alpine</title>
+   <programlisting role="shell">
+<![CDATA[
+# apk add php83
+]]>
+   </programlisting>
+  </example>
+  <simpara>
+   Alpine ne configure pas PHP pour un serveur web automatiquement. Pour les
+   configurations FastCGI, installez <literal>php83-fpm</literal> et activez
+   le service OpenRC <literal>php-fpm83</literal> (il est à noter que le nom du paquet
+   et le nom du service utilisent un ordre différent pour le suffixe de version).
+   Par exemple :
+  </simpara>
+  <example xml:id="install.unix.alpine.example2">
+   <title>Activation et démarrage de PHP-FPM</title>
+   <programlisting role="shell">
+<![CDATA[
+# apk add php83-fpm
+# rc-update add php-fpm83 default
+# rc-service php-fpm83 start
+]]>
+   </programlisting>
+  </example>
+ </sect2>
+ <sect2 xml:id="install.unix.alpine.config">
+  <title>Contrôle affiné de la configuration</title>
+  <para>
+   Seules les extensions principales sont installées avec le paquet de base.
+   Des extensions supplémentaires telles que
+   <simplelist type="inline">
+    <member><link linkend="book.mysql">MySQL</link></member>
+    <member><link linkend="book.curl">cURL</link></member>
+    <member><link linkend="book.image">GD</link></member>
+    <member>etc.</member>
+   </simplelist>
+   peuvent être installées en tant que paquets séparés.
+  </para>
+  <example xml:id="install.unix.alpine.config.example">
+   <title>Recherche des paquets PHP disponibles</title>
+   <programlisting role="shell">
+<![CDATA[
+# apk search php83
+]]>
+   </programlisting>
+  </example>
+  <simpara>
+   La liste des paquets comprend la CLI, FPM et de nombreuses extensions.
+   Lorsque des extensions sont installées, leurs dépendances sont résolues
+   automatiquement.
+  </simpara>
+  <example xml:id="install.unix.alpine.config.example2">
+   <title>Installation de PHP avec MySQL et GD</title>
+   <programlisting role="shell">
+<![CDATA[
+# apk add php83-mysqli php83-gd
+]]>
+   </programlisting>
+  </example>
+  <simpara>
+   Les extensions sont automatiquement activées lors de leur installation ;
+   aucune modification manuelle de &php.ini; n'est nécessaire. Les fichiers de
+   configuration sont placés dans <filename>/etc/php83/conf.d/</filename>.
+   Après l'installation de nouvelles extensions, PHP-FPM (ou le serveur web)
+   doit être redémarré pour que les modifications prennent effet.
+  </simpara>
+ </sect2>
+</sect1>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
Closes #3401

Syncs with php/doc-en#5266 (commit 5a5899391ef91a4d42bca9495c8a1d323d38f23a).

- New `install/unix/alpine.xml`: French translation of the Alpine Linux installation guide (apk packages, PHP-FPM setup, extension management)
- `install/unix/index.xml`: adds `&install.unix.alpine;` after `&install.unix.dnf;`