### PR TITLE
[Sync-En] crypt(): add the CVE warning about unsuitable algorithms

### DIFF
--- a/reference/strings/functions/crypt.xml
+++ b/reference/strings/functions/crypt.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 46efd980535e8de6f6639a0015d2ad1e4bfe9d00 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 4850727cb124abe071e9adaf851f86a872eb2adf Maintainer: lacatoire Status: ready -->
 <refentry xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://docbook.org/ns/docbook" xml:id="function.crypt">
  <refnamediv>
   <refname>crypt</refname>
@@ -57,6 +57,21 @@
    premiers 8 octets retourneront le même résultat (tant que le
    salt est toujours le même).
   </para>
+  <warning>
+   <simpara>
+    Aucun des algorithmes listés ci-dessous n'est adapté au hachage de nouveaux
+    mots de passe. <constant>CRYPT_STD_DES</constant>,
+    <constant>CRYPT_EXT_DES</constant> et <constant>CRYPT_MD5</constant> sont
+    bien trop rapides pour résister à un cassage hors ligne ; md5crypt a été
+    déclaré en fin de vie pour cette raison (CVE-2012-3287).
+    Le temps d'exécution de <constant>CRYPT_SHA256</constant> et de
+    <constant>CRYPT_SHA512</constant> croît avec le carré de la longueur de
+    <parameter>string</parameter>, si bien qu'une entrée non bornée permet
+    d'épuiser le processeur (CVE-2016-20013).
+    Il faut utiliser <function>password_hash</function> à la place, qui
+    sélectionne automatiquement un algorithme et un coût adaptés.
+   </simpara>
+  </warning>
   <simpara>
    Les types de hash suivants sont supportés :
   </simpara>


### PR DESCRIPTION
Translation of php/doc-en#3447 (commit 4850727): warning about CVE-2012-3287 and CVE-2016-20013 before the list of supported hash types. EN-Revision updated.

Fixes: #3423