### PR TITLE
[Sync-En] pcntl_wait, pcntl_waitpid: document the resource_usage parameter

### DIFF
--- a/reference/pcntl/functions/pcntl-wait.xml
+++ b/reference/pcntl/functions/pcntl-wait.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 61374bbe228e8e9c55a24aba59a1e2bb2a871148 Maintainer: dams Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: ec891f50fa7c999195c1c792261bfd15e41daf73 Maintainer: dams Status: ready -->
 <refentry xml:id="function.pcntl-wait" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>pcntl_wait</refname>
@@ -88,6 +86,25 @@
         </tgroup>
        </table>
       </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>resource_usage</parameter></term>
+     <listitem>
+      <simpara>
+       Le paramètre <parameter>resource_usage</parameter> est défini sur un
+       <type>array</type> associatif contenant les statistiques d'utilisation
+       des ressources du processus enfant. Pour le détail de son contenu, voir
+       <function>getrusage</function>.
+      </simpara>
+      <simpara>
+       Ceci n'est pris en charge que si l'appel système
+       <literal>wait3(2)</literal> est disponible sur le système ; sinon, le
+       paramètre est laissé inchangé.
+       Si aucun processus enfant n'a été récolté, c'est-à-dire si la fonction
+       retourne <literal>0</literal> ou <literal>-1</literal>, le paramètre est
+       défini sur un <type>array</type> vide.
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>

--- a/reference/pcntl/functions/pcntl-waitid.xml
+++ b/reference/pcntl/functions/pcntl-waitid.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 4fbe0691312fbf85d67674f2e80c1abb5c36187f Maintainer: Fan2Shrek Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: ec891f50fa7c999195c1c792261bfd15e41daf73 Maintainer: Fan2Shrek Status: ready -->
 <refentry xml:id="function.pcntl-waitid" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>pcntl_waitid</refname>
@@ -250,13 +249,18 @@
    <varlistentry>
     <term><parameter>resource_usage</parameter></term>
     <listitem>
-     <para>
-      Le paramètre <parameter>resource_usage</parameter> est défini sur un tableau
-      contenant les statistiques d’utilisation des ressources du processus enfant.
-
-      Ceci est pris en charge soit si l’appel système wait6 est disponible
-      (par exemple sur FreeBSD), soit sur Linux via l’appel système brut waitid.
-     </para>
+     <simpara>
+      Le paramètre <parameter>resource_usage</parameter> est défini sur un
+      <type>array</type> associatif contenant les statistiques d'utilisation
+      des ressources du processus enfant. Pour le détail de son contenu, voir
+      <function>getrusage</function>.
+     </simpara>
+     <simpara>
+      Ceci n'est pris en charge que si l'appel système
+      <literal>wait6(2)</literal> est disponible, par exemple sur FreeBSD, ou
+      sur Linux via l'appel système brut <literal>waitid(2)</literal> ; sinon,
+      le paramètre est laissé inchangé.
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>

--- a/reference/pcntl/functions/pcntl-waitpid.xml
+++ b/reference/pcntl/functions/pcntl-waitpid.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: a747e132c5506a0273c686cbe20e227c980d8ec7 Maintainer: dams Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: ec891f50fa7c999195c1c792261bfd15e41daf73 Maintainer: dams Status: ready -->
 <refentry xml:id="function.pcntl-waitpid" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>pcntl_waitpid</refname>
@@ -134,6 +132,25 @@
       </para>
      </listitem>
     </varlistentry>
+    <varlistentry>
+     <term><parameter>resource_usage</parameter></term>
+     <listitem>
+      <simpara>
+       Le paramètre <parameter>resource_usage</parameter> est défini sur un
+       <type>array</type> associatif contenant les statistiques d'utilisation
+       des ressources du processus enfant. Pour le détail de son contenu, voir
+       <function>getrusage</function>.
+      </simpara>
+      <simpara>
+       Ceci n'est pris en charge que si l'appel système
+       <literal>wait4(2)</literal> est disponible sur le système ; sinon, le
+       paramètre est laissé inchangé.
+       Si aucun processus enfant n'a été récolté, c'est-à-dire si la fonction
+       retourne <literal>0</literal> ou <literal>-1</literal>, le paramètre est
+       défini sur un <type>array</type> vide.
+      </simpara>
+     </listitem>
+    </varlistentry>
    </variablelist>
   </para>
  </refsect1>
@@ -148,12 +165,72 @@
   </para>
  </refsect1>
 
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Exemple avec <function>pcntl_waitpid</function></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+function checkChild(int $pid, bool $wait): void
+{
+    $flags = ($wait ? 0 : WNOHANG);
+    $deadPid = pcntl_waitpid($pid, $status, $flags, $rusage);
+    if ($deadPid === -1) {
+        $errNo = pcntl_get_last_error();
+        $errMsg = pcntl_strerror($errNo);
+        print "PARENT pcntl_waitpid FAILED ({$errNo}): {$errMsg}\n";
+    } elseif ($deadPid === 0) {
+        print "PARENT pcntl_waitpid: No exited children.\n";
+    } elseif (pcntl_wifexited($status)) {
+        print "PARENT pcntl_waitpid: Child PID {$deadPid} exited with status: "
+            . pcntl_wexitstatus($status) . "\n";
+        var_dump($rusage);
+    } else {
+        print "PARENT pcntl_waitpid: Child PID {$deadPid} was terminated by signal: "
+            . pcntl_wtermsig($status) . "\n";
+    }
+}
+
+$parentPid = getmypid();
+$forkedPid = pcntl_fork();
+if ($forkedPid == -1) {
+    die('Could not fork');
+} else if ($forkedPid) {
+    // Processus parent
+    print "PARENT {$parentPid} has forked {$forkedPid}\n";
+
+    print "PARENT is checking for exited children\n";
+    checkChild($forkedPid, false);
+
+    // Empêche les enfants de rester en "processus zombie"
+    print "PARENT is waiting for a child to exit\n";
+    checkChild($forkedPid, true);
+
+    print "PARENT is checking for exited children\n";
+    checkChild($forkedPid, false);
+
+    print "PARENT is exiting\n";
+} else {
+    // Processus enfant
+    $pid = getmypid();
+    print "CHILD {$pid} is sleeping\n";
+    sleep(10);
+    print "CHILD is exiting\n";
+    exit(7);
+}
+]]>
+   </programlisting>
+  </example>
+ </refsect1>
+
  <refsect1 role="seealso">
   &reftitle.seealso;
   <para>
    <simplelist>
     <member><function>pcntl_fork</function></member>
     <member><function>pcntl_signal</function></member>
+    <member><function>pcntl_wait</function></member>
     <member><function>pcntl_wifexited</function></member>
     <member><function>pcntl_wifstopped</function></member>
     <member><function>pcntl_wifsignaled</function></member>


### PR DESCRIPTION
Translation of php/doc-en#4917 (commit ec891f50fa): `pcntl_wait()` and `pcntl_waitpid()` now describe their undocumented `resource_usage` parameter, including the wait3/wait4 availability condition and the empty array returned when no child was reaped; `pcntl_waitid()` gets the same wording. Adds the `pcntl_waitpid()` example and the missing see-also link.

Also drops the leftover `$Revision$` and `Reviewed` markers. EN-Revision updated.

Fixes: #3499