### PR TITLE
[Sync-En] swoole: document the Timer class and its remaining methods

### DIFF
--- a/reference/swoole/swoole.timer.xml
+++ b/reference/swoole/swoole.timer.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: Fan2Shrek Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 6e77169fdc9c087749f357bef877607ccc05f442 Maintainer: Fan2Shrek Status: ready -->
+
 <reference xml:id="class.swoole-timer" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>La classe Swoole\Timer</title>
  <titleabbrev>Swoole\Timer</titleabbrev>
@@ -10,9 +10,70 @@
 <!-- {{{ Swoole\Timer intro -->
   <section xml:id="swoole-timer.intro">
    &reftitle.intro;
+   <simpara>
+    Minuteur d'une précision de l'ordre de la milliseconde. L'implémentation sous-jacente
+    repose sur epoll_wait et setitimer, avec un tas-min qui permet d'ajouter un grand
+    nombre de minuteurs.
+   </simpara>
+   <simpara>
+    Dans les processus à E/S synchrones, tels que les processus Manager et TaskWorker,
+    elle repose sur setitimer et les signaux.
+   </simpara>
+   <simpara>
+    Dans les processus à E/S asynchrones, elle repose sur le délai d'expiration de
+    epoll_wait/kevent/poll/select.
+   </simpara>
    <para>
-
+    Le système sous-jacent ne prend pas en charge les minuteurs dont le délai vaut
+    <literal>0</literal> : une valeur inférieure à <literal>1</literal> milliseconde
+    émet une <constant>E_WARNING</constant> et l'appel échoue. Cela diffère de langages
+    tels que Node.js.
+    <methodname linkend="swoole-event.defer">Swoole\Event::defer</methodname>
+    permet d'obtenir un résultat similaire.
+    <programlisting role="php">
+<![CDATA[
+<?php
+Swoole\Event::defer(function () {
+  echo "hello\n";
+});
+?>
+]]>
+    </programlisting>
    </para>
+   <simpara>
+    Correction du minuteur : la durée d'exécution de la fonction de rappel n'influe pas
+    sur l'instant du déclenchement suivant. Par exemple, pour un minuteur tick de 10 ms
+    créé à 0,002 s, le premier rappel est exécuté à 0,012 s ; si la fonction de rappel
+    prend 5 ms, le déclenchement suivant a tout de même lieu à 0,022 s, et non à 0,027 s.
+   </simpara>
+   <simpara>
+    En revanche, si la fonction de rappel s'exécute trop longtemps, au point de couvrir
+    l'instant du déclenchement suivant, le système sous-jacent corrige le temps : il
+    abandonne les déclenchements périmés et rappelle la fonction au prochain instant
+    disponible. Par exemple, si la fonction de rappel exécutée à 0,012 s prend 15 ms, ce
+    qui retarde le minuteur prévu à 0,022 s, le rappel est déclenché à nouveau à 0,032 s.
+   </simpara>
+   <simpara>
+    Par défaut, une coroutine est automatiquement créée pour exécuter la fonction de
+    rappel lorsqu'un minuteur se déclenche. Ce comportement se désactive avec
+    <function>swoole_async_set</function>.
+   </simpara>
+   <warning>
+    <simpara>
+     Un minuteur ne fonctionne que dans l'espace du processus courant.
+    </simpara>
+   </warning>
+   <warning>
+    <simpara>
+     Les minuteurs sont purement asynchrones et incompatibles avec les fonctions d'E/S
+     synchrones.
+    </simpara>
+   </warning>
+   <warning>
+    <simpara>
+     L'exécution d'un minuteur peut présenter de légers écarts de temps.
+    </simpara>
+   </warning>
   </section>
 <!-- }}} -->
 

