### PR TITLE
[Sync-En] yar: add protocol chapter, PIE install, examples and clarifications

### DIFF
--- a/reference/yac/book.xml
+++ b/reference/yac/book.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 1a42637cd40d0f75af1435ff051c7caa9b1c83e0 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: d3a03f8f542cd083d793bbd8ef3d7756aae7711f Maintainer: lacatoire Status: ready -->
 
 <book xml:id="book.yac" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <?phpdoc extension-membership="pecl" ?>
@@ -23,11 +23,29 @@
    ratée que l'appelant peut simplement réessayer.
   </simpara>
   <simpara>
+   Sans verrou ni communication inter-processus dans le chemin d'accès,
+   une lecture est essentiellement une recherche dans une table de hachage
+   en mémoire partagée. Yac est ainsi extrêmement rapide, avec une latence
+   de lecture à la microseconde, et son débit peut s'adapter au nombre de
+   workers tant que les écritures sont réparties sur plusieurs clés.
+  </simpara>
+  <simpara>
    Parce que Yac échange des garanties de cohérence contre vitesse et
    débit, il convient mieux aux données coûteuses à produire mais faciles à
    recréer : fragments de page, instantanés de configuration, petites
    réponses de service et autres caches locaux. Il ne doit pas être utilisé
    comme stockage faisant autorité pour des données irremplaçables.
+  </simpara>
+  <simpara>
+   Depuis yac 2.4.0, les petites valeurs scalaires —
+   <constant>NULL</constant>, booléens, entiers, courtes chaînes jusqu'à
+   7 octets et tableaux vides — sont stockées directement dans le slot de
+   la table de hachage plutôt que dans un bloc de valeur séparé
+   (« valeurs intégrées »), ce qui supprime l'allocation et la copie de
+   bloc à chaque accès et améliore significativement les performances tout
+   en réduisant l'utilisation mémoire. La version 2.4.0 a également
+   remplacé le moteur de compression FastLZ par LZ4, rendant les lectures
+   compressées plusieurs fois plus rapides.
   </simpara>
   <note>
    <simpara>

--- a/reference/yac/setup.xml
+++ b/reference/yac/setup.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 1a42637cd40d0f75af1435ff051c7caa9b1c83e0 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: d3a03f8f542cd083d793bbd8ef3d7756aae7711f Maintainer: lacatoire Status: ready -->
 
 <chapter xml:id="yac.setup" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.setup;
@@ -15,6 +15,10 @@
  <section xml:id="yac.installation">
   &reftitle.install;
   <simpara>
+   Yac peut être installé de trois façons : via PECL, via PIE ou en
+   compilant depuis les sources.
+  </simpara>
+  <simpara>
    &pecl.moved;
   </simpara>
   <simpara>
@@ -24,29 +28,64 @@
   <simpara>
    &pecl.windows.download.avail;
   </simpara>
-  <para>
-   Le code source est hébergé sur
-   <link xlink:href="&url.git.hub;laruence/yac">GitHub</link>. Pour compiler
-   l'extension depuis les sources :
-   <screen>
+  <example>
+   <title>Installer Yac avec PECL</title>
+   <programlisting role="shell">
 <![CDATA[
-$ git clone https://github.com/laruence/yac.git
-$ cd yac
-$ phpize
-$ ./configure
-$ make
-$ sudo make install
+pecl install yac
 ]]>
-   </screen>
-  </para>
+   </programlisting>
+  </example>
+  <simpara>
+   Depuis Yac 2.3.2, l'extension peut être installée avec
+   &link.pie;, le PHP Installer for Extensions, en exécutant la commande
+   suivante.
+  </simpara>
+  <example>
+   <title>Installer Yac avec PIE</title>
+   <programlisting role="shell">
+<![CDATA[
+pie install laruence/yac
+]]>
+   </programlisting>
+  </example>
+  <simpara>
+   Des sérialisateurs optionnels peuvent être activés à l'installation :
+  </simpara>
+  <example>
+   <title>Installer Yac avec PIE et un sérialisateur</title>
+   <programlisting role="shell">
+<![CDATA[
+pie install laruence/yac --enable-json
+]]>
+   </programlisting>
+  </example>
+  <simpara>
+   Le code source est hébergé sur
+   <link xlink:href="&url.git.hub;laruence/yac">GitHub</link>. Pour
+   compiler l'extension depuis les sources, exécuter les commandes
+   suivantes en remplaçant les chemins par ceux de l'installation PHP
+   locale.
+  </simpara>
+  <example>
+   <title>Compiler Yac depuis les sources</title>
+   <programlisting role="shell">
+<![CDATA[
+/chemin/vers/phpize
+./configure --with-php-config=/chemin/vers/php-config
+make && make install
+]]>
+   </programlisting>
+  </example>
   <simpara>
    Les options <literal>configure</literal> suivantes sont disponibles :
   </simpara>
   <simpara>
-   Les valeurs sont compressées avec LZ4 avant d'être stockées. Par défaut,
-   Yac utilise la copie de LZ4 fournie avec l'extension ; aucun indicateur
-   supplémentaire n'est nécessaire. Pour lier l'extension contre la
-   bibliothèque LZ4 système, utiliser le commutateur
+   Les valeurs sont compressées avec LZ4 avant d'être stockées. Le moteur
+   de compression LZ4 a été introduit dans Yac 2.4.0, remplaçant l'ancien
+   FastLZ. Par défaut, Yac utilise la copie de LZ4 fournie avec l'extension ;
+   aucun indicateur supplémentaire n'est nécessaire. Pour lier l'extension
+   contre la bibliothèque LZ4 système, utiliser le commutateur
    <option role="configure">--with-system-lz4</option>, qui nécessite que
    l'en-tête <literal>lz4.h</literal> et <literal>liblz4</literal> soient
    installés.

--- a/reference/yac/yac.xml
+++ b/reference/yac/yac.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 1a42637cd40d0f75af1435ff051c7caa9b1c83e0 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: d3a03f8f542cd083d793bbd8ef3d7756aae7711f Maintainer: lacatoire Status: ready -->
 
 <reference xml:id="class.yac" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -11,9 +11,27 @@
 <!-- {{{ Yac intro -->
   <section xml:id="yac.intro">
    &reftitle.intro;
-   <para>
-
-   </para>
+   <simpara>
+    La classe <classname>Yac</classname> est l'interface du cache. Chaque
+    instance sur le même hôte est un handle léger vers un cache partagé :
+    toutes les instances lisent et écrivent les mêmes entrées, et en créer
+    une n'alloue rien au-delà du handle lui-même.
+   </simpara>
+   <simpara>
+    Le préfixe optionnel passé à
+    <methodname>Yac::__construct</methodname> est ajouté à chaque clé, ce
+    qui permet à plusieurs instances (ou applications) de partager un même
+    cache sans collision de clés. En plus des opérations classiques de cache
+    (<methodname>Yac::add</methodname>,
+    <methodname>Yac::set</methodname>,
+    <methodname>Yac::get</methodname>,
+    <methodname>Yac::delete</methodname> et
+    <methodname>Yac::flush</methodname>), la classe fournit
+    <methodname>Yac::info</methodname> et
+    <methodname>Yac::dump</methodname> pour inspecter le cache, et surcharge
+    l'accès aux propriétés pour que lire ou écrire une propriété d'objet lise
+    ou écrive une entrée du cache.
+   </simpara>
   </section>
 <!-- }}} -->
 
