### PR TITLE
[Sync-En] snmp: add SNMPv3 security parameter entities and expand protocol values

### DIFF
--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -2821,6 +2821,42 @@ Reportez-vous à la section sur les exemples pour plus de détails.
 </refsect1>
 '>
 
+<!-- SNMP entities -->
+
+<!ENTITY snmp.changelog.auth-protocol-sha2 '<row xmlns="http://docbook.org/ns/docbook">
+ <entry>8.1.0</entry>
+ <entry>
+  Le protocole d&#39;authentification accepte désormais <literal>"SHA256"</literal>
+  et <literal>"SHA512"</literal> lorsqu&#39;ils sont supportés par la bibliothèque Net-SNMP.
+ </entry>
+</row>'>
+
+<!ENTITY snmp.changelog.privacy-protocol-aes '<row xmlns="http://docbook.org/ns/docbook">
+ <entry>8.6.0</entry>
+ <entry>
+  Le protocole de confidentialité accepte désormais <literal>"AES192"</literal>,
+  <literal>"AES192C"</literal>, <literal>"AES256"</literal> et
+  <literal>"AES256C"</literal> lorsqu&#39;ils sont supportés par la bibliothèque Net-SNMP.
+ </entry>
+</row>'>
+
+<!ENTITY snmp.parameter.security-name '<simpara xmlns="http://docbook.org/ns/docbook">Le nom de sécurité, généralement une sorte de nom d&#39;utilisateur.</simpara>'>
+
+<!ENTITY snmp.parameter.security-level '<simpara xmlns="http://docbook.org/ns/docbook">Le niveau de sécurité : <literal>"noAuthNoPriv"</literal>,
+<literal>"authNoPriv"</literal> ou <literal>"authPriv"</literal>.</simpara>'>
+
+<!ENTITY snmp.parameter.auth-protocol '<simpara xmlns="http://docbook.org/ns/docbook">Le protocole d&#39;authentification : <literal>"MD5"</literal>, <literal>"SHA"</literal>,
+<literal>"SHA256"</literal> ou <literal>"SHA512"</literal>.</simpara>'>
+
+<!ENTITY snmp.parameter.auth-passphrase '<simpara xmlns="http://docbook.org/ns/docbook">La phrase secrète d&#39;authentification.</simpara>'>
+
+<!ENTITY snmp.parameter.privacy-protocol '<simpara xmlns="http://docbook.org/ns/docbook">Le protocole de confidentialité : <literal>"DES"</literal> ou <literal>"AES"</literal>,
+accepté aussi comme <literal>"AES128"</literal>. <literal>"AES192"</literal>, <literal>"AES192C"</literal>,
+<literal>"AES256"</literal> et <literal>"AES256C"</literal> sont acceptés lorsqu&#39;ils sont supportés par la
+bibliothèque Net-SNMP.</simpara>'>
+
+<!ENTITY snmp.parameter.privacy-passphrase '<simpara xmlns="http://docbook.org/ns/docbook">La phrase secrète de confidentialité.</simpara>'>
+
  <!-- Eio -->
 <!ENTITY eio.callback.proto '<para xmlns="http://docbook.org/ns/docbook">
 La fonction de rappel <parameter xmlns="http://docbook.org/ns/docbook">callback</parameter>

--- a/reference/snmp/functions/snmp3-get.xml
+++ b/reference/snmp/functions/snmp3-get.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: dd22c782164c9f8d79f5de8991876d1588a21015 Maintainer: lacatoire Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 1ab1069cdd60b4ec4c18c0832924e20109159902 Maintainer: lacatoire Status: ready -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.snmp3-get">
  <refnamediv>
   <refname>snmp3_get</refname>
@@ -43,49 +42,37 @@
    <varlistentry>
     <term><parameter>security_name</parameter></term>
     <listitem>
-     <simpara>
-      Le nom de la sécurité, habituellement, le nom d'utilisateur.
-     </simpara>
+     &snmp.parameter.security-name;
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>security_level</parameter></term>
     <listitem>
-     <simpara>
-      Le niveau de sécurité (noAuthNoPriv|authNoPriv|authPriv).
-     </simpara>
+     &snmp.parameter.security-level;
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>auth_protocol</parameter></term>
     <listitem>
