### PR TITLE
[Sync-En] ext/intl: document the PHP 8.5 Locale changes

### DIFF
--- a/reference/intl/locale.xml
+++ b/reference/intl/locale.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 1f68eecaa7c4c723abe72a5a040ea7b15023a5aa Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 255b4f159662a2915dd5ac7e415148d064ff1c62 Maintainer: yannick Status: ready -->
 <reference xml:id="class.locale" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>La classe Locale</title>
  <titleabbrev>Locale</titleabbrev>
@@ -37,6 +36,9 @@
    </simpara>
    <simpara>
     Les locales ne peuvent pas être instanciées. Ce sont toutes des fonctions statiques.
+    Utiliser <methodname>Locale::getDefault</methodname> et
+    <methodname>Locale::setDefault</methodname> pour lire et écrire la locale
+    par défaut utilisée par ICU.
    </simpara>
    <simpara>
     La chaîne &null; ou vide permet d'obtenir la locale racine. La racine est l'équivalent
@@ -120,9 +122,7 @@
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.locale')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Locale'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.locale')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='Locale'])"/>
    </classsynopsis>
    <!-- }}} -->
 
@@ -166,6 +166,14 @@
       </row>
      </thead>
      <tbody>
+      <row>
+       <entry>8.5.0</entry>
+       <entry>
+        Les méthodes de <classname>Locale</classname> lancent désormais une
+        <exceptionname>ValueError</exceptionname> lorsqu'un argument de locale
+        contient des octets nuls.
+       </entry>
+      </row>
       <row>
        <entry>8.4.0</entry>
        <entry>

--- a/reference/intl/locale/add-likely-subtags.xml
+++ b/reference/intl/locale/add-likely-subtags.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 255b4f159662a2915dd5ac7e415148d064ff1c62 Maintainer: lacatoire Status: ready -->
+<refentry xml:id="locale.addlikelysubtags" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Locale::addLikelySubtags</refname>
+  <refname>locale_add_likely_subtags</refname>
+  <refpurpose>Ajoute les sous-étiquettes probables à une locale</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <simpara>
+   &style.oop;
+  </simpara>
+  <methodsynopsis role="Locale">
+   <modifier>public</modifier> <modifier>static</modifier> <type class="union"><type>string</type><type>false</type></type><methodname>Locale::addLikelySubtags</methodname>
+   <methodparam><type>string</type><parameter>locale</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   &style.procedural;
+  </simpara>
+  <methodsynopsis>
+   <type class="union"><type>string</type><type>false</type></type><methodname>locale_add_likely_subtags</methodname>
+   <methodparam><type>string</type><parameter>locale</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Développe une étiquette de locale en y ajoutant les sous-étiquettes probables
+   d'après les données de locale d'ICU. Par exemple, <literal>en</literal>
+   devient <literal>en_Latn_US</literal>.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>locale</parameter></term>
+    <listitem>
+     <simpara>
+      La locale à développer.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Retourne la locale complétée de ses sous-étiquettes probables, ou &false; en
+   cas d'échec.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simpara>
+   Lance une <exceptionname>ValueError</exceptionname> lorsque l'argument
+   <parameter>locale</parameter> contient des octets nuls.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Locale::minimizeSubtags</methodname></member>
+   <member><methodname>Locale::canonicalize</methodname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/intl/locale/minimize-subtags.xml
+++ b/reference/intl/locale/minimize-subtags.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 255b4f159662a2915dd5ac7e415148d064ff1c62 Maintainer: lacatoire Status: ready -->
+<refentry xml:id="locale.minimizesubtags" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Locale::minimizeSubtags</refname>
+  <refname>locale_minimize_subtags</refname>
+  <refpurpose>Retire les sous-étiquettes probables d'une locale</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <simpara>
+   &style.oop;
+  </simpara>
+  <methodsynopsis role="Locale">
+   <modifier>public</modifier> <modifier>static</modifier> <type class="union"><type>string</type><type>false</type></type><methodname>Locale::minimizeSubtags</methodname>
+   <methodparam><type>string</type><parameter>locale</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   &style.procedural;
+  </simpara>
+  <methodsynopsis>
+   <type class="union"><type>string</type><type>false</type></type><methodname>locale_minimize_subtags</methodname>
+   <methodparam><type>string</type><parameter>locale</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Réduit une étiquette de locale en retirant les sous-étiquettes qui peuvent
+   être déduites des données de sous-étiquettes probables d'ICU. Par exemple,
+   <literal>en_Latn_US</literal> devient <literal>en</literal>.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>locale</parameter></term>
+    <listitem>
+     <simpara>
+      La locale à réduire.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Retourne la locale privée de ses sous-étiquettes probables, ou &false; en cas
+   d'échec.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simpara>
+   Lance une <exceptionname>ValueError</exceptionname> lorsque l'argument
+   <parameter>locale</parameter> contient des octets nuls.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Locale::addLikelySubtags</methodname></member>
+   <member><methodname>Locale::canonicalize</methodname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
Translation of php/doc-en#5806 (commit 255b4f1): Locale::addLikelySubtags() and Locale::minimizeSubtags() are translated for the first time, and the class page gains the 8.5 changelog entry about ValueError on null bytes plus the pointer to getDefault()/setDefault(). EN-Revision updated.

Fixes: #3479