### PR TITLE
[Sync-En] userlandnaming: explain the identifier rules and refresh the examples

### DIFF
--- a/appendices/userlandnaming.xml
+++ b/appendices/userlandnaming.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- EN-Revision: 077012fff21b527d01ffde600ad3282098aa1c91 Maintainer: jpauli Status: ready -->
-<!-- Reviewed: yes -->
 <appendix xml:id="userlandnaming" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Guide de nommage de l'espace utilisateur</title>
  <simpara>

--- a/appendices/userlandnaming.xml
+++ b/appendices/userlandnaming.xml
@@ -1,69 +1,70 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 0ad6aa08fb58311737ae61515d12651d7f14626e Maintainer: jpauli Status: ready -->
+<!-- EN-Revision: 077012fff21b527d01ffde600ad3282098aa1c91 Maintainer: jpauli Status: ready -->
 <!-- Reviewed: yes -->
-
 <appendix xml:id="userlandnaming" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Guide de nommage de l'espace utilisateur</title>
- <para>
-  Ce guide permet de choisir de la meilleure façon possible
-  les noms pour les identifiants dans le code PHP de l'espace utilisateur.
-  Lors du choix des noms pour n'importe quel code qui crée des symboles
-  dans l'espace de noms global, il est important de prendre en compte ce guide
-  afin d'éviter d'éventuels problèmes avec les futures versions de PHP et
-  les symboles utilisés.
- </para>
+ <simpara>
+  Ce guide permet de choisir de la meilleure façon possible les noms des
+  identifiants dans le code PHP de l'espace utilisateur. Lors du choix des noms
+  pour n'importe quel code qui crée des symboles dans l'espace de noms global,
+  il est important de prendre en compte ce guide afin d'éviter que les futures
+  versions de PHP n'entrent en conflit avec les symboles de l'utilisateur.
+ </simpara>
 
  <section xml:id="userlandnaming.globalnamespace">
   <title>Espace de noms global</title>
   <para>
-   Ceci est une vue de la construction du code qui ira dans l'espace de noms global :
+   Voici une vue d'ensemble des constructions de code qui vont dans l'espace de
+   noms global :
   </para>
 
   <itemizedlist>
-   <listitem><para>fonctions</para></listitem>
-   <listitem><para>classes</para></listitem>
-   <listitem><para>interfaces</para></listitem>
-   <listitem><para>constantes (et non les constantes de classe)</para></listitem>
+   <listitem><simpara>fonctions</simpara></listitem>
+   <listitem><simpara>classes</simpara></listitem>
+   <listitem><simpara>interfaces</simpara></listitem>
+   <listitem><simpara>traits</simpara></listitem>
+   <listitem><simpara>énumérations</simpara></listitem>
+   <listitem><simpara>constantes (et non les constantes de classe)</simpara></listitem>
    <listitem>
-    <para>variables définies à l'extérieur des fonctions/méthodes</para>
+    <simpara>variables définies en dehors des fonctions et des méthodes</simpara>
    </listitem>
   </itemizedlist>
  </section>
 
  <section xml:id="userlandnaming.rules">
   <title>Règles</title>
-  <para>
+  <simpara>
    La liste suivante fournit un aperçu global des droits que le projet PHP
    se réserve lors du choix des noms pour les nouveaux identifiants
-   internes. Le guide définitif est l'officiel
-   <link xlink:href="&url.userlandnaming.cs;">CODING STANDARDS</link> :
-  </para>
+   internes. Le guide définitif est constitué par les
+   <link xlink:href="&url.userlandnaming.cs;">standards de codage de PHP</link> :
+  </simpara>
 
   <itemizedlist>
    <listitem>
     <para>
      PHP possède l'espace de noms de haut niveau mais tente de trouver
-     des noms descriptifs cohérents.
+     des noms descriptifs corrects et d'éviter tout conflit évident.
     </para>
    </listitem>
    <listitem>
-    <para>
-     Les noms des fonctions utilisent un underscore entre les mots, tandis que
-     les noms des classes utilisent les notations <literal>camelCase</literal>
-     et <literal>PascalCase</literal>.
-    </para>
+    <simpara>
+     Les noms des fonctions utilisent un underscore entre les mots, les noms
+     des classes utilisent la notation <literal>PascalCase</literal>, et les
+     noms des méthodes la notation <literal>camelCase</literal>.
+    </simpara>
    </listitem>
    <listitem>
-    <para>
+    <simpara>
      PHP préfixe tous les symboles globaux d'une extension avec le nom
-     de l'extension. (Dans le passé, il y avait quelques exceptions à cette règle)
+     de l'extension. (Dans le passé, il y a eu de nombreuses exceptions à
+     cette règle, si bien que certains noms existants ne sont pas préfixés.)
      Exemples :
-    </para>
+    </simpara>
 
     <itemizedlist>
-     <listitem><para><function>curl_close</function></para></listitem>
-     <listitem><para><function>mysql_query</function></para></listitem>
+     <listitem><simpara><function>curl_exec</function></simpara></listitem>
+     <listitem><simpara><function>mysqli_query</function></simpara></listitem>
      <listitem><para>PREG_SPLIT_DELIM_CAPTURE</para></listitem>
      <listitem><para>new DOMDocument()</para></listitem>
      <listitem>
