### PR TITLE
[Sync-En] document the partitioned cookie attribute (PHP 8.5)

### DIFF
--- a/reference/network/functions/setcookie.xml
+++ b/reference/network/functions/setcookie.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 6122a8317ca0068fc71f6a5167e0a2d99166ec7c Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 736b8b384a6f02033a20f4819ca51115b7833818 Maintainer: yannick Status: ready -->
 <refentry xml:id="function.setcookie" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>setcookie</refname>
@@ -156,7 +156,7 @@
       <simpara>
        Un &array; associatif qui peut avoir comme clés
        <literal>expires</literal>, <literal>path</literal>, <literal>domain</literal>,
-       <literal>secure</literal>, <literal>httponly</literal> et <literal>samesite</literal>.
+       <literal>secure</literal>, <literal>httponly</literal>, <literal>partitioned</literal> et <literal>samesite</literal>.
        Les valeurs ont la même signification que celles décrites pour les paramètres
        avec le même nom. La valeur de l'élément <literal>samesite</literal> doit
        être <literal>None</literal>, <literal>Lax</literal> ou <literal>Strict</literal>.
@@ -176,6 +176,13 @@
         Si <literal>samesite</literal> vaut <literal>"None"</literal>, alors
         <literal>secure</literal> doit également être activé, sinon le cookie sera
         bloqué par le client.
+       </simpara>
+      </note>
+      <note>
+       <simpara>
+        Si <literal>partitioned</literal> vaut &true;, alors
+        <literal>secure</literal> doit également être activé, sinon une
+        <exceptionname>ValueError</exceptionname> est lancée.
        </simpara>
       </note>
      </listitem>
@@ -225,6 +232,13 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       L'entrée "partitioned" a été ajoutée au tableau <parameter>options</parameter>.
+       Si elle vaut <literal>true</literal>, le cookie sera marqué comme Partitioned (CHIPS).
+      </entry>
+     </row>
      <row>
       <entry>8.2.0</entry>
       <entry>

--- a/reference/network/functions/setrawcookie.xml
+++ b/reference/network/functions/setrawcookie.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: d829c7d11f311e5b115865fe6920f63aa2d9bde7 Maintainer: yannick Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 736b8b384a6f02033a20f4819ca51115b7833818 Maintainer: yannick Status: ready -->
 <refentry xml:id="function.setrawcookie" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>setrawcookie</refname>
@@ -50,28 +49,33 @@
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>7.3.0</entry>
-       <entry>
-        Une signature alternative supportant un tableau 
-        d'<parameter>options</parameter> a été ajoutée. Cette signature supporte
-        la définition de l'attribut SameSite du cookie.
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       L'entrée "partitioned" a été ajoutée au tableau <parameter>options</parameter>.
+       Si elle vaut <literal>true</literal>, le cookie sera marqué comme Partitioned (CHIPS).
+      </entry>
+     </row>
+     <row>
+      <entry>7.3.0</entry>
+      <entry>
+       Une signature alternative supportant un tableau
+       d'<parameter>options</parameter> a été ajoutée. Cette signature supporte
+       la définition de l'attribut SameSite du cookie.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/session/functions/session-get-cookie-params.xml
+++ b/reference/session/functions/session-get-cookie-params.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 35b95a56ccc03b66af7117fc815ac7881e2e0ad3 Maintainer: girgias Status: ready -->
+<!-- EN-Revision: 736b8b384a6f02033a20f4819ca51115b7833818 Maintainer: girgias Status: ready -->
 <!-- Reviewed: yes -->
 
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.session-get-cookie-params">
@@ -56,6 +56,12 @@
     </listitem>
     <listitem>
      <simpara>
+      <link linkend="ini.session.cookie-partitioned">"<literal>partitioned</literal>"</link> :
+      le cookie est marqué comme Partitioned (CHIPS).
+     </simpara>
+    </listitem>
+    <listitem>
+     <simpara>
       <link linkend="ini.session.cookie-httponly">"<literal>httponly</literal>"</link> : 
       le cookie ne sera accessible que via le protocole HTTP.
      </simpara>
@@ -82,6 +88,12 @@
       </row>
      </thead>
      <tbody>
+      <row>
+       <entry>8.5.0</entry>
+       <entry>
+        L'entrée "<literal>partitioned</literal>" a été ajoutée dans le tableau retourné.
+       </entry>
+      </row>
       <row>
        <entry>7.3.0</entry>
        <entry>
@@ -112,6 +124,9 @@
     </member>
     <member>
      <link linkend="ini.session.cookie-httponly">session.cookie_httponly</link>
+    </member>
+    <member>
+     <link linkend="ini.session.cookie-partitioned">session.cookie_partitioned</link>
     </member>
     <member>
      <link linkend="ini.session.cookie-samesite">session.cookie_samesite</link>

