### PR TITLE
[Sync-En] ext/sqlite3, ext/sockets: document the PHP 8.5 additions

### DIFF
--- a/reference/sockets/constants.xml
+++ b/reference/sockets/constants.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 890cc22d38fa747c9930fd0d5984c170f2490c1b Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: e079b2a53251ac649dbcf055e604acb2a4ffa513 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: no -->
 <appendix xml:id="sockets.constants" xmlns="http://docbook.org/ns/docbook">
  &reftitle.constants;
@@ -3185,6 +3185,203 @@
     <simpara>
      Lie un socket à une interface réseau spécifique par son index.
      Disponible à partir de PHP 8.4.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.shut-rd">
+   <term>
+    <constant>SHUT_RD</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Désactive les opérations de réception ultérieures sur le socket.
+     Utilisée avec <function>socket_shutdown</function>.
+     Disponible à partir de PHP 8.5.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.shut-wr">
+   <term>
+    <constant>SHUT_WR</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Désactive les opérations d'envoi ultérieures sur le socket.
+     Utilisée avec <function>socket_shutdown</function>.
+     Disponible à partir de PHP 8.5.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.shut-rdwr">
+   <term>
+    <constant>SHUT_RDWR</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Désactive les opérations d'envoi et de réception ultérieures sur le socket.
+     Utilisée avec <function>socket_shutdown</function>.
+     Disponible à partir de PHP 8.5.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.udp-segment">
+   <term>
+    <constant>UDP_SEGMENT</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Définit la taille maximale des segments UDP GSO (Generic Segmentation
+     Offload), ce qui permet d'envoyer plusieurs datagrammes en un seul appel
+     système.
+     Disponible uniquement sous Linux.
+     Disponible à partir de PHP 8.5.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.so-busy-poll">
+   <term>
+    <constant>SO_BUSY_POLL</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Définit la durée approximative, en microsecondes, d'attente active lors
+     d'une réception bloquante en l'absence de données. Cela réduit la latence
+     au prix d'une consommation de CPU.
+     Disponible uniquement sous Linux.
+     Disponible à partir de PHP 8.5.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.ip-bindany">
+   <term>
+    <constant>IP_BINDANY</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Autorise l'association d'un socket à n'importe quelle adresse, même si
+     elle n'est pas locale.
+     Disponible uniquement sous FreeBSD, NetBSD et OpenBSD.
+     Disponible à partir de PHP 8.5.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tcp-function-blk">
+   <term>
+    <constant>TCP_FUNCTION_BLK</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Sélectionne la pile TCP (bloc de fonctions) utilisée par le socket. Avec
+     <function>socket_set_option</function>, la valeur est le nom de la pile
+     sous forme de <type>string</type> ; <function>socket_get_option</function>
+     retourne un tableau contenant les clés <literal>function_set_name</literal>
+     et <literal>pcbcnt</literal>.
+     Disponible uniquement sous FreeBSD.
+     Disponible à partir de PHP 8.5.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tcp-function-alias">
+   <term>
+    <constant>TCP_FUNCTION_ALIAS</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Récupère l'alias de la pile TCP utilisée par le socket, sous forme d'un
+     tableau contenant les clés <literal>function_set_name</literal> et
+     <literal>pcbcnt</literal>.
+     Disponible uniquement sous FreeBSD.
+     Disponible à partir de PHP 8.5.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tcp-reusport-lb-numa">
+   <term>
+    <constant>TCP_REUSPORT_LB_NUMA</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Contrôle l'affinité de domaine NUMA pour la réutilisation de port avec
+     répartition de charge.
+     Disponible uniquement sous FreeBSD.
+     Disponible à partir de PHP 8.5.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tcp-reusport-lb-numa-nodom">
+   <term>
+    <constant>TCP_REUSPORT_LB_NUMA_NODOM</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Valeur de la constante <constant>TCP_REUSPORT_LB_NUMA</constant> indiquant
+     l'absence d'affinité de domaine NUMA.
+     Disponible uniquement sous FreeBSD.
+     Disponible à partir de PHP 8.5.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tcp-reusport-lb-numa-curdom">
+   <term>
+    <constant>TCP_REUSPORT_LB_NUMA_CURDOM</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Valeur de la constante <constant>TCP_REUSPORT_LB_NUMA</constant> indiquant
+     une affinité avec le domaine NUMA courant.
+     Disponible uniquement sous FreeBSD.
+     Disponible à partir de PHP 8.5.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.tcp-bbr-algorithm">
+   <term>
+    <constant>TCP_BBR_ALGORITHM</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Option de socket liée à l'algorithme de contrôle de congestion BBR
+     (Bottleneck Bandwidth and Round-trip propagation time).
+     Disponible uniquement sous FreeBSD.
+     Disponible à partir de PHP 8.5.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.ipproto-icmp">
+   <term>
+    <constant>IPPROTO_ICMP</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Numéro de protocole ICMP (Internet Control Message Protocol), utilisé lors
+     de la création de sockets bruts.
+     Disponible à partir de PHP 8.5.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.ipproto-icmpv6">
+   <term>
+    <constant>IPPROTO_ICMPV6</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Numéro de protocole ICMPv6 (Internet Control Message Protocol version 6),
+     utilisé lors de la création de sockets IPv6 bruts.
+     Disponible à partir de PHP 8.5.0.
     </simpara>
    </listitem>
   </varlistentry>

