### PR TITLE
[Sync-En] socket_select: document key preservation, and correct both select pages

### DIFF
--- a/reference/sockets/functions/socket-select.xml
+++ b/reference/sockets/functions/socket-select.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 14dc7c47365f2b71f6c907a5ba5bccf42534d5a9 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 3e6082f609ead63cfa7b33a06d8e0c723d51bc65 Maintainer: yannick Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="function.socket-select" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -65,7 +64,7 @@
     <varlistentry>
      <term><parameter>seconds</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Les paramètres <parameter>seconds</parameter> et <parameter>microseconds</parameter>
        ensembles forment le paramètre <literal>timeout</literal> (délai d'expiration).
        Le <literal>timeout</literal> est la durée maximale de temps avant que
@@ -74,31 +73,33 @@
        <function>socket_select</function> retournera immédiatement. C'est très
        pratique pour faire du polling (sondage). Si <parameter>seconds</parameter> est &null;
        (pas de timeout), <function>socket_select</function> peut se bloquer indéfiniment.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>microseconds</parameter></term>
      <listitem>
-      <para>
-      </para>
+      <simpara>
+       Voir la description de <parameter>seconds</parameter>.
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
   </para>
   <warning>
-   <para>
+   <simpara>
     En sortie de fonction, les tableaux sont modifiés pour indiquer
     quels sockets ont changé d'état.
-   </para>
+    Les clés d'origine des &array;s sont préservées.
+   </simpara>
   </warning>
-  <para>
-   Il n'est pas nécessaire de passer tous les tableaux à
-   <function>socket_select</function>. Il est possible des omettre, ou
-   utiliser un tableau vide, ou encore &null; à la place. Il ne faut pas oublier
-   que ces tableaux sont passés par <emphasis>référence</emphasis> et
-   seront modifiés par <function>socket_select</function>.
-  </para>
+  <simpara>
+   Les trois tableaux doivent tous être fournis, mais un tableau sans intérêt
+   peut être un &array; vide ou &null; ; au moins l'un d'entre eux doit être
+   un &array; non vide. Ils sont passés par
+   <emphasis>référence</emphasis> et sont modifiés une fois que
+   <function>socket_select</function> a retourné.
+  </simpara>
   <note>
    <para>
     À cause d'une limitation du moteur Zend actuel, il n'est pas possible
@@ -123,13 +124,13 @@ socket_select($r, $w, $e, 0);
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    En cas de succès, <function>socket_select</function> retourne le nombre de
    sockets contenues dans les tableaux modifiés. Ce nombre peut être zéro si
    la durée maximale d'attente a été atteinte. En cas d'erreur, &false;
    est retourné. Le code d'erreur généré peut être obtenu en appelant la
    fonction <function>socket_last_error</function>.
-  </para>
+  </simpara>
   <note>
    <para>
     Il faut s'assurer bien d'utiliser l'opérateur <literal>===</literal>
@@ -207,9 +208,10 @@ if ($num_changed_sockets === false) {
      </listitem>
      <listitem>
       <simpara>
-       Si l'on écrit ou lit avec un socket retourné dans un tableau,
-       il faut savoir qu'il ne pourra pas écrire ou lire toutes les données
-       que l'on demande. Il faut être prêt à ne pouvoir lire qu'un seul octet.
+       Lors de la lecture ou de l'écriture sur un socket retourné dans les
+       tableaux, il faut savoir que la totalité des données demandées n'est pas
+       nécessairement lue ou écrite. Il faut être prêt à ne traiter qu'un seul
+       octet.
       </simpara>
      </listitem>
      <listitem>
@@ -227,14 +229,13 @@ if ($num_changed_sockets === false) {
 
  <refsect1 role="seealso">
   &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><function>socket_read</function></member>
-    <member><function>socket_write</function></member>
-    <member><function>socket_last_error</function></member>
-    <member><function>socket_strerror</function></member>
-   </simplelist>
-  </para>
+  <simplelist>
+   <member><function>socket_read</function></member>
+   <member><function>socket_write</function></member>
+   <member><function>socket_last_error</function></member>
+   <member><function>socket_strerror</function></member>
+   <member><function>stream_select</function></member>
+  </simplelist>
  </refsect1>
 
 </refentry>

--- a/reference/sockets/functions/socket-select.xml
+++ b/reference/sockets/functions/socket-select.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: 3e6082f609ead63cfa7b33a06d8e0c723d51bc65 Maintainer: yannick Status: ready -->
-<!-- Reviewed: yes -->
 <refentry xml:id="function.socket-select" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>socket_select</refname>

--- a/reference/stream/functions/stream-select.xml
+++ b/reference/stream/functions/stream-select.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: a758e79c3bf173203550cb78ef07509cf859b212 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 3e6082f609ead63cfa7b33a06d8e0c723d51bc65 Maintainer: lacatoire Status: ready -->
 <!-- Reviewed: yes -->
 <refentry xml:id="function.stream-select" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -16,12 +16,15 @@
    <methodparam><type class="union"><type>int</type><type>null</type></type><parameter>seconds</parameter></methodparam>
    <methodparam choice="opt"><type class="union"><type>int</type><type>null</type></type><parameter>microseconds</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    <function>stream_select</function> accepte un tableau de flux et
-   attend que l'un d'entre eux change de statut. Cette opération est
-   équivalente à ce que fait la fonction <function>socket_select</function>,
-   hormis le fait qu'elle travaille sur un flux.
-  </para>
+   attend que l'un d'entre eux change de statut. C'est l'équivalent de
+   <function>socket_select</function> pour les flux, mais les deux fonctions
+   ne se comportent pas identiquement en tout point : elles ne signalent pas
+   les arguments invalides de la même manière, et
+   <function>stream_select</function> peut se terminer sans consulter du tout
+   le système d'exploitation, comme décrit dans les notes ci-dessous.
+  </simpara>
  </refsect1>
  
  <refsect1 role="parameters">
@@ -232,18 +235,28 @@ if (false === stream_select($r, $w, $e, 0)) {
    </para>
   </note>
   <note>
-   <para>
-    Si l'on a écrit ou lu dans un flux qui est retourné dans les tableaux
-    de flux, soyez bien conscient que ces flux n'ont peut être pas écrit
-    ou lu la totalité des données demandées. Soyez en
-    mesure de lire un seul octet.
-   </para>
+   <simpara>
+    Lors de la lecture ou de l'écriture sur un flux retourné dans les tableaux,
+    il faut savoir que la totalité des données demandées n'est pas
+    nécessairement lue ou écrite. Il faut être prêt à ne traiter qu'un seul
+    octet.
+   </simpara>
   </note>
   <note>
-   <para>
+   <simpara>
     Quelques flux (comme <literal>zlib</literal>) ne peuvent pas être
     sélectionnés par cette fonction.
-   </para>
+   </simpara>
+  </note>
+  <note>
+   <simpara>
+    Un flux qui dispose déjà de données tamponnées du côté de PHP est signalé
+    comme prêt sans que l'appel <literal>select()</literal> sous-jacent ne soit
+    effectué. Dans ce cas, les tableaux <parameter>write</parameter> et
+    <parameter>except</parameter> sont vidés sans avoir été examinés : un flux
+    qui était prêt en écriture n'est donc pas signalé, et la valeur de retour ne
+    compte que les flux disponibles en lecture.
+   </simpara>
   </note>
   <note>
    <title>Compatibilité Windows</title>
@@ -264,6 +277,7 @@ if (false === stream_select($r, $w, $e, 0)) {
   &reftitle.seealso;
   <simplelist>
    <member><function>stream_set_blocking</function></member>
+   <member><function>socket_select</function></member>
   </simplelist>
  </refsect1>
 </refentry>

--- a/reference/stream/functions/stream-select.xml
+++ b/reference/stream/functions/stream-select.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: 3e6082f609ead63cfa7b33a06d8e0c723d51bc65 Maintainer: lacatoire Status: ready -->
-<!-- Reviewed: yes -->
 <refentry xml:id="function.stream-select" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>stream_select</refname>


### PR DESCRIPTION
Translation of php/doc-en#5829 (commit 3e6082f609): `socket_select()` now states that the original array keys are preserved, that all three arrays must be passed with at least one non-empty, and fills in the empty `microseconds` description; `stream_select()` gains the note about a stream with buffered data being reported ready without the underlying `select()` call, which empties the write and except arrays. The two pages now cross-link each other.

Also drops the leftover `$Revision$` marker from `socket-select.xml`. EN-Revision updated.

Fixes: #3495