### PR TITLE
[Sync-En] openssl, ldap, zip: warn against truthy checks on the return value

### DIFF
--- a/reference/ldap/functions/ldap-compare.xml
+++ b/reference/ldap/functions/ldap-compare.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: b7cbd468cb4c46d55d43a44cade0eb4590d25dea Maintainer: dams Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 9e5f75b8c1d87da6ee825ae7d1b2a3da218b5c69 Maintainer: dams Status: ready -->
 <refentry xml:id="function.ldap-compare" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>ldap_compare</refname>
@@ -78,6 +77,14 @@
    Retourne &true; si la valeur <parameter>value</parameter> correspond, sinon,
    retourne &false;. Retourne -1 si une erreur survient.
   </para>
+  <warning>
+   <simpara>
+    &true; et <literal>-1</literal> sont tous deux
+    <link linkend="language.types.boolean.casting">évalués à &true;</link>, si bien qu'un simple
+    test de vérité tel que <code>if (ldap_compare(...))</code> traite une erreur
+    comme une correspondance. Le résultat doit être comparé strictement à &true;.
+   </simpara>
+  </warning>
  </refsect1>
 
  <refsect1 role="changelog">

--- a/reference/openssl/functions/openssl-pkcs7-verify.xml
+++ b/reference/openssl/functions/openssl-pkcs7-verify.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 497c40ac164d5873fd87f622dfdeb5206392b446 Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 9e5f75b8c1d87da6ee825ae7d1b2a3da218b5c69 Maintainer: yannick Status: ready -->
 <refentry xml:id="function.openssl-pkcs7-verify" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>openssl_pkcs7_verify</refname>
@@ -110,6 +108,15 @@
    sinon (le message a été modifié, ou bien le certificat de signature est
    invalide) ou -1 si une erreur survient.
   </para>
+  <warning>
+   <simpara>
+    &true; et <literal>-1</literal> sont tous deux
+    <link linkend="language.types.boolean.casting">évalués à &true;</link>, si bien qu'un simple
+    test de vérité tel que <code>if (openssl_pkcs7_verify(...))</code> traite une erreur
+    comme une vérification réussie. Le résultat doit être comparé strictement à
+    &true;.
+   </simpara>
+  </warning>
  </refsect1>
 
  <refsect1 role="changelog">

--- a/reference/openssl/functions/openssl-verify.xml
+++ b/reference/openssl/functions/openssl-verify.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: ddcd63907372580151daf69458d6a8268232b703 Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 9e5f75b8c1d87da6ee825ae7d1b2a3da218b5c69 Maintainer: yannick Status: ready -->
 <refentry xml:id="function.openssl-verify" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>openssl_verify</refname>
@@ -93,6 +91,15 @@ MIIBCgK...</literal>.
    Retourne 1 si la signature est correcte, 0 si elle
    est incorrecte et -1 ou &false; si une erreur survient.
   </para>
+  <warning>
+   <simpara>
+    La valeur de succès et la valeur d'erreur sont toutes deux
+    <link linkend="language.types.boolean.casting">évaluées à &true;</link>, si bien qu'un simple
+    test de vérité tel que <code>if (openssl_verify(...))</code> traite une erreur
+    comme une vérification réussie. Le résultat doit être comparé strictement à
+    <literal>1</literal>.
+   </simpara>
+  </warning>
  </refsect1>
 
  <refsect1 role="changelog">
