### PR TITLE
[Sync-En] ext/pdo_sqlite: document the PHP 8.5 additions and behaviour changes

### DIFF
--- a/reference/pdo/pdo/quote.xml
+++ b/reference/pdo/pdo/quote.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: eff8e0d4dd463ae6bd387f304effeaf3d5ce44d5 Maintainer: lacatoire Status: ready -->
 <refentry xml:id="pdo.quote" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>PDO::quote</refname>
@@ -81,6 +81,31 @@
    dans une requête SQL. Retourne &false; si le pilote ne supporte pas
    ce type de protections.
   </simpara>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Lors de l'utilisation du pilote SQLite, une <exceptionname>PDOException</exceptionname>
+       est désormais lancée ou une alerte est émise, selon le mode d'erreur, si la
+       chaîne <parameter>string</parameter> contient un octet nul ; auparavant, la
+       chaîne était silencieusement tronquée au niveau de l'octet nul.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/pdo_sqlite/configure.xml
+++ b/reference/pdo_sqlite/configure.xml
@@ -1,19 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 859713422861ee5d25d5e8504928a4af9ce198ad Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: eff8e0d4dd463ae6bd387f304effeaf3d5ce44d5 Maintainer: yannick Status: ready -->
 
 <section xml:id="ref.pdo-sqlite.installation" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.install;
- <para>
+ <simpara>
   Le driver PDO PDO_SQLITE est actif par défaut. Pour le désactiver,
   utiliser l'option de compilation
   <option role="configure">--without-pdo-sqlite[=DIR]</option>, où
   <literal>[=DIR]</literal> (optionnel) représente le chemin vers le
   dossier d'installation de base de sqlite.
-  À partir de PHP 7.4.0 <link xlink:href="&url.sqlite;">libsqlite</link> ≥ 3.5.0 est requis.
+  À partir de PHP 7.4.0 <link xlink:href="&url.sqlite;">libsqlite</link> ≥ 3.5.0 est requis,
+  et à partir de PHP 8.5.0 libsqlite ≥ 3.7.17 est requis.
   Auparavant, la libsqlite intégrée pouvait être utilisée à la place, et était par défaut, si <literal>[=DIR]</literal> était omis.
- </para>
+ </simpara>
  <note>
   <title>Installation supplémentaire sur Windows à partir de PHP 7.4.0</title>
   <para>

--- a/reference/pdo_sqlite/pdo-sqlite.xml
+++ b/reference/pdo_sqlite/pdo-sqlite.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: ae7db14ea8cb8f3041e114f0ef865d86a95f72d6 Maintainer: Fan2Shrek Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: eff8e0d4dd463ae6bd387f304effeaf3d5ce44d5 Maintainer: Fan2Shrek Status: ready -->
 <reference xml:id="class.pdo-sqlite" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>La classe Pdo\Sqlite</title>
  <titleabbrev>Pdo\Sqlite</titleabbrev>
@@ -100,6 +99,78 @@
      <type>int</type>
      <varname linkend="pdo-sqlite.constants.attr-extended-result-codes">Pdo\Sqlite::ATTR_EXTENDED_RESULT_CODES</varname>
     </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="pdo-sqlite.constants.attr-busy-statement">Pdo\Sqlite::ATTR_BUSY_STATEMENT</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="pdo-sqlite.constants.attr-explain-statement">Pdo\Sqlite::ATTR_EXPLAIN_STATEMENT</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="pdo-sqlite.constants.explain-mode-prepared">Pdo\Sqlite::EXPLAIN_MODE_PREPARED</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="pdo-sqlite.constants.explain-mode-explain">Pdo\Sqlite::EXPLAIN_MODE_EXPLAIN</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="pdo-sqlite.constants.explain-mode-explain-query-plan">Pdo\Sqlite::EXPLAIN_MODE_EXPLAIN_QUERY_PLAN</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="pdo-sqlite.constants.attr-transaction-mode">Pdo\Sqlite::ATTR_TRANSACTION_MODE</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="pdo-sqlite.constants.transaction-mode-deferred">Pdo\Sqlite::TRANSACTION_MODE_DEFERRED</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="pdo-sqlite.constants.transaction-mode-immediate">Pdo\Sqlite::TRANSACTION_MODE_IMMEDIATE</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="pdo-sqlite.constants.transaction-mode-exclusive">Pdo\Sqlite::TRANSACTION_MODE_EXCLUSIVE</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="pdo-sqlite.constants.ok">Pdo\Sqlite::OK</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="pdo-sqlite.constants.deny">Pdo\Sqlite::DENY</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="pdo-sqlite.constants.ignore">Pdo\Sqlite::IGNORE</varname>