@@ -54,7 +72,13 @@
     <varlistentry xml:id="yac.props.prefix">
      <term><varname>_prefix</varname></term>
      <listitem>
-      <para></para>
+      <simpara>
+       Le préfixe de clé défini via
+       <methodname>Yac::__construct</methodname>. Il est ajouté à chaque
+       clé utilisée avec l'instance ; aucun séparateur n'est inséré, il
+       faut donc en inclure un dans le préfixe si nécessaire. Le préfixe
+       ne doit pas dépasser <constant>YAC_MAX_KEY_LEN</constant> (48) octets.
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>

--- a/reference/yac/yac/delete.xml
+++ b/reference/yac/yac/delete.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 1a42637cd40d0f75af1435ff051c7caa9b1c83e0 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: d3a03f8f542cd083d793bbd8ef3d7756aae7711f Maintainer: lacatoire Status: ready -->
 
 <refentry xml:id="yac.delete" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -17,6 +17,21 @@
   <simpara>
    Supprime un ou plusieurs éléments du cache.
   </simpara>
+  <note>
+   <simpara>
+    La suppression est implémentée en marquant l'entrée comme expirée
+    plutôt qu'en vidant son slot : l'entrée cesse immédiatement d'être
+    lisible, mais le slot reste occupé jusqu'à ce que la même clé soit
+    stockée à nouveau ou qu'une écriture ultérieure le récupère. En
+    conséquence, le nombre de slots utilisés rapporté par
+    <methodname>Yac::info</methodname> ne diminue pas après une
+    suppression, et <methodname>Yac::dump</methodname> liste toujours
+    l'entrée supprimée jusqu'à ce que son slot soit recyclé ; un
+    <literal>ttl</literal> non nul dans le passé indique une entrée
+    supprimée ou expirée, il appartient donc à l'appelant de les
+    filtrer dans la sortie de <methodname>Yac::dump</methodname>.
+   </simpara>
+  </note>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -49,7 +64,15 @@
   &reftitle.returnvalues;
   <simpara>
    Retourne &true; en cas de succès, ou &false; si la clé n'était pas
-   présente dans le cache.
+   présente dans le cache. Comme une suppression ne fait que marquer
+   l'entrée comme expirée, une clé supprimée mais pas encore écrasée est
+   toujours considérée comme présente : supprimer la même clé à nouveau
+   retourne &true;.
+  </simpara>
+  <simpara>
+   Quand un <type>array</type> de clés est fourni, &true; est retourné
+   uniquement si toutes les clés étaient présentes ; si une clé est
+   absente, &false; est retourné.
   </simpara>
  </refsect1>
 
@@ -63,16 +86,25 @@
 $yac = new Yac();
 $yac->set("foo", "bar");
 
-var_dump($yac->delete("foo"));            // bool(true)
-var_dump($yac->delete("foo"));            // bool(false): déjà supprimé
+var_dump($yac->delete("foo"));      // bool(true) : marquée expirée
+var_dump($yac->get("foo"));         // bool(false) : manquant désormais
+var_dump($yac->delete("foo"));      // bool(true) à nouveau : le slot n'a pas
+                                     // encore été écrasé
+var_dump($yac->delete("jamais"));   // bool(false) : jamais stockée
 
-// suppression différée : garder l'entrée lisible encore 60 secondes,
-// elle disparaît seulement après ce délai
+// une suppression ne libère pas le slot : slots_used ne diminue pas, et
+// l'entrée expirée apparaît toujours dans le dump
+var_dump($yac->info()["slots_used"]); // int(1)
+print_r($yac->dump());                // "foo" est toujours listée ; son ttl
+                                       // est dans le passé
+
+// suppression différée : garder l'entrée lisible encore 60 secondes
 $yac->set("tmp", "value");
-var_dump($yac->delete("tmp", 60));        // bool(true)
+var_dump($yac->delete("tmp", 60));    // bool(true)
 
-// supprimer plusieurs clés à la fois
-var_dump($yac->delete(array("a", "b")));
+// supprimer plusieurs clés à la fois retourne true uniquement si toutes
+// les clés étaient présentes
+var_dump($yac->delete(array("tmp", "non"))); // bool(false) : "non" absente
 ?>
 ]]>
    </programlisting>
@@ -85,6 +117,8 @@ var_dump($yac->delete(array("a", "b")));
    <simplelist>
     <member><methodname>Yac::set</methodname></member>
     <member><methodname>Yac::flush</methodname></member>
+    <member><methodname>Yac::info</methodname></member>
+    <member><methodname>Yac::dump</methodname></member>
    </simplelist>
   </para>
  </refsect1>

--- a/reference/yac/yac/dump.xml
+++ b/reference/yac/yac/dump.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 1a42637cd40d0f75af1435ff051c7caa9b1c83e0 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: d3a03f8f542cd083d793bbd8ef3d7756aae7711f Maintainer: lacatoire Status: ready -->
 
 <refentry xml:id="yac.dump" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -29,15 +29,25 @@
      <simpara>
       Nombre maximum d'entrées à retourner.
      </simpara>
+     <simpara>
+      Passer <literal>-1</literal> comme <parameter>limit</parameter> vide
+      toutes les entrées actuellement présentes dans le cache. Il est à
+      noter que construire la liste complète peut utiliser une quantité
+      considérable de mémoire pour un grand cache ; quand la mémoire est
+      un critère, il vaut mieux paginer les entrées avec
+      <parameter>limit</parameter> et <parameter>offset</parameter>.
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>offset</parameter></term>
     <listitem>
      <simpara>
-      Nombre d'entrées à sauter avant de collecter, qui peut être utilisé
-      pour paginer un cache contenant plus d'entrées que
-      <parameter>limit</parameter>.
+      Nombre d'entrées à sauter avant de collecter. Ce paramètre est
+      disponible à partir de PECL yac 2.4.0 ; les versions antérieures
+      commencent toujours depuis la première entrée. Combiné avec
+      <parameter>limit</parameter>, il peut être utilisé pour paginer un
+      cache contenant plus d'entrées qu'un seul appel ne peut en retourner.
      </simpara>
     </listitem>
    </varlistentry>

--- a/reference/yar/book.xml
+++ b/reference/yar/book.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 75d48299ef85693f10eee31af1be88488fb84c6f Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 60ce1c5c7cc6d340191828de21f1d6b48cd83807 Maintainer: lacatoire Status: ready -->
 
 <book xml:id="book.yar" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <?phpdoc extension-membership="pecl" ?>
@@ -24,11 +24,13 @@
    processus mandataire n'est requis.
   </simpara>
   <simpara>
