### PR TITLE
[Sync-En] ext/session: document the 8.4.0 INI deprecations

### DIFF
--- a/reference/session/ini.xml
+++ b/reference/session/ini.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 7fabff299de8a894888e8064797ed3278f50b356 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 736b8b384a6f02033a20f4819ca51115b7833818 Maintainer: lacatoire Status: ready -->
 
 <section xml:id="session.configuration" xmlns="http://docbook.org/ns/docbook">
  &reftitle.runtime;
@@ -165,13 +165,19 @@
       <entry><link linkend="ini.session.sid-length">session.sid_length</link></entry>
       <entry>"32"</entry>
       <entry><constant>INI_ALL</constant></entry>
-      <entry>&php.version.added; 7.1.0. Obsolète à partir de PHP 8.4.0.</entry>
+      <entry>
+       &php.version.added; 7.1.0.
+       Modifier cette directive est obsolète à partir de PHP 8.4.0.
+      </entry>
      </row>
      <row>
       <entry><link linkend="ini.session.sid-bits-per-character">session.sid_bits_per_character</link></entry>
       <entry>"4"</entry>
       <entry><constant>INI_ALL</constant></entry>
-      <entry>&php.version.added; 7.1.0. Obsolète à partir de PHP 8.4.0.</entry>
+      <entry>
+       &php.version.added; 7.1.0.
+       Modifier cette directive est obsolète à partir de PHP 8.4.0.
+      </entry>
      </row>
      <row>
       <entry><link linkend="ini.session.upload-progress.enabled">session.upload_progress.enabled</link></entry>
@@ -846,27 +852,15 @@
       comprise entre 22 et 256.
      </simpara>
      <simpara>
-      La valeur par défaut est 32. En cas de besoin de compatibilité, il est possible de
-       spécifier 32, 40, etc. L'ID de session plus long est plus difficile
-      à deviner. Au moins 32 caractères sont recommandés.
+      La valeur par défaut est 32. Un ID de session plus long est plus difficile
+      à deviner.
      </simpara>
-     <tip>
-      <para>
-       Note de compatibilité: utiliser 32 au lieu de
-       <literal>session.hash_function</literal>=0 (MD5) et
-       <literal>session.hash_bits_per_character</literal>=4,
-       <literal>session.hash_function</literal>=1 (SHA1) et
-       <literal>session.hash_bits_per_character</literal>=6. Utiliser 26 au lieu de
-       <literal>session.hash_function</literal>=0 (MD5) et
-       <literal>session.hash_bits_per_character</literal>=5. Utiliser 22 au lieu de
-       <literal>session.hash_function</literal>=0 (MD5) et
-       <literal>session.hash_bits_per_character</literal>=6.
-       Il faut configurer les valeurs INI pour qu'il y ait 128 bits dans
-       l'ID de session. Il ne faut pas oublier de définir la valeur appropriée à
-       <literal>session.sid_bits_per_character</literal>, sinon on aura des
-       ID de session plus faibles.
-      </para>
-     </tip>
+     <warning>
+      <simpara>
+       Modifier <literal>session.sid_length</literal> par rapport à sa valeur
+       par défaut est obsolète à partir de PHP 8.4.0.
+      </simpara>
+     </warning>
      <note>
       <simpara>
        &php.version.added; 7.1.0.
@@ -888,11 +882,15 @@
       '4' (0-9, a-f), '5' (0-9, a-v), et '6' (0-9, a-z, A-Z, "-", ",").
      </simpara>
      <simpara>
-      La valeur par défaut est 4. Plus de bits aboutit à un ID de session plus
-      fort. 5 est la valeur recommandée pour la plupart des environnements.
+      La valeur par défaut est 4. Un nombre de bits plus élevé aboutit à un ID
+      de session plus fort.
      </simpara>
-     <para>
-     </para>
+     <warning>
+      <simpara>
+       Modifier <literal>session.sid_bits_per_character</literal> par rapport à
+       sa valeur par défaut est obsolète à partir de PHP 8.4.0.
+      </simpara>
+     </warning>
      <note>
       <simpara>
        &php.version.added; 7.1.0.

--- a/reference/session/security.xml
+++ b/reference/session/security.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 55e0481a24fd4d7db21b62f1885973edbca25e60 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 35cadcfe561fc27ee973457a64880f0b85db2ec5 Maintainer: yannick Status: ready -->
 <!-- Reviewed: no -->
 
 <chapter xml:id="session.security" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -726,14 +726,18 @@
     <para>
      <link linkend="ini.session.use-trans-sid">session.use_trans_sid</link>=Off
     </para>
-    <para>
-     L'utilisation d'un gestionnaire d'identifiants de sessions transparent
-     n'est pas interdit. Les développeurs doivent l'employer lorsque nécessaire.
-     Pourtant, la désactivation de la gestion des identifiants de session de 
-     façon transparente permet de sécuriser un peu plus les identifiants de session
-     en éliminant la possibilité d'une injection d'identifiant de sessions ou
-     de fuite de cet identifiant.
-    </para>
+    <simpara>
+     La désactivation de la gestion transparente des identifiants de session
+     permet de sécuriser un peu plus les identifiants de session en éliminant
+     la possibilité d'une injection d'identifiant de session ou de fuite de cet
+     identifiant.
+    </simpara>
+    <warning>
+     <simpara>
+      Activer <literal>session.use_trans_sid</literal> est obsolète à partir de
+      PHP 8.4.0.
+     </simpara>
+    </warning>
     <note>
      <para>
       L'identifiant de session peut fuiter depuis des URLs sauvegardées, 
@@ -743,48 +747,62 @@
    </listitem>
    
    <listitem>