--- a/reference/swoole/swoole/timer/after.xml
+++ b/reference/swoole/swoole/timer/after.xml
@@ -1,42 +1,57 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 322606e4f1742a6f959e952c63fb1f8bcd6d6ba0 Maintainer: Fan2Shrek Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 6e77169fdc9c087749f357bef877607ccc05f442 Maintainer: Fan2Shrek Status: ready -->
+
 <refentry xml:id="swoole-timer.after" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Swoole\Timer::after</refname>
-  <refpurpose>Déclenche une fonction de rappel après une période de temps.</refpurpose>
+  <refpurpose>Exécute une fonction après un temps donné</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier>public</modifier> <modifier>static</modifier> <type>void</type><methodname>Swoole\Timer::after</methodname>
-   <methodparam><type>int</type><parameter>after_time_ms</parameter></methodparam>
+   <modifier>public</modifier> <modifier>static</modifier> <type class="union"><type>int</type><type>false</type></type><methodname>Swoole\Timer::after</methodname>
+   <methodparam><type>int</type><parameter>ms</parameter></methodparam>
    <methodparam><type>callable</type><parameter>callback</parameter></methodparam>
+   <methodparam rep="repeat"><type>mixed</type><parameter>params</parameter></methodparam>
   </methodsynopsis>
-  <para>
-    Déclenche une fonction de rappel après une période de temps.
-  </para>
-
+  <simpara>
+   Crée un minuteur à usage unique, détruit dès que sa fonction de rappel a été
+   exécutée. Contrairement à <function>sleep</function>, il ne bloque pas le
+   processus courant.
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
   &reftitle.parameters;
   <variablelist>
    <varlistentry>
-    <term><parameter>after_time_ms</parameter></term>
+    <term><parameter>ms</parameter></term>
     <listitem>
-     <para>
-
-     </para>
+     <simpara>
+      Le délai, en millisecondes. Doit être supérieur ou égal à
+      <literal>1</literal> ; une valeur inférieure émet une
+      <constant>E_WARNING</constant> et l'appel échoue.
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>callback</parameter></term>
     <listitem>
-     <para>
-
-     </para>
+     <simpara>
+      La fonction à exécuter une fois le délai écoulé. Elle est appelée sous la
+      forme <literal>callback(mixed ...$params)</literal>. Contrairement à
+      <methodname>Swoole\Timer::tick</methodname>, l'identifiant du minuteur
+      n'est pas transmis à la fonction de rappel.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>params</parameter></term>
+    <listitem>
+     <simpara>
+      Valeurs supplémentaires transmises à <parameter>callback</parameter>.
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -44,12 +59,36 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
-
-  </para>
+  <simpara>
+   Retourne l'identifiant du minuteur, qui peut être transmis à
+   <methodname>Swoole\Timer::clear</methodname> pour annuler le minuteur avant
+   son déclenchement. Retourne &false; si le minuteur n'a pas pu être créé, en
+   particulier lorsque <parameter>ms</parameter> est inférieur à
+   <literal>1</literal>.
+  </simpara>
  </refsect1>
 
-
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Exemple avec <function>Swoole\Timer::after</function></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+Swoole\Timer::after(1000, function (string $name) {
+    echo "Hello, $name\n";
+}, "Swoole");
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+Hello, Swoole
+]]>
+   </screen>
+  </example>
+ </refsect1>
 </refentry>
 
 <!-- Keep this comment at the end of the file

--- a/reference/swoole/swoole/timer/clear.xml
+++ b/reference/swoole/swoole/timer/clear.xml
@@ -1,22 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 86e6094e86b84a51d00ab217ac50ce8dde33d82a Maintainer: Fan2Shrek Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 6e77169fdc9c087749f357bef877607ccc05f442 Maintainer: Fan2Shrek Status: ready -->
+
 <refentry xml:id="swoole-timer.clear" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Swoole\Timer::clear</refname>
-  <refpurpose>Supprime un minuteur par ID de minuteur.</refpurpose>
+  <refpurpose>Supprime un minuteur par son identifiant</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier>public</modifier> <modifier>static</modifier> <type>void</type><methodname>Swoole\Timer::clear</methodname>
+   <modifier>public</modifier> <modifier>static</modifier> <type>bool</type><methodname>Swoole\Timer::clear</methodname>
    <methodparam><type>int</type><parameter>timer_id</parameter></methodparam>
   </methodsynopsis>