--- a/reference/sqlite3/sqlite3stmt.xml
+++ b/reference/sqlite3/sqlite3stmt.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4d17b7b4947e7819ff5036715dd706be87ae4def Maintainer: yannick Status: ready -->
+<!-- EN-Revision: e079b2a53251ac649dbcf055e604acb2a4ffa513 Maintainer: yannick Status: ready -->
 <!-- Reviewed: yes -->
 <reference xml:id="class.sqlite3stmt" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>&class.theclass; <classname>SQLite3Stmt</classname></title>
@@ -10,10 +10,13 @@
 <!-- {{{ SQLite3Stmt intro -->
   <section xml:id="sqlite3stmt.intro">
    &reftitle.intro;
-   <para>
-    La classe qui représente les commandes préparées 
-    pour une base de données SQLite3.
-   </para>
+   <simpara>
+    La classe qui gère les commandes préparées pour l'extension SQLite 3.
+    Les instances sont obtenues via <methodname>SQLite3::prepare</methodname>.
+    L'appel à <methodname>SQLite3Stmt::execute</methodname> exécute la requête
+    et retourne un <classname>SQLite3Result</classname> pour les jeux de
+    résultats.
+   </simpara>
   </section>
 <!-- }}} -->
 
@@ -26,17 +29,80 @@
      <classname>SQLite3Stmt</classname>
     </ooclass>
 
+    <classsynopsisinfo role="comment">&Constants;</classsynopsisinfo>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="sqlite3stmt.constants.explain-mode-prepared">SQLite3Stmt::EXPLAIN_MODE_PREPARED</varname>
+     <initializer>0</initializer>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="sqlite3stmt.constants.explain-mode-explain">SQLite3Stmt::EXPLAIN_MODE_EXPLAIN</varname>
+     <initializer>1</initializer>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="sqlite3stmt.constants.explain-mode-explain-query-plan">SQLite3Stmt::EXPLAIN_MODE_EXPLAIN_QUERY_PLAN</varname>
+     <initializer>2</initializer>
+    </fieldsynopsis>
+
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.sqlite3stmt')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='SQLite3Stmt'])">
-     <xi:fallback/>
-    </xi:include>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.sqlite3stmt')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SQLite3Stmt'])">
-     <xi:fallback/>
-    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.sqlite3stmt')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='SQLite3Stmt'])"/>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.sqlite3stmt')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SQLite3Stmt'])"/>
    </classsynopsis>
 <!-- }}} -->
 
   </section>
+
+<!-- {{{ SQLite3Stmt constants -->
+  <section xml:id="sqlite3stmt.constants">
+   &reftitle.constants;
+   <variablelist>
+
+    <varlistentry xml:id="sqlite3stmt.constants.explain-mode-prepared">
+     <term><constant>SQLite3Stmt::EXPLAIN_MODE_PREPARED</constant></term>
+     <listitem>
+      <simpara>
+       La commande fonctionne en mode commande préparée normal (sans
+       <literal>EXPLAIN</literal>).
+       Disponible à partir de PHP 8.5.0, lorsque compilé avec libsqlite &gt;= 3.43.0.
+      </simpara>
+     </listitem>
+    </varlistentry>
+
+    <varlistentry xml:id="sqlite3stmt.constants.explain-mode-explain">
+     <term><constant>SQLite3Stmt::EXPLAIN_MODE_EXPLAIN</constant></term>
+     <listitem>
+      <simpara>
+       La commande fonctionne comme si elle était préfixée par
+       <literal>EXPLAIN</literal>, et retourne les informations sur les opcodes
+       de la machine virtuelle.
+       Disponible à partir de PHP 8.5.0, lorsque compilé avec libsqlite &gt;= 3.43.0.
+      </simpara>
+     </listitem>
+    </varlistentry>
+
+    <varlistentry xml:id="sqlite3stmt.constants.explain-mode-explain-query-plan">
+     <term><constant>SQLite3Stmt::EXPLAIN_MODE_EXPLAIN_QUERY_PLAN</constant></term>
+     <listitem>
+      <simpara>
+       La commande fonctionne comme si elle était préfixée par
+       <literal>EXPLAIN QUERY PLAN</literal>, et retourne les informations de
+       haut niveau sur le plan de requête.
+       Disponible à partir de PHP 8.5.0, lorsque compilé avec libsqlite &gt;= 3.43.0.
+      </simpara>
+     </listitem>
+    </varlistentry>
+
+   </variablelist>
+  </section>
+<!-- }}} -->
 
  </partintro>
 

