### PR TITLE
fpm: fix two garbled sentences in the configuration reference

### DIFF
--- a/install/fpm/configuration.xml
+++ b/install/fpm/configuration.xml
@@ -642,8 +642,8 @@
       </term>
       <listitem>
        <para>
-        Le timeout pour servir une requête dans laquelle la backtrace PHP sera vidée
-        dans le fichier 'slowlog'. Une valeur de '0' signifie 'Off'.
+        Le timeout pour servir une requête après lequel une backtrace PHP sera
+        écrite dans le fichier 'slowlog'. Une valeur de '0' signifie 'Off'.
         Unités disponibles : s(econdes)(défaut), m(inutes), h(eures), ou j(ours).
         Par défaut : 0.
        </para> 
@@ -742,7 +742,7 @@
       </term>
       <listitem>
        <para>
-        Active la décoration de sortie pour les travailleurs de sortie quand
+        Active la décoration de la sortie des processus de travail quand
         <link linkend="catch-workers-output">catch_workers_output</link> est activé.
         Valeur par défaut : yes.
         Disponible à partir de PHP 7.3.0.


### PR DESCRIPTION
request_slowlog_timeout said the backtrace was dumped "dans une requête" where the English says *after which*; decorate_workers_output read "la décoration de sortie pour les travailleurs de sortie". Both now match the English. No EN-Revision change: neither English paragraph moved.