### PR TITLE
[Sync-En] sqlite3: add enableExtendedResultCodes and lastExtendedErrorCode

### DIFF
--- a/reference/sqlite3/sqlite3.xml
+++ b/reference/sqlite3/sqlite3.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 6a2ad3ecf9b77855446019ed2d74aa6f734d35a8 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 32916e1adeb2b92179db162f422c63a69d9c9036 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <reference xml:id="class.sqlite3" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>&class.theclass; <classname>SQLite3</classname></title>
@@ -263,21 +263,31 @@
     <varlistentry xml:id="sqlite3.constants.ok">
      <term><constant>SQLite3::OK</constant></term>
      <listitem>
-      <para/>
+      <simpara>
+       Retourné depuis un callback d'autorisation pour autoriser l'action.
+      </simpara>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="sqlite3.constants.deny">
      <term><constant>SQLite3::DENY</constant></term>
      <listitem>
-      <para/>
+      <simpara>
+       Retourné depuis un callback d'autorisation pour rejeter l'intégralité
+       de l'instruction SQL avec une erreur.
+      </simpara>
      </listitem>
     </varlistentry>
 
     <varlistentry xml:id="sqlite3.constants.ignore">
      <term><constant>SQLite3::IGNORE</constant></term>
      <listitem>
-      <para/>
+      <simpara>
+       Retourné depuis un callback d'autorisation pour interdire l'action
+       spécifique tout en permettant à l'instruction SQL d'être compilée.
+       Voir <methodname>SQLite3::setAuthorizer</methodname> pour l'effet sur
+       chaque action.
+      </simpara>
      </listitem>
     </varlistentry>
 

--- a/reference/sqlite3/sqlite3/enableextendedresultcodes.xml
+++ b/reference/sqlite3/sqlite3/enableextendedresultcodes.xml
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 32916e1adeb2b92179db162f422c63a69d9c9036 Maintainer: lacatoire Status: ready -->
+<refentry xml:id="sqlite3.enableextendedresultcodes" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>SQLite3::enableExtendedResultCodes</refname>
+  <refpurpose>
+   Active ou désactive l'utilisation des codes de résultat étendus
+  </refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="SQLite3">
+   <modifier>public</modifier> <type>bool</type><methodname>SQLite3::enableExtendedResultCodes</methodname>
+   <methodparam choice="opt"><type>bool</type><parameter>enable</parameter><initializer>&true;</initializer></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Active ou désactive l'utilisation des codes de résultat étendus, qui sont
+   ensuite rapportés par <methodname>SQLite3::lastErrorCode</methodname>.
+   <methodname>SQLite3::lastExtendedErrorCode</methodname> n'est pas affecté par
+   ce réglage et retourne toujours le code de résultat étendu.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>enable</parameter></term>
+    <listitem>
+     <simpara>
+      Si l'utilisation des codes de résultat étendus doit être activée
+      (&true;) ou désactivée (&false;).
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   &return.success;
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Exemple avec <methodname>SQLite3::enableExtendedResultCodes</methodname></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$db = new SQLite3(':memory:');
+$db->enableExceptions(true);
+$db->exec('CREATE TABLE t (a INTEGER UNIQUE)');
+$db->exec('INSERT INTO t VALUES (1)');
+
+try {
+    $db->exec('INSERT INTO t VALUES (1)');
+} catch (Exception $e) {
+}
+
+// Le code de résultat primaire (SQLITE_CONSTRAINT), puis le code de résultat
+// étendu (SQLITE_CONSTRAINT_UNIQUE).
+var_dump($db->lastErrorCode(), $db->lastExtendedErrorCode());
+
+// Une fois activé, SQLite3::lastErrorCode() rapporte également le code de
+// résultat étendu.
+$db->enableExtendedResultCodes();
+var_dump($db->lastErrorCode());
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+int(19)
+int(2067)
+int(2067)
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>SQLite3::lastExtendedErrorCode</methodname></member>
+   <member><methodname>SQLite3::lastErrorCode</methodname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/sqlite3/sqlite3/lastextendederrorcode.xml
+++ b/reference/sqlite3/sqlite3/lastextendederrorcode.xml
@@ -1,22 +1,26 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: 32916e1adeb2b92179db162f422c63a69d9c9036 Maintainer: lacatoire Status: ready -->
-<refentry xml:id="sqlite3.lasterrorcode" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+<refentry xml:id="sqlite3.lastextendederrorcode" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
-  <refname>SQLite3::lastErrorCode</refname>
+  <refname>SQLite3::lastExtendedErrorCode</refname>
   <refpurpose>
-   Retourne le code erreur de la dernière requête SQL ayant échoué
+   Retourne le code de résultat étendu numérique de la dernière requête SQLite échouée
   </refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis role="SQLite3">
-   <modifier>public</modifier> <type>int</type><methodname>SQLite3::lastErrorCode</methodname>
+   <modifier>public</modifier> <type>int</type><methodname>SQLite3::lastExtendedErrorCode</methodname>
    <void/>
   </methodsynopsis>
-  <para>
-   Retourne le code erreur de la dernière requête SQL ayant échoué.
-  </para>
+  <simpara>
+   Retourne le code de résultat étendu numérique de la dernière requête SQLite
+   échouée. Contrairement à <methodname>SQLite3::lastErrorCode</methodname>,
+   cette méthode retourne toujours le code de résultat étendu, que les codes
+   de résultat étendus aient été activés ou non avec
+   <methodname>SQLite3::enableExtendedResultCodes</methodname>.
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -26,17 +30,17 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
-   Retourne un entier représentant le code erreur de la dernière requête ayant
-   échoué.
-  </para>
+  <simpara>
+   Retourne un entier représentant le code de résultat étendu numérique de la
+   dernière requête SQLite échouée.
+  </simpara>
  </refsect1>
 
  <refsect1 role="seealso">
   &reftitle.seealso;
   <simplelist>
-   <member><methodname>SQLite3::lastExtendedErrorCode</methodname></member>
    <member><methodname>SQLite3::enableExtendedResultCodes</methodname></member>
+   <member><methodname>SQLite3::lastErrorCode</methodname></member>
    <member><methodname>SQLite3::lastErrorMsg</methodname></member>
   </simplelist>
  </refsect1>


### PR DESCRIPTION
Closes #3405

Syncs with php/doc-en#5659 (commit 32916e1adeb2b92179db162f422c63a69d9c9036).

- New `sqlite3/enableextendedresultcodes.xml`: French translation of `SQLite3::enableExtendedResultCodes` (PHP 7.4+)
- New `sqlite3/lastextendederrorcode.xml`: French translation of `SQLite3::lastExtendedErrorCode` (PHP 7.4+)
- `sqlite3/lasterrorcode.xml`: add seealso section referencing the two new methods
- `sqlite3/sqlite3.xml`: add descriptions for `SQLite3::OK`, `SQLite3::DENY`, and `SQLite3::IGNORE` constants
- `sqlite3/versions.xml`: add new functions and fix `lastInsertRowID` casing