### PR TITLE
[Sync-En] core: document the PHP 8.5 language features and deprecations

### DIFF
--- a/appendices/ini.core.xml
+++ b/appendices/ini.core.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: a52e3d27cca786940272d0ae8efc21b5d6739070 Maintainer: lacatoire Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: cf7dcffba0ab8ce14dbfd6019f2861f5a6843ed5 Maintainer: lacatoire Status: ready -->
 
  <section xml:id="ini.core" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
   <title>Description des directives internes du &php.ini;</title>
@@ -456,6 +455,12 @@ Fatal error: Maximum execution time of 30+2 seconds exceeded (terminated) in Unk
         <entry><constant>INI_ALL</constant></entry>
         <entry></entry>
        </row>
+       <row>
+        <entry><link linkend="ini.max-memory-limit">max_memory_limit</link></entry>
+        <entry>"-1"</entry>
+        <entry><constant>INI_SYSTEM</constant></entry>
+        <entry>Disponible à partir de PHP 8.5.0</entry>
+       </row>
       </tbody>
      </tgroup>
     </table>
@@ -477,9 +482,32 @@ Fatal error: Maximum execution time of 30+2 seconds exceeded (terminated) in Unk
         la mémoire par un script mal codé.  Il est à noter que pour n'avoir aucune limite,
         il faut définir cette directive à <literal>-1</literal>.
        </para>
-       
+
        &ini.shorthandbytes;
-       
+
+      </listitem>
+     </varlistentry>
+     <varlistentry xml:id="ini.max-memory-limit">
+      <term>
+       <parameter>max_memory_limit</parameter>
+       <type>int</type>
+      </term>
+      <listitem>
+       <simpara>
+        Disponible à partir de PHP 8.5.0. Cette option, modifiable uniquement
+        au démarrage, contrôle la valeur maximale à laquelle
+        <link linkend="ini.memory-limit">memory_limit</link> peut être
+        configurée, que ce soit au démarrage ou à l'exécution (par exemple via
+        <function>ini_set</function>). Définir
+        <link linkend="ini.memory-limit">memory_limit</link> à une valeur
+        dépassant <parameter>max_memory_limit</parameter> produit un
+        avertissement et la valeur est plafonnée. Définir cette directive à
+        <literal>-1</literal> (la valeur par défaut) pour n'imposer aucune
+        borne supérieure.
+       </simpara>
+
+       &ini.shorthandbytes;
+
       </listitem>
      </varlistentry>
     </variablelist>

--- a/language/constants.xml
+++ b/language/constants.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 6e885e52412ad979aa5fbb620bb84e886fc0ebe8 Maintainer: lacatoire Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: 4c352e683436649edba35a3272210d8ca4cae611 Maintainer: lacatoire Status: ready -->
 <!-- CREDITS: DAnnebicque -->
 <chapter xml:id="language.constants" xmlns="http://docbook.org/ns/docbook" annotations="interactive">
  <title>Les constantes</title>
@@ -20,6 +18,12 @@
    Avant PHP 8.0.0, les constantes définies en utilisant la fonction
    <function>define</function> peuvent être insensibles à la casse.
   </para>
+ </note>
+
+ <note>
+  <simpara>
+   À partir de PHP 8.5.0, redéclarer une constante déjà définie est obsolète.
+  </simpara>
  </note>
 
  <para>
@@ -231,6 +235,33 @@ echo ANIMALS_DEF[1] . "\n"; // affiche "chat"
     blocs <literal>try</literal>/<literal>catch</literal>.
    </para>
   </note>
+
+  <sect2 role="changelog">
+   &reftitle.changelog;
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>8.5.0</entry>
+       <entry>
+        Ajout du support des transtypages (par exemple <code>(int)</code>,
+        <code>(string)</code>) dans les expressions constantes.
+        Ajout également du support des
+        <link linkend="functions.anonymous">fonctions anonymes</link> et des
+        <link linkend="functions.first_class_callable_syntax">callables de
+        première classe</link> dans les expressions constantes.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </sect2>
 
   <sect2 role="seealso">
    &reftitle.seealso;

