### PR TITLE
[Sync-En] strings: split the illegal string offsets output by PHP version

### DIFF
--- a/language/types/string.xml
+++ b/language/types/string.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 0d964bcaac6618dd80b974eb6fcdf3c67ca07340 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: eb4bde8a489ee6523879baa482247ed49aea951d Maintainer: yannick Status: ready -->
 <sect1 xml:id="language.types.string">
  <title>Chaînes</title>
 
@@ -1063,10 +1063,16 @@ var_dump($str);
     </programlisting>
    </example>
 
-   <para>
-    Les offsets de chaîne doivent être des entiers ou des chaînes ressemblant à des entiers,
-    sinon un avertissement sera émis.
-   </para>
+   <simpara>
+    Les offsets de chaîne doivent être des entiers ou des chaînes ressemblant à
+    des entiers. À partir de PHP 8.0.0, toute autre chaîne lève une
+    <exceptionname>TypeError</exceptionname>, à l'exception d'une chaîne
+    commençant par un entier suivi d'autres caractères, qui émet une erreur de
+    niveau <constant>E_WARNING</constant> et est interprétée comme cet entier
+    initial. Antérieur à PHP 8.0.0, aucune
+    <exceptionname>TypeError</exceptionname> n'était levée : un offset illégal
+    émettait une erreur de niveau <constant>E_WARNING</constant> à la place.
+   </simpara>
 
    <example>
     <title>Exemple d'offsets de chaîne illégaux</title>
@@ -1091,7 +1097,7 @@ foreach ($keys as $keyToTry) {
 ?>
 ]]>
     </programlisting>
-    &example.outputs;
+    &example.outputs.8;
     <screen>
 <![CDATA[
 bool(true)
@@ -1105,7 +1111,29 @@ Cannot access offset of type string on string
 
 bool(false)
 
-Warning: Illegal string offset "1x" in Standard input code on line 10
+Warning: Illegal string offset "1x" in example.php on line 10
+string(1) "b"
+]]>
+    </screen>
+    &example.outputs.7;
+    <screen>
+<![CDATA[
+bool(true)
+string(1) "b"
+
+bool(false)
+
+Warning: Illegal string offset '1.0' in example.php on line 10
+string(1) "b"
+
+bool(false)
+
+Warning: Illegal string offset 'x' in example.php on line 10
+string(1) "a"
+
+bool(false)
+
+Notice: A non well formed numeric value encountered in example.php on line 10
 string(1) "b"
 ]]>
     </screen>


### PR DESCRIPTION
Translation of php/doc-en#5232 (commit eb4bde8): the example now shows the PHP 8 and PHP 7 outputs separately, and the introductory paragraph states the PHP 8 rule. EN-Revision updated.

Fixes: #3431