### PR TITLE
[Sync-En] datetime: fix the CLF and WDDX rows of the compound formats table

### DIFF
--- a/reference/datetime/formats.xml
+++ b/reference/datetime/formats.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 17c238517825dfb7ec3edfef5972acd944ffbc1e Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 7a6040b9cd004863db74a49acb1326308c9e0063 Maintainer: lacatoire Status: ready -->
 <chapter xml:id="datetime.formats" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Formats supportés de temps et de dates</title>
 
@@ -116,11 +116,11 @@ var_dump($res);
      <screen>
 <![CDATA[
 object(DateTimeImmutable)#1 (3) {
-  ["date"] =>
+  ["date"]=>
   string(26) "2015-10-04 17:24:43.000000"
-  ["timezone_type"] =>
+  ["timezone_type"]=>
   int(3)
-  ["timezone"] =>
+  ["timezone"]=>
   string(13) "Europe/London"
 }
 ]]>
@@ -320,7 +320,7 @@ object(DateTimeImmutable)#1 (3) {
     </thead>
     <tbody>
      <row>
-      <entry><literal>suffixe des jours</literal></entry>
+      <entry><literal>daysuf</literal></entry>
       <entry>"st" | "nd" | "rd" | "th"</entry>
       <entry></entry>
      </row>
@@ -520,7 +520,7 @@ object(DateTimeImmutable)#1 (3) {
       <entry>"-0002-07-26", "+1978-04-17", "1814-05-17"</entry>
      </row>
      <row>
-      <entry>Année à cinq chiffres avec le signe, le mois et le jour requis</entry>
+      <entry>Année à cinq chiffres ou plus, avec signe, mois et jour requis</entry>
       <entry>[+-] <literal>YYY</literal> "-" <literal>MM</literal> "-" <literal>DD</literal></entry>
       <entry>"-81120-02-26", "+20192-04-17"</entry>
      </row>
@@ -621,6 +621,16 @@ object(DateTimeImmutable)#1 (3) {
     </thead>
     <tbody>
      <row>
+      <entry><literal>daysuf</literal></entry>
+      <entry>"st" | "nd" | "rd" | "th"</entry>
+      <entry></entry>
+     </row>
+     <row>
+      <entry><literal>dd</literal></entry>
+      <entry>([0-2]?[0-9] | "3"[01]) <literal>daysuf</literal>?</entry>
+      <entry>"7th", "22nd", "31"</entry>
+     </row>
+     <row>
       <entry><literal>DD</literal></entry>
       <entry>"0" [0-9] | [1-2][0-9] | "3" [01]</entry>
       <entry>"02", "12", "31"</entry>
@@ -637,8 +647,8 @@ object(DateTimeImmutable)#1 (3) {
      </row>
      <row>
       <entry><literal>hh</literal></entry>
-      <entry>"0"?[1-9] | "1"[0-2]</entry>
-      <entry>"04", "7", "12"</entry>
+      <entry>[01]?[0-9] | "2"[0-4]</entry>
+      <entry>"04", "9", "19"</entry>
      </row>
      <row>
       <entry><literal>HH</literal></entry>
@@ -666,12 +676,17 @@ object(DateTimeImmutable)#1 (3) {
       <entry></entry>
      </row>
      <row>
+      <entry><literal>mm</literal></entry>
+      <entry>"0"? [0-9] | "1"[0-2]</entry>
+      <entry>"0", "04", "7", "12"</entry>
+     </row>
+     <row>
       <entry><literal>MM</literal></entry>
       <entry>[0-1][0-9]</entry>
       <entry>"00", "12"</entry>
      </row>
      <row>
-      <entry><literal>espace</literal></entry>
+      <entry><literal>space</literal></entry>
       <entry>[ \t]</entry>
       <entry></entry>
      </row>
@@ -783,7 +798,7 @@ object(DateTimeImmutable)#1 (3) {
     <tbody>
      <row>
       <entry>Format de log commun</entry>
-      <entry><literal>dd</literal> "/" <literal>M</literal> "/" <literal>YY</literal> : <literal>HH</literal> ":" <literal>II</literal> ":" <literal>SS</literal> <literal>space</literal> <literal>tzcorrection</literal></entry>
+      <entry><literal>dd</literal> "/" <literal>M</literal> "/" <literal>YY</literal> ":" <literal>HH</literal> ":" <literal>II</literal> ":" <literal>SS</literal> <literal>space</literal> <literal>tzcorrection</literal></entry>
       <entry>"10/Oct/2000:13:55:36 -0700"</entry>
      </row>
      <row>
@@ -969,12 +984,12 @@ object(DateTimeImmutable)#1 (3) {
      </row>
      <row>
       <entry>'back of' <literal>hour</literal></entry>
-      <entry>15 minutes avant l'heure précisée</entry>
+      <entry>15 minutes après l'heure indiquée</entry>
       <entry>"back of 7pm", "back of 15"</entry>
      </row>
      <row>
       <entry>'front of' <literal>hour</literal></entry>
-      <entry>15 minutes après l'heure spécifiée</entry>
+      <entry>15 minutes avant l'heure indiquée</entry>
       <entry>"front of 5am", "front of 23"</entry>
      </row>
      <row>
@@ -1115,7 +1130,7 @@ object(DateTimeImmutable)#1 (3) {
     Il est à noter que le "of" dans "<literal>ordinal</literal>
     <literal>space</literal> <literal>dayname</literal>
     <literal>space</literal> 'of' " et "'last' <literal>space</literal>
-    <literal>dayname</literal> <literal>espace</literal> 'of' " fait quelque
+    <literal>dayname</literal> <literal>space</literal> 'of' " fait quelque
     chose de spécial.
    </simpara>
    <orderedlist>


### PR DESCRIPTION
Translation of php/doc-en#3410 (commit 7a6040b9cd): the Common Log Format row was missing the quotes around its ":" separator, the compound "Used Symbols" table did not define `dd`, `daysuf` and `mm` although the CLF and WDDX rows use them, and `hh` is documented there as the 12-hour clock while every compound format using it parses as `hour24`.

Fixed a few defects in the same file along the way: `daysuf` was defined under a translated name while the `dd` row referenced it, the compound table defined `espace` while the CLF row referenced `space`, the `back of` and `front of` descriptions were swapped, the expanded-year row claimed exactly five digits, and the `var_dump()` output in the introduction had a stray space before `=>`. EN-Revision updated.

Fixes: #3493