### PR TITLE
[Sync-En] ext/mbstring: clarify the ValueError conditions of mb_*code_numericentity()

### DIFF
--- a/reference/mbstring/functions/mb-decode-numericentity.xml
+++ b/reference/mbstring/functions/mb-decode-numericentity.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4e69a9f2b14deefca0befec576335e33152448f3 Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 3505aae96c190f3970e15bf3b7a12ead73b95662 Maintainer: yannick Status: ready -->
 <refentry xml:id="function.mb-decode-numericentity" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>mb_decode_numericentity</refname>
@@ -63,7 +62,8 @@
   &reftitle.errors;
   <simpara>
    Lève une exception <exceptionname>ValueError</exceptionname> si
-   <parameter>map</parameter> n'est pas une liste d'&integer;s.
+   <parameter>map</parameter> contient une valeur qui n'est ni un
+   &integer;, ni un &float;, ni un &boolean;, ni &null;, ni une <link linkend="language.types.numeric-strings">chaîne numérique</link>.
   </simpara>
  </refsect1>
 
@@ -81,9 +81,9 @@
      <row>
       <entry>8.4.0</entry>
       <entry>
-       <function>mb_decode_numericentity</function> lève désormais une
+       La fonction <function>mb_decode_numericentity</function> lève désormais une
        exception <exceptionname>ValueError</exceptionname> si <parameter>map</parameter>
-       n'est pas une liste d'&integer;s.
+       contient une valeur qui ne peut pas être convertie implicitement en int.
       </entry>
      </row>
      &mbstring.changelog.encoding-nullable;

--- a/reference/mbstring/functions/mb-encode-numericentity.xml
+++ b/reference/mbstring/functions/mb-encode-numericentity.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: a60ef65239113c7871643be68ada91081376c936 Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 3505aae96c190f3970e15bf3b7a12ead73b95662 Maintainer: yannick Status: ready -->
 <refentry xml:id="function.mb-encode-numericentity" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>mb_encode_numericentity</refname>
@@ -73,7 +72,8 @@
   &reftitle.errors;
   <simpara>
    Lève une exception <exceptionname>ValueError</exceptionname> si
-   <parameter>map</parameter> n'est pas une liste d'&integer;s.
+   <parameter>map</parameter> contient une valeur qui n'est ni un
+   &integer;, ni un &float;, ni un &boolean;, ni &null;, ni une <link linkend="language.types.numeric-strings">chaîne numérique</link>.
   </simpara>
  </refsect1>
 
@@ -91,9 +91,9 @@
      <row>
       <entry>8.4.0</entry>
       <entry>
-       <function>mb_encode_numericentity</function> lève désormais une
+       La fonction <function>mb_encode_numericentity</function> lève désormais une
        exception <exceptionname>ValueError</exceptionname> si <parameter>map</parameter>
-       n'est pas une liste d'&integer;s.
+       contient une valeur qui ne peut pas être convertie implicitement en int.
       </entry>
      </row>
      &mbstring.changelog.encoding-nullable;


### PR DESCRIPTION
Translation of php/doc-en#4852 (commit 3505aae): the `ValueError` is raised when `map` contains a value that is not an `int`, `float`, `bool`, `null` or a numeric string, rather than when `map` is not a list of ints. The 8.4.0 changelog row is reworded to match. EN-Revision updated.

Fixes: #3447