-   Le protocole est agnostique vis-à-vis du langage : des implémentations
-   compatibles existent pour C, Java et Lua.
+   Le protocole est agnostique vis-à-vis du langage, les services peuvent
+   donc être consommés par n'importe quel langage ; voir
+   <link linkend="yar.protocol">Le protocole Yar</link> pour les détails.
   </simpara>
  </preface>
 
+ &reference.yar.protocol;
  &reference.yar.setup;
  &reference.yar.constants;
  &reference.yar.examples;

--- a/reference/yar/constants.xml
+++ b/reference/yar/constants.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 75d48299ef85693f10eee31af1be88488fb84c6f Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 60ce1c5c7cc6d340191828de21f1d6b48cd83807 Maintainer: lacatoire Status: ready -->
 
 <appendix xml:id="yar.constants" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.constants;
@@ -314,6 +314,20 @@
     <simpara>
      Le service distant a levé une exception lors du traitement de la
      requête.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.yar-err-forbidden">
+   <term>
+    <constant>YAR_ERR_FORBIDDEN</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     La requête a été rejetée par l'authentification du serveur
+     (voir les champs <literal>provider</literal> et
+     <literal>token</literal> de
+     <link linkend="yar.protocol">l'en-tête du protocole Yar</link>).
     </simpara>
    </listitem>
   </varlistentry>

--- a/reference/yar/examples.xml
+++ b/reference/yar/examples.xml
@@ -1,15 +1,35 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 75d48299ef85693f10eee31af1be88488fb84c6f Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 60ce1c5c7cc6d340191828de21f1d6b48cd83807 Maintainer: lacatoire Status: ready -->
 
 <chapter xml:id="yar.examples" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.examples;
+ <simpara>
+  Les exemples ci-dessous décrivent un service complet : un serveur qui
+  expose quelques méthodes arithmétiques, un client synchrone qui les
+  appelle, un client qui parallélise plusieurs appels, et un client qui
+  dialogue avec un serveur via TCP.
+ </simpara>
+
  <example>
   <title>Exemple de serveur Yar</title>
+  <simpara>
+   Un service Yar est simplement une classe PHP ordinaire enveloppée par
+   <classname>Yar_Server</classname>. Chaque méthode publique de l'objet
+   devient un point d'entrée RPC ; les méthodes protégées et privées, ainsi
+   que celles dont le nom commence par un tiret bas, restent cachées aux
+   clients. Les commentaires de documentation des méthodes publiques sont
+   collectés et affichés sur la page d'information du service.
+  </simpara>
+  <simpara>
+   Les requêtes RPC arrivent comme des requêtes HTTP POST portant un payload
+   binaire au format du protocole Yar, donc le script est habituellement
+   mappé à un URI sur un serveur web classique.
+  </simpara>
   <programlisting role="php">
 <![CDATA[
 <?php
 
-/* supposons que cette page soit accessible via http://example.com/operator.php */
+/* supposons que cette page soit accessible via http://api.example.com/operator.php */
 
 class Operator {
 
@@ -56,11 +76,13 @@ $server->handle();
  <example>
   <title>Accès au serveur depuis un navigateur (requête GET)</title>
   <simpara>
-   Lorsqu'une requête GET est envoyée à l'URI du service, Yar affiche une
-   page d'information listant chaque méthode publique de l'objet exécuteur
-   accompagnée de son commentaire de documentation. Ceci est contrôlé par
-   la directive
-   <link linkend="ini.yar.expose-info">yar.expose_info</link>.
+   Lorsqu'une requête GET est envoyée à l'URI du service — par exemple en
+   l'ouvrant dans un navigateur — Yar n'effectue pas d'appel RPC mais
+   affiche une page d'information listant chaque méthode publique de l'objet
+   exécuteur accompagnée de son commentaire de documentation. Ceci est
+   contrôlé par la directive
+   <link linkend="ini.yar.expose-info">yar.expose_info</link> ; quand elle
+   est désactivée, une requête GET échoue à la place.
   </simpara>
   &example.outputs.similar;
   <mediaobject>
@@ -73,10 +95,23 @@ $server->handle();
 
  <example>
   <title>Exemple de client Yar</title>
+  <simpara>
+   Un <classname>Yar_Client</classname> est lié à une seule adresse de
+   service. Appeler n'importe quelle méthode non définie dessus est
+   transparentement transformé en appel RPC synchrone, les méthodes distantes
+   se comportant donc comme des méthodes locales ;
+   <methodname>Yar_Client::call</methodname> fait la même chose explicitement
+   par nom.
+  </simpara>
+  <simpara>
+   Les méthodes protégées ne sont pas exposées : les appeler échoue avec une
+   <exceptionname>Yar_Client_Exception</exceptionname> dont le code est
+   <constant>YAR_ERR_REQUEST</constant>.
+  </simpara>
   <programlisting role="php">
 <![CDATA[
 <?php
-$client = new Yar_Client("http://example.com/operator.php");
+$client = new Yar_Client("http://api.example.com/operator.php");
 
 /* appel direct */
 var_dump($client->add(1, 2));
@@ -94,17 +129,35 @@ var_dump($client->_add(1, 2));
 <![CDATA[
 int(3)
 int(5)
-PHP Fatal error:  Uncaught Yar_Server_Request_Exception: call to undefined api Operator::_add() in *
+PHP Fatal error:  Uncaught Yar_Client_Exception: call to undefined api Operator::_add() in *
 ]]>
   </screen>
  </example>
 
  <example>
   <title>Exemple de client Yar concurrent</title>
+  <simpara>
+   Au lieu d'appeler les services l'un après l'autre,
+   <classname>Yar_Concurrent_Client</classname> enregistre d'abord plusieurs
+   appels, puis les dispatch tous en même temps avec
+   <methodname>Yar_Concurrent_Client::loop</methodname>. Les réponses sont
+   passées au callback dans l'ordre où elles arrivent, pas dans l'ordre où
+   les appels ont été enregistrés.
+  </simpara>
+  <simpara>
+   Juste après que toutes les requêtes ont été envoyées, le callback est
+   invoqué une fois avec des arguments &null; pour signaler à l'appelant
+   qu'aucune requête n'est plus en attente ; l'exemple ci-dessous vérifie
+   cette notification.
+  </simpara>
   <programlisting role="php">
 <![CDATA[
 <?php
 function callback($ret, $callinfo) {
+    if ($callinfo == NULL) {
+        /* toutes les requêtes ont été envoyées, en attente des réponses */
+        return;
+    }
     echo $callinfo['method'], " résultat : ", $ret, "\n";
 }
 
@@ -113,9 +166,9 @@ function error_callback($type, $error, $callinfo) {
 }
 
 /* enregistre les appels asynchrones vers les services distants */
-Yar_Concurrent_Client::call("http://example.com/operator.php", "add", array(1, 2), "callback");
-Yar_Concurrent_Client::call("http://example.com/operator.php", "sub", array(2, 1), "callback");
-Yar_Concurrent_Client::call("http://example.com/operator.php", "mul", array(2, 2), "callback");
+Yar_Concurrent_Client::call("http://api.example.com/operator.php", "add", array(1, 2), "callback");
+Yar_Concurrent_Client::call("http://api.example.com/operator.php", "sub", array(2, 1), "callback");
+Yar_Concurrent_Client::call("http://api.example.com/operator.php", "mul", array(2, 2), "callback");
 
 /* envoie toutes les requêtes et attend les réponses */
 Yar_Concurrent_Client::loop("callback", "error_callback");
@@ -137,8 +190,9 @@ add résultat : 3
   <simpara>
    Outre HTTP, <classname>Yar_Client</classname> peut dialoguer avec des
    serveurs compatibles Yar via TCP ou des sockets Unix, par exemple un
-   service implémenté avec le framework Yar en C. Le serveur distant doit
-   implémenter le même protocole binaire Yar.
+   service implémenté avec le
+   <link xlink:href="&url.git.hub;laruence/yar-c">framework Yar en C</link>,
+   qui utilise le même protocole binaire Yar que le serveur PHP.
   </simpara>
   <programlisting role="php">
 <![CDATA[

--- a/reference/yar/protocol.xml
+++ b/reference/yar/protocol.xml
@@ -1,0 +1,144 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 60ce1c5c7cc6d340191828de21f1d6b48cd83807 Maintainer: lacatoire Status: ready -->
+
+<chapter xml:id="yar.protocol" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <title>Le protocole Yar</title>
+ <simpara>
+  Yar ne s'appuie pas sur un schéma ou un fichier IDL : tout est échangé
+  sur le réseau sous forme d'octets bruts. N'importe quel langage capable
+  de lire et d'écrire des octets peut communiquer avec un service Yar, sans
+  installer aucun framework — il suffit de construire un en-tête binaire de
+  taille fixe et un corps de requête sérialisé, de les envoyer à l'URI du
+  service, et d'analyser la réponse.
+ </simpara>
+ <simpara>
+  Un message se compose d'un en-tête de taille fixe de 82 octets suivi d'un
+  corps. L'en-tête est disposé exactement comme la structure C suivante,
+  compactée sans remplissage, et est écrit sur le réseau champ après champ
+  dans l'ordre de déclaration :
+ </simpara>
+ <programlisting role="c">
+<![CDATA[
+typedef struct _yar_header {
+    uint32_t       id;            /* identifiant de transaction */
+    uint16_t       version;       /* version du protocole, toujours 0 actuellement */
+    uint32_t       magic_num;     /* doit valoir 0x80DFEC60 */
+    uint32_t       reserved;
+    unsigned char  provider[32];  /* émetteur de la requête (authentification) */
+    unsigned char  token[32];     /* jeton de la requête (authentification) */
+    uint32_t       body_len;      /* longueur du corps entier, y compris
+                                     l'identifiant d'empaqueteur */
+} __attribute__ ((packed)) yar_header_t;
+]]>
+ </programlisting>
+ <simpara>
+  Les champs <literal>id</literal>, <literal>magic_num</literal>,
+  <literal>reserved</literal> et <literal>body_len</literal> sont stockés
+  dans l'ordre réseau (gros-boutiste) ; les champs restants sont des octets
+  bruts.
+ </simpara>
+ <simpara>
+  Le corps commence par un identifiant d'empaqueteur de 8 octets —
+  <literal>PHP</literal>, <literal>JSON</literal> ou
+  <literal>MSGPACK</literal>, complété par des zéros — indiquant au
+  destinataire comment le reste a été encodé, suivi du contenu sérialisé
+  lui-même.
+ </simpara>
+ <itemizedlist>
+  <listitem>
+   <simpara>
+    Le corps de requête se décode en un tableau avec les clés
+    <literal>i</literal> (l'identifiant de transaction),
+    <literal>m</literal> (la méthode appelée) et <literal>p</literal>
+    (la liste des paramètres).
+   </simpara>
+  </listitem>
+  <listitem>
+   <simpara>
+    Le corps de réponse se décode en un tableau avec les clés
+    <literal>i</literal> (l'identifiant de transaction),
+    <literal>s</literal> (le statut, l'un des codes
+    <literal>YAR_ERR_*</literal>), <literal>r</literal> (la valeur de
+    retour), <literal>o</literal> (toute sortie produite par la méthode
+    du service) et <literal>e</literal> (l'erreur ou l'exception, quand
+    l'appel a échoué).
+   </simpara>
+  </listitem>
+ </itemizedlist>
+ <simpara>
+  En HTTP le message est envoyé comme corps d'une requête POST, la réponse
+  arrivant comme corps de la réponse ; en TCP ou socket Unix il est écrit
+  directement sur le flux.
+ </simpara>
+ <example>
+  <title>Appel d'un service Yar sans l'extension</title>
+  <simpara>
+   Le script autonome suivant construit une requête Yar valide pour
+   l'empaqueteur <literal>php</literal> avec uniquement des sockets
+   standard, l'envoie à un URI de service et affiche la réponse décodée.
+   Exécuté contre le service <classname>Operator</classname> des
+   <link linkend="yar.examples">exemples</link>, il affiche
+   <literal>int(3)</literal>.
+  </simpara>
+  <programlisting role="php">
+<![CDATA[
+<?php
+
+$uri = "http://api.example.com/operator.php";
+
+/* 1. le corps : identifiant d'empaqueteur + requête sérialisée */
+$serialized = serialize(array("i" => 1, "m" => "add", "p" => array(1, 2)));
+$body = str_pad("PHP", 8, "\0") . $serialized;
+
+/* 2. l'en-tête : 82 octets, entiers multi-octets dans l'ordre réseau */
+$header = pack("N", 1)                    /* id */
+        . pack("v", 0)                    /* version */
+        . pack("N", 0x80DFEC60)           /* nombre magique */
+        . pack("N", 0)                    /* reserved */
+        . str_pad("", 32, "\0")           /* provider */
+        . str_pad("", 32, "\0")           /* token */
+        . pack("N", strlen($body));       /* longueur du corps */
+
+/* 3. l'envoyer comme corps d'une requête POST */
+$stream = stream_context_create(array("http" => array(
+    "method"  => "POST",
+    "header"  => "Content-Type: application/octet-stream\r\n",
+    "content" => $header . $body,
+)));
+$reply = file_get_contents($uri, false, $stream);
+
+/* 4. analyser la réponse : en-tête de 82 octets, puis le corps */
+$response = unserialize(substr($reply, 82 + 8));
+var_dump($response["r"]);
+?>
+]]>
+  </programlisting>
+ </example>
+ <simpara>
+  Une implémentation client plus complète en PHP pur, qui décode également
+  l'en-tête de réponse et supporte les appels concurrents, se trouve dans
+  le répertoire <literal>tools/</literal> du
+  <link xlink:href="&url.git.hub;laruence/yar">dépôt source de Yar</link>.
+ </simpara>
+</chapter>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/yar/setup.xml
+++ b/reference/yar/setup.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 75d48299ef85693f10eee31af1be88488fb84c6f Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 60ce1c5c7cc6d340191828de21f1d6b48cd83807 Maintainer: lacatoire Status: ready -->
 
 <chapter xml:id="yar.setup" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.setup;
@@ -27,6 +27,10 @@
  <section xml:id="yar.installation">
   &reftitle.install;
   <simpara>
+   Yar peut être installé de trois façons : via PECL, via PIE ou en
+   compilant depuis les sources.
+  </simpara>
+  <simpara>
    &pecl.moved;
   </simpara>
   <simpara>
@@ -36,66 +40,99 @@
   <simpara>
    &pecl.windows.download.avail;
   </simpara>
-  <para>
-   Le code source est hébergé sur
-   <link xlink:href="&url.git.hub;laruence/yar">GitHub</link>. Pour compiler
-   l'extension à partir des sources :
-   <screen>
+  <example>
+   <title>Installer Yar avec PECL</title>
+   <programlisting role="shell">
 <![CDATA[
-$ git clone https://github.com/laruence/yar.git
-$ cd yar
-$ phpize
-$ ./configure
-$ make
-$ sudo make install
+pecl install yar
 ]]>
-   </screen>
-  </para>
-  <para>
+   </programlisting>
+  </example>
+  <simpara>
+   Depuis Yar 2.4.0, l'extension peut être installée avec
+   &link.pie;, le PHP Installer for Extensions, en exécutant la commande
+   suivante.
+  </simpara>
+  <example>
+   <title>Installer Yar avec PIE</title>
+   <programlisting role="shell">
+<![CDATA[
+pie install laruence/yar
+]]>
+   </programlisting>
+  </example>
+  <simpara>
+   Le packager msgpack peut être activé à l'installation :
+  </simpara>
+  <example>
+   <title>Installer Yar avec PIE et msgpack</title>
+   <programlisting role="shell">
+<![CDATA[
+pie install laruence/yar --enable-msgpack
+]]>
+   </programlisting>
+  </example>
+  <simpara>
+   Le code source est hébergé sur
+   <link xlink:href="&url.git.hub;laruence/yar">GitHub</link>. Pour
+   compiler l'extension depuis les sources, exécuter les commandes suivantes
+   en remplaçant les chemins par ceux de l'installation PHP locale.
+  </simpara>
+  <example>
+   <title>Compiler Yar depuis les sources</title>
+   <programlisting role="shell">
+<![CDATA[
+/chemin/vers/phpize
+./configure --with-php-config=/chemin/vers/php-config
+make && make install
+]]>
+   </programlisting>
+  </example>
+  <simpara>
    Les options de <literal>configure</literal> suivantes sont disponibles :
-   <variablelist>
-    <varlistentry>
-     <term>
-      <option role="configure">--with-curl</option>
-     </term>
-     <listitem>
-      <simpara>
-       Emplacement de l'installation de cURL, s'il n'est pas trouvé dans les
-       chemins d'inclusion par défaut.
-      </simpara>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term>
-      <option role="configure">--enable-msgpack</option>
-     </term>
-     <listitem>
-      <simpara>
-       Active le packager <literal>msgpack</literal> et fait de l'extension
-       <literal>msgpack</literal> une dépendance optionnelle. Lorsque Yar est
-       compilé avec cette option, la valeur par défaut de
-       <link linkend="ini.yar.packager">yar.packager</link> devient
-       <literal>msgpack</literal>.
-      </simpara>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term>
-      <option role="configure">--enable-epoll</option>
-     </term>
-     <listitem>
-      <simpara>
-       Utilise <literal>epoll</literal> de Linux au lieu de
-       <literal>select()</literal> pour le multiplexage des entrées/sorties,
-       disponible à partir de Yar 2.1.2. Cela peut améliorer les performances
-       de <classname>Yar_Concurrent_Client</classname> en cas de forte
-       concurrence. Cela ne prend effet que sous Linux ; sur les autres
-       plateformes, l'option est ignorée silencieusement.
-      </simpara>
-     </listitem>
-    </varlistentry>
-   </variablelist>
-  </para>
+  </simpara>
+  <variablelist>
+   <varlistentry>
+    <term>
+     <option role="configure">--with-curl</option>
+    </term>
+    <listitem>
+     <simpara>
+      Emplacement de l'installation de cURL, s'il n'est pas trouvé dans les
+      chemins d'inclusion par défaut.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>
+     <option role="configure">--enable-msgpack</option>
+    </term>
+    <listitem>
+     <simpara>
+      Active le packager <literal>msgpack</literal> et fait de l'extension
+      <literal>msgpack</literal> une dépendance optionnelle. Lorsque Yar est
+      compilé avec cette option, la valeur par défaut de
+      <link linkend="ini.yar.packager">yar.packager</link> devient
+      <literal>msgpack</literal>.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>
+     <option role="configure">--enable-epoll</option>
+    </term>
+    <listitem>
+     <simpara>
+      Utilise <literal>epoll</literal> de Linux au lieu de
+      <literal>select()</literal> pour le multiplexage des entrées/sorties,
+      disponible à partir de Yar 2.1.2. Cela peut améliorer les performances
+      de <classname>Yar_Concurrent_Client</classname> en cas de forte
+      concurrence. Cela ne prend effet que sous Linux ; sur les autres
+      plateformes, l'option est ignorée silencieusement.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
  </section>
  <!-- }}} -->
 

--- a/reference/yar/yar-concurrent-client.xml
+++ b/reference/yar/yar-concurrent-client.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 75d48299ef85693f10eee31af1be88488fb84c6f Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 60ce1c5c7cc6d340191828de21f1d6b48cd83807 Maintainer: lacatoire Status: ready -->
 
 <reference xml:id="class.yar-concurrent-client" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -17,9 +17,22 @@
     envoyés immédiatement ; ils sont tous émis ensemble, en parallèle, par
     <methodname>Yar_Concurrent_Client::loop</methodname>.
    </simpara>
+   <simpara>
+    La classe est destinée aux applications qui ont besoin des résultats de
+    plusieurs appels distants. Seuls les appels indépendants — ceux qui
+    n'ont pas besoin du résultat les uns des autres — peuvent être regroupés
+    ainsi ; quand un appel dépend du résultat d'un autre, les deux doivent
+    s'exécuter séquentiellement. Via <classname>Yar_Client</classname>, les
+    appels sont envoyés l'un après l'autre, chacun payant son temps
+    d'aller-retour complet ; avec le client concurrent, ils sont envoyés en
+    même temps, de sorte que le temps d'attente total se réduit à la durée
+    du seul appel le plus lent.
+   </simpara>
    <note>
     <simpara>
      Seuls les services HTTP(S) sont supportés pour les appels concurrents.
+     Ils sont envoyés simultanément via l'interface multi-handle de curl,
+     que le transport TCP/socket Unix n'implémente pas.
     </simpara>
    </note>
   </section>

--- a/reference/yar/yar-server.xml
+++ b/reference/yar/yar-server.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 75d48299ef85693f10eee31af1be88488fb84c6f Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 60ce1c5c7cc6d340191828de21f1d6b48cd83807 Maintainer: lacatoire Status: ready -->
 
 <reference xml:id="class.yar-server" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -15,6 +15,11 @@
     Enveloppe un objet et expose toutes ses méthodes publiques en tant que
     service distant, servi via HTTP par
     <methodname>Yar_Server::handle</methodname>.
+   </simpara>
+   <simpara>
+    L'extension PHP ne fournit qu'un serveur HTTP. Un serveur TCP et socket
+    Unix utilisant le même protocole Yar est fourni par le
+    <link xlink:href="&url.git.hub;laruence/yar-c">framework Yar en C</link>.
    </simpara>
   </section>
 <!-- }}} -->

--- a/reference/yar/yar_client/call.xml
+++ b/reference/yar/yar_client/call.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 75d48299ef85693f10eee31af1be88488fb84c6f Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 60ce1c5c7cc6d340191828de21f1d6b48cd83807 Maintainer: lacatoire Status: ready -->
 
 <refentry xml:id="yar-client.call" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -17,8 +17,8 @@
   <simpara>
    Émet un appel RPC vers la méthode distante <literal>method</literal>.
    C'est exactement ce qui se produit lorsqu'une méthode inexistante est
-   invoquée sur un objet <classname>Yar_Client</classname> (voir
-   <methodname>Yar_Client::__call</methodname>) ;
+   invoquée sur un objet <classname>Yar_Client</classname> (via la méthode
+   magique <literal>__call</literal> de PHP) ;
    <methodname>Yar_Client::call</methodname> n'existe que pour que les
    méthodes distantes nommées littéralement <literal>call</literal> ou
    <literal>__call</literal> restent accessibles.
@@ -57,18 +57,51 @@
  <refsect1 role="errors">
   &reftitle.errors;
   <simpara>
-   Lorsque la méthode <literal>call</literal> n'existe pas du côté du
-   serveur, une exception
-   <exceptionname>Yar_Server_Request_Exception</exceptionname> est lancée.
-   Voir <methodname>Yar_Client::__call</methodname> pour la liste complète
-   des échecs et de leurs classes d'exception.
+   Lorsque la méthode distante n'existe pas sur le serveur, ou n'est pas
+   publique, le client lance une
+   <exceptionname>Yar_Client_Exception</exceptionname> avec le code
+   <constant>YAR_ERR_REQUEST</constant>. Voir
+   <link linkend="class.yar-client-exception">Yar_Client_Exception</link>
+   pour les autres échecs côté client et leurs classes d'exception.
   </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Exemple avec <methodname>Yar_Client::call</methodname></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$client = new Yar_Client("http://api.example.com/operator.php");
+
+/* La façon habituelle : invoquer la méthode distante comme si elle était locale.
+ * Cela est transformé en call("add", array(1, 2)) en coulisses. */
+var_dump($client->add(1, 2));
+
+/* Équivalent : appeler la méthode explicitement par nom */
+var_dump($client->call("add", array(1, 2)));
+
+/* Nécessaire uniquement lorsque le service distant expose littéralement une
+ * méthode nommée call (ou __call), que la magie __call ne peut pas atteindre */
+var_dump($client->call("call", array($some_argument)));
+?>
+]]>
+   </programlisting>
+   &example.outputs.similar;
+   <screen>
+<![CDATA[
+int(3)
+int(3)
+...
+]]>
+   </screen>
+  </example>
  </refsect1>
 
  <refsect1 role="seealso">
   &reftitle.seealso;
   <simplelist>
-   <member><methodname>Yar_Client::__call</methodname></member>
    <member><methodname>Yar_Client::setOpt</methodname></member>
   </simplelist>
  </refsect1>

--- a/reference/yar/yar_client/construct.xml
+++ b/reference/yar/yar_client/construct.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 75d48299ef85693f10eee31af1be88488fb84c6f Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 60ce1c5c7cc6d340191828de21f1d6b48cd83807 Maintainer: lacatoire Status: ready -->
 
 <refentry xml:id="yar-client.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -70,10 +70,10 @@
    <programlisting role="php">
 <![CDATA[
 <?php
-$client = new Yar_Client("http://host/api/");
+$client = new Yar_Client("http://api.example.com/operator.php");
 
 /* avec des options */
-$client = new Yar_Client("http://host/api/", [
+$client = new Yar_Client("http://api.example.com/operator.php", [
     YAR_OPT_TIMEOUT => 1000,
     YAR_OPT_PACKAGER => "json",
 ]);
@@ -86,7 +86,7 @@ $client = new Yar_Client("http://host/api/", [
  <refsect1 role="seealso">
   &reftitle.seealso;
   <simplelist>
-   <member><methodname>Yar_Client::__call</methodname></member>
+   <member><methodname>Yar_Client::call</methodname></member>
    <member><methodname>Yar_Client::setOpt</methodname></member>
   </simplelist>
  </refsect1>

--- a/reference/yar/yar_client/getopt.xml
+++ b/reference/yar/yar_client/getopt.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 75d48299ef85693f10eee31af1be88488fb84c6f Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 60ce1c5c7cc6d340191828de21f1d6b48cd83807 Maintainer: lacatoire Status: ready -->
 
 <refentry xml:id="yar-client.getopt" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -51,7 +51,7 @@
    <programlisting role="php">
 <![CDATA[
 <?php
-$client = new Yar_Client("http://host/api/");
+$client = new Yar_Client("http://api.example.com/operator.php");
 $client->setOpt(YAR_OPT_TIMEOUT, 1000);
 
 var_dump($client->getOpt(YAR_OPT_TIMEOUT));

--- a/reference/yar/yar_client/setopt.xml
+++ b/reference/yar/yar_client/setopt.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 75d48299ef85693f10eee31af1be88488fb84c6f Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 60ce1c5c7cc6d340191828de21f1d6b48cd83807 Maintainer: lacatoire Status: ready -->
 
 <refentry xml:id="yar-client.setopt" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -104,7 +104,7 @@
 <![CDATA[
 <?php
 
-$client = new Yar_Client("http://host/api/");
+$client = new Yar_Client("http://api.example.com/operator.php");
 
 /* Définit le délai d'expiration à 1s */
 $client->setOpt(YAR_OPT_TIMEOUT, 1000);
@@ -130,7 +130,7 @@ $result = $client->some_method("parameter");
   &reftitle.seealso;
   <simplelist>
    <member><methodname>Yar_Client::getOpt</methodname></member>
-   <member><methodname>Yar_Client::__call</methodname></member>
+   <member><methodname>Yar_Client::call</methodname></member>
   </simplelist>
  </refsect1>
 

--- a/reference/yar/yar_client_exception/gettype.xml
+++ b/reference/yar/yar_client_exception/gettype.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 75d48299ef85693f10eee31af1be88488fb84c6f Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 60ce1c5c7cc6d340191828de21f1d6b48cd83807 Maintainer: lacatoire Status: ready -->
 
 <refentry xml:id="yar-client-exception.gettype" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -43,7 +43,7 @@
    <programlisting role="php">
 <![CDATA[
 <?php
-$client = new Yar_Client("http://host/api/");
+$client = new Yar_Client("http://api.example.com/operator.php");
 
 try {
     $client->some_method("parameter");

--- a/reference/yar/yar_concurrent_client/call.xml
+++ b/reference/yar/yar_concurrent_client/call.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 75d48299ef85693f10eee31af1be88488fb84c6f Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 60ce1c5c7cc6d340191828de21f1d6b48cd83807 Maintainer: lacatoire Status: ready -->
 
 <refentry xml:id="yar-concurrent-client.call" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -26,8 +26,9 @@
   </simpara>
   <note>
    <simpara>
-    Seules les URI HTTP et HTTPS sont supportées. Les transports TCP et
-    socket Unix ne sont pas disponibles pour les appels concurrents.
+    Seules les URI HTTP et HTTPS sont supportées. Les appels concurrents
+    sont envoyés simultanément via l'interface multi-handle de curl, que
+    le transport TCP/socket Unix n'implémente pas.
    </simpara>
   </note>
  </refsect1>
@@ -66,11 +67,20 @@
      <simpara>
       Un <type>callable</type> invoqué lorsque la réponse à cet appel
       arrive, avec deux arguments : la valeur de la réponse, et un
-      &array; <literal>callinfo</literal> avec les clés
-      <literal>sequence</literal>, <literal>uri</literal> et
-      <literal>method</literal>. S'il est omis, la fonction de rappel
+      &array; <literal>callinfo</literal> décrivant l'appel :
+     </simpara>
+     <simplelist>
+      <member><literal>sequence</literal> — le numéro de séquence retourné
+       lors de l'enregistrement de l'appel</member>
+      <member><literal>uri</literal> — l'adresse du service</member>
+      <member><literal>method</literal> — le nom de la méthode distante</member>
+     </simplelist>
+     <simpara>
+      S'il est omis, la fonction de rappel
       <literal>callback</literal> de
-      <methodname>Yar_Concurrent_Client::loop</methodname> est utilisée.
+      <methodname>Yar_Concurrent_Client::loop</methodname> est utilisée ;
+      voir cette méthode pour ce qui se passe quand ni l'un ni l'autre n'est
+      fourni.
      </simpara>
     </listitem>
    </varlistentry>
@@ -81,9 +91,11 @@
       Un <type>callable</type> invoqué lorsque cet appel échoue, avec trois
       arguments : le type d'erreur (l'un des codes
       <literal>YAR_ERR_*</literal>), le message d'erreur, et l'&array;
-      <literal>callinfo</literal>. S'il est omis, la fonction de rappel
-      <literal>error_callback</literal> de
-      <methodname>Yar_Concurrent_Client::loop</methodname> est utilisée.
+      <literal>callinfo</literal> décrit ci-dessus. S'il est omis, la
+      fonction de rappel <literal>error_callback</literal> de
+      <methodname>Yar_Concurrent_Client::loop</methodname> est utilisée ;
+      voir cette méthode pour ce qui se passe quand ni l'un ni l'autre n'est
+      fourni.
      </simpara>
     </listitem>
    </varlistentry>
@@ -132,16 +144,16 @@ function error_callback($type, $error, $callinfo)
     error_log($error);
 }
 
-Yar_Concurrent_Client::call("http://host/api/", "some_method", array("parameters"), "callback");
+Yar_Concurrent_Client::call("http://api.example.com/operator.php", "some_method", array("parameters"), "callback");
 
 /* Si la fonction de rappel n'est pas spécifiée, celle de loop() sera utilisée */
-Yar_Concurrent_Client::call("http://host/api/", "some_method", array("parameters"));
+Yar_Concurrent_Client::call("http://api.example.com/operator.php", "some_method", array("parameters"));
 
 /* Ce serveur accepte le packager JSON */
-Yar_Concurrent_Client::call("http://host/api/", "some_method", array("parameters"), "callback", NULL, array(YAR_OPT_PACKAGER => "json"));
+Yar_Concurrent_Client::call("http://api.example.com/operator.php", "some_method", array("parameters"), "callback", NULL, array(YAR_OPT_PACKAGER => "json"));
 
 /* Délai d'attente maximal personnalisé */
-Yar_Concurrent_Client::call("http://host/api/", "some_method", array("parameters"), "callback", NULL, array(YAR_OPT_TIMEOUT => 1000));
+Yar_Concurrent_Client::call("http://api.example.com/operator.php", "some_method", array("parameters"), "callback", NULL, array(YAR_OPT_TIMEOUT => 1000));
 
 /* Les requêtes ne sont pas encore envoyées */
 ]]>

--- a/reference/yar/yar_concurrent_client/loop.xml
+++ b/reference/yar/yar_concurrent_client/loop.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 75d48299ef85693f10eee31af1be88488fb84c6f Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 60ce1c5c7cc6d340191828de21f1d6b48cd83807 Maintainer: lacatoire Status: ready -->
 
 <refentry xml:id="yar-concurrent-client.loop" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -21,6 +21,19 @@
    que chaque réponse soit arrivée et ait été traitée. La liste des appels
    est vidée lorsque cette méthode retourne.
   </simpara>
+  <simpara>
+   Comme les appels s'exécutent simultanément, la boucle ne dure que le
+   temps du seul appel le plus lent, plutôt que la somme de tous les appels.
+   Les callbacks, cependant, ne sont pas invoqués dans l'ordre où les appels
+   ont été enregistrés : un callback se déclenche dès que sa réponse arrive.
+   Pour savoir à quel appel appartient une réponse, comparer l'entrée
+   <literal>sequence</literal> de l'argument <literal>callinfo</literal> avec
+   le numéro de séquence retourné par
+   <methodname>Yar_Concurrent_Client::call</methodname>. Le &array;
+   <literal>callinfo</literal> contient la <literal>sequence</literal>,
+   l'<literal>uri</literal> et la <literal>method</literal> de l'appel ; voir
+   <methodname>Yar_Concurrent_Client::call</methodname>.
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -35,6 +48,10 @@
       après l'envoi de toutes les requêtes, il est de plus appelé une fois
       avec deux arguments &null;, avant l'arrivée de toute réponse.
      </simpara>
+     <simpara>
+      Si ce paramètre est omis, la valeur de retour d'un appel réussi est
+      simplement affichée lorsque sa réponse arrive.
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
@@ -46,6 +63,11 @@
       Il reçoit trois arguments : le type d'erreur (l'un des codes
       <literal>YAR_ERR_*</literal>), le message d'erreur et le &array;
       <literal>callinfo</literal>.
+     </simpara>
+     <simpara>
+      Si ce paramètre est omis, un appel échoué émet un avertissement PHP ;
+      contrairement au <classname>Yar_Client</classname> synchrone, aucune
+      exception n'est levée.
      </simpara>
     </listitem>
    </varlistentry>
@@ -93,10 +115,10 @@ function error_callback($type, $error, $callinfo) {
     error_log($error);
 }
 
-Yar_Concurrent_Client::call("http://host/api/", "some_method", array("parameters"), "callback");
+Yar_Concurrent_Client::call("http://api.example.com/operator.php", "some_method", array("parameters"), "callback");
 
 /* si la fonction de rappel n'est pas spécifiée, celle de loop() sera utilisée */
-Yar_Concurrent_Client::call("http://host/api/", "some_method", array("parameters"));
+Yar_Concurrent_Client::call("http://api.example.com/operator.php", "some_method", array("parameters"));
 
 Yar_Concurrent_Client::loop("callback", "error_callback");
 ?>

--- a/reference/yar/yar_concurrent_client/reset.xml
+++ b/reference/yar/yar_concurrent_client/reset.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 75d48299ef85693f10eee31af1be88488fb84c6f Maintainer: girgias Status: ready -->
+<!-- EN-Revision: 60ce1c5c7cc6d340191828de21f1d6b48cd83807 Maintainer: lacatoire Status: ready -->
 
 <refentry xml:id="yar-concurrent-client.reset" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -52,7 +52,7 @@ function callback($retval, $callinfo) {
     var_dump($retval);
 }
 
-Yar_Concurrent_Client::call("http://host/api/", "some_method", array("parameters"), "callback");
+Yar_Concurrent_Client::call("http://api.example.com/operator.php", "some_method", array("parameters"), "callback");
 
 /* jamais envoyé : abandonne l'appel enregistré */
 Yar_Concurrent_Client::reset();

--- a/reference/yar/yar_server/construct.xml
+++ b/reference/yar/yar_server/construct.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 75d48299ef85693f10eee31af1be88488fb84c6f Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 60ce1c5c7cc6d340191828de21f1d6b48cd83807 Maintainer: lacatoire Status: ready -->
 
 <refentry xml:id="yar-server.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -29,6 +29,43 @@
       Tout objet dont les méthodes publiques devraient être exposées comme
       services RPC. Les méthodes protégées et privées, ainsi que les méthodes
       dont le nom commence par un tiret bas, ne sont pas exposées.
+     </simpara>
+     <simpara>
+      L'exécuteur peut optionnellement définir deux méthodes magiques
+      protégées, reconnues par
+      <methodname>Yar_Server::handle</methodname> et jamais exposées
+      comme points d'entrée RPC :
+     </simpara>
+     <itemizedlist>
+      <listitem>
+       <simpara>
+        <literal>protected function __info(string $markup):
+        string</literal> — depuis Yar 2.3.0. Appelée lorsque la page
+        d'information du service est demandée ; elle reçoit le contenu de
+        la page que Yar aurait sinon affichée, et si elle retourne une
+        &string;, cette chaîne est envoyée au client à la place. Voir
+        <methodname>Yar_Server::handle</methodname>.
+       </simpara>
+      </listitem>
+      <listitem>
+       <simpara>
+        <literal>protected function __auth(string $provider, string
+        $token): bool</literal> — depuis Yar 2.3.0. Appelée au tout
+        début de chaque requête avec les champs
+        <literal>provider</literal> et <literal>token</literal> de
+        l'en-tête de requête, définis par le client avec les options
+        <constant>YAR_OPT_PROVIDER</constant> et
+        <constant>YAR_OPT_TOKEN</constant>. Retourner exactement
+        &false; rejette la requête ; toute autre valeur de retour la
+        laisse s'exécuter. Voir
+        <methodname>Yar_Server::handle</methodname>.
+       </simpara>
+      </listitem>
+     </itemizedlist>
+     <simpara>
+      Les deux méthodes ne prennent effet que lorsqu'elles sont
+      <literal>protected</literal> ; une méthode publique ou privée
+      portant le même nom est ignorée.
      </simpara>
     </listitem>
    </varlistentry>

--- a/reference/yar/yar_server/handle.xml
+++ b/reference/yar/yar_server/handle.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 07275f5d03cf34c5a2218e0c103978f8024da153 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 60ce1c5c7cc6d340191828de21f1d6b48cd83807 Maintainer: lacatoire Status: ready -->
 
 <refentry xml:id="yar-server.handle" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -30,13 +30,11 @@
   </note>
   <note>
    <simpara>
-    À partir de Yar 2.3.0, la page d'informations du service peut être
-    personnalisée en définissant une méthode <literal>protected</literal>
-    nommée <literal>__info</literal> sur l'objet exécuteur. Lorsqu'une
-    requête GET arrive, Yar appelle cette méthode en lui passant le balisage
-    de la page qu'il aurait autrement produite ; si la méthode retourne une
-    &string;, cette chaîne est envoyée au client à la place de la page par
-    défaut.
+    À partir de Yar 2.3.0, l'objet exécuteur peut définir les méthodes
+    magiques protégées <literal>__info</literal> et
+    <literal>__auth</literal> pour personnaliser la page d'informations du
+    service et authentifier les requêtes ; voir
+    <methodname>Yar_Server::__construct</methodname> pour les détails.
    </simpara>
   </note>
  </refsect1>

--- a/reference/yar/yar_server_exception/gettype.xml
+++ b/reference/yar/yar_server_exception/gettype.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 75d48299ef85693f10eee31af1be88488fb84c6f Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 60ce1c5c7cc6d340191828de21f1d6b48cd83807 Maintainer: lacatoire Status: ready -->
 
 <refentry xml:id="yar-server-exception.gettype" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -60,7 +60,7 @@ $service->handle();
 <![CDATA[
 <?php
 /* Client.php */
-$client = new Yar_Client("http://host/api.php");
+$client = new Yar_Client("http://api.example.com/operator.php");
 
 try {
     $client->throw_exception("client");


### PR DESCRIPTION
Closes #3406
Closes #3360
Closes #3389

Sync with php/doc-en PR #5815 (60ce1c5c7cc6d340191828de21f1d6b48cd83807), which supersedes commits 75d48299 (#5804) and 07275f5d (#5807).

- `protocol.xml` (new): chapter documenting the 82-byte binary header, body layout, packager identifiers, and a plain-PHP client example
- `book.xml`: update language-agnostic description, add `&reference.yar.protocol;`
- `constants.xml`: add `YAR_ERR_FORBIDDEN` (authentication rejection via `__auth`)
- `setup.xml`: intro simpara; PECL/PIE/source `<example>` blocks; PIE availability (2.4.0); extract `variablelist` from `para`
- `examples.xml`: intro simpara; explanatory simparas per example; fix error class (`Yar_Client_Exception`); null-check in concurrent callback; meaningful URIs
- `yar-concurrent-client.xml`: independent-calls design; curl multi-handle note
- `yar-server.xml`: HTTP-only note, link to Yar C framework
- `yar_client/call.xml`: `__call` magic, `Yar_Client_Exception` errors, new examples section
- `yar_client/construct.xml`, `yar_client/setopt.xml`: seealso `__call` → `call`
- `yar_concurrent_client/call.xml`: HTTP note; `callinfo` simplelist; fallback descriptions
- `yar_concurrent_client/loop.xml`: simultaneous-calls simpara; omission behavior for callback/error_callback
- `yar_server/construct.xml`: document `__info`/`__auth` protected magic methods (2.3.0)
- `yar_server/handle.xml`: update note to cover both `__info` and `__auth`; supersedes #5807
- `yar-client-protocol-exception.xml`: already translated at 07275f5d; closing #3389 via this PR
- URI placeholder fixes: `example.com` → `api.example.com`, `host/api` → `api.example.com`