### PR TITLE
[Sync-En] ext/readline: document the functions unavailable where the feature is not supported

### DIFF
--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9e5166dc6a5ff650b649298470d19eb7c3637a63 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 8648d1cda141537b5dbd403a0bf0e6eb8c086e9d Maintainer: lacatoire Status: ready -->
 <!-- Relecture des Notes, Précautions, Avertissements, Astuces, Divers et Retour le 2018-12-29 par girgias -->
 
 <!--
@@ -4840,6 +4840,15 @@ anglais. On devrait penser à leur utilité :
     </tbody>
    </tgroup>
   </informaltable>
+'>
+
+<!-- readline -->
+<!ENTITY readline.system-callback-support '
+  <simpara xmlns="http://docbook.org/ns/docbook">
+   Cette fonction est disponible uniquement si la bibliothèque readline avec
+   laquelle PHP a été compilé la prend en charge. Elle est indisponible sur
+   Windows.
+  </simpara>
 '>
 
 <!-- Keep this comment at the end of the file

--- a/reference/readline/book.xml
+++ b/reference/readline/book.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 53208f9bd0a035a4e1409ba700106540474c9ef1 Maintainer: yannick Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 8648d1cda141537b5dbd403a0bf0e6eb8c086e9d Maintainer: yannick Status: ready -->
 <book xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="book.readline">
  <?phpdoc extension-membership="bundledexternal" ?>
  <title>GNU Readline</title>
@@ -22,7 +20,10 @@
    <link linkend="features.commandline">ligne de commande</link>.
   </simpara>
   <simpara>
-   À partir de PHP 7.1.0 cette extension est supportée sur Windows.  </simpara>
+   À partir de PHP 7.1.0 cette extension est supportée sur Windows, où elle est
+   compilée avec libedit. Toutes les fonctions ne sont pas présentes dans cette
+   compilation ; voir <link linkend="readline.requirements">les prérequis</link>.
+  </simpara>
   <caution>
    <simpara>
     L'extension readline n'est pas thread-safe ! Par conséquent l'usage de celle-ci

--- a/reference/readline/functions/readline-callback-handler-install.xml
+++ b/reference/readline/functions/readline-callback-handler-install.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: be246a268d0d5ab0b215c429cb031e70c98327ef Maintainer: lacatoire Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 8648d1cda141537b5dbd403a0bf0e6eb8c086e9d Maintainer: lacatoire Status: ready -->
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.readline-callback-handler-install">
  <refnamediv>
   <refname>readline_callback_handler_install</refname>
@@ -27,6 +26,7 @@
    l'interconnexion IO / entrée utilisateur, à la différence de
    <function>readline</function>.
   </simpara>
+  &readline.system-callback-support;
  </refsect1>
 
  <refsect1 role="parameters">

--- a/reference/readline/functions/readline-callback-handler-remove.xml
+++ b/reference/readline/functions/readline-callback-handler-remove.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 53208f9bd0a035a4e1409ba700106540474c9ef1 Maintainer: yannick Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 8648d1cda141537b5dbd403a0bf0e6eb8c086e9d Maintainer: yannick Status: ready -->
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.readline-callback-handler-remove">
  <refnamediv>
   <refname>readline_callback_handler_remove</refname>
@@ -18,6 +16,7 @@
    Efface un gestionnaire de rappel installé précédemment et restaure les
    paramètres du terminal.
   </simpara>
+  &readline.system-callback-support;
  </refsect1>
 
  <refsect1 role="parameters">

--- a/reference/readline/functions/readline-callback-read-char.xml
+++ b/reference/readline/functions/readline-callback-read-char.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 53208f9bd0a035a4e1409ba700106540474c9ef1 Maintainer: yannick Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 8648d1cda141537b5dbd403a0bf0e6eb8c086e9d Maintainer: yannick Status: ready -->
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.readline-callback-read-char">
  <refnamediv>
   <refname>readline_callback_read_char</refname>
@@ -20,6 +18,7 @@
    <function>readline_callback_handler_install</function>
    qu'une ligne est prête à être entrée.
   </simpara>
+  &readline.system-callback-support;
  </refsect1>
 
  <refsect1 role="parameters">

--- a/reference/readline/functions/readline-list-history.xml
+++ b/reference/readline/functions/readline-list-history.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 53208f9bd0a035a4e1409ba700106540474c9ef1 Maintainer: yannick Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 8648d1cda141537b5dbd403a0bf0e6eb8c086e9d Maintainer: yannick Status: ready -->
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.readline-list-history">
  <refnamediv>
   <refname>readline_list_history</refname>
