### PR TITLE
[Sync-En] array_unique: explain what the 7.2 rebuild actually changes

### DIFF
--- a/appendices/migration72/incompatible.xml
+++ b/appendices/migration72/incompatible.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 8859c8b96cd9e80652813f7bcf561432a5e9f934 Maintainer: jbnahan Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 5e26d11dc3f606b25c95467df22f9469636781f9 Maintainer: jbnahan Status: ready -->
 
 <sect1 xml:id="migration72.incompatible">
  <title>Évolutions incompatibles avec les versions précédentes</title>
@@ -275,13 +273,16 @@ int(2)
  <sect2 xml:id="migration72.incompatible.array-unique">
   <title><function>array_unique</function> avec <constant>SORT_STRING</constant></title>
 
-  <para>
-   Alors que <function>array_unique</function> avec <constant>SORT_STRING</constant>
-   copiait anciennement le tableau et supprimait des éléments non uniques
-   (sans emballer le tableau par la suite), maintenant un nouveau tableau
-   est construit en ajoutant les éléments uniques.
-   Cela peut entraîner des index numériques différents.
-  </para>
+  <simpara>
+   <function>array_unique</function> avec <constant>SORT_STRING</constant>
+   construit le tableau retourné en ajoutant les éléments uniques à un nouveau
+   tableau ; auparavant, il s'agissait d'une copie du tableau d'entrée dont les
+   éléments non uniques étaient supprimés.
+   Les deux contiennent les mêmes éléments sous les mêmes clés, mais si
+   l'élément ayant la plus grande clé entière fait partie de ceux supprimés,
+   l'index généré pour un élément ajouté au tableau retourné diffère de celui
+   qu'aurait généré le tableau d'entrée.
+  </simpara>
  </sect2>
 
  <sect2 xml:id="migration72.incompatible.bcmod-and-floats">
@@ -322,9 +323,9 @@ int(2)
 
   <para>
    Les séquences générées par <function>rand</function> et
-   <function>mt_rand</function> pour des cas spécifiques peuvent différer
+   <function>mt_rand</function> pour une graine donnée peuvent différer
    de PHP 7.1 sur les machines 64 bits (en raison de la correction d'un bug
-   dans l'implémentation de la polarisation du modulo).
+   de biais de modulo dans l'implémentation).
   </para>
  </sect2>
 

--- a/reference/array/functions/array-unique.xml
+++ b/reference/array/functions/array-unique.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 47cbf365f535be1517473eee446e94d096778ca8 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 5e26d11dc3f606b25c95467df22f9469636781f9 Maintainer: lacatoire Status: ready -->
 <refentry xml:id="function.array-unique" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>array_unique</refname>
@@ -13,9 +13,8 @@
    <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer><constant>SORT_STRING</constant></initializer></methodparam>
   </methodsynopsis>
   <para>
-   <function>array_unique</function> extrait du tableau 
-   <parameter>array</parameter> les valeurs distinctes,
-   et supprime tous les doublons.
+   Prend le tableau d'entrée <parameter>array</parameter> et retourne un
+   nouveau tableau sans valeurs dupliquées.
   </para>
   <para>
    Il est à noter que les clés sont préservées. Si plusieurs éléments comparés
@@ -26,7 +25,8 @@
    <simpara>
     Deux éléments sont considérés comme égaux si et seulement si
     <literal>(string) $elem1 === (string) $elem2</literal>, c.-à-d.
-    lorsque la représentation en chaîne de caractères est identique.
+    lorsque la représentation en chaîne de caractères est identique, auquel
+    cas le premier élément est conservé.
    </simpara>
   </note>
  </refsect1>
@@ -111,10 +111,14 @@
        <entry>7.2.0</entry>
        <entry>
         Si <parameter>flags</parameter> est <constant>SORT_STRING</constant>,
-        antérieurement <parameter>array</parameter> était copié et les éléments
-        non-uniques étaient supprimés (sans compresser le tableau après), mais
-        maintenant un nouveau tableau est construit en ajoutant les éléments uniques.
-        Par conséquent, le résultat final peut avoir des index numériques différents.
+        le tableau retourné est construit en ajoutant les éléments uniques à un
+        nouveau tableau ; auparavant, il s'agissait d'une copie de
+        <parameter>array</parameter> dont les éléments non uniques étaient
+        supprimés.
+        Les deux contiennent les mêmes éléments sous les mêmes clés, mais si
+        l'élément ayant la plus grande clé entière fait partie de ceux
+        supprimés, l'index généré pour un élément ajouté au tableau retourné
+        diffère de celui qu'aurait généré <parameter>array</parameter>.
        </entry>
       </row>
      </tbody>


### PR DESCRIPTION
Translation of php/doc-en#5825 (commit 5e26d11): the 7.2 changelog entry and the migration appendix now say what the rebuild actually changes, namely the index generated for an element appended to the returned array. Picked up a few stale sentences in the same two files along the way. EN-Revision updated.

Fixes: #3472