### PR TITLE
[Sync-En] migration82: note the default time zone fallback to UTC

### DIFF
--- a/appendices/migration82/other-changes.xml
+++ b/appendices/migration82/other-changes.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: b1116af46680f7baf89c46610430a3b63ce9a1f0 Maintainer: pierrick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: e4666d527453044f07c94da5ab51fd5cd4c1a615 Maintainer: pierrick Status: ready -->
 <sect1 xml:id="migration82.other-changes" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Autres changements</title>
 
@@ -125,6 +124,11 @@
    <para>
     Les propriétés de <classname>DatePeriod</classname> sont désormais correctement déclarées.
    </para>
+
+   <simpara>
+    Le fuseau horaire par défaut se rabattra sur UTC si l'option de configuration
+    <link linkend="ini.date.timezone">date.timezone</link> n'est pas définie.
+   </simpara>
   </sect3>
 
   <sect3 xml:id="migration82.other-changes.extensions.intl">


### PR DESCRIPTION
Translation of php/doc-en#4017 (commit e4666d5): the Date section now states that the default time zone falls back to UTC when the `date.timezone` setting is not set. EN-Revision updated.

Fixes: #3457
