### PR TITLE
[Sync-En] ext/intl: correct the offset semantics of localtime, parse and parseToCalendar

### DIFF
--- a/reference/intl/dateformatter/localtime.xml
+++ b/reference/intl/dateformatter/localtime.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 8ddf539e5993e427cb1385c5a01b6d2ce971b418 Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 8871302d240f124f7e9dabac85862e31bf97b442 Maintainer: yannick Status: ready -->
 <refentry xml:id="intldateformatter.localtime" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>IntlDateFormatter::localtime</refname>
@@ -26,13 +25,14 @@
    <methodparam><type>string</type><parameter>string</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter role="reference">offset</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
-   Convertit la chaîne $value en une date décomposée (un &array; de
-   champs), en commençant à la position $parse_pos et en consommant autant
-   de caractères que possible.
-  </para> 
+  <simpara>
+   Convertit <parameter>string</parameter> en une valeur temporelle décomposée
+   en champs (un &array; de divers champs), en commençant à
+   <parameter>offset</parameter> et en consommant autant que possible de la
+   chaîne d'entrée.
+  </simpara>
  </refsect1>
- 
+
  <refsect1 role="parameters">
   &reftitle.parameters;
   <para>
@@ -40,45 +40,48 @@
     <varlistentry>
      <term><parameter>formatter</parameter></term>
      <listitem>
-      <para>
-       La ressource de formateur <classname>IntlDateFormatter</classname>.
-      </para>
+      <simpara>
+       L'objet <classname>IntlDateFormatter</classname>.
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>string</parameter></term>
      <listitem>
-      <para>
-       La chaîne à convertir.
-      </para>
+      <simpara>
+       La chaîne à convertir en temps.
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>offset</parameter></term>
      <listitem>