--- a/reference/sqlite3/sqlite3stmt/busy.xml
+++ b/reference/sqlite3/sqlite3stmt/busy.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: e079b2a53251ac649dbcf055e604acb2a4ffa513 Maintainer: lacatoire Status: ready -->
+<refentry xml:id="sqlite3stmt.busy" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>SQLite3Stmt::busy</refname>
+  <refpurpose>Indique si la commande a été exécutée mais n'est pas encore terminée</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="SQLite3Stmt">
+   <modifier>public</modifier> <type>bool</type><methodname>SQLite3Stmt::busy</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   Indique si la commande est occupée, c'est-à-dire si elle a été démarrée avec
+   <methodname>SQLite3Stmt::execute</methodname> et qu'il reste des lignes à
+   récupérer, sans avoir encore été terminée ni réinitialisée.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Retourne &true; si la commande a été exécutée et qu'il reste des lignes à
+   récupérer, &false; sinon.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Cette méthode a été ajoutée.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>SQLite3Stmt::execute</methodname></member>
+   <member><methodname>SQLite3Stmt::reset</methodname></member>
+   <member><methodname>SQLite3Stmt::close</methodname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/sqlite3/sqlite3stmt/explain.xml
+++ b/reference/sqlite3/sqlite3stmt/explain.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: e079b2a53251ac649dbcf055e604acb2a4ffa513 Maintainer: lacatoire Status: ready -->
+<refentry xml:id="sqlite3stmt.explain" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>SQLite3Stmt::explain</refname>
+  <refpurpose>Retourne le mode explain de la commande</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="SQLite3Stmt">
+   <modifier>public</modifier> <type>int</type><methodname>SQLite3Stmt::explain</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   Retourne le mode explain actuellement défini sur la commande avec
+   <methodname>SQLite3Stmt::setExplain</methodname>.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Retourne l'une des valeurs
+   <constant>SQLite3Stmt::EXPLAIN_MODE_PREPARED</constant>,
+   <constant>SQLite3Stmt::EXPLAIN_MODE_EXPLAIN</constant> ou
+   <constant>SQLite3Stmt::EXPLAIN_MODE_EXPLAIN_QUERY_PLAN</constant>.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>SQLite3Stmt::setExplain</methodname></member>
+   <member><methodname>SQLite3Stmt::execute</methodname></member>
+   <member><methodname>SQLite3Stmt::reset</methodname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/sqlite3/sqlite3stmt/setexplain.xml
+++ b/reference/sqlite3/sqlite3stmt/setexplain.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: e079b2a53251ac649dbcf055e604acb2a4ffa513 Maintainer: lacatoire Status: ready -->
+<refentry xml:id="sqlite3stmt.setexplain" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>SQLite3Stmt::setExplain</refname>
+  <refpurpose>Modifie le mode explain de la commande</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="SQLite3Stmt">
+   <modifier>public</modifier> <type>bool</type><methodname>SQLite3Stmt::setExplain</methodname>
+   <methodparam><type>int</type><parameter>mode</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Modifie le mode explain de la commande, de sorte qu'elle se comporte comme si
+   son SQL était préfixé par <literal>EXPLAIN</literal> ou
+   <literal>EXPLAIN QUERY PLAN</literal>, ou de nouveau comme une commande
+   ordinaire.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>mode</parameter></term>
+    <listitem>
+     <simpara>
+      L'une des valeurs
+      <constant>SQLite3Stmt::EXPLAIN_MODE_PREPARED</constant>,
+      <constant>SQLite3Stmt::EXPLAIN_MODE_EXPLAIN</constant> ou
+      <constant>SQLite3Stmt::EXPLAIN_MODE_EXPLAIN_QUERY_PLAN</constant>.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   &return.success;
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simpara>
+   Une <exceptionname>ValueError</exceptionname> est lancée si
+   <parameter>mode</parameter> ne vaut pas l'une des constantes
+   <constant>SQLite3Stmt::EXPLAIN_MODE_*</constant>.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>SQLite3Stmt::explain</methodname></member>
+   <member><methodname>SQLite3Stmt::execute</methodname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
Translation of php/doc-en#5819 (commit e079b2a532): the fourteen socket constants added in PHP 8.5 (SHUT_*, UDP_SEGMENT, SO_BUSY_POLL, IP_BINDANY, the FreeBSD TCP options and IPPROTO_ICMP/ICMPV6), the SQLite3Stmt::EXPLAIN_MODE_* constants, and the three new SQLite3Stmt method pages (busy, explain, setExplain), which did not exist in French.

Also picks up an older doc-en commit on `sqlite3stmt.xml` removing the empty `xi:fallback` elements. EN-Revision updated.

Fixes: #3494