### PR TITLE
[Sync-En] yac: document embedded values, LZ4, PIE install, delete semantics

### DIFF
--- a/reference/yac/book.xml
+++ b/reference/yac/book.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 1a42637cd40d0f75af1435ff051c7caa9b1c83e0 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: d3a03f8f542cd083d793bbd8ef3d7756aae7711f Maintainer: lacatoire Status: ready -->
 
 <book xml:id="book.yac" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <?phpdoc extension-membership="pecl" ?>
@@ -23,11 +23,29 @@
    ratée que l'appelant peut simplement réessayer.
   </simpara>
   <simpara>
+   Sans verrou ni communication inter-processus dans le chemin d'accès,
+   une lecture est essentiellement une recherche dans une table de hachage
+   en mémoire partagée. Yac est ainsi extrêmement rapide, avec une latence
+   de lecture à la microseconde, et son débit peut s'adapter au nombre de
+   workers tant que les écritures sont réparties sur plusieurs clés.
+  </simpara>
+  <simpara>
    Parce que Yac échange des garanties de cohérence contre vitesse et
    débit, il convient mieux aux données coûteuses à produire mais faciles à
    recréer : fragments de page, instantanés de configuration, petites
    réponses de service et autres caches locaux. Il ne doit pas être utilisé
    comme stockage faisant autorité pour des données irremplaçables.
+  </simpara>
+  <simpara>
+   Depuis yac 2.4.0, les petites valeurs scalaires —
+   <constant>NULL</constant>, booléens, entiers, courtes chaînes jusqu'à
+   7 octets et tableaux vides — sont stockées directement dans le slot de
+   la table de hachage plutôt que dans un bloc de valeur séparé
+   (« valeurs intégrées »), ce qui supprime l'allocation et la copie de
+   bloc à chaque accès et améliore significativement les performances tout
+   en réduisant l'utilisation mémoire. La version 2.4.0 a également
+   remplacé le moteur de compression FastLZ par LZ4, rendant les lectures
+   compressées plusieurs fois plus rapides.
   </simpara>
   <note>
    <simpara>

--- a/reference/yac/setup.xml
+++ b/reference/yac/setup.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 1a42637cd40d0f75af1435ff051c7caa9b1c83e0 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: d3a03f8f542cd083d793bbd8ef3d7756aae7711f Maintainer: lacatoire Status: ready -->
 
 <chapter xml:id="yac.setup" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.setup;
@@ -15,6 +15,10 @@
  <section xml:id="yac.installation">
   &reftitle.install;
   <simpara>
+   Yac peut être installé de trois façons : via PECL, via PIE ou en
+   compilant depuis les sources.
+  </simpara>
+  <simpara>
    &pecl.moved;
   </simpara>
   <simpara>
@@ -24,29 +28,64 @@
   <simpara>
    &pecl.windows.download.avail;
   </simpara>
-  <para>
-   Le code source est hébergé sur
-   <link xlink:href="&url.git.hub;laruence/yac">GitHub</link>. Pour compiler
-   l'extension depuis les sources :
-   <screen>
+  <example>
+   <title>Installer Yac avec PECL</title>
+   <programlisting role="shell">
 <![CDATA[
-$ git clone https://github.com/laruence/yac.git
-$ cd yac
-$ phpize
-$ ./configure
-$ make
-$ sudo make install
+pecl install yac
 ]]>
-   </screen>
-  </para>
+   </programlisting>
+  </example>
+  <simpara>
+   Depuis Yac 2.3.2, l'extension peut être installée avec
+   &link.pie;, le PHP Installer for Extensions, en exécutant la commande
+   suivante.
+  </simpara>
+  <example>
+   <title>Installer Yac avec PIE</title>
+   <programlisting role="shell">
+<![CDATA[
+pie install laruence/yac
+]]>
+   </programlisting>
+  </example>
+  <simpara>
+   Des sérialisateurs optionnels peuvent être activés à l'installation :
+  </simpara>
+  <example>
+   <title>Installer Yac avec PIE et un sérialisateur</title>
+   <programlisting role="shell">
+<![CDATA[
+pie install laruence/yac --enable-json
+]]>
+   </programlisting>
+  </example>
+  <simpara>
+   Le code source est hébergé sur
+   <link xlink:href="&url.git.hub;laruence/yac">GitHub</link>. Pour
+   compiler l'extension depuis les sources, exécuter les commandes
+   suivantes en remplaçant les chemins par ceux de l'installation PHP
+   locale.
+  </simpara>
+  <example>
+   <title>Compiler Yac depuis les sources</title>
+   <programlisting role="shell">
+<![CDATA[
+/chemin/vers/phpize
+./configure --with-php-config=/chemin/vers/php-config
+make && make install
+]]>
+   </programlisting>
+  </example>
   <simpara>
    Les options <literal>configure</literal> suivantes sont disponibles :
   </simpara>
   <simpara>