-     <simpara>
-      Le protocole d'authentification (MD5 or SHA)
-     </simpara>
+     &snmp.parameter.auth-protocol;
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>auth_passphrase</parameter></term>
     <listitem>
-     <simpara>
-      La phrase secrète d'authentification.
-     </simpara>
+     &snmp.parameter.auth-passphrase;
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>privacy_protocol</parameter></term>
     <listitem>
-     <simpara>
-      Le protocole de confidentialité (<literal>"DES"</literal> ou <literal>"AES"</literal>).
-     </simpara>
+     &snmp.parameter.privacy-protocol;
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>privacy_passphrase</parameter></term>
     <listitem>
-     <simpara>
-      La phrase secrète de confidentialité.
-     </simpara>
+     &snmp.parameter.privacy-passphrase;
     </listitem>
    </varlistentry>
    <varlistentry>
@@ -134,6 +121,7 @@
      </row>
     </thead>
     <tbody>
+     &snmp.changelog.privacy-protocol-aes;
      <row>
       <entry>8.5.0</entry>
       <entry>
@@ -144,14 +132,7 @@
        trop grandes.
       </entry>
      </row>
-     <row>
-      <entry>8.1.0</entry>
-      <entry>
-       Le paramètre <parameter>auth_protocol</parameter> accepte désormais
-       <literal>"SHA256"</literal> et <literal>"SHA512"</literal>
-       lorsqu'il est supporté par libnetsnmp.
-      </entry>
-     </row>
+     &snmp.changelog.auth-protocol-sha2;
     </tbody>
    </tgroup>
   </informaltable>

--- a/reference/snmp/functions/snmp3-getnext.xml
+++ b/reference/snmp/functions/snmp3-getnext.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 40906725410aac6fe8cac4913a557a1784bf04b9 Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 1ab1069cdd60b4ec4c18c0832924e20109159902 Maintainer: lacatoire Status: ready -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.snmp3-getnext">
  <refnamediv>
   <refname>snmp3_getnext</refname>
@@ -44,49 +43,37 @@
    <varlistentry>
     <term><parameter>security_name</parameter></term>
     <listitem>
-     <simpara>
-      Le nom de la sécurité, habituellement, le nom d'utilisateur.
-     </simpara>
+     &snmp.parameter.security-name;
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>security_level</parameter></term>
     <listitem>
-     <simpara>
-      Le degré de sécurité (noAuthNoPriv|authNoPriv|authPriv).
-     </simpara>
+     &snmp.parameter.security-level;
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>auth_protocol</parameter></term>
     <listitem>
-     <simpara>
-      Le protocole d'authentification (MD5 ou SHA).
-     </simpara>
+     &snmp.parameter.auth-protocol;
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>auth_passphrase</parameter></term>
     <listitem>
-     <simpara>
-      La phrase secrète d'authentification.
-     </simpara>
+     &snmp.parameter.auth-passphrase;
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>privacy_protocol</parameter></term>
     <listitem>
-     <simpara>
-      Le protocole de confidentialité (DES ou AES).
-     </simpara>
+     &snmp.parameter.privacy-protocol;
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>privacy_passphrase</parameter></term>
     <listitem>
-     <simpara>
-      La phrase secrète privée.
-     </simpara>
+     &snmp.parameter.privacy-passphrase;
     </listitem>
    </varlistentry>
    <varlistentry>
@@ -137,14 +124,8 @@
      </row>
     </thead>
     <tbody>
-     <row>
-      <entry>8.1.0</entry>
-      <entry>
-       Le paramètre <parameter>auth_protocol</parameter> accepte désormais
-       <literal>"SHA256"</literal> et <literal>"SHA512"</literal>
-       lorsqu'il est supporté par libnetsnmp.
-      </entry>
-     </row>
+     &snmp.changelog.privacy-protocol-aes;
+     &snmp.changelog.auth-protocol-sha2;
     </tbody>
    </tgroup>
   </informaltable>

--- a/reference/snmp/functions/snmp3-real-walk.xml
+++ b/reference/snmp/functions/snmp3-real-walk.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 40906725410aac6fe8cac4913a557a1784bf04b9 Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 1ab1069cdd60b4ec4c18c0832924e20109159902 Maintainer: lacatoire Status: ready -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.snmp3-real-walk">
  <refnamediv>
   <refname>snmp3_real_walk</refname>