--- a/language/errors/basics.xml
+++ b/language/errors/basics.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: de9c65c91ff1710d8b2d2ec955caea0162679305 Maintainer: jbnahan Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 4c352e683436649edba35a3272210d8ca4cae611 Maintainer: jbnahan Status: ready -->
 
 <sect1 xml:id="language.errors.basics" xmlns="http://docbook.org/ns/docbook">
  <title>Bases</title>
@@ -78,6 +76,31 @@
    l'enregistrant dans un fichier, comme en envoyant un courriel électronique.
   </para>
  </sect2>
+
+ <sect2 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Les erreurs fatales (comme un temps d'exécution maximal dépassé)
+       incluent désormais une trace de la pile d'appels dans leur message
+       d'erreur.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </sect2>
+
 </sect1>
  
 <!-- Keep this comment at the end of the file

--- a/language/functions.xml
+++ b/language/functions.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: c19f29d4fcf92c1a2d2c46d68adab31e98fcbe78 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 4c352e683436649edba35a3272210d8ca4cae611 Maintainer: lacatoire Status: ready -->
 <chapter xml:id="language.functions" xmlns="http://docbook.org/ns/docbook" annotations="interactive">
  <title>Les fonctions</title>
  
@@ -1431,6 +1431,14 @@ Stack trace:
       </thead>
       <tbody>
        <row>
+        <entry>8.5.0</entry>
+        <entry>
+         Les fonctions anonymes peuvent désormais être utilisées dans les
+         expressions constantes (par exemple les valeurs par défaut de
+         propriétés, les paramètres d'attributs, les constantes).
+        </entry>
+       </row>
+       <row>
         <entry>8.3.0</entry>
         <entry>
          Les fermetures créées à partir des <link linkend="language.oop5.magic">méthodes
@@ -1744,6 +1752,30 @@ $obj?->prop->method(...);
     </informalexample>
    </para>
   </note>
+
+   <sect2 role="changelog">
+    &reftitle.changelog;
+    <informaltable>
+     <tgroup cols="2">
+      <thead>
+       <row>
+        <entry>&Version;</entry>
+        <entry>&Description;</entry>
+       </row>
+      </thead>
+      <tbody>
+       <row>
+        <entry>8.5.0</entry>
+        <entry>
+         Les callables de première classe peuvent désormais être utilisés dans
+         les expressions constantes (par exemple les valeurs par défaut de
+         propriétés, les paramètres d'attributs, les constantes).
+        </entry>
+       </row>
+      </tbody>
+     </tgroup>
+    </informaltable>
+   </sect2>
  </sect1>
 
 </chapter>

--- a/language/oop5/magic.xml
+++ b/language/oop5/magic.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: dff848b17dafaabfb7662ffb5fecfcb04e3b771d Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: cf7dcffba0ab8ce14dbfd6019f2861f5a6843ed5 Maintainer: lacatoire Status: ready -->
  <sect1 xml:id="language.oop5.magic" xmlns="http://docbook.org/ns/docbook">
   <title>Méthodes magiques</title>
   <simpara>
@@ -586,6 +586,11 @@ object(A)#2 (2) {
     alors toutes les propriétés publiques, protégées et privées seront
     affichées.
    </para>
+   <simpara>
+    À partir de PHP 8.5.0, retourner &null; depuis
+    <link linkend="object.debuginfo">__debugInfo()</link> est obsolète.
+    Retourner un <type>array</type> vide à la place.
+   </simpara>
    <example>
     <title>Utilisation de <link linkend="object.debuginfo">__debugInfo()</link></title>
     <programlisting role="php">

--- a/language/operators/increment.xml
+++ b/language/operators/increment.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 16934048f79c6e117cd16a23c09c1b2ea502e284 Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: cf7dcffba0ab8ce14dbfd6019f2861f5a6843ed5 Maintainer: yannick Status: ready -->
 <sect1 xml:id="language.operators.increment">
  <title>Opérateurs d'incrémentation et décrémentation</title>
  <titleabbrev>Incrémentation et décrémentation</titleabbrev>
@@ -130,6 +129,8 @@ int(4)
    <simpara>
     Cette fonctionnalité est obsolète de manière souple à partir de PHP 8.3.0.
     La fonction <function>str_increment</function> devrait être utilisée à la place.
+    À partir de PHP 8.5.0, incrémenter une chaîne non numérique émet un
+    avertissement d'obsolescence.
    </simpara>
   </warning>
 

--- a/language/predefined/closure/bind.xml
+++ b/language/predefined/closure/bind.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9c74079f12d67cabb52c124d761f48275417d7eb Maintainer: yannick Status: ready -->
-<!-- Reviewed: yes Maintainer: mikaelkael -->
+<!-- EN-Revision: cf7dcffba0ab8ce14dbfd6019f2861f5a6843ed5 Maintainer: yannick Status: ready -->
 <refentry xml:id="closure.bind" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Closure::bind</refname>
@@ -30,29 +29,29 @@
    <varlistentry>
     <term><parameter>closure</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       La fonction anonyme à lier.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>newThis</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       L'objet auquel lier la fonction anonyme, ou &null; pour délier.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>newScope</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       Le contexte de classe à associer à la fermeture, ou 'static' pour conserver le
       contexte actuel. Si un objet est utilisé, son type sera utilisé.
       Ceci détermine les accès protégés et privés de l'objet lié.
-      Il n'est pas autorisé de passer (un objet d') une classe interne pour 
+      Il n'est pas autorisé de passer (un objet d') une classe interne pour
       ce paramètre.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -60,9 +59,33 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retourne un nouvel objet <classname>Closure</classname>, ou &null; en cas d'échec.
-  </para>
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Lier une instance à une fermeture statique, ou lier une méthode issue
+       d'une hiérarchie de classes incompatible, est désormais obsolète (ces
+       cas émettaient déjà un <constant>E_WARNING</constant>).
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">

