### PR TITLE
[Sync-En] fpm: warn that an exposed FastCGI endpoint allows arbitrary code execution

### DIFF
--- a/install/fpm/configuration.xml
+++ b/install/fpm/configuration.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 7cd12cc82bc0a778241189596022acdda016d857 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 7efe863bc4b65788f652e3d9eff27941b1a74540 Maintainer: lacatoire Status: ready -->
 <sect1 xml:id="install.fpm.configuration" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Configuration</title>
  <para>
@@ -251,7 +251,25 @@
       L'adresse pour accepter des requêtes FastCGI. Syntaxes valides :
       'ip.add.re.ss:port', 'port', '/path/to/unix/socket'.
       Cette option est obligatoire pour chaque pool.
-     </para> 
+     </para>
+     <warning>
+      <simpara>
+       Un point d'entrée FastCGI exposé permet l'exécution de code arbitraire.
+       Lorsque le serveur web s'exécute sur la même machine, il est préférable
+       d'utiliser un socket Unix ; sous Linux, son accès est alors contrôlé par
+       <link linkend="listen-owner">listen.owner</link>,
+       <literal>listen.group</literal> et <literal>listen.mode</literal>, bien
+       que de nombreux systèmes dérivés de BSD acceptent les connexions quelles
+       que soient ces permissions.
+       Lorsqu'un socket TCP est utilisé, les adresses autorisées à se connecter
+       doivent être listées dans
+       <link linkend="listen-allowed-clients">listen.allowed_clients</link>,
+       qui n'est pas définie par défaut et accepte alors toute adresse.
+       Dans un environnement conteneurisé, le service FPM ne doit pas publier
+       son port sur l'hôte ; les conteneurs d'un même réseau se joignent
+       directement.
+      </simpara>
+     </warning>
     </listitem>
    </varlistentry>
    <varlistentry xml:id="listen-backlog">
@@ -642,8 +660,8 @@
       </term>
       <listitem>
        <para>
-        Le timeout pour servir une requête dans laquelle la backtrace PHP sera vidée
-        dans le fichier 'slowlog'. Une valeur de '0' signifie 'Off'.
+        Le timeout pour servir une requête après lequel une backtrace PHP sera
+        écrite dans le fichier 'slowlog'. Une valeur de '0' signifie 'Off'.
         Unités disponibles : s(econdes)(défaut), m(inutes), h(eures), ou j(ours).
         Par défaut : 0.
        </para> 
@@ -742,7 +760,7 @@
       </term>
       <listitem>
        <para>
-        Active la décoration de sortie pour les travailleurs de sortie quand
+        Active la décoration de la sortie des processus de travail quand
         <link linkend="catch-workers-output">catch_workers_output</link> est activé.
         Valeur par défaut : yes.
         Disponible à partir de PHP 7.3.0.

--- a/install/fpm/index.xml
+++ b/install/fpm/index.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 04210d535db52aed64b82572817f059059ddfebc Maintainer: jpauli Status: ready -->
-<!-- Reviewed: yes Maintainer: mikaelkael -->
+<!-- EN-Revision: 7efe863bc4b65788f652e3d9eff27941b1a74540 Maintainer: jpauli Status: ready -->
 <chapter xml:id="install.fpm" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>FastCGI Process Manager (FPM)</title>
  &fpm.intro;
@@ -41,10 +39,10 @@
     </para>
    </listitem>
    <listitem>
-    <para>
+    <simpara>
      <function>fastcgi_finish_request</function> - fonction spéciale pour terminer la requête et vider toutes les données
      tout en continuant d'exécuter une tâche consommatrice (conversion vidéo par exemple) ;
-    </para>
+    </simpara>
    </listitem>
    <listitem>
     <para>
@@ -64,7 +62,20 @@
    </listitem>
   </itemizedlist>
  </para>
- 
+
+ <warning>
+  <simpara>
+   php-fpm ne doit pas être joignable depuis un réseau non fiable.
+   Un client capable d'ouvrir une connexion FastCGI contrôle la configuration
+   utilisée pour la requête, dont
+   <link linkend="ini.auto-prepend-file">auto_prepend_file</link>, et peut donc
+   exécuter du code arbitraire.
+   L'accès se restreint par les directives
+   <link linkend="listen">listen</link> et
+   <link linkend="listen-allowed-clients">listen.allowed_clients</link>.
+  </simpara>
+ </warning>
+
  &install.fpm.install;
  &install.fpm.configuration;
 </chapter>


### PR DESCRIPTION
Translation of php/doc-en#5263 (commit 7efe863): the FPM chapter and the listen directive now warn that a client able to open a FastCGI connection controls the configuration used for the request, and point at listen and listen.allowed_clients. Fixed a few garbled sentences in the same file along the way. EN-Revision updated.

Fixes: #3473