### PR TITLE
[Sync-En] ssh2: translate five previously undocumented functions

### DIFF
--- a/reference/ssh2/functions/ssh2-auth-agent.xml
+++ b/reference/ssh2/functions/ssh2-auth-agent.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 12f0e72200ea9249d0fc2f118528bd24b24c44a6 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 3c1b1141df03aeb2633273aeef9aaa9de8619221 Maintainer: yannick Status: ready -->
 <!-- Reviewed: no -->
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.ssh2-auth-agent">
  <refnamediv>
@@ -21,7 +21,7 @@
   <note>
     <simpara>
      La fonction <function>ssh2_auth_agent</function> n'est disponible que
-     lorsque l'extension ssh2 a été compilée avec libssh &gt;= 1.2.3.
+     lorsque l'extension ssh2 a été compilée avec libssh2 &gt;= 1.2.3.
     </simpara>
   </note>
  </refsect1>

--- a/reference/ssh2/functions/ssh2-auth-pubkey-file.xml
+++ b/reference/ssh2/functions/ssh2-auth-pubkey-file.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 74ef2355c59e814d14f75a0792d22727be72f137 Maintainer: yannick Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 3c1b1141df03aeb2633273aeef9aaa9de8619221 Maintainer: yannick Status: ready -->
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.ssh2-auth-pubkey-file">
  <refnamediv>
   <refname>ssh2_auth_pubkey_file</refname>
