### PR TITLE
[Sync-En] closures: make the variable inheritance example explain itself

### DIFF
--- a/language/functions.xml
+++ b/language/functions.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e290572f2599305beb62b13988024b5da187979d Maintainer: lacatoire Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: c19f29d4fcf92c1a2d2c46d68adab31e98fcbe78 Maintainer: lacatoire Status: ready -->
 <chapter xml:id="language.functions" xmlns="http://docbook.org/ns/docbook" annotations="interactive">
  <title>Les fonctions</title>
  
@@ -1169,36 +1168,38 @@ $greet('PHP');
    <programlisting role="php">
 <![CDATA[
 <?php
+// Une variable définie dans le contexte parent
 $message = 'hello';
 
-// Pas de "use"
+// $message n'est pas héritée et est indéfinie, faute de
+// clause "use"
 $example = function () {
     var_dump($message);
 };
 $example();
 
-// Hérite $message
+// $message est héritée du contexte parent grâce à la
+// clause "use"
 $example = function () use ($message) {
     var_dump($message);
 };
 $example();
 
-// La valeur de la variable héritée est définie lorsque la fonction est 
-// définie non quand elle est appelée
+// La valeur de la variable héritée est celle du moment où la fonction
+// est définie, non de celui où elle est appelée
 $message = 'world';
 $example();
 
-// Réinitialisation de la variable message
+// Réinitialisation de $message
 $message = 'hello';
 
-// Héritage par référence
+// Héritage par référence : un changement fait dans le contexte parent
+// après la définition de la fonction y est visible
 $example = function () use (&$message) {
     var_dump($message);
 };
 $example();
 
-// Le changement de valeur dans le contexte parent est reflété lors de 
-// l'appel de la fonction.
 $message = 'world';
 $example();
 
@@ -1208,24 +1209,31 @@ $example = function ($arg) use ($message) {
 };
 $example("hello");
 
-// La déclaration du type de retour vient après la clause use
-$example = function () use ($message): string {
-    return "hello $message";
+// Les fonctions anonymes peuvent retourner des valeurs comme n'importe
+// quelle fonction ; la déclaration du type de retour vient après la
+// clause use
+$example = function () use ($message): array {
+    return ["hello", $message];
 };
 var_dump($example());
 ]]>
    </programlisting>
-   &example.outputs.similar;
+   &example.outputs;
    <screen>
 <![CDATA[
-Notice: Undefined variable: message in /example.php on line 6
+Warning: Undefined variable $message in script on line 8
 NULL
 string(5) "hello"
 string(5) "hello"
 string(5) "hello"
 string(5) "world"
 string(11) "hello world"
-string(11) "hello world"
+array(2) {
+  [0]=>
+  string(5) "hello"
+  [1]=>
+  string(5) "world"
+}
 ]]>
    </screen>
   </example>


### PR DESCRIPTION
Translation of php/doc-en#4826 (commit c19f29d): the comments of the "inheriting variables from the parent scope" example now say what each closure demonstrates, the return type example returns an array, and the output block matches current PHP. EN-Revision updated.

Fixes: #3476