-      <para>
-       La position à partir de laquelle commencer l'analyse dans la valeur $value.
-       Les positions commencent à 0. Si aucune erreur ne survient durant l'analyse
-       de $value, $parse_pos contiendra -1, et sinon, il va contenir la position à laquelle
-       l'analyse s'est terminée (et l'erreur est survenue). Cette variable va contenir 
-       la position de fin si l'analyse échoue.
-       Si $parse_pos &gt; strlen($value), l'analyse échoue immédiatement.
-      </para>
+      <simpara>
+       Position à laquelle commencer l'analyse dans <parameter>string</parameter>
+       (à base zéro).
+       Au retour, <parameter>offset</parameter> contient la position à laquelle
+       l'analyse s'est terminée, que celle-ci ait réussi ou non.
+       Si <parameter>offset</parameter> est négatif ou supérieur à
+       <literal>strlen($string)</literal>, l'analyse échoue immédiatement et
+       <parameter>offset</parameter> est laissé inchangé.
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
   </para>
  </refsect1>
- 
- 
+
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
-   Un tableau d'entier compatible avec localtime : il contient l'heure
-   sur 24 heures dans le champ tm_hour, &return.falseforfailure;.
-  </para>
+  <simpara>
+   Un tableau associatif d'entiers dont les clés sont celles de
+   <function>localtime</function>, l'heure étant donnée sur une horloge de
+   24 heures dans <literal>tm_hour</literal>&return.falseforfailure;.
+   Il est à noter que <literal>tm_yday</literal> commence ici à 1, alors que
+   <function>localtime</function> le retourne en commençant à 0.
+  </simpara>
  </refsect1>
- 
+
  <refsect1 role="examples">
   &reftitle.examples;
   <example>
@@ -94,7 +97,9 @@ $fmt = datefmt_create(
     'America/Los_Angeles',
     IntlDateFormatter::GREGORIAN
 );
+
 $arr = datefmt_localtime($fmt, 'Wednesday, December 31, 1969 at 4:00:00 PM Pacific Standard Time', $offset);
+
 echo 'Résultat de l\'analyse ';
 if ($arr) {
     foreach ($arr as $key => $value) {
@@ -111,6 +116,7 @@ if ($arr) {
    <programlisting role="php">
 <![CDATA[
 <?php
+
 $fmt = new IntlDateFormatter(
     'en_US',
     IntlDateFormatter::FULL,
@@ -118,7 +124,9 @@ $fmt = new IntlDateFormatter(
     'America/Los_Angeles',
     IntlDateFormatter::GREGORIAN
 );
+
 $arr = $fmt->localtime('Wednesday, December 31, 1969 at 4:00:00 PM Pacific Standard Time', $offset);
+
 echo 'Résultat de l\'analyse ';
 if ($arr) {
     foreach ($arr as $key => $value) {
@@ -138,7 +146,7 @@ tm_mday : 31 , tm_wday : 3 , tm_yday : 365 , tm_mon : 11 , tm_isdst : 0 ,
 ]]>
   </screen>
  </refsect1>
- 
+
  <refsect1 role="seealso">
   &reftitle.seealso;
   <para>

--- a/reference/intl/dateformatter/parse.xml
+++ b/reference/intl/dateformatter/parse.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 1976eae0d815797af97a1e16c5cd90ffc2868395 Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 8871302d240f124f7e9dabac85862e31bf97b442 Maintainer: yannick Status: ready -->
 <refentry xml:id="intldateformatter.parse" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>IntlDateFormatter::parse</refname>
@@ -39,9 +38,9 @@
     <varlistentry>
      <term><parameter>formatter</parameter></term>
      <listitem>
-      <para>
-       La ressource de formateur <classname>IntlDateFormatter</classname>.
-      </para>
+      <simpara>
+       L'objet <classname>IntlDateFormatter</classname>.
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
@@ -55,14 +54,15 @@
     <varlistentry>
      <term><parameter>offset</parameter></term>
      <listitem>
-      <para>
-       La position à partir de laquelle commencer l'analyse dans la valeur <parameter>string</parameter>.
-       Les positions commencent à 0. Si aucune erreur ne survient durant l'analyse
-       de <parameter>string</parameter>, <parameter>offset</parameter> contiendra -1, et sinon, il va contenir la position à laquelle
-       l'analyse s'est terminée (et l'erreur est survenue). Cette variable va contenir
-       la position de fin si l'analyse échoue.
-       Si <parameter>offset</parameter> &gt; <code>strlen($string)</code>, l'analyse échoue immédiatement.
-      </para>
+      <simpara>
+       Position à laquelle commencer l'analyse dans <parameter>string</parameter>
+       (à base zéro).
+       Au retour, <parameter>offset</parameter> contient la position à laquelle
+       l'analyse s'est terminée, que celle-ci ait réussi ou non.
+       Si <parameter>offset</parameter> est négatif ou supérieur à
+       <literal>strlen($string)</literal>, l'analyse échoue immédiatement et
+       <parameter>offset</parameter> est laissé inchangé.
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>

--- a/reference/intl/dateformatter/parsetocalendar.xml
+++ b/reference/intl/dateformatter/parsetocalendar.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 20687bf9c58232244e41272d118b98ef4af16a69 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 8871302d240f124f7e9dabac85862e31bf97b442 Maintainer: lacatoire Status: ready -->
 <refentry xml:id="intldateformatter.parsetocalendar" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>IntlDateFormatter::parseToCalendar</refname>
@@ -39,12 +39,13 @@
     <term><parameter>offset</parameter></term>
     <listitem>
      <simpara>
-      Position à laquelle commencer l'analyse dans <parameter>string</parameter> (à base zéro).
-      Si aucune erreur ne survient avant que <parameter>string</parameter> ne soit consommée,
-      <parameter>offset</parameter> contiendra -1, sinon il contiendra la position à laquelle
-      l'analyse s'est terminée (et où l'erreur est survenue).
-      Cette variable contiendra la position de fin si l'analyse échoue.
-      Si <parameter>offset</parameter> &gt; <code>strlen($string)</code>, l'analyse échoue immédiatement.
+      Position à laquelle commencer l'analyse dans <parameter>string</parameter>
+      (à base zéro).
+      Au retour, <parameter>offset</parameter> contient la position à laquelle
+      l'analyse s'est terminée, que celle-ci ait réussi ou non.
+      Si <parameter>offset</parameter> est supérieur à
+      <literal>strlen($string)</literal>, l'analyse échoue immédiatement et
+      <parameter>offset</parameter> est laissé inchangé.
      </simpara>
     </listitem>
    </varlistentry>


### PR DESCRIPTION
Translation of php/doc-en#4820 (commit 8871302): on return `offset` holds the position where parsing ended, whether or not it succeeded, and an out-of-range `offset` makes parsing fail immediately while leaving it untouched. The previous mention of `-1` is gone, and the `localtime()` return value is described in full. EN-Revision updated.

Fixes: #3454
