### PR TITLE
[Sync-En] ext/pcntl: document the SIGALRM default for restart_syscalls

### DIFF
--- a/reference/pcntl/functions/pcntl-signal.xml
+++ b/reference/pcntl/functions/pcntl-signal.xml
@@ -1,12 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 5fe0f8494374d594762e56b2d769c2828b1e0ddb Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 3866fba43ed70c07afa89df7daf21529b09b4f3b Maintainer: yannick Status: ready -->
 <refentry xml:id="function.pcntl-signal" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>pcntl_signal</refname>
   <refpurpose>Installe un gestionnaire de signaux</refpurpose>
  </refnamediv>
- 
+
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
@@ -16,13 +15,12 @@
    <methodparam choice="opt"><type>bool</type><parameter>restart_syscalls</parameter><initializer>&true;</initializer></methodparam>
   </methodsynopsis>
   <para>
-   <function>pcntl_signal</function> installe un nouveau gestionnaire
-   de signaux ou remplace le gestionnaire de signaux courant
-   pour le signal indiqué par le paramètre
-   <parameter>signal</parameter>.
+   La fonction <function>pcntl_signal</function> installe un nouveau
+   gestionnaire de signaux ou remplace le gestionnaire de signaux courant
+   pour le signal indiqué par <parameter>signal</parameter>.
   </para>
  </refsect1>
- 
+
  <refsect1 role="parameters">
   &reftitle.parameters;
   <para>
@@ -38,13 +36,13 @@
     <varlistentry>
      <term><parameter>handler</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Le gestionnaire de signaux. Peut être un <type>callable</type>,
        qui sera appelé pour gérer le signal, ou bien l'une des deux
        constantes globales <constant>SIG_IGN</constant> ou <constant>SIG_DFL</constant>,
        qui vont, respectivement, ignorer le signal ou restaurer le gestionnaire
        de signaux par défaut.
-      </para>
+      </simpara>
       <para>
        Si un <type>callable</type> est fourni, il doit implémenter la signature
        suivante :
@@ -57,7 +55,7 @@
        </methodsynopsis>
        <variablelist>
         <varlistentry>
-         <term><parameter>signal</parameter></term>
+         <term><parameter>signo</parameter></term>
          <listitem>
           <simpara>
            Le signal à gérer.
@@ -75,12 +73,12 @@
        </variablelist>
       </para>
       <note>
-       <para>
-        À noter que lorsque l'on configure le gestionnaire avec une méthode d'objet,
-        le compteur de référence de l'objet est incrémenté, ce qui le rend persistant
-        jusqu'à ce que l'on change le gestionnaire de signaux pour un autre, ou que
-        le script se termine.
-       </para>
+       <simpara>
+        Lorsque le gestionnaire est défini avec une méthode d'objet, le compteur
+        de références de cet objet est incrémenté, ce qui le rend persistant
+        jusqu'à ce que le gestionnaire soit remplacé par un autre, ou que le
+        script se termine.
+       </simpara>
       </note>
      </listitem>
     </varlistentry>
@@ -88,23 +86,49 @@
      <term><parameter>restart_syscalls</parameter></term>
      <listitem>
       <para>
-       Le paramètre optionnel <parameter>restart_syscalls</parameter>
-       spécifie si l'appel système de redémarrage (restarting) doit être utilisé
+       Spécifie si le redémarrage des appels système doit être utilisé
        lorsque ce signal arrive.
       </para>
+      <note>
+       <simpara>
+        Bien que la valeur par défaut de ce paramètre soit &true;, cette valeur
+        par défaut ne s'applique pas à <constant>SIGALRM</constant> : lorsque
+        <parameter>restart_syscalls</parameter> n'est pas fourni et que
+        <parameter>signal</parameter> vaut <constant>SIGALRM</constant>, le
+        redémarrage des appels système est désactivé. Il faut fournir &true;
+        explicitement pour activer le redémarrage des appels système pour
+        <constant>SIGALRM</constant>.
+       </simpara>
+      </note>
      </listitem>
     </varlistentry>
    </variablelist>
   </para>
  </refsect1>
- 
+
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
    &return.success;
   </para>
  </refsect1>
- 
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simpara>
+   Une <exceptionname>ValueError</exceptionname> est levée si
+   <parameter>signal</parameter> est inférieur à <literal>1</literal> ou
+   supérieur ou égal à <constant>NSIG</constant>, ou si
+   <parameter>handler</parameter> est un <type>int</type> autre que
+   <constant>SIG_DFL</constant> ou <constant>SIG_IGN</constant>.
+  </simpara>
+  <simpara>
+   Une <exceptionname>TypeError</exceptionname> est levée si
+   <parameter>handler</parameter> n'est ni un <type>callable</type> ni un
+   <type>int</type>.
+  </simpara>
+ </refsect1>
+
  <refsect1 role="changelog">
   &reftitle.changelog;
   <para>
@@ -117,6 +141,16 @@
       </row>
      </thead>
      <tbody>
+      <row>
+       <entry>7.4.0</entry>
+       <entry>
+        <parameter>restart_syscalls</parameter> est désormais pris en compte
+        pour <constant>SIGALRM</constant> ; antérieurement, le redémarrage des
+        appels système était toujours désactivé pour ce signal. Lorsque
+        l'argument n'est pas fourni, le redémarrage des appels système reste
+        désactivé pour <constant>SIGALRM</constant>.
+       </entry>
+      </row>
       <row>
        <entry>7.1.0</entry>
        <entry>
@@ -131,7 +165,7 @@
    </informaltable>
   </para>
  </refsect1>
- 
+
  <refsect1 role="examples">
   &reftitle.examples;
   <para>
@@ -187,13 +221,13 @@ echo "Fait\n";
    </example>
   </para>
  </refsect1>
- 
+
  <refsect1 role="notes"><!-- {{{ -->
   &reftitle.notes;
-  <para>
+  <simpara>
    La fonction <function>pcntl_signal</function> ne place pas dans une pile
    les gestionnaires de signaux, mais les remplace.
-  </para>
+  </simpara>
   <refsect2>
    <title>Méthode de dispatch</title>
    <para>
@@ -210,20 +244,18 @@ echo "Fait\n";
    </para>
   </refsect2>
  </refsect1><!-- }}} -->
- 
+
  <refsect1 role="seealso">
   &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><link xlink:href="https://fr.wikipedia.org/wiki/Signal_(informatique)">Signal (IPC)</link> sur Wikipedia</member>
-    <member><function>pcntl_async_signals</function></member>
-    <member><function>pcntl_fork</function></member>
-    <member><function>pcntl_signal_dispatch</function></member>
-    <member><function>pcntl_waitpid</function></member>
-   </simplelist>
-  </para>
+  <simplelist>
+   <member><link xlink:href="https://fr.wikipedia.org/wiki/Signal_(informatique)">Signal (IPC)</link> sur Wikipedia</member>
+   <member><function>pcntl_async_signals</function></member>
+   <member><function>pcntl_fork</function></member>
+   <member><function>pcntl_signal_dispatch</function></member>
+   <member><function>pcntl_waitpid</function></member>
+  </simplelist>
  </refsect1>
- 
+
 </refentry>
 <!-- Keep this comment at the end of the file
 Local variables:


### PR DESCRIPTION
Translation of php/doc-en#5821 (commit 3866fba): the note about `restart_syscalls` being ignored for `SIGALRM`, the new errors section (`ValueError`, `TypeError`) and the 7.4.0 changelog row. EN-Revision updated.

The Wikipedia link in the see-also section is kept on the French article, as it already was.

Fixes: #3448