@@ -107,7 +106,7 @@ if (ssh2_auth_pubkey_file($connection, 'username',
   &reftitle.notes;
   <note>
    <simpara>
-    La bibliothèque libssh sous-jacente ne supporte pas très proprement les
+    La bibliothèque libssh2 sous-jacente ne supporte pas très proprement les
     authentifications partielles.
     C'est-à-dire que si l'on doit fournir à la
     fois une clé publique et un mot de passe alors cela apparaitra comme si

--- a/reference/ssh2/functions/ssh2-auth-pubkey.xml
+++ b/reference/ssh2/functions/ssh2-auth-pubkey.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 74ef2355c59e814d14f75a0792d22727be72f137 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 3c1b1141df03aeb2633273aeef9aaa9de8619221 Maintainer: yannick Status: ready -->
 <!-- Reviewed: no -->
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.ssh2-auth-pubkey">
  <refnamediv>
@@ -108,7 +108,7 @@ if (ssh2_auth_pubkey($connection, 'username',
   &reftitle.notes;
   <note>
    <simpara>
-    La bibliothèque libssh sous-jacente ne supporte pas très proprement les
+    La bibliothèque libssh2 sous-jacente ne supporte pas très proprement les
     authentifications partielles.
     C'est-à-dire que si l'on doit fournir à la
     fois une clé publique et un mot de passe alors cela apparaitra comme si

--- a/reference/ssh2/functions/ssh2-keepalive-config.xml
+++ b/reference/ssh2/functions/ssh2-keepalive-config.xml
@@ -1,0 +1,142 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 3c1b1141df03aeb2633273aeef9aaa9de8619221 Maintainer: lacatoire Status: ready -->
+<refentry xml:id="function.ssh2-keepalive-config" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>ssh2_keepalive_config</refname>
+  <refpurpose>Configure la fréquence d'envoi des messages de maintien de connexion</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>void</type><methodname>ssh2_keepalive_config</methodname>
+   <methodparam><type>resource</type><parameter>session</parameter></methodparam>
+   <methodparam><type>bool</type><parameter>want_reply</parameter></methodparam>
+   <methodparam><type>int</type><parameter>interval</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Configure la fréquence d'envoi des messages de maintien de connexion sur la
+   <parameter>session</parameter> fournie, et détermine si une réponse est
+   demandée au serveur.
+  </simpara>
+  <simpara>
+   Les messages de maintien de connexion ne sont pas envoyés automatiquement.
+   Une fois la configuration faite, il faut appeler
+   <function>ssh2_keepalive_send</function> pour envoyer effectivement un
+   message de maintien de connexion.
+  </simpara>
+  <note>
+   <simpara>
+    Cette fonction n'est disponible que lorsque l'extension est compilée avec
+    une version de libssh2 fournissant le support du maintien de connexion.
+   </simpara>
+  </note>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>session</parameter></term>
+    <listitem>
+     <simpara>
+      Un identifiant de lien de connexion SSH, obtenu depuis un appel à
+      <function>ssh2_connect</function>.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>want_reply</parameter></term>
+    <listitem>
+     <simpara>
+      Indique si une réponse aux messages de maintien de connexion est demandée
+      au serveur. Demander une réponse permet de détecter un serveur qui ne
+      répond plus, au prix d'un trafic supplémentaire.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>interval</parameter></term>
+    <listitem>
+     <simpara>
+      Le nombre de secondes pouvant s'écouler sans aucun trafic avant qu'un
+      message de maintien de connexion ne soit envoyé. La valeur
+      <literal>0</literal> désactive les messages de maintien de connexion, et
+      la valeur <literal>1</literal> est traitée comme <literal>2</literal> par
+      la bibliothèque sous-jacente.
+     </simpara>
+     <simpara>
+      Les valeurs acceptées vont de <literal>0</literal> à
+      <literal>4294967295</literal>.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   &return.void;
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simpara>
+   Une erreur de niveau <constant>E_WARNING</constant> est émise lorsque
+   <parameter>interval</parameter> est en dehors de l'intervalle accepté ;
+   dans ce cas, la configuration du maintien de connexion reste inchangée.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Envoi de messages de maintien de connexion</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$connection = ssh2_connect('shell.example.com', 22);
+ssh2_auth_password($connection, 'username', 'password');
+
+// Demande une réponse au serveur, après 30 secondes sans aucun trafic
+ssh2_keepalive_config($connection, true, 30);
+
+// Les messages de maintien de connexion ne sont envoyés que lors de cet appel
+ssh2_keepalive_send($connection);
+?>
+]]>
+   </programlisting>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>ssh2_keepalive_send</function></member>
+   <member><function>ssh2_connect</function></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/ssh2/functions/ssh2-keepalive-send.xml
+++ b/reference/ssh2/functions/ssh2-keepalive-send.xml
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 3c1b1141df03aeb2633273aeef9aaa9de8619221 Maintainer: lacatoire Status: ready -->
+<refentry xml:id="function.ssh2-keepalive-send" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>ssh2_keepalive_send</refname>
+  <refpurpose>Envoie un message de maintien de connexion</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type class="union"><type>int</type><type>false</type></type><methodname>ssh2_keepalive_send</methodname>
+   <methodparam><type>resource</type><parameter>session</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Envoie un message de maintien de connexion sur la <parameter>session</parameter>
+   fournie, conformément à la configuration définie avec
+   <function>ssh2_keepalive_config</function>.
+  </simpara>
+  <note>
+   <simpara>
+    Cette fonction n'est disponible que lorsque l'extension est compilée avec
+    une version de libssh2 fournissant le support du maintien de connexion.
+   </simpara>
+  </note>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>session</parameter></term>
+    <listitem>
+     <simpara>
+      Un identifiant de lien de connexion SSH, obtenu depuis un appel à
+      <function>ssh2_connect</function>.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Retourne le nombre de secondes pouvant s'écouler avant qu'un nouveau message
+   de maintien de connexion ne doive être envoyé, ou &false; en cas d'échec.
+   <literal>0</literal> est retourné lorsque les messages de maintien de
+   connexion sont désactivés.
+  </simpara>
+  <simpara>
+   <literal>0</literal> et &false; étant tous deux évalués à faux, l'opérateur
+   <literal>===</literal> doit être utilisé pour les distinguer.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Envoi d'un message de maintien de connexion</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$connection = ssh2_connect('shell.example.com', 22);
+ssh2_auth_password($connection, 'username', 'password');
+ssh2_keepalive_config($connection, true, 30);
+
+$seconds = ssh2_keepalive_send($connection);
+
+if ($seconds === false) {
+    echo "Le message de maintien de connexion n'a pas pu être envoyé", PHP_EOL;
+} elseif ($seconds === 0) {
+    echo "Les messages de maintien de connexion sont désactivés", PHP_EOL;
+} else {
+    echo "Prochain message de maintien de connexion dans $seconds secondes", PHP_EOL;
+}
+?>
+]]>
+   </programlisting>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>ssh2_keepalive_config</function></member>
+   <member><function>ssh2_connect</function></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/ssh2/functions/ssh2-send-signal.xml
+++ b/reference/ssh2/functions/ssh2-send-signal.xml
@@ -1,0 +1,126 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 3c1b1141df03aeb2633273aeef9aaa9de8619221 Maintainer: lacatoire Status: ready -->
+<refentry xml:id="function.ssh2-send-signal" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>ssh2_send_signal</refname>
+  <refpurpose>Envoie un signal à un processus distant</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>bool</type><methodname>ssh2_send_signal</methodname>
+   <methodparam><type>resource</type><parameter>channel</parameter></methodparam>
+   <methodparam><type>string</type><parameter>signal</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Envoie un signal au processus s'exécutant à l'extrémité distante du
+   <parameter>channel</parameter> fourni.
+  </simpara>
+  <note>
+   <simpara>
+    Cette fonction n'est disponible que lorsque l'extension est compilée avec
+    libssh2 &gt;= 1.9.0.
+   </simpara>
+  </note>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>channel</parameter></term>
+    <listitem>
+     <simpara>
+      Un flux de canal SSH, tel que retourné par <function>ssh2_exec</function>
+      ou <function>ssh2_shell</function>.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>signal</parameter></term>
+    <listitem>
+     <simpara>
+      Le nom du signal à envoyer, sans le préfixe <literal>SIG</literal>, tel
+      que défini par le protocole de connexion SSH
+      (<link xlink:href="&url.rfc;4254">RFC 4254</link>) ; par exemple
+      <literal>TERM</literal>, <literal>KILL</literal> ou
+      <literal>INT</literal>.
+     </simpara>
+     <simpara>
+      La valeur est transmise telle quelle au serveur ; elle n'est pas validée
+      par rapport aux noms listés par le protocole.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   &return.success;
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simpara>
+   Une erreur de niveau <constant>E_WARNING</constant> est émise lorsque
+   <parameter>channel</parameter> n'est pas un flux de canal SSH, et lorsque le
+   signal n'a pas pu être envoyé.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Interruption d'une commande distante</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$connection = ssh2_connect('shell.example.com', 22);
+ssh2_auth_password($connection, 'username', 'password');
+
+$stream = ssh2_exec($connection, 'trap "echo interrupted" INT; sleep 60');
+
+ssh2_send_signal($stream, 'INT');
+
+stream_set_blocking($stream, true);
+echo stream_get_contents($stream);
+?>
+]]>
+   </programlisting>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>ssh2_exec</function></member>
+   <member><function>ssh2_shell</function></member>
+   <member><function>ssh2_send_eof</function></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/ssh2/functions/ssh2-set-timeout.xml
+++ b/reference/ssh2/functions/ssh2-set-timeout.xml
@@ -1,0 +1,118 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 3c1b1141df03aeb2633273aeef9aaa9de8619221 Maintainer: lacatoire Status: ready -->
+<refentry xml:id="function.ssh2-set-timeout" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>ssh2_set_timeout</refname>
+  <refpurpose>Définit le délai d'expiration des opérations bloquantes d'une session</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>void</type><methodname>ssh2_set_timeout</methodname>
+   <methodparam><type>resource</type><parameter>session</parameter></methodparam>
+   <methodparam><type>int</type><parameter>seconds</parameter></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>microseconds</parameter><initializer>0</initializer></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Définit la durée pendant laquelle une opération bloquante sur la
+   <parameter>session</parameter> fournie peut attendre avant d'être considérée
+   comme expirée.
+  </simpara>
+  <simpara>
+   Lorsque le délai résultant vaut <literal>0</literal>, ce qui est la valeur
+   par défaut, aucun délai d'expiration n'est appliqué et les opérations
+   bloquantes peuvent attendre indéfiniment.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>session</parameter></term>
+    <listitem>
+     <simpara>
+      Un identifiant de lien de connexion SSH, obtenu depuis un appel à
+      <function>ssh2_connect</function>.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>seconds</parameter></term>
+    <listitem>
+     <simpara>
+      Le délai d'expiration, en secondes.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>microseconds</parameter></term>
+    <listitem>
+     <simpara>
+      Un nombre de microsecondes supplémentaires ajouté au délai d'expiration.
+      La bibliothèque sous-jacente ne supporte qu'une précision à la
+      milliseconde, cette valeur est donc arrondie à la milliseconde entière
+      supérieure.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   &return.void;
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Limitation du temps d'attente des opérations bloquantes</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$connection = ssh2_connect('shell.example.com', 22);
+
+// Abandonne les opérations bloquantes après 5,5 secondes
+ssh2_set_timeout($connection, 5, 500000);
+
+ssh2_auth_password($connection, 'username', 'password');
+?>
+]]>
+   </programlisting>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>ssh2_connect</function></member>
+   <member><function>ssh2_keepalive_config</function></member>
+   <member><function>stream_set_timeout</function></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/ssh2/functions/ssh2-shell-resize.xml
+++ b/reference/ssh2/functions/ssh2-shell-resize.xml
@@ -1,0 +1,151 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 3c1b1141df03aeb2633273aeef9aaa9de8619221 Maintainer: lacatoire Status: ready -->
+<refentry xml:id="function.ssh2-shell-resize" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>ssh2_shell_resize</refname>
+  <refpurpose>Change les dimensions du pseudo-terminal d'un canal</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>bool</type><methodname>ssh2_shell_resize</methodname>
+   <methodparam><type>resource</type><parameter>channel</parameter></methodparam>
+   <methodparam><type>int</type><parameter>width</parameter></methodparam>
+   <methodparam><type>int</type><parameter>height</parameter></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>width_px</parameter><initializer>0</initializer></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>height_px</parameter><initializer>0</initializer></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Demande que le pseudo-terminal (PTY) attaché au <parameter>channel</parameter>
+   fourni soit redimensionné aux dimensions données.
+  </simpara>
+  <note>
+   <simpara>
+    L'extension ne déclare que les trois premiers paramètres, avec le nom
+    <literal>session</literal> pour <parameter>channel</parameter>. Par
+    conséquent, <parameter>width_px</parameter> et
+    <parameter>height_px</parameter> ne peuvent être fournis que
+    positionnellement.
+   </simpara>
+  </note>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>channel</parameter></term>
+    <listitem>
+     <simpara>
+      Un flux de canal SSH, tel que retourné par <function>ssh2_exec</function>
+      ou <function>ssh2_shell</function>.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>width</parameter></term>
+    <listitem>
+     <simpara>
+      La largeur du terminal, en caractères.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>height</parameter></term>
+    <listitem>
+     <simpara>
+      La hauteur du terminal, en caractères.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>width_px</parameter></term>
+    <listitem>
+     <simpara>
+      La largeur du terminal en pixels, ou <literal>0</literal> pour laisser
+      les dimensions en pixels non spécifiées.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>height_px</parameter></term>
+    <listitem>
+     <simpara>
+      La hauteur du terminal en pixels, ou <literal>0</literal> pour laisser
+      les dimensions en pixels non spécifiées.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Retourne &true;, ou &false; lorsque <parameter>channel</parameter> n'est pas
+   un flux de canal SSH.
+  </simpara>
+  <simpara>
+   Le résultat de la demande de redimensionnement elle-même n'est pas rapporté:
+   &true; est retourné même lorsque l'extrémité distante ne l'honore pas.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simpara>
+   Une erreur de niveau <constant>E_WARNING</constant> est émise lorsque
+   <parameter>channel</parameter> n'est pas un flux de canal SSH.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Redimensionnement du pseudo-terminal d'un shell</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$connection = ssh2_connect('shell.example.com', 22);
+ssh2_auth_password($connection, 'username', 'password');
+
+$shell = ssh2_shell($connection, 'xterm', null, 80, 24);
+
+// Indique à l'extrémité distante que le terminal fait désormais 132 colonnes sur 43 lignes
+ssh2_shell_resize($shell, 132, 43);
+?>
+]]>
+   </programlisting>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>ssh2_shell</function></member>
+   <member><function>ssh2_exec</function></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/ssh2/setup.xml
+++ b/reference/ssh2/setup.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 12f0e72200ea9249d0fc2f118528bd24b24c44a6 Maintainer: yannick Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 3c1b1141df03aeb2633273aeef9aaa9de8619221 Maintainer: yannick Status: ready -->
 <chapter xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="ssh2.setup">
  &reftitle.setup;
 
@@ -22,11 +21,11 @@
   </simpara>
   <simpara>
    La fonction <function>ssh2_auth_agent</function> ne sera disponible qu'avec
-   libssh &gt;= 1.2.3.
+   libssh2 &gt;= 1.2.3.
   </simpara>
   <simpara>
    Le support de la fonction <function>stream_set_timeout</function>
-   pour les flux d'un canal ne sera disponible qu'avec libssh &gt;= 1.2.9.
+   pour les flux d'un canal ne sera disponible qu'avec libssh2 &gt;= 1.2.9.
   </simpara>
   <simpara>
    Libssh2 peut contenir deux versions : gcrypt ou openssl.


### PR DESCRIPTION
Translation of php/doc-en#5688 (commit 3c1b114): new pages for ssh2_keepalive_config(), ssh2_keepalive_send(), ssh2_send_signal(), ssh2_set_timeout() and ssh2_shell_resize(), plus the libssh -> libssh2 fixes in the existing pages. EN-Revision updated.

Fixes: #3429