-  <para>
-    Supprime un minuteur par ID de minuteur.
-  </para>
-
+  <simpara>
+   Supprime le minuteur portant l'identifiant donné. Seuls les minuteurs créés
+   par le processus courant peuvent être supprimés ; ceux qui appartiennent à
+   d'autres processus ne sont pas visibles ici.
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -25,9 +26,11 @@
    <varlistentry>
     <term><parameter>timer_id</parameter></term>
     <listitem>
-     <para>
-
-     </para>
+     <simpara>
+      L'identifiant de minuteur retourné par
+      <methodname>Swoole\Timer::tick</methodname> ou
+      <methodname>Swoole\Timer::after</methodname>.
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -35,12 +38,35 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
-
-  </para>
+  <simpara>
+   &return.success;
+   &false; est retourné lorsqu'aucun minuteur ne porte cet identifiant dans le
+   processus courant, ou lorsque l'identifiant désigne un minuteur interne.
+  </simpara>
  </refsect1>
 
-
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Exemple avec <function>Swoole\Timer::clear</function></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$timer_id = Swoole\Timer::after(1000, function () {
+    echo "jamais affiché\n";
+});
+var_dump(Swoole\Timer::clear($timer_id));
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+bool(true)
+]]>
+   </screen>
+  </example>
+ </refsect1>
 </refentry>
 
 <!-- Keep this comment at the end of the file

--- a/reference/swoole/swoole/timer/clearAll.xml
+++ b/reference/swoole/swoole/timer/clearAll.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 6e77169fdc9c087749f357bef877607ccc05f442 Maintainer: lacatoire Status: ready -->
+
+<refentry xml:id="swoole-timer.clearall" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Swoole\Timer::clearAll</refname>
+  <refpurpose>Supprime tous les minuteurs du processus courant</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>public</modifier> <modifier>static</modifier> <type>bool</type><methodname>Swoole\Timer::clearAll</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   Supprime tous les minuteurs du processus courant. À partir de Swoole 4.4.0.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   &return.success;
+   &false; est retourné lorsqu'aucun minuteur n'a encore été créé dans ce
+   processus. Seuls les minuteurs créés depuis PHP sont supprimés ; les
+   minuteurs internes sont laissés en place.
+  </simpara>
+ </refsect1>
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/swoole/swoole/timer/exists.xml
+++ b/reference/swoole/swoole/timer/exists.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 86e6094e86b84a51d00ab217ac50ce8dde33d82a Maintainer: Fan2Shrek Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 6e77169fdc9c087749f357bef877607ccc05f442 Maintainer: Fan2Shrek Status: ready -->
+
 <refentry xml:id="swoole-timer.exists" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Swoole\Timer::exists</refname>
-  <refpurpose>Vérifie si un minuteur existe.</refpurpose>
+  <refpurpose>Vérifie si un minuteur existe</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -13,9 +13,10 @@
    <modifier>public</modifier> <modifier>static</modifier> <type>bool</type><methodname>Swoole\Timer::exists</methodname>
    <methodparam><type>int</type><parameter>timer_id</parameter></methodparam>
   </methodsynopsis>
-  <para>
-    Vérifie si un minuteur existe.
-  </para>
+  <simpara>
+   Vérifie si un minuteur portant l'identifiant donné existe dans le processus
+   courant.
+  </simpara>
 
  </refsect1>
 
@@ -25,9 +26,11 @@
    <varlistentry>
     <term><parameter>timer_id</parameter></term>
     <listitem>
