### PR TITLE
[Sync-En] Add grapheme_levenshtein function documentation

### DIFF
--- a/reference/intl/grapheme/grapheme-levenshtein.xml
+++ b/reference/intl/grapheme/grapheme-levenshtein.xml
@@ -1,0 +1,220 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 469efd89e78e8d003d7222550f7cdcf4a8f417b1 Maintainer: lacatoire Status: ready -->
+<refentry xml:id="function.grapheme-levenshtein" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>grapheme_levenshtein</refname>
+  <refpurpose>Calcule la distance de Levenshtein entre deux chaînes en unités de graphèmes</refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+  <simpara>&style.procedural;</simpara>
+  <methodsynopsis>
+   <type class="union"><type>int</type><type>false</type></type><methodname>grapheme_levenshtein</methodname>
+   <methodparam><type>string</type><parameter>string1</parameter></methodparam>
+   <methodparam><type>string</type><parameter>string2</parameter></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>insertion_cost</parameter><initializer>1</initializer></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>replacement_cost</parameter><initializer>1</initializer></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>deletion_cost</parameter><initializer>1</initializer></methodparam>
+   <methodparam choice="opt"><type>string</type><parameter>locale</parameter><initializer>""</initializer></methodparam>
+  </methodsynopsis>
+  <simpara>
+   La distance de Levenshtein est définie comme le nombre minimal de
+   clusters de graphèmes qui doivent être remplacés, insérés ou supprimés pour
+   transformer <parameter>string1</parameter> en <parameter>string2</parameter>.
+   La complexité de l'algorithme est <literal>O(m*n)</literal>,
+   où <literal>n</literal> et <literal>m</literal> sont les longueurs de
+   <parameter>string1</parameter> et <parameter>string2</parameter>
+   en unités de graphèmes.
+  </simpara>
+  <simpara>
+   Contrairement à <function>levenshtein</function>, qui opère sur les octets,
+   cette fonction compte les clusters de graphèmes Unicode, de sorte que les
+   formes composée et décomposée d'un même caractère (par exemple
+   <literal>U+00E9</literal> et <literal>U+0065 U+0301</literal>, représentant
+   tous deux <literal>é</literal>) sont traitées comme équivalentes et ont une
+   distance de zéro.
+  </simpara>
+  <simpara>
+   Si <parameter>insertion_cost</parameter>, <parameter>replacement_cost</parameter>
+   et/ou <parameter>deletion_cost</parameter> ne sont pas égaux à <literal>1</literal>,
+   l'algorithme s'adapte pour choisir les transformations les moins coûteuses.
+   Par exemple, si <literal>$insertion_cost + $deletion_cost &lt; $replacement_cost</literal>,
+   aucun remplacement ne sera effectué, mais des insertions et des suppressions
+   seront réalisées à la place.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>string1</parameter></term>
+     <listitem>
+      <simpara>
+       L'une des chaînes évaluées pour la distance de Levenshtein.
+       Doit être de l'UTF-8 valide.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>string2</parameter></term>
+     <listitem>
+      <simpara>
+       L'une des chaînes évaluées pour la distance de Levenshtein.
+       Doit être de l'UTF-8 valide.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>insertion_cost</parameter></term>
+     <listitem>
+      <simpara>
+       Définit le coût d'une insertion. Doit être supérieur à <literal>0</literal>.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>replacement_cost</parameter></term>
+     <listitem>
+      <simpara>
+       Définit le coût d'un remplacement. Doit être supérieur à <literal>0</literal>.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>deletion_cost</parameter></term>
+     <listitem>
+      <simpara>
+       Définit le coût d'une suppression. Doit être supérieur à <literal>0</literal>.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>locale</parameter></term>
+     <listitem>
+      &intl.param.grapheme.locale;
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Retourne la distance de Levenshtein entre les deux chaînes, mesurée en
+   unités de graphèmes, ou &false; en cas d'échec. Utilisez
+   <function>intl_get_error_message</function> pour obtenir des détails
+   sur l'échec.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simpara>
+   Lève une <exceptionname>ValueError</exceptionname> si
+   <parameter>insertion_cost</parameter>, <parameter>replacement_cost</parameter>
+   ou <parameter>deletion_cost</parameter> est inférieur ou égal à
+   <literal>0</literal>.
+  </simpara>
+  <simpara>
+   Retourne &false; et définit une erreur intl si l'une ou l'autre des
+   chaînes d'entrée n'est pas de l'UTF-8 valide, si
+   <parameter>locale</parameter> n'est pas un identifiant de locale valide,
+   ou si une erreur ICU interne se produit.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Cette fonction a été ajoutée.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Exemple avec <function>grapheme_levenshtein</function></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+
+// Forme composée (NFC) : U+00E9 LATIN SMALL LETTER E WITH ACUTE
+$e_compose = "\u{00E9}";
+
+// Forme décomposée (NFD) : U+0065 + U+0301 (e + accent aigu combinant)
+$e_decompose = "\u{0065}\u{0301}";
+
+// grapheme_levenshtein les traite comme le même cluster de graphèmes
+var_dump(grapheme_levenshtein($e_compose, $e_decompose));
+
+// levenshtein() opère sur les octets et les voit comme différents
+var_dump(levenshtein($e_compose, $e_decompose));
+
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+int(0)
+int(3)
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>levenshtein</function></member>
+    <member><function>grapheme_strlen</function></member>
+    <member><function>grapheme_substr</function></member>
+    <member><function>similar_text</function></member>
+    <member>
+     <link xlink:href="&uri.unicode.graphemes;">
+      Unicode Text Segmentation: Grapheme Cluster Boundaries
+     </link>
+    </member>
+   </simplelist>
+  </para>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
Closes #3399

Syncs with php/doc-en#5005 (commit 469efd89e78e8d003d7222550f7cdcf4a8f417b1).

- New `reference/intl/grapheme/grapheme-levenshtein.xml`: French translation of the grapheme_levenshtein function (added in PHP 8.5.0), covering description, parameters, return values, errors, changelog, example, and see-also sections.