+    </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo-sqlite')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Pdo\\Sqlite'])">
@@ -170,8 +241,175 @@
       </simpara>
      </listitem>
     </varlistentry>
+    <varlistentry xml:id="pdo-sqlite.constants.attr-busy-statement">
+     <term><constant>Pdo\Sqlite::ATTR_BUSY_STATEMENT</constant></term>
+     <listitem>
+      <simpara>
+       Un attribut de requête préparée en lecture seule, récupéré avec
+       <methodname>PDOStatement::getAttribute</methodname>, qui vaut &true; si
+       la requête préparée a été exécutée et possède encore une ligne en attente,
+       et &false; sinon.
+       Disponible à partir de PHP 8.5.0.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="pdo-sqlite.constants.attr-explain-statement">
+     <term><constant>Pdo\Sqlite::ATTR_EXPLAIN_STATEMENT</constant></term>
+     <listitem>
+      <simpara>
+       Un attribut de requête préparée contrôlant le mode d'explication, défini avec
+       <methodname>PDOStatement::setAttribute</methodname>. Les valeurs possibles sont
+       <constant>Pdo\Sqlite::EXPLAIN_MODE_PREPARED</constant>,
+       <constant>Pdo\Sqlite::EXPLAIN_MODE_EXPLAIN</constant> et
+       <constant>Pdo\Sqlite::EXPLAIN_MODE_EXPLAIN_QUERY_PLAN</constant>.
+       Une <exceptionname>ValueError</exceptionname> est lancée si PHP a été compilé
+       avec une libsqlite antérieure à 3.43.0.
+       Disponible à partir de PHP 8.5.0.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="pdo-sqlite.constants.explain-mode-prepared">
+     <term><constant>Pdo\Sqlite::EXPLAIN_MODE_PREPARED</constant></term>
+     <listitem>
+      <simpara>
+       Valeur pour <constant>Pdo\Sqlite::ATTR_EXPLAIN_STATEMENT</constant> :
+       retourne la requête telle qu'elle a été préparée (aucune explication).
+       Disponible à partir de PHP 8.5.0, lorsque PHP est compilé avec une libsqlite &gt;= 3.43.0.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="pdo-sqlite.constants.explain-mode-explain">
+     <term><constant>Pdo\Sqlite::EXPLAIN_MODE_EXPLAIN</constant></term>
+     <listitem>
+      <simpara>
+       Valeur pour <constant>Pdo\Sqlite::ATTR_EXPLAIN_STATEMENT</constant> :
+       retourne les opcodes de la machine virtuelle utilisée pour exécuter la requête
+       (équivalent à l'instruction <literal>EXPLAIN</literal> de SQLite).
+       Disponible à partir de PHP 8.5.0, lorsque PHP est compilé avec une libsqlite &gt;= 3.43.0.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="pdo-sqlite.constants.explain-mode-explain-query-plan">
+     <term><constant>Pdo\Sqlite::EXPLAIN_MODE_EXPLAIN_QUERY_PLAN</constant></term>
+     <listitem>
+      <simpara>
+       Valeur pour <constant>Pdo\Sqlite::ATTR_EXPLAIN_STATEMENT</constant> :
+       retourne le plan d'exécution de la requête (équivalent à l'instruction
+       <literal>EXPLAIN QUERY PLAN</literal> de SQLite).
+       Disponible à partir de PHP 8.5.0, lorsque PHP est compilé avec une libsqlite &gt;= 3.43.0.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="pdo-sqlite.constants.attr-transaction-mode">
+     <term><constant>Pdo\Sqlite::ATTR_TRANSACTION_MODE</constant></term>
+     <listitem>
+      <simpara>
+       Un attribut de connexion configurant le mode de transaction utilisé par
+       <methodname>PDO::beginTransaction</methodname>. Les valeurs possibles sont
+       <constant>Pdo\Sqlite::TRANSACTION_MODE_DEFERRED</constant>,
+       <constant>Pdo\Sqlite::TRANSACTION_MODE_IMMEDIATE</constant> et
+       <constant>Pdo\Sqlite::TRANSACTION_MODE_EXCLUSIVE</constant>.
+       Disponible à partir de PHP 8.5.0.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="pdo-sqlite.constants.transaction-mode-deferred">
+     <term><constant>Pdo\Sqlite::TRANSACTION_MODE_DEFERRED</constant></term>
+     <listitem>
+      <simpara>
+       Valeur pour <constant>Pdo\Sqlite::ATTR_TRANSACTION_MODE</constant> :
+       utilise le mode de transaction DEFERRED de SQLite (le mode par défaut).
+       Disponible à partir de PHP 8.5.0.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="pdo-sqlite.constants.transaction-mode-immediate">
+     <term><constant>Pdo\Sqlite::TRANSACTION_MODE_IMMEDIATE</constant></term>
+     <listitem>
+      <simpara>
+       Valeur pour <constant>Pdo\Sqlite::ATTR_TRANSACTION_MODE</constant> :
+       utilise le mode de transaction IMMEDIATE de SQLite.
+       Disponible à partir de PHP 8.5.0.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="pdo-sqlite.constants.transaction-mode-exclusive">
+     <term><constant>Pdo\Sqlite::TRANSACTION_MODE_EXCLUSIVE</constant></term>
+     <listitem>
+      <simpara>
+       Valeur pour <constant>Pdo\Sqlite::ATTR_TRANSACTION_MODE</constant> :
+       utilise le mode de transaction EXCLUSIVE de SQLite.
+       Disponible à partir de PHP 8.5.0.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="pdo-sqlite.constants.ok">
+     <term><constant>Pdo\Sqlite::OK</constant></term>
+     <listitem>
+      <simpara>
+       Valeur de retour d'une fonction de rappel d'autorisation définie avec
+       <methodname>Pdo\Sqlite::setAuthorizer</methodname>, autorisant l'action.
+       Disponible à partir de PHP 8.5.0.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="pdo-sqlite.constants.deny">
+     <term><constant>Pdo\Sqlite::DENY</constant></term>
+     <listitem>
+      <simpara>
+       Valeur de retour d'une fonction de rappel d'autorisation définie avec
+       <methodname>Pdo\Sqlite::setAuthorizer</methodname>, refusant l'action.
+       Disponible à partir de PHP 8.5.0.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="pdo-sqlite.constants.ignore">
+     <term><constant>Pdo\Sqlite::IGNORE</constant></term>
+     <listitem>
+      <simpara>
+       Valeur de retour d'une fonction de rappel d'autorisation définie avec
+       <methodname>Pdo\Sqlite::setAuthorizer</methodname>, substituant une valeur
+       &null; à la colonne qui aurait été lue.
+       Disponible à partir de PHP 8.5.0.
+      </simpara>
+     </listitem>
+    </varlistentry>
    </variablelist>
   </section>
