### PR TITLE
[Sync-En] SolrQuery: clarify the highlight query accessors

### DIFF
--- a/reference/solr/solrquery/gethighlightquery.xml
+++ b/reference/solr/solrquery/gethighlightquery.xml
@@ -1,22 +1,24 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 45819f24afaf2ce388bdbb9b2dcbbbe62414a4f7 Maintainer: Fan2Shrek Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: e549ce16fdd9c1f73653700729d29ed7d3272fab Maintainer: Fan2Shrek Status: ready -->
 <refentry xml:id="solrquery.gethighlightquery" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>SolrQuery::getHighlightQuery</refname>
-  <refpurpose>Renvoie la requête de mise en évidence (hl.q)</refpurpose>
+  <refpurpose>Retourne la requête de mise en évidence</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier>public</modifier> <type>string</type><methodname>SolrQuery::getHighlightQuery</methodname>
+   <modifier>public</modifier> <type class="union"><type>string</type><type>null</type></type><methodname>SolrQuery::getHighlightQuery</methodname>
    <void/>
   </methodsynopsis>
-  <para>
-   Renvoie la requête de mise en évidence précédemment définie.
+  <simpara>
+   Retourne la requête de mise en évidence précédemment définie via le
+   paramètre <literal>hl.q</literal>.
    Ce paramètre permet de mettre en évidence des termes ou des champs différents de ceux utilisés pour récupérer les documents.
-  </para>
+   Voir la section <link xlink:href="https://solr.apache.org/guide/solr/latest/query-guide/highlighting.html">Highlighting</link>
+   pour plus de détails.
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -26,9 +28,20 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
-   Renvoie la chaîne de requête de mise en évidence actuelle, ou null si elle n'est pas définie.
-  </para>
+  <simpara>
+   Retourne une chaîne contenant la requête de mise en évidence de l'objet
+   <classname>SolrQuery</classname> courant, ou &null; si la requête de mise en
+   évidence n'est pas définie.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>SolrQuery::setHighlightQuery</methodname></member>
+   <member><methodname>SolrQuery::getHighlightFields</methodname></member>
+   <member><methodname>SolrQuery::setHighlightFields</methodname></member>
+  </simplelist>
  </refsect1>
 </refentry>
 <!-- Keep this comment at the end of the file

--- a/reference/solr/solrquery/sethighlightquery.xml
+++ b/reference/solr/solrquery/sethighlightquery.xml
@@ -1,10 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 1d92acb7add86f36f352334a52679c078e328704 Maintainer: Fan2Shrek Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: e549ce16fdd9c1f73653700729d29ed7d3272fab Maintainer: Fan2Shrek Status: ready -->
 <refentry xml:id="solrquery.sethighlightquery" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>SolrQuery::setHighlightQuery</refname>
-  <refpurpose>Une requête désignée pour la mise en évidence (hl.q)</refpurpose>
+  <refpurpose>Une requête désignée pour la mise en évidence</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -13,13 +12,21 @@
    <modifier>public</modifier> <type>SolrQuery</type><methodname>SolrQuery::setHighlightQuery</methodname>
    <methodparam><type>string</type><parameter>q</parameter></methodparam>
   </methodsynopsis>
-  <para>
-   Une requête à utiliser pour la mise en évidence.
+  <simpara>
+   Une requête à utiliser pour la mise en évidence, qui sera affectée au
+   paramètre Solr <literal>hl.q</literal>.
    Ce paramètre permet de mettre en évidence des termes ou des champs différents de ceux utilisés pour récupérer les documents.
-  </para>
+  </simpara>
 
-  <para>La valeur par défaut si non défini: la valeur du paramètre q de la requête</para>
-  <para>Référence du paramètre Solr: hl.q</para>
+  <simpara>
+   Valeur par défaut lorsqu'elle n'est pas définie : la valeur du paramètre
+   <literal>q</literal> de la requête.
+  </simpara>
+
+  <simpara>
+   Voir la section <link xlink:href="https://solr.apache.org/guide/solr/latest/query-guide/highlighting.html">Highlighting</link>
+   pour plus de détails sur le paramètre Solr <literal>hl.q</literal>.
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -29,9 +36,9 @@
     <varlistentry>
      <term><parameter>q</parameter></term>
      <listitem>
-      <para>
-       La requête de mise en évidence
-      </para>
+      <simpara>
+       La requête de mise en évidence.
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -40,9 +47,18 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
-   Renvoie l'objet <classname>SolrQuery</classname> courant, si la valeur retournée est utilisée.
-  </para>
+  <simpara>
+   Retourne l'objet <classname>SolrQuery</classname> courant.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>SolrQuery::getHighlightQuery</methodname></member>
+   <member><methodname>SolrQuery::setHighlightFields</methodname></member>
+   <member><methodname>SolrQuery::getHighlightFields</methodname></member>
+  </simplelist>
  </refsect1>
 
 </refentry>


### PR DESCRIPTION
Translation of php/doc-en#3742 (commit e549ce1): getHighlightQuery() and setHighlightQuery() now name the Solr hl.q parameter explicitly, return the current SolrQuery rather than a SolrHighlightQuery string, link to the Solr highlighting guide and gain seealso sections. EN-Revision updated.

Fixes: #3478