### PR TITLE
[Sync-En] variables: describe how non-ASCII variable names behave

### DIFF
--- a/language/variables.xml
+++ b/language/variables.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 64007e9f6b23f70d8874be11c4eb9d45556b742f Maintainer: lacatoire Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 0e72b54621406de1c5642334258462725ca99a29 Maintainer: lacatoire Status: ready -->
 
 <chapter xml:id="language.variables" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink"
   annotations="interactive">
@@ -26,10 +25,25 @@
   
   <note>
    <simpara>
-    PHP ne prend pas en charge les noms de variables Unicode, cependant, certains
-    encodages de caractères (comme UTF-8) encodent les caractères de manière
-    que tous les octets d'un caractère multi-octet soient dans la plage
-    autorisée, ce qui en fait ainsi un nom de variable valide.
+    Les noms de variables sont comparés octet par octet, et non caractère par
+    caractère. PHP n'interprète ni ne valide l'encodage des octets de 128 à
+    255, et deux noms désignent la même variable uniquement si leurs octets
+    sont identiques.
+   </simpara>
+   <simpara>
+    Une conséquence est que les noms écrits en UTF-8 fonctionnent, car chaque
+    octet d'une séquence multi-octet UTF-8 se situe dans la plage acceptée. Il
+    en va de même pour tout encodage dont les octets non ASCII se situent tous
+    dans cette plage, ainsi que pour des suites d'octets qui ne constituent un
+    texte valide dans aucun encodage. Les encodages qui utilisent des octets
+    inférieurs à 128 au sein d'une séquence multi-octet, comme Shift-JIS ou
+    UTF-16, ne fonctionnent pas.
+   </simpara>
+   <simpara>
+    Une autre est que deux noms qui s'affichent de manière identique peuvent
+    être distincts. <literal>ä</literal> encodé en U+00E4 et <literal>a</literal>
+    suivi du tréma combinant U+0308 sont deux variables différentes, tout comme
+    un nom avec et sans une espace insécable U+00A0 finale.
    </simpara>
   </note>
   


### PR DESCRIPTION
Translation of php/doc-en#5831 (commit 0e72b54621): the note no longer claims Unicode variable names are unsupported. It now says names are compared as bytes, which encodings that works for and which it does not, and that two names displaying identically may still be distinct variables.

Also drops the leftover `Reviewed` marker. EN-Revision updated.

Fixes: #3502