### PR TITLE
[Sync-En] hash_algos: point at the algorithm categories in the extension introduction

### DIFF
--- a/reference/hash/functions/hash-algos.xml
+++ b/reference/hash/functions/hash-algos.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 71e12e2df7b0bcf0dc2743681b73790ac0d45ccc Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 9d8fd9317e3167cee8da1c22031ece5f760e0fd9 Maintainer: yannick Status: ready -->
 <refentry xml:id="function.hash-algos" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>hash_algos</refname>
@@ -26,6 +24,14 @@
    Retourne un tableau indexé numériquement contenant la liste des algorithmes
    de hachage disponibles.
   </para>
+  <note>
+   <simpara>
+    Tous les algorithmes ne conviennent pas à tous les usages.
+    Voir l'<link linkend="intro.hash">introduction de l'extension Hash</link>
+    pour une description des différentes catégories (somme de contrôle,
+    non cryptographique et cryptographique).
+   </simpara>
+  </note>
  </refsect1>
 
  <refsect1 role="changelog"><!-- {{{ -->


### PR DESCRIPTION
Translation of php/doc-en#5273 (commit 9d8fd93): a note on the return value warns that not every algorithm suits every use case, and links to the checksum / non-cryptographic / cryptographic categories described in the Hash introduction. EN-Revision updated.

Fixes: #3474