### PR TITLE
[Sync-En] in_array(): clarify the loose comparison behaviour as of PHP 8.0

### DIFF
--- a/reference/array/functions/in-array.xml
+++ b/reference/array/functions/in-array.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 2e60c5134e7a847c99f81eb3f7ecee1f5efeeace Maintainer: yannick Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 40514c7a2d1262c4126d2c8906835ecaf53d6354 Maintainer: yannick Status: ready -->
 <refentry xml:id="function.in-array" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>in_array</refname>
@@ -55,14 +54,24 @@
        correspond au type de la valeur trouvée dans <parameter>haystack</parameter>.
       </para>
       <note>
-       <para>
-        Avant PHP 8.0.0, un <literal>string</literal> <parameter>needle</parameter> correspondra
-        à une valeur de tableau de <literal>0</literal> en mode non strict et vice versa.
-        Cela peut conduire à des résultats non souhaitables.
-        Des cas particuliers similaires existent également pour d'autres types.
-        Si l'on n'est pas absolument certain des types de valeurs concernés,
-        toujours utiliser le drapeau <parameter>strict</parameter> pour éviter tout comportement inattendu.
-       </para>
+       <simpara>
+        Antérieur à PHP 8.0.0, un <parameter>needle</parameter> de type
+        <type>string</type> non numérique correspondait de manière lâche à une
+        valeur <literal>0</literal> de <parameter>haystack</parameter>, et
+        inversement. À partir de PHP 8.0.0, le nombre est converti en
+        <type>string</type> et les deux sont comparés en tant que chaînes ; seule
+        une <type>string</type> numérique de même valeur correspond donc encore.
+       </simpara>
+       <simpara>
+        Le mode non strict utilise néanmoins une
+        <link linkend="types.comparisions-loose">comparaison lâche</link>, si
+        bien que des valeurs de types différents peuvent toujours être
+        considérées comme égales : &true; correspond à toute <type>string</type>
+        évaluée à vrai, et &false; correspond à la fois à <literal>""</literal>
+        et à <literal>"0"</literal>. À moins de connaître avec certitude les
+        types de toutes les valeurs concernées, il faut toujours fournir
+        <parameter>strict</parameter> pour forcer une comparaison d'identité.
+       </simpara>
       </note>
      </listitem>
     </varlistentry>


### PR DESCRIPTION
Translation of php/doc-en#5519 (commit 40514c7): the note on non-strict mode now describes the PHP 8.0 string/number comparison and the remaining loose-comparison pitfalls. EN-Revision updated.

Fixes: #3428