### PR TITLE
[Sync-En] Update PCRE extension to PCRE2 references

### DIFF
--- a/reference/pcre/book.xml
+++ b/reference/pcre/book.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: c1f37a6c270aadbbb3da56a3973ffd62197adf2b Maintainer: yannick Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: b55141fe2d4f601e32555c33fb00e1f9225c4638 Maintainer: lacatoire Status: ready -->
 
 <book xml:id="book.pcre" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" annotations="interactive">
  <?phpdoc extension-membership="core" ?>
@@ -9,43 +8,36 @@
 
  <preface xml:id="intro.pcre">
   &reftitle.intro;
-  <para>
-   La syntaxe des masques utilisés dans ces fonctions ressemble
-   fort à celle de Perl. Les expressions seront entourées
-   de délimiteurs, slash (/), par exemple. Un délimiteur peut
-   être n'importe quel caractère, tant qu'il
-   n'est pas alphanumérique, un caractère blanc, 
-   l'antislash (&#92;) ou le caractère nul (\0).
-   Si un délimiteur doit être utilisé dans
-   l'expression, il faudra le protéger avec un antislash.
-   Les délimiteurs à la Perl (), {}, [], et &lt;&gt; peuvent aussi être utilisés.
+  <simpara>
+   Cette extension intègre la prise en charge des expressions régulières dans
+   PHP. Elle est basée sur la bibliothèque libre et open-source
+   <link xlink:href="&url.pcre2.website;">PCRE2</link>.
+   Cette bibliothèque implémente la correspondance de motifs d'expressions
+   régulières en utilisant une syntaxe et des sémantiques compatibles avec
+   Perl, avec quelques
+   <link xlink:href="&url.pcre2.perlcompat;">différences documentées</link>.
    Voir la <link linkend="reference.pcre.pattern.syntax">syntaxe des masques</link>
-   pour plus d'explications.
-  </para>
-  <para>
-   Le délimiteur final peut être suivi d'options qui
-   affecteront la recherche. Voir aussi
-   <link linkend="reference.pcre.pattern.modifiers">options de recherche</link>.
-  </para>
+   et les <link linkend="reference.pcre.pattern.modifiers">options de recherche</link>
+   pour une explication détaillée.
+  </simpara>
+  <simpara>
+   Pour améliorer les performances, l'extension met en cache les expressions
+   régulières compilées. Chaque thread possède son propre cache dédié,
+   capable de contenir jusqu'à 4096 expressions.
+  </simpara>
   <note>
