### PR TITLE
[Sync-En] exceptions: warn that exceptions cannot be cloned

### DIFF
--- a/language/exceptions.xml
+++ b/language/exceptions.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 525aa5f198d482c0d03be54ddee5af13b376ab99 Maintainer: lacatoire Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 62562234f18ac091ecd1fb648ac0d56172c74a1a Maintainer: lacatoire Status: ready -->
 
 <chapter xml:id="language.exceptions" xmlns="http://docbook.org/ns/docbook" annotations="interactive">
  <title>Les exceptions</title>
@@ -421,7 +420,7 @@ string(6) "Fourth"
 <?php
 class Exception implements Throwable
 {
-    protected $message = 'Unknown exception';   // Message d'exception
+    protected $message = '';                    // Message d'exception
     private   $string;                          // cache de __toString
     protected $code = 0;                        // code d'exception défini par l'utilisateur
     protected $file;                            // nom de fichier source de l'exception
@@ -431,7 +430,7 @@ class Exception implements Throwable
 
     public function __construct($message = '', $code = 0, ?Throwable $previous = null);
 
-    final private function __clone();           // Inhibe la duplication des exceptions.
+    private function __clone();                 // Inhibe la duplication des exceptions.
 
     final public function getMessage();        // message de l'exception
     final public function getCode();           // code de l'exception
@@ -458,11 +457,12 @@ class Exception implements Throwable
    sous forme de chaîne de caractères.
   </para>
   <note>
-   <para>
+   <simpara>
     Les exceptions ne peuvent pas être clonées. Tenter de <link
-    linkend="language.oop5.cloning">cloner</link> une Exception entraînera une
-    erreur fatale <constant>E_ERROR</constant>.
-   </para>
+    linkend="language.oop5.cloning">cloner</link> une exception lève une
+    <exceptionname>Error</exceptionname>, même si une sous-classe déclare sa
+    propre méthode <link linkend="object.clone">__clone()</link>.
+   </simpara>
   </note>
   <example>
    <title>Étendre la classe Exception</title>

--- a/language/predefined/exception/clone.xml
+++ b/language/predefined/exception/clone.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 35c16b1543e292fa6913f02598daa435e58d997c Maintainer: yannick Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 62562234f18ac091ecd1fb648ac0d56172c74a1a Maintainer: yannick Status: ready -->
 <refentry xml:id="exception.clone" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Exception::__clone</refname>
@@ -13,10 +12,19 @@
    <modifier>private</modifier> <type>void</type><methodname>Exception::__clone</methodname>
    <void/>
   </methodsynopsis>
-  <para>
-   Les <classname>Exception</classname>s ne peuvent pas être clonées,
-   et tenter de le faire va lever une exception <classname>Error</classname>.
-  </para>
+  <simpara>
+   Les exceptions ne prennent pas en charge le clonage ; cette méthode existe
+   uniquement pour l'empêcher.
+  </simpara>
+  <warning>
+   <simpara>
+    Les exceptions ne peuvent pas être clonées, qu'il s'agisse d'instances de
+    <exceptionname>Exception</exceptionname> ou d'une sous-classe.
+    Tenter de <link linkend="language.oop5.cloning">cloner</link> une
+    exception lève une <exceptionname>Error</exceptionname>, qui peut être
+    interceptée.
+   </simpara>
+  </warning>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -52,7 +60,12 @@
      <row>
       <entry>8.1.0</entry>
       <entry>
-       <methodname>Exception::__clone</methodname> n'est plus final.
+       <methodname>Exception::__clone</methodname> n'est plus déclarée
+       <modifier>final</modifier>, car
+       <link linkend="language.oop5.final">déclarer une méthode
+       <modifier>private</modifier> comme
+       <modifier>final</modifier></link> émet un avertissement à partir de
+       PHP 8.0.0. Les exceptions restent non clonables.
       </entry>
      </row>
     </tbody>


### PR DESCRIPTION
Translation of php/doc-en#5276 (commit 6256223): cloning an exception throws a catchable `Error`, even when a subclass declares its own `__clone()`, and the 8.1.0 changelog row explains why the method is no longer `final`. EN-Revision updated.

Fixes: #3451