@@ -77,7 +78,7 @@
    <listitem>
     <para>
      Les itérateurs et les exceptions sont cependant simplement suffixés
-     par respectivement, "<literal>Iterator</literal>" et "<literal>Exception</literal>."
+     par "<literal>Iterator</literal>" et "<literal>Exception</literal>."
      Exemples :
     </para>
     <itemizedlist>
@@ -86,16 +87,19 @@
     </itemizedlist>
    </listitem>
    <listitem>
-    <para>
+    <simpara>
      PHP réserve tous les symboles commençant par un <literal>__</literal>
-     comme étant magique. Il est recommandé de ne pas créer de symboles
-     commençant par un <literal>__</literal> en PHP sauf pour
-     utiliser les fonctionnalités magiques documentées.
-     Exemple :
-    </para>
+     comme étant magiques. Il est recommandé de ne pas créer de symboles
+     commençant par un <literal>__</literal> en PHP, sauf pour utiliser les
+     fonctionnalités magiques documentées. Exemples :
+    </simpara>
     <itemizedlist>
-     <listitem><para><link linkend="object.get">__get()</link></para></listitem>
-     <listitem><para><function>__autoload</function></para></listitem>
+     <listitem>
+      <simpara><link linkend="object.get">__get()</link></simpara>
+     </listitem>
+     <listitem>
+      <simpara><link linkend="object.construct">__construct()</link></simpara>
+     </listitem>
     </itemizedlist>
    </listitem>
   </itemizedlist>
@@ -103,16 +107,16 @@
 
  <section xml:id="userlandnaming.tips">
   <title>Astuces</title>
+  <simpara>
+   Pour écrire du code pérenne, il est recommandé de ne pas placer de
+   nombreuses variables, fonctions ou classes dans l'espace de noms global.
+   Cela empêchera les conflits de nommage avec le code tiers ainsi qu'avec
+   d'éventuels ajouts futurs au langage.
+  </simpara>
   <para>
-   Pour écrire du code portable, il est recommandé de ne pas placer
-   de nombreuses variables, fonctions ou classes dans l'espace de noms global. 
-   Cela empêchera les conflits de nommage avec le code tiers ainsi que des 
-   ajouts possibles au langage.
-  </para>
-<para>
-   Une façon commune de prévenir les conflits de noms de fonctions et de 
- classes est de les ajouter à leur propre 
- <link linkend="language.namespaces">namespace</link>.
+   Une façon courante de prévenir les conflits de noms de fonctions et de
+   classes est de les ajouter à leur propre
+   <link linkend="language.namespaces">espace de noms</link> dédié.
   </para>
   <informalexample>
    <programlisting role="php">
@@ -121,38 +125,39 @@
 
 namespace MyProject;
 
-function my_function() {
+function my_function()
+{
     return true;
 }
 
 \MyProject\my_function();
+
+?>
 ]]>
    </programlisting>
   </informalexample>
-  <para>
-   Il faut toujours garder une trace des namespaces déjà utilisés,
-   mais une fois un namespace choisi, il est possible d'y
-   ajouter toutes les fonctions et les classes sans se soucier des
-   conflits.
-  </para>
-  <para>
-   Il est considéré comme la meilleure pratique pour limiter le nombre de 
-   variables ajoutées à la portée globale afin d'éviter les conflits de nommage 
-   avec le code tiers.
-  </para>
+  <simpara>
+   Il reste nécessaire de garder une trace des espaces de noms déjà utilisés,
+   mais une fois un espace de noms choisi, toutes les fonctions et les classes
+   peuvent y être ajoutées sans avoir à se soucier de nouveau des conflits.
+  </simpara>
+  <simpara>
+   Il est considéré comme une bonne pratique de limiter le nombre de variables
+   ajoutées à la portée globale afin d'éviter les conflits de nommage avec le
+   code tiers.
+  </simpara>
   <note>
    <title>Portée des variables</title>
    <para>
-    En raison des <link linkend="language.variables.scope">règles de portée</link> 
-    de PHP, les variables définies à l'intérieur des fonctions et des méthodes 
-    ne sont pas dans la portée globale et, en tant que telles, ne peuvent pas 
+    En raison des <link linkend="language.variables.scope">règles de portée</link>
+    de PHP, les variables définies à l'intérieur des fonctions et des méthodes
+    ne sont pas dans la portée globale et, en tant que telles, ne peuvent pas
     entrer en conflit avec d'autres variables définies dans la portée globale.
    </para>
   </note>
  </section>
 
 </appendix>
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml


### PR DESCRIPTION
Translation of php/doc-en#4032 (commit 077012fff2): the global namespace list gains traits and enumerations, the naming rule now distinguishes `PascalCase` for classes from `camelCase` for methods, the extension prefix examples move to `curl_exec()` and `mysqli_query()`, and the magic symbol examples replace the removed `__autoload()` with `__construct()`.

Also drops the leftover `$Revision$` marker. EN-Revision updated.

Fixes: #3496