### PR TITLE
[Sync-En] ext/date: document that DateInterval addition depends on how the interval was created

### DIFF
--- a/reference/datetime/dateinterval.xml
+++ b/reference/datetime/dateinterval.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: victor-prdh Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 18c0977d5ec59f4207cb0b306c5473508bf640ed Maintainer: victor-prdh Status: ready -->
 <reference xml:id="class.dateinterval" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  
  <title>La classe <classname>DateInterval</classname></title>
@@ -9,7 +7,6 @@
  
  <partintro>
   
-  <!-- {{{ DateInterval intro -->
   <section xml:id="dateinterval.intro">
    &reftitle.intro;
    <para>
@@ -32,18 +29,32 @@
     est en calculant la différence entre deux objets dates/moments à travers
     <methodname>DateTimeInterface::diff</methodname>.
    </para>
+   <simpara>
+    La façon dont la partie horaire d'un intervalle, c'est-à-dire les heures,
+    les minutes, les secondes et les microsecondes, est appliquée lorsque
+    l'intervalle est ajouté à un objet date/heure, ou soustrait de celui-ci,
+    dépend de la manière dont l'intervalle a été créé. Pour un intervalle créé
+    avec <methodname>DateInterval::__construct</methodname>, la partie horaire
+    correspond au temps écoulé, tandis que pour un intervalle créé avec
+    <methodname>DateInterval::createFromDateString</methodname>, ou retourné
+    par <methodname>DateTimeInterface::diff</methodname>, elle incrémente ou
+    décrémente les valeurs individuelles des composants. La partie date,
+    c'est-à-dire les années, les mois et les jours, incrémente ou décrémente
+    toujours les valeurs individuelles des composants. Les deux ne donnent donc
+    un résultat différent que lorsqu'une transition de fuseau horaire tombe
+    dans la partie horaire de l'intervalle ; voir
+    <link linkend="datetime.examples-arithmetic">Arithmétique avec DateTime</link>.
+   </simpara>
    <para>
     Comme il n'y a pas une manière bien définie pour comparer les intervalles,
     les instances de <classname>DateInterval</classname> sont
     <link linkend="language.operators.comparison.incomparable">incomparables</link>.
    </para>
   </section>
-  <!-- }}} -->
   
   <section xml:id="dateinterval.synopsis">
    &reftitle.classsynopsis;
    
-<!-- {{{ Synopsis -->
    <classsynopsis class="class">
     <ooclass>
      <classname>DateInterval</classname>
@@ -107,14 +118,9 @@
     </fieldsynopsis>
     
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dateinterval')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='DateInterval'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dateinterval')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DateInterval'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dateinterval')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='DateInterval'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.dateinterval')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='DateInterval'])"/>
    </classsynopsis>
-<!-- }}} -->
    
   </section>
   
@@ -231,7 +237,7 @@
     </varlistentry>
    </variablelist>
   </section>
-  <section role="changelog" xml:id="dateinterval.changelog"><!-- {{{ -->
+  <section role="changelog" xml:id="dateinterval.changelog">
    &reftitle.changelog;
    <para>
     <informaltable>
@@ -274,7 +280,7 @@
      </tgroup>
     </informaltable>
    </para>
-  </section><!-- }}} -->
+  </section>
  </partintro>
  
  &reference.datetime.entities.dateinterval;

--- a/reference/datetime/dateinterval/createfromdatestring.xml
+++ b/reference/datetime/dateinterval/createfromdatestring.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 911fe79de766ef4475bf22446903667a0f3a24d3 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 18c0977d5ec59f4207cb0b306c5473508bf640ed Maintainer: lacatoire Status: ready -->
 <refentry xml:id="dateinterval.createfromdatestring" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>DateInterval::createFromDateString</refname>
@@ -28,27 +28,25 @@
 
  <refsect1 role="parameters">
   &reftitle.parameters;
