### PR TITLE
[Sync-En] foreach: objects do not have to be Traversable

### DIFF
--- a/language/control-structures/foreach.xml
+++ b/language/control-structures/foreach.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e674990649cd2b111b8dd1175a7a1befcc621635 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 0d9947f2b1f0997cd8ddf80227b632dd5d3f2f92 Maintainer: lacatoire Status: ready -->
 
 <sect1 xml:id="control-structures.foreach" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>foreach</title>
  <?phpdoc print-version-for="foreach"?>
  <para>
   La structure de langage <literal>foreach</literal> fournit une façon simple de
-  parcourir des <type>array</type> et objets <interfacename>Traversable</interfacename>.
+  parcourir des <type>array</type> et des objets.
   <literal>foreach</literal> générera une erreur lorsqu'il est utilisé avec
   une variable contenant un type de données différent ou avec une variable non initialisée.
   <informalexample>
@@ -27,7 +27,7 @@ foreach (iterable_expression as $key => $value) {
   </informalexample>
  </para>
  <simpara>
-  La première forme passe en revue le tableau
+  La première forme parcourt la valeur donnée par
   <literal>iterable_expression</literal>. À chaque itération, la valeur de
   l'élément courant est assignée à <literal>$value</literal>.
  </simpara>
@@ -41,7 +41,9 @@ foreach (iterable_expression as $key => $value) {
   <function>current</function> et <function>key</function>.
  </simpara>
  <simpara>
-  Il est possible de personnaliser
+  Par défaut, un objet est parcouru sur ses propriétés
+  <link linkend="language.oop5.visibility">visibles</link> depuis la portée
+  courante. Il est possible de personnaliser
   <link linkend="language.oop5.iterations">l'itération sur des objets</link>.
  </simpara>
 


### PR DESCRIPTION
Translation of php/doc-en#4535 (commit 0d9947f): any object can be iterated, so the introduction no longer restricts `foreach` to `Traversable` objects, the operand is described as a value rather than an iterable, and a sentence states that an object is traversed over its visible properties by default. EN-Revision updated.

Fixes: #3458
