### PR TITLE
[Sync-En] ext/mbstring: fix the version of the character index change (8.3.2)

### DIFF
--- a/appendices/migration84/incompatible.xml
+++ b/appendices/migration84/incompatible.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: b2acdf5697fa3c189f24c3b0147bef57cb8a6c32 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 5c52e84d0ce157d8c22f9c582719a14228c5402a Maintainer: lacatoire Status: ready -->
 <sect1 xml:id="migration84.incompatible" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Changements non rétrocompatibles</title>
 
@@ -518,19 +518,20 @@
   <title>MBString</title>
 
   <simpara>
-   En cas de chaînes invalides (celles avec des erreurs d'encodage),
-   <function>mb_substr</function> interprète désormais les indices de caractères
-   de la même manière que la plupart des autres fonctions mbstring.
-   Cela signifie que les indices de caractères retournés par <function>mb_strpos</function>
-   peuvent être passés à <function>mb_substr</function>.
+   À partir de PHP 8.3.2, en cas de chaînes invalides (celles avec des erreurs
+   d'encodage), <function>mb_substr</function> et <function>mb_strstr</function>
+   interprètent les indices de caractères de la même manière que la plupart des
+   autres fonctions mbstring. Cela signifie que les indices de caractères
+   retournés par <function>mb_strpos</function> peuvent être passés à
+   <function>mb_substr</function>.
   </simpara>
 
   <simpara>
-   Pour les chaînes SJIS-Mac (MacJapanese), les indices de caractères passés à
-   <function>mb_substr</function> font désormais référence aux indices des
-   points de code Unicode qui sont produits lorsque la chaîne est convertie en Unicode.
-   C'est significatif car environ 40 caractères SJIS-Mac se convertissent en une
-   séquence de plusieurs points de code Unicode.
+   Pour les chaînes <literal>SJIS-mac</literal> (MacJapanese), ces indices de
+   caractères font référence aux indices des points de code Unicode qui sont
+   produits lorsque la chaîne est convertie en Unicode, lesquels diffèrent des
+   indices de caractères pour les caractères <literal>SJIS-mac</literal> qui se
+   convertissent en une séquence de plusieurs points de code.
   </simpara>
  </sect2>
 

--- a/reference/mbstring/book.xml
+++ b/reference/mbstring/book.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: c1f37a6c270aadbbb3da56a3973ffd62197adf2b Maintainer: yannick Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 5c52e84d0ce157d8c22f9c582719a14228c5402a Maintainer: yannick Status: ready -->
 
 <book xml:id="book.mbstring" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" annotations="interactive">
  <?phpdoc extension-membership="bundled" ?>
@@ -22,7 +21,7 @@
    pas garde, on va obtenir une chaîne corrompue et invalide, avec
    une représentation totalement incompréhensible.
   </para>
-  <para>
+  <simpara>
    <literal>mbstring</literal> fournit les fonctions spécifiques de manipulations
    de chaînes qui permettent de travailler avec les encodages multioctets en PHP.
    En plus de cela, <literal>mbstring</literal> gère la traduction
@@ -30,7 +29,12 @@
    également connu pour gérer l'Unicode, comme UTF-8 et UCS-2 ainsi que de
    nombreux autres jeux mono-octets (listés dans
    <link linkend="mbstring.supported-encodings">Encodages de caractères pris en charge</link>).
-  </para>
+  </simpara>
+  <simpara>
+   Les tables de données Unicode utilisées par <literal>mbstring</literal> ont
+   été mises à jour vers Unicode 16.0 à partir de PHP 8.4.0, et vers
+   Unicode 17.0 à partir de PHP 8.5.0.
+  </simpara>
  </preface>
  <!-- }}} -->
 

--- a/reference/mbstring/functions/mb-strstr.xml
+++ b/reference/mbstring/functions/mb-strstr.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 95d05546430b9e5db225dd42a0d285b870f0da42 Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 5c52e84d0ce157d8c22f9c582719a14228c5402a Maintainer: yannick Status: ready -->
 <refentry xml:id="function.mb-strstr" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>mb_strstr</refname>
@@ -87,6 +86,17 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.3.2</entry>
+      <entry>
+       Sur les chaînes invalides (celles comportant des erreurs d'encodage) et
+       sur les chaînes <literal>SJIS-mac</literal> (MacJapanese), la portion de
+       <parameter>haystack</parameter> retournée lorsque
+       <parameter>before_needle</parameter> vaut &true; est désormais déterminée
+       à partir des mêmes indices de caractères que les autres fonctions
+       mbstring.
+      </entry>
+     </row>
      &mbstring.changelog.needle-empty;
      &mbstring.changelog.encoding-nullable;
     </tbody>

--- a/reference/mbstring/functions/mb-substr.xml
+++ b/reference/mbstring/functions/mb-substr.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 911fe79de766ef4475bf22446903667a0f3a24d3 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 5c52e84d0ce157d8c22f9c582719a14228c5402a Maintainer: lacatoire Status: ready -->
 <refentry xml:id="function.mb-substr" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>mb_substr</refname>
@@ -98,13 +98,19 @@
     </thead>
     <tbody>
      <row>
-      <entry>8.4.0</entry>
+      <entry>8.3.2</entry>
       <entry>
        Sur les chaînes invalides (celles comportant des erreurs d'encodage),
        les indices de caractères sont désormais interprétés de la même manière
        que la plupart des autres fonctions mbstring. Cela signifie que les indices
        de caractères retournés par <function>mb_strpos</function> peuvent être
        passés directement.
+       Pour les chaînes <literal>SJIS-mac</literal> (MacJapanese), les indices
+       de caractères font désormais référence aux indices des points de code
+       Unicode produits lorsque la chaîne est convertie en Unicode, lesquels
+       diffèrent des indices de caractères pour les caractères
+       <literal>SJIS-mac</literal> qui se convertissent en une séquence de
+       plusieurs points de code.
       </entry>
      </row>
      &mbstring.changelog.encoding-nullable;
@@ -115,12 +121,10 @@
 
  <refsect1 role="seealso">
   &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><function>mb_strcut</function></member>
-    <member><function>mb_internal_encoding</function></member>
-   </simplelist>
-  </para>
+  <simplelist>
+   <member><function>mb_strcut</function></member>
+   <member><function>mb_internal_encoding</function></member>
+  </simplelist>
  </refsect1>
 
 </refentry>


### PR DESCRIPTION
Translation of php/doc-en#5797 (commit 5c52e84): the character index change shipped in 8.3.2 and also affects mb_strstr(); SJIS-mac wording aligned, and the Unicode table versions (16.0 in 8.4.0, 17.0 in 8.5.0) added to the book. EN-Revision updated.

Fixes: #3434