@@ -47,50 +46,37 @@
    <varlistentry>
     <term><parameter>security_name</parameter></term>
     <listitem>
-     <simpara>
-      Le nom de la sécurité, habituellement, le nom d'utilisateur.
-     </simpara>
+     &snmp.parameter.security-name;
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>security_level</parameter></term>
     <listitem>
-     <simpara>
-      Le niveau de sécurité (noAuthNoPriv|authNoPriv|authPriv).
-     </simpara>
+     &snmp.parameter.security-level;
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>auth_protocol</parameter></term>
     <listitem>
-     <simpara>
-      Le protocole d'authentification (MD5 ou SHA).
-     </simpara>
+     &snmp.parameter.auth-protocol;
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>auth_passphrase</parameter></term>
     <listitem>
-     <simpara>
-      La phrase secrète d'authentification.
-     </simpara>
+     &snmp.parameter.auth-passphrase;
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>privacy_protocol</parameter></term>
     <listitem>
-     <simpara>
-      Le protocole d'authentification (<literal>"MD5"</literal>, <literal>"SHA"</literal>,
-      <literal>"SHA256"</literal> ou <literal>"SHA512"</literal>).
-     </simpara>
+     &snmp.parameter.privacy-protocol;
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>privacy_passphrase</parameter></term>
     <listitem>
-     <simpara>
-      La phrase secrète privée.
-     </simpara>
+     &snmp.parameter.privacy-passphrase;
     </listitem>
    </varlistentry>
    <varlistentry>
@@ -141,14 +127,8 @@
      </row>
     </thead>
     <tbody>
-     <row>
-      <entry>8.1.0</entry>
-      <entry>
-       Le paramètre <parameter>auth_protocol</parameter> accepte désormais
-       <literal>"SHA256"</literal> et <literal>"SHA512"</literal>
-       lorsqu'il est supporté par libnetsnmp.
-      </entry>
-     </row>
+     &snmp.changelog.privacy-protocol-aes;
+     &snmp.changelog.auth-protocol-sha2;
     </tbody>
    </tgroup>
   </informaltable>

--- a/reference/snmp/functions/snmp3-set.xml
+++ b/reference/snmp/functions/snmp3-set.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: dd22c782164c9f8d79f5de8991876d1588a21015 Maintainer: lacatoire Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 1ab1069cdd60b4ec4c18c0832924e20109159902 Maintainer: lacatoire Status: ready -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.snmp3-set">
  <refnamediv>
   <refname>snmp3_set</refname>
@@ -30,9 +29,9 @@
    le paramètre <parameter>object_id</parameter>.
   </simpara>
   <simpara>
-   Même si le niveau de sécurité n'utilise pas d'authentification
-   ou de protocole privée par mot de passe, des valeurs valides
-   doivent être spécifiées.
+   Les arguments d'authentification et de confidentialité doivent toujours être
+   passés, mais leurs valeurs sont ignorées lorsque
+   <parameter>security_level</parameter> ne les utilise pas.
   </simpara>
 
  </refsect1>
@@ -51,49 +50,37 @@
    <varlistentry>
     <term><parameter>security_name</parameter></term>
     <listitem>
-     <simpara>
-      Le nom de la sécurité, habituellement, le nom d'utilisateur.
-     </simpara>
+     &snmp.parameter.security-name;
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>security_level</parameter></term>
     <listitem>
-     <simpara>
-      Le niveau de sécurité (noAuthNoPriv|authNoPriv|authPriv).
-     </simpara>
+     &snmp.parameter.security-level;
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>auth_protocol</parameter></term>
     <listitem>
-     <simpara>
-      Le protocole d'authentification (MD5 ou SHA).
-     </simpara>
+     &snmp.parameter.auth-protocol;
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>auth_passphrase</parameter></term>
     <listitem>
-     <simpara>
-      La phrase secrète pour l'authentification.
-     </simpara>
+     &snmp.parameter.auth-passphrase;
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>privacy_protocol</parameter></term>
     <listitem>
-     <simpara>
-      Le protocole privé (DES ou AES)
-     </simpara>
+     &snmp.parameter.privacy-protocol;
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>privacy_passphrase</parameter></term>
     <listitem>