-   Les valeurs sont compressées avec LZ4 avant d'être stockées. Par défaut,
-   Yac utilise la copie de LZ4 fournie avec l'extension ; aucun indicateur
-   supplémentaire n'est nécessaire. Pour lier l'extension contre la
-   bibliothèque LZ4 système, utiliser le commutateur
+   Les valeurs sont compressées avec LZ4 avant d'être stockées. Le moteur
+   de compression LZ4 a été introduit dans Yac 2.4.0, remplaçant l'ancien
+   FastLZ. Par défaut, Yac utilise la copie de LZ4 fournie avec l'extension ;
+   aucun indicateur supplémentaire n'est nécessaire. Pour lier l'extension
+   contre la bibliothèque LZ4 système, utiliser le commutateur
    <option role="configure">--with-system-lz4</option>, qui nécessite que
    l'en-tête <literal>lz4.h</literal> et <literal>liblz4</literal> soient
    installés.

--- a/reference/yac/yac.xml
+++ b/reference/yac/yac.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 1a42637cd40d0f75af1435ff051c7caa9b1c83e0 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: d3a03f8f542cd083d793bbd8ef3d7756aae7711f Maintainer: lacatoire Status: ready -->
 
 <reference xml:id="class.yac" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -11,9 +11,27 @@
 <!-- {{{ Yac intro -->
   <section xml:id="yac.intro">
    &reftitle.intro;
-   <para>
-
-   </para>
+   <simpara>
+    La classe <classname>Yac</classname> est l'interface du cache. Chaque
+    instance sur le même hôte est un handle léger vers un cache partagé :
+    toutes les instances lisent et écrivent les mêmes entrées, et en créer
+    une n'alloue rien au-delà du handle lui-même.
+   </simpara>
+   <simpara>
+    Le préfixe optionnel passé à
+    <methodname>Yac::__construct</methodname> est ajouté à chaque clé, ce
+    qui permet à plusieurs instances (ou applications) de partager un même
+    cache sans collision de clés. En plus des opérations classiques de cache
+    (<methodname>Yac::add</methodname>,
+    <methodname>Yac::set</methodname>,
+    <methodname>Yac::get</methodname>,
+    <methodname>Yac::delete</methodname> et
+    <methodname>Yac::flush</methodname>), la classe fournit
+    <methodname>Yac::info</methodname> et
+    <methodname>Yac::dump</methodname> pour inspecter le cache, et surcharge
+    l'accès aux propriétés pour que lire ou écrire une propriété d'objet lise
+    ou écrive une entrée du cache.
+   </simpara>
   </section>
 <!-- }}} -->
 
@@ -54,7 +72,13 @@
     <varlistentry xml:id="yac.props.prefix">
      <term><varname>_prefix</varname></term>
      <listitem>
-      <para></para>
+      <simpara>
+       Le préfixe de clé défini via
+       <methodname>Yac::__construct</methodname>. Il est ajouté à chaque
+       clé utilisée avec l'instance ; aucun séparateur n'est inséré, il
+       faut donc en inclure un dans le préfixe si nécessaire. Le préfixe
+       ne doit pas dépasser <constant>YAC_MAX_KEY_LEN</constant> (48) octets.
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>

--- a/reference/yac/yac/delete.xml
+++ b/reference/yac/yac/delete.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 1a42637cd40d0f75af1435ff051c7caa9b1c83e0 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: d3a03f8f542cd083d793bbd8ef3d7756aae7711f Maintainer: lacatoire Status: ready -->
 
 <refentry xml:id="yac.delete" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -17,6 +17,21 @@
   <simpara>
    Supprime un ou plusieurs éléments du cache.
   </simpara>
+  <note>
+   <simpara>
+    La suppression est implémentée en marquant l'entrée comme expirée
+    plutôt qu'en vidant son slot : l'entrée cesse immédiatement d'être
+    lisible, mais le slot reste occupé jusqu'à ce que la même clé soit
+    stockée à nouveau ou qu'une écriture ultérieure le récupère. En
+    conséquence, le nombre de slots utilisés rapporté par
+    <methodname>Yac::info</methodname> ne diminue pas après une
+    suppression, et <methodname>Yac::dump</methodname> liste toujours
+    l'entrée supprimée jusqu'à ce que son slot soit recyclé ; un
+    <literal>ttl</literal> non nul dans le passé indique une entrée
+    supprimée ou expirée, il appartient donc à l'appelant de les
+    filtrer dans la sortie de <methodname>Yac::dump</methodname>.
+   </simpara>
+  </note>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -49,7 +64,15 @@
   &reftitle.returnvalues;
   <simpara>
    Retourne &true; en cas de succès, ou &false; si la clé n'était pas