-     <para>
-
-     </para>
+     <simpara>
+      L'identifiant de minuteur retourné par
+      <methodname>Swoole\Timer::tick</methodname> ou
+      <methodname>Swoole\Timer::after</methodname>.
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -35,9 +38,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
-
-  </para>
+  <simpara>
+   Retourne &true; si un minuteur portant cet identifiant existe dans le
+   processus courant, &false; sinon.
+  </simpara>
  </refsect1>
 
 

--- a/reference/swoole/swoole/timer/info.xml
+++ b/reference/swoole/swoole/timer/info.xml
@@ -1,0 +1,144 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 6e77169fdc9c087749f357bef877607ccc05f442 Maintainer: lacatoire Status: ready -->
+
+<refentry xml:id="swoole-timer.info" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Swoole\Timer::info</refname>
+  <refpurpose>Retourne les informations d'un minuteur</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>public</modifier> <modifier>static</modifier> <type class="union"><type>array</type><type>null</type></type><methodname>Swoole\Timer::info</methodname>
+   <methodparam><type>int</type><parameter>timer_id</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Retourne les informations d'un minuteur. À partir de Swoole 4.4.0.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>timer_id</parameter></term>
+    <listitem>
+     <simpara>
+      L'identifiant de minuteur retourné par
+      <methodname>Swoole\Timer::tick</methodname> ou
+      <methodname>Swoole\Timer::after</methodname>.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Retourne un tableau décrivant le minuteur, ou &null; si aucun minuteur ne
+   porte cet identifiant dans le processus courant. Le tableau contient les
+   clés suivantes :
+  </simpara>
+  <variablelist>
+   <varlistentry>
+    <term><literal>exec_msec</literal></term>
+    <listitem>
+     <simpara>
+      L'instant de la prochaine exécution, en millisecondes, compté depuis le
+      démarrage du sous-système de minuteurs. Ce n'est pas une durée.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><literal>exec_count</literal></term>
+    <listitem>
+     <simpara>
+      Le nombre de fois où la fonction de rappel a été exécutée.
+      Disponible à partir de Swoole 4.8.0.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><literal>interval</literal></term>
+    <listitem>
+     <simpara>
+      L'intervalle du minuteur, en millisecondes.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><literal>round</literal></term>
+    <listitem>
+     <simpara>
+      Le numéro du tour de la boucle de minuteurs durant lequel le minuteur a
+      été créé.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><literal>removed</literal></term>
+    <listitem>
+     <simpara>
+      Indique si le minuteur a été supprimé.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Exemple avec <function>Swoole\Timer::info</function></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$timer_id = Swoole\Timer::tick(1000, function () {});
+var_dump(Swoole\Timer::info($timer_id));
+Swoole\Timer::clear($timer_id);
+?>
+]]>
+   </programlisting>
+   &example.outputs.similar;
+   <screen>
+<![CDATA[
+array(5) {
+  ["exec_msec"]=>
+  int(1000)
+  ["exec_count"]=>
+  int(0)
+  ["interval"]=>
+  int(1000)
+  ["round"]=>
+  int(0)
+  ["removed"]=>
+  bool(false)
+}
+]]>
+   </screen>
+  </example>
+ </refsect1>
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/swoole/swoole/timer/list.xml
+++ b/reference/swoole/swoole/timer/list.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 6e77169fdc9c087749f357bef877607ccc05f442 Maintainer: lacatoire Status: ready -->
+
+<refentry xml:id="swoole-timer.list" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Swoole\Timer::list</refname>
+  <refpurpose>Retourne un itérateur sur les minuteurs du processus courant</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>public</modifier> <modifier>static</modifier> <type>Swoole\Timer\Iterator</type><methodname>Swoole\Timer::list</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   Retourne un itérateur sur les identifiants des minuteurs créés depuis PHP
+   dans le processus courant. Les minuteurs créés en interne par Swoole n'y
+   figurent pas. À partir de Swoole 4.4.0.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Retourne un objet <classname>Swoole\Timer\Iterator</classname>, qui étend
+   <classname>ArrayIterator</classname> et fournit les identifiants de minuteur
+   sous forme de valeurs <type>int</type>. L'itérateur est un instantané pris
+   au moment de l'appel ; il est vide lorsqu'aucun minuteur n'existe.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Exemple avec <function>Swoole\Timer::list</function></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+Swoole\Timer::tick(1000, function () {});
+Swoole\Timer::after(5000, function () {});
+
+foreach (Swoole\Timer::list() as $timer_id) {
+    echo $timer_id, "\n";
+    Swoole\Timer::clear($timer_id);
+}
+?>
+]]>
+   </programlisting>
+   &example.outputs.similar;
+   <screen>
+<![CDATA[
+1
+2
+]]>
+   </screen>
+  </example>
+ </refsect1>
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/swoole/swoole/timer/set.xml
+++ b/reference/swoole/swoole/timer/set.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 6e77169fdc9c087749f357bef877607ccc05f442 Maintainer: lacatoire Status: ready -->
+
+<refentry xml:id="swoole-timer.set" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Swoole\Timer::set</refname>
+  <refpurpose>Définit les paramètres liés aux minuteurs</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>public</modifier> <modifier>static</modifier> <type>void</type><methodname>Swoole\Timer::set</methodname>
+   <methodparam><type>array</type><parameter>settings</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Définit les options utilisées par les minuteurs du processus courant.
+  </simpara>
+
+  <warning>
+   <simpara>
+    Cette méthode a été dépréciée en Swoole 4.6.0 et supprimée en Swoole 6.0.0.
+    Utiliser <function>swoole_async_set</function> à la place.
+   </simpara>
+  </warning>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>settings</parameter></term>
+    <listitem>
+     <simpara>
+      Un tableau associatif d'options. Seule <literal>enable_coroutine</literal>
+      est reconnue : lorsqu'elle vaut &false;, les fonctions de rappel des
+      minuteurs sont exécutées directement, et non dans une coroutine
+      nouvellement créée.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   &return.void;
+  </simpara>
+ </refsect1>
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/swoole/swoole/timer/stats.xml
+++ b/reference/swoole/swoole/timer/stats.xml
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 6e77169fdc9c087749f357bef877607ccc05f442 Maintainer: lacatoire Status: ready -->
+
+<refentry xml:id="swoole-timer.stats" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Swoole\Timer::stats</refname>
+  <refpurpose>Retourne les statistiques des minuteurs</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>public</modifier> <modifier>static</modifier> <type>array</type><methodname>Swoole\Timer::stats</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   Retourne les statistiques des minuteurs. À partir de Swoole 4.4.0.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Retourne un tableau contenant les clés suivantes :
+  </simpara>
+  <variablelist>
+   <varlistentry>
+    <term><literal>initialized</literal></term>
+    <listitem>
+     <simpara>
+      Indique si le sous-système de minuteurs a été démarré. Vaut &false; tant
+      que le premier minuteur n'a pas été créé.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><literal>num</literal></term>
+    <listitem>
+     <simpara>
+      Le nombre de minuteurs actuellement enregistrés dans le processus.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><literal>round</literal></term>
+    <listitem>
+     <simpara>
+      Le tour courant de la boucle de minuteurs.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Exemple avec <function>Swoole\Timer::stats</function></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$timer_id = Swoole\Timer::tick(1000, function () {});
+var_dump(Swoole\Timer::stats());
+Swoole\Timer::clear($timer_id);
+?>
+]]>
+   </programlisting>
+   &example.outputs.similar;
+   <screen>
+<![CDATA[
+array(3) {
+  ["initialized"]=>
+  bool(true)
+  ["num"]=>
+  int(1)
+  ["round"]=>
+  int(0)
+}
+]]>
+   </screen>
+  </example>
+ </refsect1>
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/swoole/swoole/timer/tick.xml
+++ b/reference/swoole/swoole/timer/tick.xml
@@ -1,51 +1,59 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 86e6094e86b84a51d00ab217ac50ce8dde33d82a Maintainer: Fan2Shrek Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 6e77169fdc9c087749f357bef877607ccc05f442 Maintainer: Fan2Shrek Status: ready -->
+
 <refentry xml:id="swoole-timer.tick" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Swoole\Timer::tick</refname>