-  <para>
-   <variablelist>
-    <varlistentry>
-     <term><parameter>datetime</parameter></term>
-     <listitem>
-      <para>
-       Une date avec des parties relatives. Spécifiquement, le
-       <link linkend="datetime.formats.relative">format relatif</link>
-       supporté par l'analyseur utilisé pour les classes
-       <classname>DateTimeImmutable</classname>,
-       <classname>DateTime</classname>, et <function>strtotime</function>
-       sera utilisé pour construire le DateInterval.
-      </para>
-      <para>
-       Pour utiliser une chaîne au format ISO-8601 comme <literal>P7D</literal>, il faut
-       utiliser <methodname>DateInterval::__construct</methodname>.
-      </para>
-     </listitem>
-    </varlistentry>
-   </variablelist>
-  </para>
+  <variablelist>
+   <varlistentry>
+    <term><parameter>datetime</parameter></term>
+    <listitem>
+     <simpara>
+      Une date avec des parties relatives. Spécifiquement, le
+      <link linkend="datetime.formats.relative">format relatif</link>
+      supporté par l'analyseur utilisé pour les classes
+      <classname>DateTimeImmutable</classname>,
+      <classname>DateTime</classname>, et <function>strtotime</function>
+      sera utilisé pour construire le DateInterval.
+     </simpara>
+     <simpara>
+      Pour utiliser une chaîne au format ISO-8601 comme <literal>P7D</literal>,
+      il faut utiliser <methodname>DateInterval::__construct</methodname>.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
  </refsect1>
 
  <refsect1 role="returnvalues">
@@ -111,13 +109,12 @@
 
  <refsect1 role="examples">
   &reftitle.examples;
-  <para>
-   <example>
-    <title>Analyse d'intervalles de dates valides</title>
-    <programlisting role="php" annotations="non-interactive">
+  <example>
+   <title>Analyse d'intervalles de dates valides</title>
+   <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
-// Chacun de ces intervalles est égal.
+// Chaque ensemble d'intervalles décrit la même durée.
 $i = new DateInterval('P1D');
 $i = DateInterval::createFromDateString('1 day');
 
@@ -139,13 +136,24 @@ $i = DateInterval::createFromDateString('1 day + 12 hours');
 $i = new DateInterval('PT3600S');
 $i = DateInterval::createFromDateString('3600 seconds');
 ]]>
-    </programlisting>
-   </example>
-  </para>
-  <para>
-   <example>
-    <title>Analyse des combinaisons et des intervalles négatifs</title>
-    <programlisting role="php">
+   </programlisting>
+  </example>
+  <note>
+   <simpara>
+    Les intervalles d'un ensemble qui comportent une partie horaire, tels que
+    <literal>P1DT12H</literal> et <literal>1 day + 12 hours</literal>, ne sont
+    pas interchangeables lorsqu'ils sont ajoutés à un objet date/heure et
+    qu'une transition de fuseau horaire tombe dans cette partie horaire : pour
+    un intervalle créé avec <methodname>DateInterval::__construct</methodname>,
+    la partie horaire correspond au temps écoulé, tandis que pour un intervalle
+    créé avec cette méthode, elle incrémente ou décrémente les valeurs
+    individuelles des composants. Voir
+    <link linkend="datetime.examples-arithmetic">Arithmétique avec DateTime</link>.
+   </simpara>
+  </note>
+  <example>
+   <title>Analyse des combinaisons et des intervalles négatifs</title>
+   <programlisting role="php">
 <![CDATA[
 <?php
 $i = DateInterval::createFromDateString('62 weeks + 1 day + 2 weeks + 2 hours + 70 minutes');
@@ -154,20 +162,18 @@ echo $i->format('%d %h %i'), "\n";
 $i = DateInterval::createFromDateString('1 year - 10 days');
 echo $i->format('%y %d'), "\n";
 ]]>
-    </programlisting>
-    &example.outputs;
-    <screen>
+   </programlisting>
+   &example.outputs;
+   <screen>
 <![CDATA[
 449 2 70
 1 -10
 ]]>
-    </screen>
-   </example>
-  </para>
-  <para>
-   <example>
-    <title>Analyse des intervalles de dates relatifs spéciaux</title>
-    <programlisting role="php">
+   </screen>
+  </example>
+  <example>
+   <title>Analyse des intervalles de dates relatifs spéciaux</title>
+   <programlisting role="php">
 <![CDATA[
 <?php
 $i = DateInterval::createFromDateString('last day of next month');
@@ -176,9 +182,9 @@ var_dump($i);
 $i = DateInterval::createFromDateString('last weekday');
 var_dump($i);
 ]]>
