### PR TITLE
[Sync-En] appendices: note the E_STRICT deprecation, annotate T_PROPERTY_C

### DIFF
--- a/appendices/reserved.constants.core.xml
+++ b/appendices/reserved.constants.core.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 5208882ce3910d599e339209f967e183b49ba6ef Maintainer: lacatoire Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 5a91c9a81ee5c2560a15f1fca84bc5a6148cca9a Maintainer: lacatoire Status: ready -->
 <sect2 xml:id="reserved.constants.core" xmlns="http://docbook.org/ns/docbook">
  <title>Constantes prédéfinies</title>
  <simpara>
@@ -596,6 +595,13 @@
     <constant>E_ALL</constant>
     (<type>int</type>)
    </term>
+   <listitem>
+    <simpara>
+     <link linkend="errorfunc.constants">Constantes de rapport d'erreur</link>.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry>
    <term>
     <constant>E_STRICT</constant>
     (<type>int</type>)
@@ -603,6 +609,7 @@
    <listitem>
     <simpara>
      <link linkend="errorfunc.constants">Constantes de rapport d'erreur</link>.
+     Cette constante est inutilisée, et est obsolète à partir de PHP 8.4.0.
     </simpara>
    </listitem>
   </varlistentry>

--- a/appendices/tokens.xml
+++ b/appendices/tokens.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 5f720ab2b9c8122d1a127684748712fc57a24d06 Maintainer: lacatoire Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 5a91c9a81ee5c2560a15f1fca84bc5a6148cca9a Maintainer: lacatoire Status: ready -->
 <appendix xml:id="tokens" xmlns="http://docbook.org/ns/docbook">
  <title>Liste des jetons de l'analyseur</title>
  <para>
@@ -1064,7 +1063,7 @@ defined('T_FN') || define('T_FN', 10001);
      </entry>
      <entry>__PROPERTY__</entry>
      <entry>
-      <link linkend="language.constants.magic">constantes magiques</link>
+      <link linkend="language.constants.magic">constantes magiques</link> (disponible à partir de PHP 8.4.0)
      </entry>
     </row>
     <row xml:id="constant.t-protected">


### PR DESCRIPTION
Translation of php/doc-en#5799 (commit 5a91c9a): E_STRICT gets its own entry stating it is unused and deprecated as of 8.4.0, and T_PROPERTY_C is marked as available as of PHP 8.4.0. EN-Revision updated.

Fixes: #3432