-  <refpurpose>Répète une fonction donnée à chaque intervalle de temps donné.</refpurpose>
+  <refpurpose>Définit un minuteur répétitif</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier>public</modifier> <modifier>static</modifier> <type>void</type><methodname>Swoole\Timer::tick</methodname>
-   <methodparam><type>int</type><parameter>interval_ms</parameter></methodparam>
+   <modifier>public</modifier> <modifier>static</modifier> <type class="union"><type>int</type><type>false</type></type><methodname>Swoole\Timer::tick</methodname>
+   <methodparam><type>int</type><parameter>ms</parameter></methodparam>
    <methodparam><type>callable</type><parameter>callback</parameter></methodparam>
-   <methodparam choice="opt"><type>string</type><parameter>param</parameter></methodparam>
+   <methodparam rep="repeat"><type>mixed</type><parameter>params</parameter></methodparam>
   </methodsynopsis>
-  <para>
-
-  </para>
-
+  <simpara>
+   Définit un minuteur qui se déclenche toutes les <parameter>ms</parameter>
+   millisecondes. Contrairement à un minuteur créé avec
+   <methodname>Swoole\Timer::after</methodname>, il continue de se déclencher
+   jusqu'à sa suppression avec <methodname>Swoole\Timer::clear</methodname>.
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
   &reftitle.parameters;
   <variablelist>
    <varlistentry>