-    </programlisting>
-    &example.outputs.82;
-    <screen role="php">
+   </programlisting>
+   &example.outputs.82;
+   <screen role="php">
 <![CDATA[
 object(DateInterval)#1 (2) {
   ["from_string"]=>
@@ -193,9 +199,9 @@ object(DateInterval)#2 (2) {
   string(12) "last weekday"
 }
 ]]>
-    </screen>
-    &example.outputs.8.similar;
-    <screen role="php">
+   </screen>
+   &example.outputs.8.similar;
+   <screen role="php">
 <![CDATA[
 object(DateInterval)#1 (16) {
   ["y"]=>
@@ -266,9 +272,8 @@ object(DateInterval)#2 (16) {
   int(1)
 }
 ]]>
-    </screen>
-   </example>
-  </para>
+   </screen>
+  </example>
  </refsect1>
 
 </refentry>

--- a/reference/datetime/datetimeimmutable/add.xml
+++ b/reference/datetime/datetimeimmutable/add.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 726154e3c846bc0e16c60542377ea806df32e55d Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 18c0977d5ec59f4207cb0b306c5473508bf640ed Maintainer: lacatoire Status: ready -->
 <refentry xml:id="datetimeimmutable.add" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>DateTimeImmutable::add</refname>
@@ -117,6 +117,7 @@ echo $newDate2->format('Y-m-d') . "\n";
    <member><function>DateTimeImmutable::sub</function></member>
    <member><function>DateTimeImmutable::diff</function></member>
    <member><function>DateTimeImmutable::modify</function></member>
+   <member><link linkend="datetime.examples-arithmetic">Arithmétique avec DateTime</link></member>
   </simplelist>
  </refsect1>
 </refentry>

--- a/reference/datetime/datetimeimmutable/sub.xml
+++ b/reference/datetime/datetimeimmutable/sub.xml
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 726154e3c846bc0e16c60542377ea806df32e55d Maintainer: lacatoire Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 18c0977d5ec59f4207cb0b306c5473508bf640ed Maintainer: lacatoire Status: ready -->
 <refentry xml:id="datetimeimmutable.sub" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>DateTimeImmutable::sub</refname>
-  <refpurpose>Soustrait un nombre de jours, mois, années, heures et secondes</refpurpose>
+  <refpurpose>
+   Soustrait un nombre de jours, mois, années, heures, minutes et secondes
+  </refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -153,6 +154,7 @@ echo $newDate2->format('Y-m-d') . "\n";
    <member><function>DateTimeImmutable::add</function></member>
    <member><function>DateTimeImmutable::diff</function></member>
    <member><function>DateTimeImmutable::modify</function></member>
+   <member><link linkend="datetime.examples-arithmetic">Arithmétique avec DateTime</link></member>
   </simplelist>
  </refsect1>
 

--- a/reference/datetime/examples.xml
+++ b/reference/datetime/examples.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: cd8b964b8566801265f0d287db6eb651f93be950 Maintainer: Fan2Shrek Status: ready -->
-<!-- Reviewed: yes -->
-<!-- CREDITS: DAnnebicque -->
+<!-- EN-Revision: 18c0977d5ec59f4207cb0b306c5473508bf640ed Maintainer: Fan2Shrek Status: ready -->
 
 <chapter xml:id="datetime.examples" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.examples;
@@ -9,18 +7,17 @@
  <section xml:id="datetime.examples-arithmetic">
   <title>Arithmétique avec DateTime</title>
   <para>
-   Les exemples suivants montrent quelques pièges de l'arithmétique de DateTime 
-   en ce qui concerne les transitions DST et les mois ayant un nombre différent 
+   Les exemples suivants montrent quelques pièges de l'arithmétique de DateTime
+   en ce qui concerne les transitions DST et les mois ayant un nombre différent
    de jours.
   </para>