+
+  <section role="changelog">
+   &reftitle.changelog;
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>8.5.0</entry>
+       <entry>
+        Ajout des constantes <constant>Pdo\Sqlite::ATTR_BUSY_STATEMENT</constant>,
+        <constant>Pdo\Sqlite::ATTR_EXPLAIN_STATEMENT</constant>,
+        <constant>Pdo\Sqlite::EXPLAIN_MODE_PREPARED</constant>,
+        <constant>Pdo\Sqlite::EXPLAIN_MODE_EXPLAIN</constant>,
+        <constant>Pdo\Sqlite::EXPLAIN_MODE_EXPLAIN_QUERY_PLAN</constant>,
+        <constant>Pdo\Sqlite::ATTR_TRANSACTION_MODE</constant>,
+        <constant>Pdo\Sqlite::TRANSACTION_MODE_DEFERRED</constant>,
+        <constant>Pdo\Sqlite::TRANSACTION_MODE_IMMEDIATE</constant>,
+        <constant>Pdo\Sqlite::TRANSACTION_MODE_EXCLUSIVE</constant>,
+        <constant>Pdo\Sqlite::OK</constant>,
+        <constant>Pdo\Sqlite::DENY</constant> et
+        <constant>Pdo\Sqlite::IGNORE</constant>.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </section>
+
  </partintro>
 
  &reference.pdo-sqlite.pdo.entities.sqlite;