-   <para>
-    Cette extension maintient un cache global par thread des expressions
-    régulières compilées (jusqu'à 4096).
-   </para>
+   <simpara>
+    Lorsque le cache est plein, un lot des entrées les plus anciennes
+    non utilisées est supprimé pour faire de la place pour de nouvelles.
+    La taille du cache n'est pas configurable.
+   </simpara>
   </note>
   <warning>
-   <para>
-    Il faut être conscient des limitations de PCRE.
-    Consulter <link xlink:href="&url.pcre.man;">&url.pcre.man;</link> pour plus de détails.
-   </para>
+   <simpara>
+    PCRE2 impose des <link xlink:href="&url.pcre2.limits;">limites de taille
+    et autres</link> qui peuvent être pertinentes dans certains cas.
+   </simpara>
   </warning>
-  <!-- FIXME: Check what Perl version implementation corresponds -->
-  <para>
-   La bibliothèque PCRE est un ensemble de fonctions qui implémentent les
-   expressions régulières en utilisant la même syntaxe et sémantique
-   que Perl 5 avec seulement quelques différences (voir plus bas). L'implémentation
-   courante correspond à Perl 5.005.
-  </para>
  </preface>
 
  &reference.pcre.setup;

--- a/reference/pcre/configure.xml
+++ b/reference/pcre/configure.xml
@@ -1,38 +1,37 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 62a00eed7c748c2331eb5744c7a48af8582a2046 Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: b55141fe2d4f601e32555c33fb00e1f9225c4638 Maintainer: lacatoire Status: ready -->
 
 <section xml:id="pcre.installation" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.install;
- <para>
-  L'extension PCRE est une extension native de PHP, elle est donc toujours
-  activée. Par défaut, cette extension est compilée en utilisant la
-  bibliothèque PCRE empaquetée. Optionnellement, il est possible d'utiliser une
-  bibliothèque PCRE externe en passant l'option de configuration
-  <option role="configure">--with-pcre-regex=DIR</option> où
-  <literal>DIR</literal> est l'emplacement des fichiers de la bibliothèque PCRE.
-  Il est recommandé d'utiliser PCRE 8.10 ou plus récent ;
-  à partir de PHP 7.3.0, PCRE2 est requis.
- </para>
- <para>
-  La compilation à la volée (Just In Time) de PCRE est supportée par défaut,
-  et peut être désactivée avec l'option de configuration
-  <option role="configure">--without-pcre-jit</option> à partir de PHP 7.0.12.
- </para>
+ <simpara>
+  L'extension PCRE est une extension native de PHP et est toujours activée.
+ </simpara>
+ <simpara>
+  Par défaut, l'extension utilise une version embarquée de la bibliothèque PCRE2.
+  Sur les systèmes non-Windows, une bibliothèque PCRE2 externe peut être utilisée
+  à la place avec l'option de configuration
+  <option role="configure">--with-external-pcre</option>. La version minimale
+  supportée est la 10.30. Les versions Windows utilisent toujours la bibliothèque
+  embarquée.
+ </simpara>
+ <simpara>
+  La compilation à la volée (Just In Time) de PCRE2 est activée par défaut.
+  Elle peut être désactivée avec l'option de configuration
+  <option role="configure">--without-pcre-jit</option>.
+ </simpara>
  &windows.builtin;
- <para>
-  PCRE est un projet actif et au fur et à mesure où il change, les
+ <simpara>
+  PCRE2 est un projet actif et au fur et à mesure où il change, les
   fonctionnalités PHP changent également. Il est possible que certaines
-  parties du manuel PHP soient obsolètes et qu'elles ne couvrent pas
-  les nouvelles fonctionnalités que fournit PCRE. Pour une liste des
-  modifications, se reporter au
-  <link xlink:href="&url.pcre.changelog;">changelog de la bibliothèque PCRE</link>
-  ainsi qu'à l'historique suivant de la version PCRE incluse dans PHP :
- </para>
+  parties du manuel PHP soient obsolètes. Pour une liste des modifications,
+  se reporter au
+  <link xlink:href="&url.pcre2.changelog;">changelog de la bibliothèque PCRE2</link>.
+  L'historique des mises à jour de la bibliothèque embarquée est listé
+  ci-dessous :
+ </simpara>
  <para>
   <table>
-   <title>Historique des mises à jour de la bibliothèque PCRE incluse dans PHP</title>
+   <title>Historique des mises à jour de la bibliothèque PCRE embarquée dans PHP</title>
    <tgroup cols="3">
     <thead>
      <row>
@@ -43,13 +42,28 @@
     </thead>
     <tbody>
      <row>
+      <entry>8.4.0</entry>
+      <entry>10.44</entry>
+      <entry></entry>
+     </row>
+     <row>
+      <entry>8.3.0</entry>
+      <entry>10.42</entry>
+      <entry></entry>
+     </row>
+     <row>
       <entry>8.2.0</entry>
       <entry>10.40</entry>
       <entry></entry>
      </row>
      <row>
-      <entry>8.1.0</entry>
+      <entry>8.1.1</entry>
       <entry>10.39</entry>
+      <entry></entry>
+     </row>
+     <row>
+      <entry>8.1.0</entry>
+      <entry>10.37</entry>
       <entry></entry>
      </row>
      <row>

--- a/reference/pcre/pattern.differences.xml
+++ b/reference/pcre/pattern.differences.xml
@@ -1,145 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 96c9d88bad9a7d7d44bfb7f26c226df7ee9ddf26 Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
-
-<article xml:id="reference.pcre.pattern.differences" xmlns="http://docbook.org/ns/docbook">
+<!-- EN-Revision: b55141fe2d4f601e32555c33fb00e1f9225c4638 Maintainer: lacatoire Status: ready -->
+<!-- splitted from ./en/functions/pcre.xml, last change in rev 1.2 -->
+<article xml:id="reference.pcre.pattern.differences" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Différences avec Perl</title>
  <titleabbrev>Différences avec Perl</titleabbrev>
- <para>
-  Les différences avec Perl 5.005 sont présentées ici :
-  <orderedlist>
-   <listitem>
-    <simpara>
-     Par défaut, un caractère d'espacement correspond à
-     n'importe quel caractère que la fonction C <literal>isspace()</literal> reconnaît,
-     bien qu'il soit possible de recompiler la bibliothèque PCRE avec
-     d'autres tables de caractères. Normalement, <literal>isspace()</literal> retourne
-     &true; pour les espaces, les retours chariot, les
-     nouvelles lignes, les formfeed, les tabulations verticales et horizontales.
-     Perl 5 n'accepte plus la tabulation verticale comme caractère
-     d'espacement. La séquence \v qui était dans la documentation
-     Perl depuis longtemps n'a jamais été reconnue. Cependant, la
-     tabulation verticale elle-même était reconnue comme un
-     caractère d'espacement jusqu'à la version 5.002. Avec les
-     versions 5.004 et 5.005, l'option \s l'ignore.
-    </simpara>
-   </listitem>
-   <listitem>
-    <simpara>
-     PCRE ne tolère pas la répétition de quantificateurs
-     dans les expressions. Perl le permet, mais cela ne signifie pas ce qu'il serait possible de
-      penser. Par exemple, (?!a){3} ne s'interprète pas : les trois
-     caractères suivants ne sont pas des "a". En fait, cela
-     s'interprète comme : le caractère suivant n'est pas "a" trois fois.
-    </simpara>
-   </listitem>
-   <listitem>
-    <simpara>
-     Les occurrences de sous-masques qui interviennent dans des assertions
-     négatives sont comptées, mais elles ne sont pas
-     enregistrées dans le vecteur d'occurrences. Perl modifie ses
-     variables numériques pour toutes les occurrences de sous-masque,
-     avant que l'assertion ne vérifie le masque entier, et uniquement si
-     les sous-masques ne trouvent qu'une seule occurrence.
-    </simpara>
-   </listitem>
-   <listitem>
-    <simpara>
-     Bien que les caractères nul soient tolérés dans la
-     chaîne de recherche, ils ne sont pas acceptés dans le
-     masque, car le masque est utilisé comme une chaîne C
-     standard, terminée par le caractère nul. Il faut donc
-     utiliser la séquence d'échappement "\x00" dans le masque
-     pour rechercher les caractères nul.
-    </simpara>
-    </listitem>
-    <listitem>
-    <simpara>
-     Les séquences d'échappement suivantes ne sont pas
-     supportées par Perl : \l, \u, \L, \U.
-     En fait, elles sont implémentées par la gestion
-     intrinsèque de chaînes Perl, et ne font pas partie
-     de ses caractères spéciaux.
-    </simpara>
-    </listitem>
-    <listitem>
-    <simpara>
-     L'assertion \G du Perl n'est pas supportée car elle n'est pas
-     pertinente pour faire des recherches avec des masques uniques.
-    </simpara>
-    </listitem>
-    <listitem>
-    <simpara>
-     De manière assez évidente, PCRE n'accepte pas la
-     construction <literal>(?{code})</literal> et <literal>(??{code})</literal>.
-     Cependant, les masques récursifs sont supportés.
-    </simpara>
-    </listitem>
-    <listitem>
-    <simpara>
-     Au moment de l'écriture de PCRE, Perl 5.005_02 avait quelques
-     comportements étranges avec la capture des chaînes
-     lorsqu'une partie du masque est redoublée. Par exemple, "aba" avec
-     le masque /^(a(b)?)+$/ va affecter à $2 la valeur "b", mais la
-     même manipulation avec "aabbaa" et /^(aa(bb)?)+$/ laissera $2 vide.
-     Cependant, si le masque est remplacé par /^(aa(b(b))?)+$/ alors $2
-     (et d'ailleurs $3) seront correctement affectés. Avec le Perl
-     5.004, $2 sera correctement affecté dans les deux cas, et c'est
-     aussi vrai avec PCRE. Si Perl évolue vers un autre comportement
-     cohérent, PCRE s'adaptera probablement.
-    </simpara>
-    </listitem>
-    <listitem>
-    <simpara>
-     Une autre différence encore non résolue est le fait qu'en
-     Perl 5.005_02 le masque /^(a)?(?(1)a|b)+$/ accepte la chaîne "a",
-     tandis que PCRE ne l'accepte pas. Cependant, que ce soit avec Perl ou
-     PCRE /^(a)?a/ et "a" laisseront $1 vide.
-    </simpara>
-    </listitem>
-    <listitem>
-    <para>
-     PCRE propose quelques extensions aux expressions régulières du Perl.
-      <orderedlist>
-       <listitem>
-        <simpara>
-         (a) Bien que les assertions arrières (<literal>lookbehind</literal>) soient obligées
-         de rechercher une chaîne de longueur fixe, toutes les assertions
-         arrières peuvent avoir une longueur différente. Perl 5.005 leur
-         impose d'avoir toutes la même longueur.
-       </simpara>
-      </listitem>
-      <listitem>
-       <simpara>
-        (b) Si <link linkend="reference.pcre.pattern.modifiers">PCRE_DOLLAR_ENDONLY</link> est
-        activé, et que <link linkend="reference.pcre.pattern.modifiers">PCRE_MULTILINE</link>
-        ne l'est pas, le métacaractère <literal>$</literal> ne s'applique qu'à
-        la fin physique de la chaîne, et non pas avant les caractères
-        de nouvelle ligne.
-       </simpara>
-      </listitem>
-      <listitem>
-       <simpara>
-        (c) Si <link linkend="reference.pcre.pattern.modifiers">PCRE_EXTRA</link> est
-        activé, un antislash suivi d'une lettre sans signification
-        spéciale est considéré comme une erreur.
-       </simpara>
-      </listitem>
-      <listitem>
-       <simpara>
-        (d) Si <link linkend="reference.pcre.pattern.modifiers">PCRE_UNGREEDY</link> est
-        activé, la "gourmandise" des quantificateurs de
-        répétition est inversée, ce qui les rend non
-        gourmand par défaut, mais s'ils sont suivis de ?, ils seront
-        gourmands.
-       </simpara>
-      </listitem>
-     </orderedlist>
-    </para>
-   </listitem>
-  </orderedlist>
- </para>
+ <simpara>
+  Perl et PCRE2 évoluent continuellement, de sorte que l'ensemble exact des
+  différences dépend de la version de la bibliothèque PCRE2 utilisée. Se
+  reporter à la
+  <link xlink:href="&url.pcre2.perlcompat;">documentation PCRE2 sur les
+  différences entre PCRE2 et Perl</link> pour une liste à jour.
+ </simpara>
 </article>
 
 <!-- Keep this comment at the end of the file

--- a/reference/pcre/pattern.syntax.xml
+++ b/reference/pcre/pattern.syntax.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 61d512bfd7098a177b6490e0b478c72ed6fb90d6 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: b55141fe2d4f601e32555c33fb00e1f9225c4638 Maintainer: lacatoire Status: ready -->
 
 <chapter xml:id="reference.pcre.pattern.syntax" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Syntaxe des masques</title>
@@ -32,7 +32,7 @@
   <simpara>
    Lors de l'utilisation des fonctions PCRE, il est nécessaire que le motif soit encadré
    par des <emphasis>délimiteurs</emphasis>. Un délimiteur peut être n'importe quel caractère
-   sur un seul octet non alpha-numérique autre qu'un backslash ou qu'un espace.
+   sur un seul octet non alpha-numérique autre qu'un backslash, un octet NUL ou un espace blanc.
    Les caractères d'espacement blanc avant un délimiteur valide sont silencieusement ignorés.
   </simpara>
   <note>


### PR DESCRIPTION
Closes #3398

Sync with php/doc-en PR #4875 (b55141fe2d4f601e32555c33fb00e1f9225c4638).

- `book.xml`: rewrite intro to reference PCRE2, document cache size (4096 per thread), add warning on size limits
- `configure.xml`: switch to simpara, update to PCRE2 terminology, add bundled library version history (8.1.0–8.4.0), link to PCRE2 changelog
- `pattern.differences.xml`: replace exhaustive Perl 5.005 differences list with a pointer to PCRE2 official docs
- `pattern.syntax.xml`: add non-NUL byte to valid delimiter description