-     <simpara>
-      La phrase secrète privée.
-     </simpara>
+     &snmp.parameter.privacy-passphrase;
     </listitem>
    </varlistentry>
    <varlistentry>
@@ -164,6 +151,7 @@
      </row>
     </thead>
     <tbody>
+     &snmp.changelog.privacy-protocol-aes;
      <row>
       <entry>8.5.0</entry>
       <entry>
@@ -174,6 +162,7 @@
        trop grandes.
       </entry>
      </row>
+     &snmp.changelog.auth-protocol-sha2;
     </tbody>
    </tgroup>
   </informaltable>

--- a/reference/snmp/functions/snmp3-walk.xml
+++ b/reference/snmp/functions/snmp3-walk.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 40906725410aac6fe8cac4913a557a1784bf04b9 Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 1ab1069cdd60b4ec4c18c0832924e20109159902 Maintainer: lacatoire Status: ready -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.snmp3-walk">
  <refnamediv>
   <refname>snmp3_walk</refname>
@@ -28,8 +27,9 @@
    par le paramètre <parameter>hostname</parameter>.
   </simpara>
   <simpara>
-   Même si le niveau de sécurité n'utilise pas de protocole
-   d'authentification, des valeurs valides doivent être spécifiées.
+   Les arguments d'authentification et de confidentialité doivent toujours être
+   passés, mais leurs valeurs sont ignorées lorsque
+   <parameter>security_level</parameter> ne les utilise pas.
   </simpara>
  </refsect1>
 
@@ -47,59 +47,47 @@
    <varlistentry>
     <term><parameter>security_name</parameter></term>
     <listitem>
-     <simpara>
-      Le nom de la sécurité, habituellement, le nom de l'utilisateur.
-     </simpara>
+     &snmp.parameter.security-name;
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>security_level</parameter></term>
     <listitem>
-     <simpara>
-      Le niveau de sécurité (noAuthNoPriv|authNoPriv|authPriv).
-     </simpara>
+     &snmp.parameter.security-level;
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>auth_protocol</parameter></term>
     <listitem>
-     <simpara>
-      Le protocole d'authentification (<literal>"MD5"</literal>, <literal>"SHA"</literal>,
-      <literal>"SHA256"</literal> ou <literal>"SHA512"</literal>).
-     </simpara>
+     &snmp.parameter.auth-protocol;
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>auth_passphrase</parameter></term>
     <listitem>
-     <simpara>
-      La phrase secrète d'authentification.
-     </simpara>
+     &snmp.parameter.auth-passphrase;
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>privacy_protocol</parameter></term>
     <listitem>
-     <simpara>
-      Le protocole privé (DES ou AES).
-     </simpara>
+     &snmp.parameter.privacy-protocol;
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>privacy_passphrase</parameter></term>
     <listitem>
-     <simpara>
-      La phrase secrète privée.
-     </simpara>
+     &snmp.parameter.privacy-passphrase;
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>object_id</parameter></term>
     <listitem>
      <simpara>
-      Si vaut &null;, <parameter>object_id</parameter> sera la racine
-      de l'arbre des objets <acronym>SNMP</acronym> et tous les
-      objets sous-jacents sont retournés sous forme d'un tableau.
+      Si la chaîne est vide, <parameter>object_id</parameter> sera
+      <literal>.1.3.6.1.2.1</literal>, la racine de l'arbre des objets
+      <acronym>SNMP</acronym>, et tous les objets sous-jacents sont
+      retournés sous forme d'un tableau.
      </simpara>
      <simpara>
       Si <parameter>object_id</parameter> est spécifié,
@@ -148,14 +136,8 @@
      </row>
     </thead>
     <tbody>
-     <row>
-      <entry>8.1.0</entry>
-      <entry>
-       Le paramètre <parameter>auth_protocol</parameter> accepte désormais
-       <literal>"SHA256"</literal> et <literal>"SHA512"</literal>
-       lorsqu'il est supporté par libnetsnmp.
-      </entry>
-     </row>
+     &snmp.changelog.privacy-protocol-aes;
+     &snmp.changelog.auth-protocol-sha2;
     </tbody>
    </tgroup>
   </informaltable>

--- a/reference/snmp/snmp/construct.xml
+++ b/reference/snmp/snmp/construct.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 40906725410aac6fe8cac4913a557a1784bf04b9 Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 1ab1069cdd60b4ec4c18c0832924e20109159902 Maintainer: lacatoire Status: ready -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="snmp.construct">
  <refnamediv>
   <refname>SNMP::__construct</refname>
