### PR TITLE
[Sync-En] ssl context: document the missing SSL context options

### DIFF
--- a/language/context/ssl.xml
+++ b/language/context/ssl.xml
@@ -1,293 +1,396 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 8bc832a464e33122e8129f5a623bd845b69fa7e0 Maintainer: yannick Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 6819d9e5807762161caace88a21930156a313195 Maintainer: yannick Status: ready -->
 
 <refentry xml:id="context.ssl" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" annotations="verify_info:false" role="stream_context_option">
  <refnamediv>
   <refname>Options de contexte SSL</refname>
   <refpurpose>Liste des options de contexte SSL</refpurpose>
  </refnamediv>
- 
+
  <refsect1 role="description">
   &reftitle.description;
-  <para>
+  <simpara>
    Options de contexte pour les protocoles <literal>ssl://</literal>
    et <literal>tls://</literal>.
-  </para>
+  </simpara>
  </refsect1>
- 
- <refsect1 role="options"><!-- {{{ -->
+
+ <refsect1 role="options">
   &reftitle.options;
-  <para>
-   <variablelist>
-    <varlistentry xml:id="context.ssl.peer-name">
-     <term>
-      <parameter>peer_name</parameter>
-      <type>string</type>
-     </term>
-     <listitem>
-      <para>
-       Nom du pair à utiliser. Si cette valeur n'est pas définie, alors le
-       nom sera deviné en se basant sur le nom d'hôte utilisé lors de
-       l'ouverture du flux.
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="context.ssl.verify-peer">
-     <term>
-      <parameter>verify_peer</parameter>
-      <type>bool</type>
-     </term>
-     <listitem>
-      <para>
-       Nécessite une vérification du certificat SSL utilisé.
-      </para>
-      <para>
-       Par défaut, vaut &true;.
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="context.ssl.verify-peer-name">
-     <term>
-      <parameter>verify_peer_name</parameter>
-      <type>bool</type>
-     </term>
-     <listitem>
-      <para>
-       Nécessite la vérification du nom du pair.
-      </para>
-      <para>
-       Par défaut, vaut &true;.
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="context.ssl.allow-self-signed">
-     <term>
-      <parameter>allow_self_signed</parameter>
-      <type>bool</type>
-     </term>
-     <listitem>
-      <para>
-       Permet les certificats autosignés. Requiert le
-       paramètre <link linkend="context.ssl.verify-peer"><parameter>verify_peer</parameter></link>.
-      </para>
-      <para>
-       Par défaut, vaut &false;
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="context.ssl.cafile">
-     <term>
-      <parameter>cafile</parameter>
-      <type>string</type>
-     </term>
-     <listitem>
-      <para>
-       Endroit où se trouve le fichier de l'autorité du certificat
-       sur le système de fichiers local et qui devra être utilisé
-       avec l'option de contexte <literal>verify_peer</literal>
-       pour identifier le pair distant.
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="context.ssl.capath">
-     <term>
-      <parameter>capath</parameter>
-      <type>string</type>
-     </term>
-     <listitem>
-      <para>
-       Si <literal>cafile</literal> n'est pas spécifié ou si le certificat
-       n'a pas été trouvé, une recherche dans le dossier pointé par
-       <literal>capath</literal> sera effectuée afin d'y trouver un certificat
-       valide. <literal>capath</literal> doit être un dossier de certificats correctement hachés.
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="context.ssl.local-cert">
-     <term>
-      <parameter>local_cert</parameter>
-      <type>string</type>
-     </term>
-     <listitem>
-      <para>
-       Chemin vers le certificat local, sur le système de fichiers.
-       Ce doit être un fichier encodé <acronym>PEM</acronym> qui contient le certificat
-       et la clé privée. Il peut, optionnellement, contenir la
-       chaîne de certification de l'émetteur.
-       La clé privée peut également être contenue dans un fichier distinct 
-       spécifié par <literal>local_pk</literal>.
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="context.ssl.local-pk">
-     <term>
-      <parameter>local_pk</parameter>
-      <type>string</type>
-     </term>
-     <listitem>
-      <para>
-       Chemin d'accès au fichier de clé privée locale sur le système de 
-       fichiers dans le cas de fichiers distincts pour le certificat 
-       (<literal>local_cert</literal>) et la clé privée.
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="context.ssl.passphrase">
-     <term>
-      <parameter>passphrase</parameter>
-      <type>string</type>
-     </term>
-     <listitem>
-      <para>
-       La phrase de passe avec laquelle le fichier
-       <literal>local_cert</literal> a été encodé.
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="context.ssl.verify-depth">
-     <term>
-      <parameter>verify_depth</parameter>
-      <type>int</type>
-     </term>
-     <listitem>
-      <para>
-       Échoue si la chaîne de certification est trop profonde.
-      </para>
-      <para>
-       Par défaut, aucune vérification.
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="context.ssl.ciphers">
-     <term>
-      <parameter>ciphers</parameter>
-      <type>string</type>
-     </term>
-     <listitem>
-      <para>
-       Définit la liste des chiffrements. Le format de la chaîne est décrit
-       sur la page <link xlink:href="&url.openssl.ciphers;">ciphers(1)</link>.
-      </para>
-      <para>
-       Par défaut, vaut <literal>DEFAULT</literal>.
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="context.ssl.capture-peer-cert">
-     <term>
-      <parameter>capture_peer_cert</parameter>
-      <type>bool</type>
-     </term>
-     <listitem>
-      <para>
-       Si défini à &true;, une option de contexte <literal>peer_certificate</literal>
-       sera créée, contenant le certificat du pair.
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="context.ssl.capture-peer-cert-chain">
-     <term>
-      <parameter>capture_peer_cert_chain</parameter>
-      <type>bool</type>
-     </term>
-     <listitem>
-      <para>
-       Si défini à &true;, une option de contexte <literal>peer_certificate_chain</literal>
-       sera créée, contenant la chaîne de certification.
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="context.ssl.sni-enabled">
-     <term>
-      <parameter>SNI_enabled</parameter>
-      <type>bool</type>
-     </term>
-     <listitem>
-      <para>
-       Si vaut &true;, l'indication sur le nom du serveur sera activée.
-       Le fait d'activer SNI permet d'utiliser plusieurs certificats
-       sur la même adresse IP.
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="context.ssl.disable-compression">
-     <term>
-      <parameter>disable_compression</parameter>
-      <type>bool</type>
-     </term>
-     <listitem>
-      <para>
-       Si défini, la compression TLS sera désactivée.
-       Cela peut aider à atténuer le vecteur d'attaque CRIME.
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="context.ssl.peer-fingerprint">
-     <term>
-      <parameter>peer_fingerprint</parameter>
-      <type>string</type> | <type>array</type>
-     </term>
-     <listitem>
-      <para>
-       Interrompt la connexion lorsque le condensé du certificat distant ne correspond pas au hachage spécifié.
-      </para>
-      <para>
-       Lorsqu'une &string; est utilisée, la longueur va déterminer l'algorithme
-       de hachage utilisé, soit "md5" (32), soit "sha1" (40).
-      </para>
-      <para>
-       Lorsqu'un &array; est utilisé, la clé indique le nom de l'algorithme de
-       hachage, et chaque valeur correspondante représente le condensé attendu.
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry xml:id="context.ssl.security-level">
-     <term>
-      <parameter>security_level</parameter>
-      <type>int</type>
-     </term>
-     <listitem>
-      <para>
-       Définit le niveau de sécurité. Si non spécifié, le niveau de sécurité par
-       défaut de la bibliothèque est utilisé.
-       Les niveaux de sécurité sont décrits dans 
-       <link xlink:href="&url.openssl.security-level;">SSL_CTX_get_security_level(3)</link>.
-      </para>
-      <para>
-       Disponible à partir de PHP 7.2.0 et OpenSSL 1.1.0.
-      </para>
-     </listitem>
-    </varlistentry>
-   </variablelist>
-  </para>
- </refsect1><!-- }}} -->
- 
- <refsect1 role="changelog"><!-- {{{ -->
+  <variablelist>
+   <varlistentry xml:id="context.ssl.peer-name">
+    <term>
+     <parameter>peer_name</parameter>
+     <type>string</type>
+    </term>
+    <listitem>
+     <simpara>
+      Nom du pair à utiliser. Si cette valeur n'est pas définie, alors le
+      nom sera deviné en se basant sur le nom d'hôte utilisé lors de
+      l'ouverture du flux.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="context.ssl.verify-peer">
+    <term>
+     <parameter>verify_peer</parameter>
+     <type>bool</type>
+    </term>
+    <listitem>
+     <simpara>
+      Nécessite une vérification du certificat SSL utilisé.
+     </simpara>
+     <simpara>
+      Par défaut, vaut &true;.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="context.ssl.verify-peer-name">
+    <term>
+     <parameter>verify_peer_name</parameter>
+     <type>bool</type>
+    </term>
+    <listitem>
+     <simpara>
+      Nécessite la vérification du nom du pair.
+     </simpara>
+     <simpara>
+      Par défaut, vaut &true;.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="context.ssl.allow-self-signed">
+    <term>
+     <parameter>allow_self_signed</parameter>
+     <type>bool</type>
+    </term>
+    <listitem>
+     <simpara>
+      Permet les certificats autosignés. Requiert le
+      paramètre <link linkend="context.ssl.verify-peer"><parameter>verify_peer</parameter></link>.
+     </simpara>
+     <simpara>
+      Par défaut, vaut &false;
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="context.ssl.cafile">
+    <term>
+     <parameter>cafile</parameter>
+     <type>string</type>
+    </term>
+    <listitem>
+     <simpara>
+      Endroit où se trouve le fichier de l'autorité du certificat
+      sur le système de fichiers local et qui devra être utilisé
+      avec l'option de contexte <literal>verify_peer</literal>
+      pour identifier le pair distant.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="context.ssl.capath">
+    <term>
+     <parameter>capath</parameter>
+     <type>string</type>
+    </term>
+    <listitem>
+     <simpara>
+      Si <literal>cafile</literal> n'est pas spécifié ou si le certificat
+      n'a pas été trouvé, une recherche dans le dossier pointé par
+      <literal>capath</literal> sera effectuée afin d'y trouver un certificat
+      valide. <literal>capath</literal> doit être un dossier de certificats correctement hachés.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="context.ssl.local-cert">
+    <term>
+     <parameter>local_cert</parameter>
+     <type>string</type>
+    </term>
+    <listitem>
+     <simpara>
+      Chemin vers le certificat local, sur le système de fichiers.
+      Ce doit être un fichier encodé <acronym>PEM</acronym> qui contient le certificat
+      et la clé privée. Il peut, optionnellement, contenir la
+      chaîne de certification de l'émetteur.
+      La clé privée peut également être contenue dans un fichier distinct
+      spécifié par <literal>local_pk</literal>.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="context.ssl.local-pk">
+    <term>
+     <parameter>local_pk</parameter>
+     <type>string</type>
+    </term>
+    <listitem>
+     <simpara>
+      Chemin d'accès au fichier de clé privée locale sur le système de
+      fichiers dans le cas de fichiers distincts pour le certificat
+      (<literal>local_cert</literal>) et la clé privée.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="context.ssl.passphrase">
+    <term>
+     <parameter>passphrase</parameter>
+     <type>string</type>
+    </term>
+    <listitem>
+     <simpara>
+      La phrase de passe avec laquelle le fichier
+      <literal>local_cert</literal> a été encodé.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="context.ssl.verify-depth">
+    <term>
+     <parameter>verify_depth</parameter>
+     <type>int</type>
+    </term>
+    <listitem>
+     <simpara>
+      Échoue si la chaîne de certification est trop profonde.
+     </simpara>
+     <simpara>
+      Par défaut, aucune vérification.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="context.ssl.ciphers">
+    <term>
+     <parameter>ciphers</parameter>
+     <type>string</type>
+    </term>
+    <listitem>
+     <simpara>
+      Définit la liste des chiffrements. Le format de la chaîne est décrit
+      sur la page <link xlink:href="&url.openssl.ciphers;">ciphers(1)</link>.
+     </simpara>
+     <simpara>
+      Par défaut, vaut <literal>DEFAULT</literal>.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="context.ssl.capture-peer-cert">
+    <term>
+     <parameter>capture_peer_cert</parameter>
+     <type>bool</type>
+    </term>
+    <listitem>
+     <simpara>
+      Si défini à &true;, une option de contexte <literal>peer_certificate</literal>
+      sera créée, contenant le certificat du pair.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="context.ssl.capture-peer-cert-chain">
+    <term>
+     <parameter>capture_peer_cert_chain</parameter>
+     <type>bool</type>
+    </term>
+    <listitem>
+     <simpara>
+      Si défini à &true;, une option de contexte <literal>peer_certificate_chain</literal>
+      sera créée, contenant la chaîne de certification.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="context.ssl.sni-enabled">
+    <term>
+     <parameter>SNI_enabled</parameter>
+     <type>bool</type>
+    </term>
+    <listitem>
+     <simpara>
+      Si vaut &true;, l'indication sur le nom du serveur sera activée.
+      Le fait d'activer SNI permet d'utiliser plusieurs certificats
+      sur la même adresse IP.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="context.ssl.sni-server-certs">
+    <term>
+     <parameter>SNI_server_certs</parameter>
+     <type>array</type>
+    </term>
+    <listitem>
+     <simpara>
+      Un tableau de noms de serveurs et de leurs certificats correspondants,
+      à utiliser pour SNI. Les clés sont les noms de serveurs et les valeurs
+      sont les chemins vers les fichiers de certificats sur le système de
+      fichiers local. Les fichiers de certificats doivent être encodés
+      <acronym>PEM</acronym> et contenir à la fois le certificat et la clé privée.
+     </simpara>
+     <simpara>
+      Disponible à partir de PHP 5.6.0.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="context.ssl.alpn-protocols">
+    <term>
+     <parameter>alpn_protocols</parameter>
+     <type>array</type>
+    </term>
+    <listitem>
+     <simpara>
+      Un tableau de noms de protocoles de la couche application à utiliser pour
+      ALPN (Application-Layer Protocol Negotiation). Les valeurs sont les noms
+      de protocoles sous forme de chaînes (par exemple "http/1.1", "h2").
+     </simpara>
+     <simpara>
+      Disponible à partir de PHP 7.0.0 et OpenSSL 1.0.2.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="context.ssl.no-ticket">
+    <term>
+     <parameter>no_ticket</parameter>
+     <type>bool</type>
+    </term>
+    <listitem>
+     <simpara>
+      Si défini, les tickets de session TLS sont désactivés. Cela peut aider à
+      renforcer la sécurité en fournissant la confidentialité persistante
+      (Perfect Forward Secrecy, PFS).
+     </simpara>
+     <simpara>
+      Disponible à partir de PHP 5.3.6.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="context.ssl.disable-compression">
+    <term>
+     <parameter>disable_compression</parameter>
+     <type>bool</type>
+    </term>
+    <listitem>
+     <simpara>
+      Si défini, la compression TLS sera désactivée.
+      Cela peut aider à atténuer le vecteur d'attaque CRIME.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="context.ssl.peer-fingerprint">
+    <term>
+     <parameter>peer_fingerprint</parameter>
+     <type>string</type> | <type>array</type>
+    </term>
+    <listitem>
+     <simpara>
+      Interrompt la connexion lorsque le condensé du certificat distant ne correspond pas au hachage spécifié.
+     </simpara>
+     <simpara>
+      Lorsqu'une &string; est utilisée, la longueur va déterminer l'algorithme
+      de hachage utilisé, soit "md5" (32), soit "sha1" (40).
+     </simpara>
+     <simpara>
+      Lorsqu'un &array; est utilisé, la clé indique le nom de l'algorithme de
+      hachage, et chaque valeur correspondante représente le condensé attendu.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="context.ssl.security-level">
+    <term>
+     <parameter>security_level</parameter>
+     <type>int</type>
+    </term>
+    <listitem>
+     <simpara>
+      Définit le niveau de sécurité. Si non spécifié, le niveau de sécurité par
+      défaut de la bibliothèque est utilisé.
+      Les niveaux de sécurité sont décrits dans
+      <link xlink:href="&url.openssl.security-level;">SSL_CTX_get_security_level(3)</link>.
+     </simpara>
+     <simpara>
+      Disponible à partir de PHP 7.2.0 et OpenSSL 1.1.0.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="context.ssl.min-proto-version">
+    <term>
+     <parameter>min_proto_version</parameter>
+     <type>int</type>
+    </term>
+    <listitem>
+     <simpara>
+      Définit la version minimale du protocole autorisée. Si non spécifiée, la
+      version minimale du protocole par défaut de la bibliothèque est utilisée.
+      Les versions du protocole sont décrites dans
+      <link xlink:href="&url.openssl.protocol-versions;">SSL_CTX_set_min_proto_version(3)</link>.
+     </simpara>
+     <simpara>
+      Disponible à partir de PHP 7.3.0 et OpenSSL 1.1.0.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="context.ssl.max-proto-version">
+    <term>
+     <parameter>max_proto_version</parameter>
+     <type>int</type>
+    </term>
+    <listitem>
+     <simpara>
+      Définit la version maximale du protocole autorisée. Si non spécifiée, la
+      version maximale du protocole par défaut de la bibliothèque est utilisée.
+      Les versions du protocole sont décrites dans
+      <link xlink:href="&url.openssl.protocol-versions;">SSL_CTX_set_max_proto_version(3)</link>.
+     </simpara>
+     <simpara>
+      Disponible à partir de PHP 7.3.0 et OpenSSL 1.1.0.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>7.2.0</entry>
-       <entry>
-        Ajout de <parameter>security_level</parameter>. Requiert OpenSSL &gt;= 1.1.0.
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
- </refsect1><!-- }}} -->
- 
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>7.3.0</entry>
+      <entry>
+       Ajout de <parameter>min_proto_version</parameter> et
+       <parameter>max_proto_version</parameter>. Requiert OpenSSL &gt;= 1.1.0.
+      </entry>
+     </row>
+     <row>
+      <entry>7.2.0</entry>
+      <entry>
+       Ajout de <parameter>security_level</parameter>. Requiert OpenSSL &gt;= 1.1.0.
+      </entry>
+     </row>
+     <row>
+      <entry>7.0.0</entry>
+      <entry>
+       Ajout de <parameter>alpn_protocols</parameter>. Requiert OpenSSL &gt;= 1.0.2.
+      </entry>
+     </row>
+     <row>
+      <entry>5.6.0</entry>
+      <entry>
+       Ajout de <parameter>SNI_server_certs</parameter>.
+      </entry>
+     </row>
+     <row>
+      <entry>5.3.6</entry>
+      <entry>
+       Ajout de <parameter>no_ticket</parameter>.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+
  <refsect1 role="notes">
   &reftitle.notes;
   <note>