-  <para>
-   <example>
-    <title>DateTimeImmutable::add/sub ajout d'un intervalle de temps écoulé</title>
-    <simpara>
-     Ajouter PT24H au-delà d'une transition DST semblera ajouter 23/25 heures
-     (pour la plupart des fuseaux horaires).
-    </simpara>
-    <programlisting role="php">
+  <example>
+   <title>DateTimeImmutable::add/sub ajout d'un intervalle de temps écoulé</title>
+   <simpara>
+    Ajouter PT24H au-delà d'une transition DST semblera ajouter 23/25 heures
+    (pour la plupart des fuseaux horaires).
+   </simpara>
+   <programlisting role="php">
 <![CDATA[
 <?php
 $dt = new DateTimeImmutable("2015-11-01 00:00:00", new DateTimeZone("America/New_York"));
@@ -28,25 +25,23 @@ echo "Start: ", $dt->format("Y-m-d H:i:s P"), PHP_EOL;
 $dt = $dt->add(new DateInterval("PT3H"));
 echo "End:   ", $dt->format("Y-m-d H:i:s P"), PHP_EOL;
 ]]>
-    </programlisting>
-    &example.outputs;
-    <screen>
+   </programlisting>
+   &example.outputs;
+   <screen>
 <![CDATA[
 Start: 2015-11-01 00:00:00 -04:00
 End:   2015-11-01 02:00:00 -05:00
 ]]>
-    </screen>
-   </example>
-  </para>
-  <para>
-   <example>
-    <title>DateTimeImmutable::modify et strtotime incrémentation ou décrémentation de valeurs individuelles</title>
-    <simpara>
-     Ajouter +24 heures au-delà d'une transition DST peut ajouter exactement 24 
-     heures comme vu avec la chaîne date/time 
-     (sauf si l'heure de début ou de fin est sur un point de transition).
-    </simpara>
-    <programlisting role="php">
+   </screen>
+  </example>
+  <example>
+   <title>DateTimeImmutable::modify et strtotime incrémentation ou décrémentation de valeurs individuelles</title>
+   <simpara>
+    Ajouter +24 heures au-delà d'une transition DST ajoutera exactement 24
+    heures comme vu avec la chaîne date/time
+    (sauf si l'heure de début ou de fin est sur un point de transition).
+   </simpara>
+   <programlisting role="php">
 <![CDATA[
 <?php
 $dt = new DateTimeImmutable("2015-11-01 00:00:00", new DateTimeZone("America/New_York"));
@@ -54,25 +49,54 @@ echo "Start: ", $dt->format("Y-m-d H:i:s P"), PHP_EOL;
 $dt = $dt->modify("+24 hours");
 echo "End:   ", $dt->format("Y-m-d H:i:s P"), PHP_EOL;
 ]]>
-    </programlisting>
-    &example.outputs;
-    <screen>
+   </programlisting>
+   &example.outputs;
+   <screen>
 <![CDATA[
 Start: 2015-11-01 00:00:00 -04:00
 End:   2015-11-02 00:00:00 -05:00
 ]]>
-    </screen>
-   </example>
-  </para>
-  <para>
-   <example>
-    <title>L'ajout ou la soustraction de dates/heures peut dépasser 
-     (en plus ou en moins) des dates</title>
-    <simpara>
-     Comme pour 31 janvier + 1 mois donnera comme résultat 2 mars (année bissextile) ou
-     3 mars (année normale).
-    </simpara>
-    <programlisting role="php">
+   </screen>
+  </example>
+  <example>
+   <title>DateInterval::createFromDateString crée des intervalles qui incrémentent ou décrémentent les valeurs des composants</title>
+   <simpara>
+    <methodname>DateInterval::createFromDateString</methodname> utilise
+    l'analyseur de date/heure, et la partie horaire de l'intervalle obtenu
+    incrémente ou décrémente les valeurs individuelles des composants. Pour un
+    intervalle créé avec <methodname>DateInterval::__construct</methodname>, la
+    partie horaire correspond en revanche au temps écoulé ; les deux ne sont
+    donc pas interchangeables lorsqu'une transition de fuseau horaire tombe
+    dans cette partie horaire. La partie date est appliquée de la même manière
+    dans les deux cas, si bien que <literal>P1D</literal> et
+    <literal>1 day</literal> donnent toujours le même résultat.
+   </simpara>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$dt = new DateTimeImmutable("2015-11-01 00:00:00", new DateTimeZone("America/New_York"));
+echo "Start:    ", $dt->format("Y-m-d H:i:s P"), PHP_EOL;
+echo "PT24H:    ", $dt->add(new DateInterval("PT24H"))->format("Y-m-d H:i:s P"), PHP_EOL;
+echo "24 hours: ", $dt->add(DateInterval::createFromDateString("24 hours"))->format("Y-m-d H:i:s P"), PHP_EOL;
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+Start:    2015-11-01 00:00:00 -04:00
+PT24H:    2015-11-01 23:00:00 -05:00
+24 hours: 2015-11-02 00:00:00 -05:00
+]]>
+   </screen>
+  </example>
+  <example>
+   <title>L'ajout ou la soustraction de dates/heures peut dépasser
+    (en plus ou en moins) des dates</title>
+   <simpara>
+    Comme pour 31 janvier + 1 mois donnera comme résultat 2 mars (année bissextile) ou
+    3 mars (année normale).
+   </simpara>
+   <programlisting role="php">
 <![CDATA[
 <?php
 echo "Normal year:\n"; // February has 28 days
@@ -87,9 +111,9 @@ echo "Start: ", $dt->format("Y-m-d H:i:s P"), PHP_EOL;
 $dt = $dt->modify("+1 month");
 echo "End:   ", $dt->format("Y-m-d H:i:s P"), PHP_EOL;
 ]]>