--- a/reference/session/functions/session-set-cookie-params.xml
+++ b/reference/session/functions/session-set-cookie-params.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 37be0e0626e8b96e617e800392651eacc5f65bdc Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 736b8b384a6f02033a20f4819ca51115b7833818 Maintainer: yannick Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="function.session-set-cookie-params" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -47,11 +47,12 @@
        Lors de l'utilisation de la première signature, la durée de vie du cookie, en secondes.
        Voir la directive <link linkend="ini.session.cookie-lifetime">lifetime</link>.
       </para>
-      <para>
-       Lors de l'utilisation de la deuxième signature, 
+      <simpara>
+       Lors de l'utilisation de la deuxième signature,
        un &array; associatif qui peut avoir comme clés
        <literal>lifetime</literal>, <literal>path</literal>, <literal>domain</literal>,
-       <literal>secure</literal>, <literal>httponly</literal> et <literal>samesite</literal>.
+       <literal>secure</literal>, <literal>httponly</literal>, <literal>partitioned</literal>
+       et <literal>samesite</literal>.
        Les valeurs ont la même signification que celles décrites pour les paramètres
        avec le même nom. La valeur de l'élément <literal>samesite</literal> doit soit
        être <literal>Lax</literal> soit <literal>Strict</literal>.
@@ -59,7 +60,7 @@
        identique à la valeur par défaut des paramètres explicites. Si l'élément
        <literal>samesite</literal> est omis, alors l'attribut SameSite du cookie
        ne sera pas défini.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
@@ -126,6 +127,13 @@
      </thead>
      <tbody>
       <row>
+       <entry>8.5.0</entry>
+       <entry>
+        L'entrée "partitioned" a été ajoutée au tableau <parameter>lifetime_or_options</parameter>.
+        Si elle vaut <literal>true</literal>, le cookie sera marqué comme Partitioned (CHIPS).
+       </entry>
+      </row>
+      <row>
        <entry>8.0.0</entry>
        <entry>
         <parameter>path</parameter>, <parameter>domain</parameter>,
@@ -170,6 +178,9 @@
     </member>
     <member>
      <link linkend="ini.session.cookie-httponly">session.cookie_httponly</link>
+    </member>
+    <member>
+     <link linkend="ini.session.cookie-partitioned">session.cookie_partitioned</link>
     </member>
     <member>
      <link linkend="ini.session.cookie-samesite">session.cookie_samesite</link>

--- a/reference/session/ini.xml
+++ b/reference/session/ini.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 7fabff299de8a894888e8064797ed3278f50b356 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 736b8b384a6f02033a20f4819ca51115b7833818 Maintainer: lacatoire Status: ready -->
 
 <section xml:id="session.configuration" xmlns="http://docbook.org/ns/docbook">
  &reftitle.runtime;
@@ -94,6 +94,12 @@
       <entry>"0"</entry>
       <entry><constant>INI_ALL</constant></entry>
       <entry>Antérieur à PHP 7.2.0, la valeur par défaut était <literal>""</literal>.</entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.session.cookie-partitioned">session.cookie_partitioned</link></entry>
+      <entry>"0"</entry>
+      <entry><constant>INI_ALL</constant></entry>
+      <entry>&php.version.added; 8.5.0.</entry>
      </row>
      <row>
       <entry><link linkend="ini.session.cookie-samesite">session.cookie_samesite</link></entry>
@@ -683,6 +689,25 @@
       que le cookie ne sera pas accessible par les langages de script, comme Javascript.
       Cette configuration permet de limiter les attaques comme les attaques XSS (bien
       qu'elle ne soit pas supportée par tous les navigateurs).
+     </simpara>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry xml:id="ini.session.cookie-partitioned">
+    <term>
+     <parameter>session.cookie_partitioned</parameter>
+     <type>bool</type>
+    </term>
+    <listitem>
+     <simpara>
+      Marque le cookie comme partitionné (CHIPS), ce qui signifie que le cookie sera
+      isolé dans un contexte first-party. Cette configuration permet de limiter le
+      pistage entre sites (bien qu'elle ne soit pas supportée par tous les navigateurs).
+     </simpara>
+     <simpara>
+      Si elle est activée, <link linkend="ini.session.cookie-secure">session.cookie_secure</link>
+      doit également être activée, sinon le cookie de session ne sera pas envoyé et une
+      alerte est émise.
      </simpara>
     </listitem>
    </varlistentry>


### PR DESCRIPTION
Translation of php/doc-en#5051 (commit 736b8b3): the "partitioned" option for setcookie()/setrawcookie()/session_set_cookie_params(), the entry returned by session_get_cookie_params(), and the new session.cookie_partitioned INI directive. EN-Revision updated.

Fixes: #3425