--- a/language/predefined/closure/bindto.xml
+++ b/language/predefined/closure/bindto.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 80720e59fc88b2522fe2e119b0148caaaa214b0b Maintainer: yannick Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: cf7dcffba0ab8ce14dbfd6019f2861f5a6843ed5 Maintainer: yannick Status: ready -->
 <refentry xml:id="closure.bindto" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Closure::bindTo</refname>
@@ -16,39 +15,39 @@
    <methodparam><type class="union"><type>object</type><type>null</type></type><parameter>newThis</parameter></methodparam>
    <methodparam choice="opt"><type class="union"><type>object</type><type>string</type><type>null</type></type><parameter>newScope</parameter><initializer>"static"</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Crée et retourne une nouvelle <link linkend="functions.anonymous">fonction anonyme
    </link> avec le même corps et les mêmes variables liées que l'originale, mais avec un objet lié
    qui peut être différent, et un nouveau contexte de classe.
-  </para>
+  </simpara>
 
-  <para>
+  <simpara>
    L'objet lié détermine la valeur que <literal>$this</literal> aura dans le corps de la fonction,
    et le contexte de classe représente une classe qui détermine à quels membres privés et protégés
    la fonction anonyme aura accès. Autrement dit, les propriétés qui seront visibles seront les
    mêmes que si la fonction anonyme était une méthode de la classe passée via le paramètre
    <parameter>newScope</parameter>.
-  </para>
+  </simpara>
 
-  <para>
+  <simpara>
    Les fermetures statiques ne peuvent pas avoir d'objet lié (la valeur du paramètre
    <parameter>newThis</parameter> devrait être &null;), mais cette méthode peut
    néanmoins être utilisée pour changer leur portée de classe.
-  </para>
+  </simpara>
 
-  <para>
+  <simpara>
    Cette méthode va vérifier qu'une fermeture non-statique à laquelle on passe
    un contexte d'objet deviendra liée à cet objet (et ne sera donc plus non-statique),
    et vice-versa. Dans ce but, les fermetures non-statiques auxquelles on passe un
    contexte de classe mais &null; comme contexte objet seront rendues statiques, et
    inversement.