@@ -70,9 +69,10 @@
     <term><parameter>community</parameter></term>
     <listitem>
      <simpara>
-      Spécifie le niveau de sécurité pour la <parameter>version</parameter> donnée.
-      L'objectif de la chaîne d'accès <parameter>community</parameter> est spécifique
-      à la version de <acronym>SNMP</acronym> :
+      La chaîne de communauté ou, pour <constant>SNMP::VERSION_3</constant>, le
+      nom de sécurité. L'objectif de la chaîne d'accès
+      <parameter>community</parameter> est spécifique à la version de
+      <acronym>SNMP</acronym> :
      </simpara>
      <informaltable>
       <tgroup cols="2">
@@ -100,10 +100,7 @@
           <constant>SNMP::VERSION_3</constant>
          </entry>
          <entry>
-          Nom de sécurité <acronym>SNMP</acronym>v3, peut être l'un des suivants :
-          <literal>noAuthNoPriv</literal>,
-          <literal>authNoPriv</literal> (un mot de passe d'authentification et un protocole d'authentification sont requis), ou
-          <literal>authPriv</literal> (un mot de passe et un protocole d'authentification, ainsi qu'un mot de passe et un protocole de confidentialité sont requis)
+          &snmp.parameter.security-name;
          </entry>
         </row>
        </tbody>

--- a/reference/snmp/snmp/setsecurity.xml
+++ b/reference/snmp/snmp/setsecurity.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 40906725410aac6fe8cac4913a557a1784bf04b9 Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 1ab1069cdd60b4ec4c18c0832924e20109159902 Maintainer: lacatoire Status: ready -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="snmp.setsecurity">
  <refnamediv>
   <refname>SNMP::setSecurity</refname>
@@ -31,41 +30,31 @@
    <varlistentry>
     <term><parameter>securityLevel</parameter></term>
     <listitem>
-     <simpara>
-      le niveau de sécurité (noAuthNoPriv|authNoPriv|authPriv)
-     </simpara>
+     &snmp.parameter.security-level;
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>authProtocol</parameter></term>
     <listitem>
-     <simpara>
-      le protocole d'authentification (MD5 ou SHA)
-     </simpara>
+     &snmp.parameter.auth-protocol;
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>authPassphrase</parameter></term>
     <listitem>
-     <simpara>
-      la passphrase pour l'authentification
-     </simpara>
+     &snmp.parameter.auth-passphrase;
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>privacyProtocol</parameter></term>
     <listitem>
-     <simpara>
-      le protocole de confidentialité (DES ou AES)
-     </simpara>
+     &snmp.parameter.privacy-protocol;
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>privacyPassphrase</parameter></term>
     <listitem>
-     <simpara>
-      la phrase secrète de confidentialité
-     </simpara>
+     &snmp.parameter.privacy-passphrase;
     </listitem>
    </varlistentry>
    <varlistentry>
@@ -92,6 +81,24 @@
   <simpara>
    &return.success;
   </simpara>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     &snmp.changelog.privacy-protocol-aes;
+     &snmp.changelog.auth-protocol-sha2;
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">


### PR DESCRIPTION
Closes #3407

Syncs with php/doc-en#5228 (commit 1ab1069cdd60b4ec4c18c0832924e20109159902).

- `language-snippets.ent`: add 7 shared entities (`snmp.parameter.security-name/level/auth-protocol/auth-passphrase/privacy-protocol/privacy-passphrase` and changelog rows for 8.1.0/8.6.0)
- `snmp3-get`, `snmp3-getnext`, `snmp3-real-walk`, `snmp3-set`, `snmp3-walk`: replace inline parameter descriptions with entities; replace inline 8.1.0 changelog row with entity; add 8.6.0 AES256 changelog row
- `snmp3-set`, `snmp3-walk`: update "even if security level does not use auth" wording to match EN
- `snmp3-walk`: update `object_id` null description to match EN (empty string → `.1.3.6.1.2.1`)
- `snmp/construct.xml`: update `community` description; replace VERSION_3 inline text with entity
- `snmp/setsecurity.xml`: replace inline parameter descriptions with entities; add missing changelog section