--- a/reference/pdo_sqlite/pdo/sqlite/createcollation.xml
+++ b/reference/pdo_sqlite/pdo/sqlite/createcollation.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 51610360d58ed09bc9d1312f419057c0d1d1a998 Maintainer: Fan2Shrek Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: eff8e0d4dd463ae6bd387f304effeaf3d5ce44d5 Maintainer: Fan2Shrek Status: ready -->
 <refentry xml:id="pdo-sqlite.createcollation" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>Pdo\Sqlite::createCollation</refname>
@@ -62,6 +61,38 @@
   <simpara>
    &return.success;
   </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simpara>
+   Une <exceptionname>TypeError</exceptionname> est lancée si
+   <parameter>callback</parameter> ne retourne pas un <type>int</type>.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.4.0</entry>
+      <entry>
+       Une <exceptionname>TypeError</exceptionname> est désormais lancée si
+       <parameter>callback</parameter> ne retourne pas un <type>int</type> ;
+       auparavant, la valeur retournée était convertie en <type>int</type>.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/pdo_sqlite/pdo/sqlite/setauthorizer.xml
+++ b/reference/pdo_sqlite/pdo/sqlite/setauthorizer.xml
@@ -1,0 +1,172 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: eff8e0d4dd463ae6bd387f304effeaf3d5ce44d5 Maintainer: lacatoire Status: ready -->
+<refentry xml:id="pdo-sqlite.setauthorizer" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Pdo\Sqlite::setAuthorizer</refname>
+  <refpurpose>Configure une fonction de rappel à utiliser comme autorisateur pour limiter ce qu'une instruction peut faire</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Pdo\\Sqlite">
+   <modifier>public</modifier> <type>void</type><methodname>Pdo\Sqlite::setAuthorizer</methodname>
+   <methodparam><type class="union"><type>callable</type><type>null</type></type><parameter>callback</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Définit une fonction de rappel qui sera appelée par SQLite chaque fois qu'une action
+   est effectuée (lecture, suppression, mise à jour, etc.). Cela est utilisé lors de la
+   préparation d'une instruction SQL provenant d'une source non fiable, afin de s'assurer
+   que l'instruction n'accède pas à des données qu'elle n'est pas autorisée à voir et
+   n'exécute pas d'instructions malveillantes qui endommageraient la base de données.
+  </simpara>
+  <simpara>
+   L'autorisateur n'est utilisé que pendant la phase de préparation de l'instruction.
+   Il peut être appelé plusieurs fois pour une seule instruction : une requête
+   <literal>SELECT</literal> ou <literal>UPDATE</literal> l'appelle pour chaque colonne
+   qui serait lue ou mise à jour. Il est appelé de nouveau chaque fois que SQLite
+   prépare à nouveau une instruction, ce qui peut se produire pendant que l'instruction
+   est en cours d'exécution, par exemple après une modification du schéma.
+  </simpara>
+  <simpara>
+   L'autorisateur est appelé avec jusqu'à cinq arguments. Les arguments reçus sont
+   décrits sur la page <methodname>SQLite3::setAuthorizer</methodname>.
+  </simpara>
+  <simpara>
+   Un seul autorisateur peut être en place à la fois sur une connexion à une base de
+   données. Chaque appel à cette méthode remplace le précédent. L'autorisateur est
+   désactivé par défaut, et peut être désactivé de nouveau en définissant une fonction
+   de rappel &null;.
+  </simpara>
+  <simpara>
+   La fonction de rappel ne doit pas modifier la connexion à la base de données qui
+   l'a invoquée.
+  </simpara>
+  <simpara>
+   Plus de détails sont disponibles dans la
+   <link xlink:href="&url.sqlite;c3ref/set_authorizer.html">documentation de SQLite</link>.
+  </simpara>
+  <note>
+   <simpara>
+    Cette méthode est l'équivalent de <methodname>SQLite3::setAuthorizer</methodname>,
+    à ceci près qu'elle retourne <type>void</type> au lieu de <type>bool</type>.
+   </simpara>
+  </note>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>callback</parameter></term>
+    <listitem>
+     <simpara>
+      Le <type>callable</type> à invoquer, ou &null; pour désactiver la fonction de
+      rappel d'autorisation courante.
+     </simpara>
+     <simpara>
+      Il doit retourner l'une des valeurs <constant>Pdo\Sqlite::OK</constant>,
+      <constant>Pdo\Sqlite::DENY</constant> ou
+      <constant>Pdo\Sqlite::IGNORE</constant>.
+      Lorsque <constant>Pdo\Sqlite::DENY</constant> est retourné, l'instruction qui a
+      déclenché l'autorisateur échoue avec une erreur indiquant que l'accès est refusé.
+      Lorsque <constant>Pdo\Sqlite::IGNORE</constant> est retourné pour une action de
+      lecture, l'instruction est préparée de sorte qu'une valeur &null; soit substituée
+      à la colonne qui aurait été lue.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   &return.void;
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simpara>
+   Cette méthode elle-même ne lance pas d'exception, mais si la fonction de rappel
+   d'autorisation ne retourne pas un <type>int</type>, ou retourne un <type>int</type>
+   qui n'est pas l'une des valeurs <constant>Pdo\Sqlite::OK</constant>,
+   <constant>Pdo\Sqlite::DENY</constant> ou <constant>Pdo\Sqlite::IGNORE</constant>,
+   la préparation de l'instruction lance respectivement une
+   <exceptionname>TypeError</exceptionname> ou une
+   <exceptionname>ValueError</exceptionname>.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Exemple avec <methodname>Pdo\Sqlite::setAuthorizer</methodname></title>
+   <simpara>
+    Seules les actions de lecture sont autorisées sur la connexion. Les codes d'action
+    sont exposés en tant que constantes de la classe <classname>SQLite3</classname>, ce
+    qui nécessite que l'extension <link linkend="book.sqlite3">SQLite3</link> soit
+    disponible ; leurs valeurs entières peuvent être utilisées directement dans le cas
+    contraire.
+   </simpara>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$db = new Pdo\Sqlite('sqlite::memory:');
+$db->exec('CREATE TABLE users (id, name)');
+
+$db->setAuthorizer(function (int $action, ...$args) {
+    return match ($action) {
+        SQLite3::SELECT, SQLite3::READ => Pdo\Sqlite::OK,
+        default => Pdo\Sqlite::DENY,
+    };
+});
+
+var_dump($db->query('SELECT name FROM users') instanceof PDOStatement);
+
+try {
+    $db->exec('DROP TABLE users');
+} catch (PDOException $e) {
+    echo $e->getMessage(), "\n";
+}
+?>
+]]>
+   </programlisting>
+   &example.outputs.similar;
+   <screen>
+<![CDATA[
+bool(true)
+SQLSTATE[HY000]: General error: 23 not authorized
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>SQLite3::setAuthorizer</methodname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
Translation of php/doc-en#5818 (commit eff8e0d): the new `PDO::SQLITE_ATTR_*` and mode constants, the libsqlite 3.7.17 requirement as of PHP 8.5.0, the `quote()` behaviour on a null byte and the `createCollation()` `TypeError`.

The `setAuthorizer()` page did not exist in French and is translated here for the first time.

EN-Revision updated.

Fixes: #3450
