### PR TITLE
[Sync-En] ext/pdo: document the PHP 8.5 fetch mode changes and deprecations

### DIFF
--- a/reference/pdo/pdo.xml
+++ b/reference/pdo/pdo.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: a78c7290730ac918c4eb6b199004d24051d1e93f Maintainer: yannick Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: e16d04c436e9801627139c67c1cabcb92b469ccc Maintainer: yannick Status: ready -->
 <reference xml:id="class.pdo" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>La classe PDO</title>
  <titleabbrev>PDO</titleabbrev>
@@ -497,6 +496,18 @@
       </row>
      </thead>
      <tbody>
+      <row>
+       <entry>8.5.0</entry>
+       <entry>
+        Les constantes spécifiques aux pilotes de la classe
+        <classname>PDO</classname> ont été dépréciées au profit des constantes
+        équivalentes des sous-classes spécifiques aux pilotes
+        (<classname>Pdo\Dblib</classname>,
+        <classname>Pdo\Firebird</classname>, <classname>Pdo\Mysql</classname>,
+        <classname>Pdo\Odbc</classname>, <classname>Pdo\Pgsql</classname>,
+        <classname>Pdo\Sqlite</classname>).
+       </entry>
+      </row>
       <row>
        <entry>8.4.0</entry>
        <entry>

--- a/reference/pdo/pdo/construct.xml
+++ b/reference/pdo/pdo/construct.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 7dd805d34addc6e98afaa0b3851c8656afbec9b6 Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: e16d04c436e9801627139c67c1cabcb92b469ccc Maintainer: yannick Status: ready -->
 <refentry xml:id="pdo.construct" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>PDO::__construct</refname>
@@ -59,6 +58,13 @@
            la chaîne de DSN. L'URI peut spécifier un fichier local ou distant.
           </para>
           <para><userinput>uri:file:///path/to/dsnfile</userinput></para>
+          <warning>
+           <simpara>
+            Le schéma de DSN <userinput>uri:</userinput> est obsolète à partir de
+            PHP 8.5.0, en raison de problèmes de sécurité liés aux DSN provenant
+            d'URI distantes.
+           </simpara>
+          </warning>
          </listitem>
         </varlistentry>
         <varlistentry><term>Aliasing</term>
@@ -113,11 +119,33 @@
 
  <refsect1 role="errors">
   &reftitle.errors;
-  <para>
-   Une exception <classname>PDOException</classname> est levée si la tentative
+  <simpara>
+   Une exception <exceptionname>PDOException</exceptionname> est levée si la tentative
    de connexion à la base de données demandée échoue,
    indépendamment du <constant>PDO::ATTR_ERRMODE</constant> actuellement défini.
-  </para>
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Le schéma de DSN <userinput>uri:</userinput> est désormais obsolète.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/pdo/pdostatement/fetchall.xml
+++ b/reference/pdo/pdostatement/fetchall.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: e16d04c436e9801627139c67c1cabcb92b469ccc Maintainer: lacatoire Status: ready -->
 <refentry xml:id="pdostatement.fetchall" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>PDOStatement::fetchAll</refname>
@@ -153,6 +153,17 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       L'utilisation de <constant>PDO::FETCH_INTO</constant> comme mode de
+       récupération lève désormais une <exceptionname>ValueError</exceptionname>,
+       de la même manière que <constant>PDO::FETCH_LAZY</constant>.
+       L'utilisation de <constant>PDO::FETCH_PROPS_LATE</constant> avec un mode
+       de récupération autre que <constant>PDO::FETCH_CLASS</constant> lève
+       désormais une <exceptionname>ValueError</exceptionname>.
+      </entry>
+     </row>
      <row>
       <entry>8.0.0</entry>
       <entry>

--- a/reference/pdo/pdostatement/setattribute.xml
+++ b/reference/pdo/pdostatement/setattribute.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: e16d04c436e9801627139c67c1cabcb92b469ccc Maintainer: lacatoire Status: ready -->
 <refentry xml:id="pdostatement.setattribute" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>PDOStatement::setAttribute</refname>
@@ -63,6 +63,39 @@
   <para>
    &return.success;
   </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simpara>
+   À partir de PHP 8.5.0, lors de l'utilisation du pilote Firebird, une
+   <exceptionname>ValueError</exceptionname> est levée si le nom de curseur défini via
+   <constant>PDO::ATTR_CURSOR_NAME</constant> est trop long.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Lors de l'utilisation du pilote Firebird, une <exceptionname>ValueError</exceptionname>
+       est désormais levée si le nom de curseur défini via
+       <constant>PDO::ATTR_CURSOR_NAME</constant> est trop long.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/pdo/pdostatement/setfetchmode.xml
+++ b/reference/pdo/pdostatement/setfetchmode.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 8a910daad2efdfd29acf6766be8bca7c32c3dd2a Maintainer: lacatoire Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: e16d04c436e9801627139c67c1cabcb92b469ccc Maintainer: lacatoire Status: ready -->
 <refentry xml:id="pdostatement.setfetchmode" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>PDOStatement::setFetchMode</refname>
@@ -68,9 +67,12 @@
     <varlistentry>
      <term><parameter>constructorArgs</parameter></term>
      <listitem>
-      <para>
-       Arguments du constructeur.
-      </para>
+      <simpara>
+       Arguments du constructeur. À partir de PHP 8.5.0, les clés de type chaîne
+       de caractères font office d'arguments nommés. Pour passer une variable
+       par référence, il faut utiliser un élément de référence :
+       <code>$constructorArgs = [&amp;$valByRef]</code>.
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
@@ -92,6 +94,16 @@
   </simpara>
  </refsect1>
 
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simpara>
+   À partir de PHP 8.5.0, une <exceptionname>Error</exceptionname> est levée si cette
+   méthode est appelée pendant un appel à <methodname>PDOStatement::fetch</methodname>,
+   <methodname>PDOStatement::fetchObject</methodname> ou
+   <methodname>PDOStatement::fetchAll</methodname>.
+  </simpara>
+ </refsect1>
+
  <refsect1 role="changelog">
   &reftitle.changelog;
   <informaltable>
@@ -103,6 +115,27 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Les <parameter>constructorArgs</parameter> pour
+       <constant>PDO::FETCH_CLASS</constant> suivent désormais la sémantique CUFA
+       (<function>call_user_func_array</function>) : les clés de type chaîne de
+       caractères font office d'arguments nommés, et l'encapsulation automatique
+       des arguments passés par valeur pour les paramètres par référence a été
+       supprimée.
+      </entry>
+     </row>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       L'appel de cette méthode pendant un appel à
+       <methodname>PDOStatement::fetch</methodname>,
+       <methodname>PDOStatement::fetchObject</methodname> ou
+       <methodname>PDOStatement::fetchAll</methodname> lève désormais une
+       <exceptionname>Error</exceptionname>.
+      </entry>
+     </row>
      &return.type.true.84;
     </tbody>
    </tgroup>


### PR DESCRIPTION
Translation of php/doc-en#5817 (commit e16d04c): the `PDO` fetch constants are deprecated in favour of the equivalent `PDO::FETCH_*` ones, the `uri:` DSN scheme is deprecated, string keys in `constructorArgs` act as named arguments, support for by-reference parameters is removed, and the new errors sections are added. EN-Revision updated.

Fixes: #3453
