### PR TITLE
[Sync-En] ext/intl: correct the 8.4.0 Error normalization, it only concerns cloning

### DIFF
--- a/appendices/migration84/other-changes.xml
+++ b/appendices/migration84/other-changes.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 858400b07586b88dcb1e17a95e7a178b54b89d86 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 66bf3dcc3870f91bda607fe90717a8291d195236 Maintainer: lacatoire Status: ready -->
 <sect1 xml:id="migration84.other-changes">
  <title>Autres changements</title>
 
@@ -548,9 +548,13 @@
    <title>Intl</title>
 
    <simpara>
-    Le comportement de la classe Intl a été normalisé pour toujours lancer
-    des exceptions <exceptionname>Error</exceptionname> lors de la tentative d'utilisation
-    d'un objet non initialisé, ou lorsque le clonage échoue.
+    Le clonage d'un objet Intl lève systématiquement une
+    <exceptionname>Error</exceptionname> lorsque le clonage ne peut pas être
+    effectué, soit parce que l'objet n'a pas été initialisé, soit parce que
+    l'opération de clonage ICU sous-jacente a échoué. Antérieur à cela, la
+    plupart de ces classes levaient une <exceptionname>Exception</exceptionname>
+    à la place, et <classname>Spoofchecker</classname> émettait une erreur
+    fatale.
    </simpara>
   </sect3>
 

--- a/reference/intl/book.xml
+++ b/reference/intl/book.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: a03f9eda2d45b725f75b4d6a1a22e8aec63e157a Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 66bf3dcc3870f91bda607fe90717a8291d195236 Maintainer: lacatoire Status: ready -->
 
 <book xml:id="book.intl" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <?phpdoc extension-membership="bundled" ?>
@@ -99,6 +99,18 @@
     </simpara>
    </listitem>
   </itemizedlist>
+
+  <note>
+   <simpara>
+    À partir de PHP 8.4.0, le clonage d'un objet Intl lève systématiquement une
+    <exceptionname>Error</exceptionname> lorsque le clonage ne peut pas être
+    effectué, soit parce que l'objet n'a pas été initialisé (créé sans que son
+    constructeur ne soit invoqué), soit parce que l'opération de clonage ICU
+    sous-jacente a échoué. Antérieur à cela, la plupart de ces classes levaient
+    une <exceptionname>Exception</exceptionname> à la place, et
+    <classname>Spoofchecker</classname> émettait une erreur fatale.
+   </simpara>
+  </note>
 
   <!-- {{{ Links -->
   <section xml:id="intl.links">


### PR DESCRIPTION
Translation of php/doc-en#5798 (commit 66bf3dc): the 8.4.0 change only concerns the clone handlers, so the migration entry is corrected and the same note is added to the intl book. EN-Revision updated.

Fixes: #3433