-    <term><parameter>interval_ms</parameter></term>
+    <term><parameter>ms</parameter></term>
     <listitem>
-     <para>
-
-     </para>
+     <simpara>
+      L'intervalle, en millisecondes. Doit être supérieur ou égal à
+      <literal>1</literal> ; une valeur inférieure émet une
+      <constant>E_WARNING</constant> et l'appel échoue.
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>callback</parameter></term>
     <listitem>
-     <para>
-
-     </para>
+     <simpara>
+      La fonction à exécuter à chaque déclenchement. Elle est appelée sous la
+      forme <literal>callback(int $timer_id, mixed ...$params)</literal> :
+      l'identifiant du minuteur est transmis comme premier argument, suivi des
+      valeurs données dans <parameter>params</parameter>.
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term><parameter>param</parameter></term>
+    <term><parameter>params</parameter></term>
     <listitem>
-     <para>
-
-     </para>
+     <simpara>
+      Valeurs supplémentaires transmises à <parameter>callback</parameter>
+      après l'identifiant du minuteur.
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -53,12 +61,41 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
-
-  </para>
+  <simpara>
+   Retourne l'identifiant du minuteur, qui peut être transmis à
+   <methodname>Swoole\Timer::clear</methodname>. Retourne &false; si le minuteur
+   n'a pas pu être créé, en particulier lorsque <parameter>ms</parameter> est
+   inférieur à <literal>1</literal>.
+  </simpara>
  </refsect1>
 
-
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Exemple avec <function>Swoole\Timer::tick</function></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$ticks = 0;
+Swoole\Timer::tick(1000, function (int $timer_id, string $label) use (&$ticks) {
+    echo "tick #", ++$ticks, " ($label)\n";
+    if ($ticks === 3) {
+        Swoole\Timer::clear($timer_id);
+    }
+}, "job");
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+tick #1 (job)
+tick #2 (job)
+tick #3 (job)
+]]>
+   </screen>
+  </example>
+ </refsect1>
 </refentry>
 
 <!-- Keep this comment at the end of the file


### PR DESCRIPTION
Translation of php/doc-en#4773 (commit 6e77169): the Timer intro, tick(), after(), clear() and exists() were empty stubs and are now written out, and clearAll(), info(), list(), set() and stats() are translated for the first time. EN-Revision updated.

Fixes: #3475