@@ -308,16 +411,14 @@
    </simpara>
   </note>
  </refsect1>
- 
+
  <refsect1 role="seealso">
   &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><xref linkend="context.socket" /></member>
-   </simplelist>
-  </para>
+  <simplelist>
+   <member><xref linkend="context.socket" /></member>
+  </simplelist>
  </refsect1>
- 
+
 </refentry>
 
 <!-- Keep this comment at the end of the file

--- a/reference/openssl/functions/openssl-x509-verify.xml
+++ b/reference/openssl/functions/openssl-x509-verify.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 497c40ac164d5873fd87f622dfdeb5206392b446 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 6819d9e5807762161caace88a21930156a313195 Maintainer: yannick Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.openssl-x509-verify" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -101,7 +101,7 @@ $ssloptions = array(
     "CN_match" => $hostname,
     "verify_peer" => true,
     "SNI_enabled" => true,
-    "SNI_server_name" => $hostname,
+    "peer_name" => $hostname,
 );
  
 $ctx = stream_context_create( array("ssl" => $ssloptions) );


### PR DESCRIPTION
Translation of php/doc-en#5413 (commit 6819d9e): adds SNI_server_certs, alpn_protocols, no_ticket, min_proto_version and max_proto_version, completes the changelog, unwraps the lists from their para and fixes the SNI_server_name option name in the openssl_x509_verify() example. EN-Revision updated.

Fixes: #3426