### PR TITLE
[Sync-En] intval: expand the example with a variety of bases

### DIFF
--- a/reference/var/functions/intval.xml
+++ b/reference/var/functions/intval.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 6197a68b1e9bc777323fa0df01adbed4d0c743f4 Maintainer: lacatoire Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 81a581c15721591f9fdd3e36990d8b729236689d Maintainer: lacatoire Status: ready -->
 <refentry xml:id="function.intval" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>intval</refname>
@@ -173,11 +172,16 @@ echo intval('1e10'), PHP_EOL;                  // 10000000000
 echo intval(0x1A), PHP_EOL;                    // 26
 echo intval('0x1A'), PHP_EOL;                  // 0
 echo intval('0x1A', 0), PHP_EOL;               // 26
+echo intval('1A', 16), PHP_EOL;                // 26
 echo intval(42000000), PHP_EOL;                // 42000000
 echo intval(420000000000000000000), PHP_EOL;   // -4275113695319687168
 echo intval('420000000000000000000'), PHP_EOL; // 9223372036854775807
 echo intval(42, 8), PHP_EOL;                   // 42
 echo intval('42', 8), PHP_EOL;                 // 34
+echo intval(42, 7), PHP_EOL;                   // 42
+echo intval('42', 7), PHP_EOL;                 // 30
+echo intval('1000', 11), PHP_EOL;              // 1331
+echo intval('1ya', 36), PHP_EOL;               // 2530
 echo intval(array()), PHP_EOL;                 // 0
 echo intval(array('foo', 'bar')), PHP_EOL;     // 1
 echo intval(false), PHP_EOL;                   // 0


### PR DESCRIPTION
Translation of php/doc-en#5827 (commit 81a581c157): the example now covers base 16 on a string without the `0x` prefix, and bases 7, 11 and 36, alongside the existing base 8 lines. Outputs checked against PHP 8.5.

Also drops the leftover `Reviewed` marker. EN-Revision updated.

Fixes: #3500