### PR TITLE
[Sync-En] memory_get_usage: clarify which memory is reported

### DIFF
--- a/reference/info/functions/memory-get-usage.xml
+++ b/reference/info/functions/memory-get-usage.xml
@@ -1,12 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 9af43469f46843451955b8926fe470a9f3d45034 Maintainer: yannick Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: f78a9528a2fe8e78380fb28cacbe6e152fa4bb6d Maintainer: yannick Status: ready -->
 
 <refentry xml:id="function.memory-get-usage" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>memory_get_usage</refname>
-  <refpurpose>Indique la quantité de mémoire utilisée par PHP</refpurpose>
+  <refpurpose>
+   Indique la quantité de mémoire allouée au script PHP, ou réservée auprès du
+   système par le gestionnaire de mémoire de PHP
+  </refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -15,29 +16,44 @@
    <type>int</type><methodname>memory_get_usage</methodname>
    <methodparam choice="opt"><type>bool</type><parameter>real_usage</parameter><initializer>&false;</initializer></methodparam>
   </methodsynopsis>
-  <para>
-   Retourne la quantité de mémoire allouée à PHP à cet instant.
-  </para>
+  <simpara>
+   Retourne la quantité de mémoire, en octets, actuellement allouée au script
+   PHP par le gestionnaire de mémoire de PHP. La valeur rapportée est arrondie
+   au pas d'allocation de l'allocateur, elle est donc supérieure au nombre
+   exact d'octets demandés.
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
   &reftitle.parameters;
-  <para>
-   <variablelist>
-    <varlistentry>
-     <term><parameter>real_usage</parameter></term>
-     <listitem>
-      <para>
-       Définir à &true; pour récupérer la taille totale de la mémoire allouée
-       par le système. Si ce paramètre n'est pas défini ou vaut &false;,
-       seule la mémoire utilisée sera retournée.
-      </para>
-     </listitem>
-    </varlistentry>
-   </variablelist>
-  </para>
+  <variablelist>
+   <varlistentry>
+    <term><parameter>real_usage</parameter></term>
+    <listitem>
+     <simpara>
+      Définir à &true; pour récupérer la quantité totale de mémoire que le
+      gestionnaire de mémoire de PHP a réservée auprès du système, y compris
+      les pages qui ne sont pas utilisées à cet instant. C'est la valeur sur
+      laquelle <link linkend="ini.memory-limit">memory_limit</link> est
+      appliquée. Ce n'est pas la quantité de mémoire que le système
+      d'exploitation a accordée au processus PHP, qui est généralement bien
+      plus élevée.
+     </simpara>
+     <simpara>
+      Si ce paramètre n'est pas défini ou vaut &false;, seule la mémoire
+      actuellement allouée au script PHP est rapportée.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
   <note>
-   <para>PHP ne peut suivre que la mémoire allouée par <literal>emalloc()</literal></para>
+   <simpara>
+    PHP ne suit que la mémoire allouée par son propre gestionnaire de mémoire,
+    c'est-à-dire via la fonction interne <literal>emalloc()</literal> et les
+    fonctions apparentées. La mémoire allouée de manière persistante, ou
+    directement avec <literal>malloc()</literal> par une extension, n'est pas
+    rapportée, même lorsque <parameter>real_usage</parameter> vaut &true;.
+   </simpara>
   </note>
  </refsect1>
 
@@ -56,18 +72,19 @@
     <programlisting role="php">
 <![CDATA[
 <?php
-// Ceci n'est qu'un exemple. Les chiffres ci-dessous
-// différeront suivant les systèmes et les configurations
 
-echo memory_get_usage() . "\n"; // 36640
+// Ceci n'est qu'un exemple. Les chiffres ci-dessous
+// différeront suivant le système utilisé
+
+echo memory_get_usage(), "\n"; // 36640
 
 $a = str_repeat("Hello", 4242);
 
-echo memory_get_usage() . "\n"; // 57960
+echo memory_get_usage(), "\n"; // 57960
 
 unset($a);
 
-echo memory_get_usage() . "\n"; // 36744
+echo memory_get_usage(), "\n"; // 36744
 
 ?>
 ]]>


### PR DESCRIPTION
Translation of php/doc-en#4491 (commit f78a9528a2): the page now distinguishes the memory allocated to the script from the memory PHP's memory manager reserved from the system, says that `memory_limit` is enforced against the latter, and states that memory allocated persistently or with `malloc()` is never reported.

Also drops the leftover `$Revision$` and `Reviewed` markers. EN-Revision updated.

Fixes: #3497