-   présente dans le cache.
+   présente dans le cache. Comme une suppression ne fait que marquer
+   l'entrée comme expirée, une clé supprimée mais pas encore écrasée est
+   toujours considérée comme présente : supprimer la même clé à nouveau
+   retourne &true;.
+  </simpara>
+  <simpara>
+   Quand un <type>array</type> de clés est fourni, &true; est retourné
+   uniquement si toutes les clés étaient présentes ; si une clé est
+   absente, &false; est retourné.
   </simpara>
  </refsect1>
 
@@ -63,16 +86,25 @@
 $yac = new Yac();
 $yac->set("foo", "bar");
 
-var_dump($yac->delete("foo"));            // bool(true)
-var_dump($yac->delete("foo"));            // bool(false): déjà supprimé
+var_dump($yac->delete("foo"));      // bool(true) : marquée expirée
+var_dump($yac->get("foo"));         // bool(false) : manquant désormais
+var_dump($yac->delete("foo"));      // bool(true) à nouveau : le slot n'a pas
+                                     // encore été écrasé
+var_dump($yac->delete("jamais"));   // bool(false) : jamais stockée
 
-// suppression différée : garder l'entrée lisible encore 60 secondes,
-// elle disparaît seulement après ce délai
+// une suppression ne libère pas le slot : slots_used ne diminue pas, et
+// l'entrée expirée apparaît toujours dans le dump
+var_dump($yac->info()["slots_used"]); // int(1)
+print_r($yac->dump());                // "foo" est toujours listée ; son ttl
+                                       // est dans le passé
+
+// suppression différée : garder l'entrée lisible encore 60 secondes
 $yac->set("tmp", "value");
-var_dump($yac->delete("tmp", 60));        // bool(true)
+var_dump($yac->delete("tmp", 60));    // bool(true)
 
-// supprimer plusieurs clés à la fois
-var_dump($yac->delete(array("a", "b")));
+// supprimer plusieurs clés à la fois retourne true uniquement si toutes
+// les clés étaient présentes
+var_dump($yac->delete(array("tmp", "non"))); // bool(false) : "non" absente
 ?>
 ]]>
    </programlisting>
@@ -85,6 +117,8 @@ var_dump($yac->delete(array("a", "b")));
    <simplelist>
     <member><methodname>Yac::set</methodname></member>
     <member><methodname>Yac::flush</methodname></member>
+    <member><methodname>Yac::info</methodname></member>
+    <member><methodname>Yac::dump</methodname></member>
    </simplelist>
   </para>
  </refsect1>

--- a/reference/yac/yac/dump.xml
+++ b/reference/yac/yac/dump.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 1a42637cd40d0f75af1435ff051c7caa9b1c83e0 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: d3a03f8f542cd083d793bbd8ef3d7756aae7711f Maintainer: lacatoire Status: ready -->
 
 <refentry xml:id="yac.dump" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -29,15 +29,25 @@
      <simpara>
       Nombre maximum d'entrées à retourner.
      </simpara>
+     <simpara>
+      Passer <literal>-1</literal> comme <parameter>limit</parameter> vide
+      toutes les entrées actuellement présentes dans le cache. Il est à
+      noter que construire la liste complète peut utiliser une quantité
+      considérable de mémoire pour un grand cache ; quand la mémoire est
+      un critère, il vaut mieux paginer les entrées avec
+      <parameter>limit</parameter> et <parameter>offset</parameter>.
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>offset</parameter></term>
     <listitem>
      <simpara>
-      Nombre d'entrées à sauter avant de collecter, qui peut être utilisé
-      pour paginer un cache contenant plus d'entrées que
-      <parameter>limit</parameter>.
+      Nombre d'entrées à sauter avant de collecter. Ce paramètre est
+      disponible à partir de PECL yac 2.4.0 ; les versions antérieures
+      commencent toujours depuis la première entrée. Combiné avec
+      <parameter>limit</parameter>, il peut être utilisé pour paginer un
+      cache contenant plus d'entrées qu'un seul appel ne peut en retourner.
      </simpara>
     </listitem>
    </varlistentry>


### PR DESCRIPTION
Closes #3397

Sync with php/doc-en PR #5810 (d3a03f8f542cd083d793bbd8ef3d7756aae7711f).

- `book.xml`: add simpara on microsecond-level read performance; add simpara on embedded values (yac 2.4.0) and FastLZ → LZ4 switch
- `yac.xml`: fill in class intro (2 simpara); fill in `_prefix` property description
- `setup.xml`: add intro simpara; add PECL/PIE/source `<example>` blocks; document PIE availability (2.3.2); document FastLZ → LZ4 in 2.4.0
- `yac/delete.xml`: add note on deferred expiry semantics; update return value (repeated delete returns true, array requires all keys present); update example; add `info`/`dump` to seealso
- `yac/dump.xml`: document `limit=-1` dumps all entries; document `offset` availability (yac 2.4.0)