@@ -16,6 +14,11 @@
   </methodsynopsis>
   <simpara>
    Liste l'historique.
+  </simpara>
+  <simpara>
+   Cette fonction est disponible uniquement si la bibliothèque readline avec
+   laquelle PHP a été compilé fournit le listage de l'historique. C'est toujours
+   le cas avec GNU Readline et sur Windows.
   </simpara>
  </refsect1>
 

--- a/reference/readline/functions/readline-on-new-line.xml
+++ b/reference/readline/functions/readline-on-new-line.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 53208f9bd0a035a4e1409ba700106540474c9ef1 Maintainer: yannick Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 8648d1cda141537b5dbd403a0bf0e6eb8c086e9d Maintainer: yannick Status: ready -->
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.readline-on-new-line">
  <refnamediv>
   <refname>readline_on_new_line</refname>
@@ -17,6 +15,7 @@
   <simpara>
    Informe readline que le curseur est passé à une nouvelle ligne.
   </simpara>
+  &readline.system-callback-support;
  </refsect1>
 
  <refsect1 role="parameters">
@@ -31,14 +30,11 @@
   </simpara>
  </refsect1>
 
- <refsect1 role="notes">
-  &reftitle.notes;
-  <note>
-   <simpara>
-    Cette fonction n'est disponible que si elle est supportée par la
-    bibliothèque readline sous-jacente. Elle n'est pas supportée sur Windows.
-   </simpara>
-  </note>
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>readline_callback_handler_install</function></member>
+  </simplelist>
  </refsect1>
 </refentry>
 <!-- Keep this comment at the end of the file

--- a/reference/readline/functions/readline-redisplay.xml
+++ b/reference/readline/functions/readline-redisplay.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 53208f9bd0a035a4e1409ba700106540474c9ef1 Maintainer: yannick Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 8648d1cda141537b5dbd403a0bf0e6eb8c086e9d Maintainer: yannick Status: ready -->
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.readline-redisplay">
  <refnamediv>
   <refname>readline_redisplay</refname>
@@ -17,6 +15,7 @@
   <simpara>
    Demande à readline de refaire l'affichage.
   </simpara>
+  &readline.system-callback-support;
  </refsect1>
 
  <refsect1 role="parameters">
@@ -29,6 +28,13 @@
   <simpara>
    &return.void;
   </simpara>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>readline_callback_handler_install</function></member>
+  </simplelist>
  </refsect1>
 </refentry>
 <!-- Keep this comment at the end of the file

--- a/reference/readline/setup.xml
+++ b/reference/readline/setup.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 53208f9bd0a035a4e1409ba700106540474c9ef1 Maintainer: yannick Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 8648d1cda141537b5dbd403a0bf0e6eb8c086e9d Maintainer: yannick Status: ready -->
 <chapter xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="readline.setup">
  &reftitle.setup;
 
@@ -19,6 +17,21 @@
    de la bibliothèque readline. La bibliothèque libedit est sous licence BSD
    et disponible en téléchargement sur
    <link xlink:href="&url.libedit;">&url.libedit;</link>.
+  </simpara>
+  <simpara>
+   Les deux bibliothèques ne fournissent pas les mêmes fonctionnalités, si bien
+   que certaines fonctions sont absentes de certaines compilations. Les fonctions
+   qui pilotent l'interface de rappel,
+   <function>readline_callback_handler_install</function>,
+   <function>readline_callback_handler_remove</function>,
+   <function>readline_callback_read_char</function>,
+   <function>readline_redisplay</function> et
+   <function>readline_on_new_line</function>, ne sont présentes que si la
+   bibliothèque sous-jacente les fournit, et sont absentes sur Windows. Appeler
+   une fonction absente lève une <exceptionname>Error</exceptionname>.
+   <function>function_exists</function> teste la présence d'une fonction donnée,
+   et la constante <constant>READLINE_LIB</constant> indique quelle bibliothèque
+   est utilisée.
   </simpara>
  </section>
  <!-- }}} -->


### PR DESCRIPTION
Translation of php/doc-en#4923 (commit 8648d1c): a shared snippet (`readline.system-callback-support`) states that a function is only available when the readline library PHP was built against supports it, and is unavailable on Windows, where the extension is built against libedit. It is used on the five callback pages, and the setup and book pages are updated accordingly. EN-Revision updated.

Fixes: #3449