-    </programlisting>
-    &example.outputs;
-    <screen>
+   </programlisting>
+   &example.outputs;
+   <screen>
 <![CDATA[
 Normal year:
 Start: 2015-01-31 00:00:00 -05:00
@@ -98,12 +122,12 @@ Leap year:
 Start: 2016-01-31 00:00:00 -05:00
 End:   2016-03-02 00:00:00 -05:00
 ]]>
-    </screen>
-    <simpara>
-     Pour obtenir le dernier jour du mois prochain (autrement dit pour prévenir le
-     dépassement), le format <literal>last day of</literal> est disponible.
-    </simpara>
-    <programlisting role="php">
+   </screen>
+   <simpara>
+    Pour obtenir le dernier jour du mois prochain (autrement dit pour prévenir le
+    dépassement), le format <literal>last day of</literal> est disponible.
+   </simpara>
+   <programlisting role="php">
 <![CDATA[
 <?php
 echo "Normal year:\n"; // February has 28 days
@@ -118,9 +142,9 @@ echo "Start: ", $dt->format("Y-m-d H:i:s P"), PHP_EOL;
 $dt = $dt->modify("last day of next month");
 echo "End:   ", $dt->format("Y-m-d H:i:s P"), PHP_EOL;
 ]]>
-    </programlisting>
-    &example.outputs;
-    <screen>
+   </programlisting>
+   &example.outputs;
+   <screen>
 <![CDATA[
 Normal year:
 Start: 2015-01-31 00:00:00 -05:00
@@ -129,9 +153,8 @@ Leap year:
 Start: 2016-01-31 00:00:00 -05:00
 End:   2016-02-29 00:00:00 -05:00
 ]]>
-    </screen>
-   </example>
-  </para>
+   </screen>
+  </example>
  </section>
 
 </chapter>


### PR DESCRIPTION
Translation of php/doc-en#5830 (commit 18c0977d5e): the time part of an interval is applied as elapsed time when it comes from `DateInterval::__construct`, but increments component values when it comes from `DateInterval::createFromDateString` or `DateTimeInterface::diff`. Adds the new Date/Time Arithmetic example, the rule on the DateInterval class page, the note where equality was claimed, and the see-also links. EN-Revision updated.

Also picks up two older doc-en commits on `dateinterval.xml` (skeleton comments and empty `xi:fallback` removal), and fixes a missing "minutes" in the `DateTimeImmutable::sub` refpurpose and a reversed modality in `examples.xml` along the way.

Fixes: #3492