-    <para>
-     <link linkend="ini.session.trans-sid-tags">session.trans_sid_tags</link>=[balises limitées]
-    </para>
-    <para>
-     (PHP 7.1.0 &gt;=) Les développeurs ne devraient pas réécrire de balises HTML
-     non nécessaires. La valeur par défaut doit être suffisante pour la
-     plupart des utilisations. Pour les versions de PHP plus anciennes,
-     utiliser plutôt
+    <simpara>
+     <link linkend="ini.session.trans-sid-tags">session.trans_sid_tags</link>="a=href,area=href,frame=src,form="
+    </simpara>
+    <simpara>
+     Les balises HTML non nécessaires ne devraient pas être réécrites. La valeur
+     par défaut est suffisante pour la plupart des utilisations. Pour les
+     versions de PHP plus anciennes, utiliser plutôt
      <link linkend="ini.url-rewriter.tags">url_rewriter.tags</link>.
-    </para>
+    </simpara>
+    <warning>
+     <simpara>
+      Modifier <literal>session.trans_sid_tags</literal> par rapport à sa valeur
+      par défaut est obsolète à partir de PHP 8.4.0.
+     </simpara>
+    </warning>
    </listitem>
    
    <listitem>
-    <para>
-     <link linkend="ini.session.trans-sid-hosts">session.trans_sid_hosts</link>=[hôtes limités]
-    </para>
-    <para>
-     (PHP 7.1.0 &gt;=) Ce paramètre définit une liste blanche des hôtes qui sont
-     autorisés à réécrire les identifiants de session transparents. Ne jamais
-     ajouter d'hôte qui ne sont pas de confiance !
-     Le module de session autorise uniquement <literal>$_SERVER['HTTP_HOST']</literal>
-     lorsque ce paramètre est vide.
-    </para>
+    <simpara>
+     <link linkend="ini.session.trans-sid-hosts">session.trans_sid_hosts</link>=""
+    </simpara>
+    <simpara>
+     Ce paramètre liste les hôtes pour lesquels l'identifiant de session peut
+     être ajouté aux URL. Il ne faut jamais y ajouter d'hôte qui n'est pas de
+     confiance. Lorsqu'il est vide, le module de session autorise uniquement
+     <literal>$_SERVER['HTTP_HOST']</literal>.
+    </simpara>
+    <warning>
+     <simpara>
+      Définir <literal>session.trans_sid_hosts</literal> à une valeur non vide
+      est obsolète à partir de PHP 8.4.0.
+     </simpara>
+    </warning>
    </listitem>
    
    <listitem>
-    <para>
-     <link linkend="ini.session.referer-check">session.referer_check</link>=[URL d'origine]
-    </para>
-    <para>
+    <simpara>
+     <link linkend="ini.session.referer-check">session.referer_check</link>=""
+    </simpara>
+    <simpara>
      Lorsque le paramètre <link
      linkend="ini.session.use-trans-sid">session.use_trans_sid</link>
-     est actif.
-     Ce paramètre réduit les risques d'injection d'identifiant de session.
-     Si un site web est <literal>http://example.com/</literal>,
-     définissez comme valeur à ce paramètre <literal>http://example.com/</literal>.
-     Il est à noter que les navigateurs HTTPS n'envoient pas l'en-tête referrer.
-     Les navigateurs peuvent ne pas envoyer l'en-tête referrer de part
-     leur propre configuration. Aussi, ce paramètre ne peut pas être
-     considéré comme une mesure fiable de sécurité.
-     Malgré tout, son utilisation est recommandée.
-    </para>
+     est actif, une valeur non vide réduit les risques d'injection
+     d'identifiant de session : l'identifiant de session envoyé par le client
+     est ignoré à moins que l'en-tête <literal>Referer</literal> ne contienne
+     cette valeur. Il est à noter qu'en HTTPS les navigateurs n'envoient pas
+     l'en-tête <literal>Referer</literal>, et que les navigateurs peuvent
+     l'omettre de par leur propre configuration. Aussi, ce paramètre ne peut pas
+     être considéré comme une mesure fiable de sécurité.
+    </simpara>
+    <warning>
+     <simpara>
+      Définir <literal>session.referer_check</literal> à une valeur non vide
+      est obsolète à partir de PHP 8.4.0.
+     </simpara>
+    </warning>
    </listitem>
    
    <listitem>
@@ -800,21 +818,6 @@
      peut transmettre des données privées mises en cache pour les clients
      partagés. <literal>"public"</literal> doit être uniquement utilisé lorsque le contenu HTML
      ne contient aucune donnée privée.
-    </para>
-   </listitem>
-   
-   <listitem>
-    <para>
-     <link linkend="ini.session.hash-function">session.hash_function</link>="sha256"
-    </para>
-    <para>
-     (PHP 7.1.0 &lt;) Une fonction de hachage forte va générer un identifiant
-     de session fort. Bien qu'une collision de hachage soit peu probable avec des
-     algorithmes de hachage MD5, les développeurs doivent utiliser SHA-2 ou un
-     algorithme de hachage plus fort comme sha384 et sha512.
-     Les développeurs doivent s'assurer d'une longueur suffisante de 
-     l'<link linkend="ini.session.entropy-length">entropie</link> pour la 
-     fonction de hachage utilisée.
     </para>
    </listitem>
    


### PR DESCRIPTION
Translation of php/doc-en#5800 (commit 35cadcf): conditional 8.4.0 deprecations for session.sid_length, session.sid_bits_per_character, session.use_trans_sid, session.trans_sid_tags, session.trans_sid_hosts and session.referer_check, and removal of the session.hash_function recommendation (removed in 7.1.0). EN-Revision updated.

Fixes: #3430