@@ -142,9 +149,9 @@ $pubkeyid = openssl_pkey_get_public("file://src/openssl-0.9.6/demos/sign/cert.pe
 
 // indique si la signature est correcte
 $ok = openssl_verify($data, $signature, $pubkeyid);
-if ($ok == 1) {
+if ($ok === 1) {
     echo "Signature valide";
-} elseif ($ok == 0) {
+} elseif ($ok === 0) {
     echo "Signature erronée";
 } else {
     echo "Erreur de vérification de la signature";
@@ -176,9 +183,9 @@ openssl_sign($data, $signature, $private_key_res, "sha256WithRSAEncryption");
 
 //Vérifie la signature
 $ok = openssl_verify($data, $signature, $public_key_res, OPENSSL_ALGO_SHA256);
-if ($ok == 1) {
+if ($ok === 1) {
     echo "valide";
-} elseif ($ok == 0) {
+} elseif ($ok === 0) {
     echo "invalide";
 } else {
     echo "erreur : ".openssl_error_string();

--- a/reference/openssl/functions/openssl-x509-checkpurpose.xml
+++ b/reference/openssl/functions/openssl-x509-checkpurpose.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 497c40ac164d5873fd87f622dfdeb5206392b446 Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 9e5f75b8c1d87da6ee825ae7d1b2a3da218b5c69 Maintainer: yannick Status: ready -->
 <refentry xml:id="function.openssl-x509-checkpurpose" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>openssl_x509_checkpurpose</refname>
@@ -138,6 +136,15 @@
    Retourne &true; si le certificat peut être utilisé pour un but particulier,
    &false; s'il ne le peut pas, ou -1 si une erreur survient.
   </para>
+  <warning>
+   <simpara>
+    &true; et <literal>-1</literal> sont tous deux
+    <link linkend="language.types.boolean.casting">évalués à &true;</link>, si bien qu'un simple
+    test de vérité tel que <code>if (openssl_x509_checkpurpose(...))</code> traite une erreur
+    comme une vérification réussie. Le résultat doit être comparé strictement à
+    &true;.
+   </simpara>
+  </warning>
  </refsect1>
 
  <refsect1 role="changelog">

--- a/reference/openssl/functions/openssl-x509-verify.xml
+++ b/reference/openssl/functions/openssl-x509-verify.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 6819d9e5807762161caace88a21930156a313195 Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 9e5f75b8c1d87da6ee825ae7d1b2a3da218b5c69 Maintainer: yannick Status: ready -->
 <refentry xml:id="function.openssl-x509-verify" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>openssl_x509_verify</refname>
@@ -50,6 +48,15 @@ MIIBCgK...</literal>.
    Retourne 1 si la signature est correcte, 0 si elle est incorrecte, et
    -1 si une erreur survient.
   </para>
+  <warning>
+   <simpara>
+    La valeur de succès et la valeur d'erreur sont toutes deux
+    <link linkend="language.types.boolean.casting">évaluées à &true;</link>, si bien qu'un simple
+    test de vérité tel que <code>if (openssl_x509_verify(...))</code> traite une erreur
+    comme une vérification réussie. Le résultat doit être comparé strictement à
+    <literal>1</literal>.
+   </simpara>
+  </warning>
  </refsect1>
 
  <refsect1 role="changelog">
@@ -114,8 +121,8 @@ foreach($cont["options"]["ssl"]["peer_certificate_chain"] as $chaincert)
 {
     $chainparsed = openssl_x509_parse($chaincert);
     $chain_public_key = openssl_get_publickey($chaincert);
-    $r = openssl_x509_verify($x509, $chain_public_key);   
-    if ($r==1)
+    $r = openssl_x509_verify($x509, $chain_public_key);
+    if ($r === 1)
     {
         echo $certparsed['subject']['CN'];
         echo " a été signé numériquement par ";

--- a/reference/zip/ziparchive/getarchiveflag.xml
+++ b/reference/zip/ziparchive/getarchiveflag.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 963af75faf771d12d38a74d1c3449586ac0a966a Maintainer: lacatoire Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 9e5f75b8c1d87da6ee825ae7d1b2a3da218b5c69 Maintainer: lacatoire Status: ready -->
 <refentry xml:id="ziparchive.getarchiveflag" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>ZipArchive::getArchiveFlag</refname>
@@ -70,6 +69,14 @@
   <simpara>
    Retourne 1 si le drapeau est défini pour l'archive, 0 si non, et -1 si une erreur s'est produite.
   </simpara>
+  <warning>
+   <simpara>
+    <literal>1</literal> et <literal>-1</literal> sont tous deux
+    <link linkend="language.types.boolean.casting">évalués à &true;</link>, si bien qu'un simple
+    test de vérité traite une erreur comme un drapeau défini. Le résultat doit être
+    comparé strictement à <literal>1</literal>.
+   </simpara>
+  </warning>
  </refsect1>
 
  <refsect1 role="examples">


### PR DESCRIPTION
Translation of php/doc-en#4827 (commit 9e5f75b): a warning states that the success and error values are both truthy, so a plain truthy check treats an error as a successful verification and the result must be compared strictly. The `openssl_verify()` and `openssl_x509_verify()` examples now use `===`. EN-Revision updated.

Fixes: #3456