-  </para>
+  </simpara>
 
   <note>
-   <para>
+   <simpara>
     Pour simplement dupliquer la fonction anonyme, il est possible d'utiliser
     <link linkend="language.oop5.cloning">le clonage</link> à la place.
-   </para>
+   </simpara>
   </note>
 
  </refsect1>
@@ -59,21 +58,21 @@
    <varlistentry>
     <term><parameter>newThis</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       L'objet auquel lier la fonction anonyme, ou &null; pour que la fermeture ne soit pas liée.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><parameter>newScope</parameter></term>
     <listitem>
-     <para>
+     <simpara>
       Le contexte de classe à associer à la fermeture, ou 'static' pour conserver le
       contexte actuel. Si un objet est passé, son type sera utilisé.
       Ceci détermine la visibilité des méthodes protégées et privées de l'objet lié.
-      Il n'est pas autorisé de passer (un objet d') une classe interne pour 
+      Il n'est pas autorisé de passer (un objet d') une classe interne pour
       ce paramètre.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
   </variablelist>
@@ -81,10 +80,34 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Retourne la nouvelle fermeture sous la forme d'un objet <classname>Closure</classname>,
    ou &null; en cas d'erreur.
-  </para>
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Lier une instance à une fermeture statique, ou lier une méthode issue
+       d'une hiérarchie de classes incompatible, est désormais obsolète (ces
+       cas émettaient déjà un <constant>E_WARNING</constant>).
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">

--- a/language/types/callable.xml
+++ b/language/types/callable.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 7132d8833a86604aa2d10c16c0470d0ef1a0fdfb Maintainer: lacatoire Status: ready -->
-<!-- Reviewed: yes Maintainer: girgias -->
+<!-- EN-Revision: 4c352e683436649edba35a3272210d8ca4cae611 Maintainer: lacatoire Status: ready -->
 <!-- CREDITS: DavidA -->
 <sect1 xml:id="language.types.callable">
  <title>Callables</title>
@@ -162,6 +161,8 @@ print implode(' ', $new_numbers);
    est indépendant de la portée et peut toujours être invoqué, alors qu'un type callable peut
    être dépendant de la portée et ne peut être invoqué directement.
    <classname>Closure</classname> est la méthode préférée pour créer des callables.
+   À partir de PHP 8.5.0, <classname>Closure</classname> est un véritable
+   sous-type de <type>callable</type>.
   </simpara>
 
   <note>

--- a/reference/outcontrol/functions/ob-start.xml
+++ b/reference/outcontrol/functions/ob-start.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 1ebafd8a44786824396f95102576426462835869 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: cf7dcffba0ab8ce14dbfd6019f2861f5a6843ed5 Maintainer: yannick Status: ready -->
 <refentry xml:id="function.ob-start" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>ob_start</refname>
@@ -196,6 +196,31 @@
   <para>
    &return.success;
   </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Tenter de produire une sortie (par exemple avec <function>echo</function>)
+       depuis la fonction de rappel de gestion de sortie utilisateur est
+       désormais obsolète. L'avertissement d'obsolescence contourne le
+       gestionnaire et est affiché directement.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">


### PR DESCRIPTION
Translation of php/doc-en#5824 (commit 4c352e6834) and php/doc-en#5823 (commit cf7dcffba0): casts, closures and first-class callables in constant expressions, `Closure` as a proper subtype of `callable`, stack traces in fatal error messages, the new `max_memory_limit` INI setting, and the 8.5 deprecations (constant redeclaration, `__debugInfo()` returning null, incrementing non-numeric strings, closure binding issues, output from a user output handler).

The two issues both touch `language/constants.xml`, so they share one PR: the file can only declare one EN-Revision and it must carry both commits. Also drops the leftover `$Revision$` and `Reviewed` markers from the touched files. EN-Revision updated.

Fixes: #3513
Fixes: #3515