### PR TITLE
[Sync-En] misc: add the namespace caveats to define(), defined() and constant()

### DIFF
--- a/reference/misc/functions/constant.xml
+++ b/reference/misc/functions/constant.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 6c3091b54b66181db5f81ef5afe1d2e8b6efdeac Maintainer: yannick Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 5dc2deaf9f59287a5a5e327b7de538a9ff3fddf2 Maintainer: yannick Status: ready -->
 <refentry xml:id="function.constant" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>constant</refname>
@@ -39,6 +38,28 @@
       <para>
        Le nom de la constante.
       </para>
+      <note>
+       <simpara>
+        <function>constant</function> prend le nom comme une simple
+        <type>string</type> et ne le résout pas par rapport au
+        <link linkend="language.namespaces.dynamic">namespace</link> courant :
+        le nom est recherché dans le namespace global, si bien qu'un nom non
+        qualifié peut silencieusement retourner une constante différente de
+        celle à laquelle le même identifiant nu ferait référence.
+        Pour récupérer la valeur d'une constante déclarée dans un namespace, le
+        namespace doit faire partie du nom, comme dans
+        <literal>constant('My\Namespace\MYCONST')</literal> ou
+        <literal>constant(__NAMESPACE__ . '\MYCONST')</literal>.
+        Le nom étant une simple chaîne de caractères, les alias introduits par
+        les instructions <literal>use</literal> et le préfixe
+        <literal>namespace\</literal> ne lui sont pas appliqués.
+        Dans une chaîne entre guillemets doubles, les séparateurs de namespace
+        doivent être échappés, comme dans
+        <literal>"My\\Namespace\\MYCONST"</literal>.
+        La partie namespace du nom est insensible à la casse, le nom de la
+        constante ne l'est pas.
+       </simpara>
+      </note>
      </listitem>
     </varlistentry>
    </variablelist>

--- a/reference/misc/functions/define.xml
+++ b/reference/misc/functions/define.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: a124543dd3f6b1e5567b07420d23899e582514dc Maintainer: yannick Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 5dc2deaf9f59287a5a5e327b7de538a9ff3fddf2 Maintainer: yannick Status: ready -->
 <refentry xml:id="function.define" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>define</refname>
@@ -37,6 +36,29 @@
         être récupérées avec la fonction <function>constant</function>.
         Cependant, faire ceci n'est pas recommandé.
        </para>
+       <simpara>
+        <function>define</function> prend le nom comme une simple
+        <type>string</type> et ne le résout pas par rapport au
+        <link linkend="language.namespaces.dynamic">namespace</link> courant.
+        À l'intérieur de <literal>namespace My\Namespace;</literal>,
+        <literal>define('MYCONST', 1)</literal> définit donc
+        <literal>MYCONST</literal> dans le namespace global, silencieusement et
+        sans erreur.
+        Pour placer la constante dans un namespace, le namespace doit faire
+        partie du nom, écrit sans séparateur de namespace initial, comme dans
+        <literal>define('My\Namespace\MYCONST', 1)</literal> ou
+        <literal>define(__NAMESPACE__ . '\MYCONST', 1)</literal>.
+        Contrairement à <function>defined</function> et
+        <function>constant</function>, <function>define</function> ne supprime
+        pas un séparateur initial :
+        <literal>define('\My\Namespace\MYCONST', 1)</literal> retourne &true;
+        mais crée une constante qui ne pourra jamais être récupérée.
+        Le nom étant une simple chaîne de caractères, les alias introduits par
+        les instructions <literal>use</literal> ne lui sont pas appliqués.
+        Dans une chaîne entre guillemets doubles, les séparateurs de namespace
+        doivent être échappés, comme dans
+        <literal>"My\\Namespace\\MYCONST"</literal>.
+       </simpara>
       </note>
      </listitem>
     </varlistentry>

--- a/reference/misc/functions/defined.xml
+++ b/reference/misc/functions/defined.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 36e1d917ef7be36e8b4ff5193b456390061f2e21 Maintainer: yannick Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 5dc2deaf9f59287a5a5e327b7de538a9ff3fddf2 Maintainer: yannick Status: ready -->
 <refentry xml:id="function.defined" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>defined</refname>
@@ -43,6 +41,28 @@
       <para>
        Le nom de la constante.
       </para>
+      <note>
+       <simpara>
+        <function>defined</function> prend le nom comme une simple
+        <type>string</type> et ne le résout pas par rapport au
+        <link linkend="language.namespaces.dynamic">namespace</link> courant :
+        le nom est recherché dans le namespace global, si bien qu'un nom non
+        qualifié peut silencieusement renseigner sur une constante différente
+        de celle à laquelle le même identifiant nu ferait référence.
+        Pour vérifier si une constante déclarée dans un namespace est définie,
+        le namespace doit faire partie du nom, comme dans
+        <literal>defined('My\Namespace\MYCONST')</literal> ou
+        <literal>defined(__NAMESPACE__ . '\MYCONST')</literal>.
+        Le nom étant une simple chaîne de caractères, les alias introduits par
+        les instructions <literal>use</literal> et le préfixe
+        <literal>namespace\</literal> ne lui sont pas appliqués.
+        Dans une chaîne entre guillemets doubles, les séparateurs de namespace
+        doivent être échappés, comme dans
+        <literal>"My\\Namespace\\MYCONST"</literal>.
+        La partie namespace du nom est insensible à la casse, le nom de la
+        constante ne l'est pas.
+       </simpara>
+      </note>
      </listitem>
     </varlistentry>
    </variablelist>


### PR DESCRIPTION
Translation of php/doc-en#5256 (commit 5dc2dea): the three pages now state that the constant name is taken as a plain string, is not resolved against the current namespace and ignores `use` aliases, that `define()` keeps a leading separator where `defined()` and `constant()` strip it, and that separators must be escaped in double-quoted strings. EN-Revision updated.

Fixes: #3455
