### PR TITLE
[Sync-En] imagick: document the image types

### DIFF
--- a/reference/imagick/constants.xml
+++ b/reference/imagick/constants.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 3bbb0751e2cbb98aa239dedea41d622cf9d654aa Maintainer: yannick Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 0aa15a23a0b1457ab2545d7f38eb292fd2f4b66e Maintainer: yannick Status: ready -->
 
 <appendix xmlns="http://docbook.org/ns/docbook" xml:id="imagick.constants">
  &reftitle.constants;
@@ -1036,36 +1034,65 @@
  
  <variablelist xml:id="imagick.constants.imagetype">
   <title>Constantes <constant>IMGTYPE_<replaceable>*</replaceable></constant></title>
-  <para></para>
+  <simpara>
+   Un type d'image combine un modèle colorimétrique et la présence ou l'absence
+   d'un canal alpha.
+   Passer une de ces constantes à
+   <methodname>Imagick::setImageType</methodname> convertit l'image vers ce
+   type.
+   <methodname>Imagick::getImageType</methodname> indique le type d'une image,
+   mais ne retourne jamais qu'un type décrivant des données de pixels réelles,
+   jamais <constant>imagick::IMGTYPE_UNDEFINED</constant> ni
+   <constant>imagick::IMGTYPE_OPTIMIZE</constant>.
+  </simpara>
+  <simpara>
+   Les constantes dont le nom se termine par <literal>MATTE</literal> sont les
+   variantes qui portent un canal alpha ; les autres n'en ont pas.
+   Dans ImageMagick 6, le canal alpha était appelé canal matte, et lorsque
+   Imagick est compilé avec ImageMagick 7, chacune de ces constantes existe
+   aussi sous un nom
+   <constant>IMGTYPE_<replaceable>*</replaceable>ALPHA</constant> ayant la même
+   valeur.
+  </simpara>
   <varlistentry xml:id="imagick.constants.imgtype-undefined">
    <term>
     <constant>imagick::IMGTYPE_UNDEFINED</constant>
     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
+   </term>
+   <listitem>
+    <simpara>
+      Le type de l'image est inconnu.
+      <methodname>Imagick::setImageType</methodname> ne convertit rien pour
+      cette valeur, mais l'enregistre tout de même sur l'image.
+    </simpara>
+   </listitem>
   </varlistentry>
   <varlistentry xml:id="imagick.constants.imgtype-bilevel">
    <term>
     <constant>imagick::IMGTYPE_BILEVEL</constant>
     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
+   </term>
+   <listitem>
+    <simpara>
+      Deux couleurs seulement.
+      L'image est convertie en niveaux de gris, son contraste est étiré, et
+      chaque pixel devient noir ou blanc selon qu'il est plus clair ou plus
+      sombre qu'un gris moyen ; tout canal alpha est abandonné.
+    </simpara>
+   </listitem>
   </varlistentry>
   <varlistentry xml:id="imagick.constants.imgtype-grayscale">
    <term>
     <constant>imagick::IMGTYPE_GRAYSCALE</constant>
     (<type>int</type>)
-    </term>
-    <listitem>
-     <simpara>
-     </simpara>
-    </listitem>
+   </term>
+   <listitem>
+    <simpara>
+      Des nuances de gris.
+      L'image est convertie vers l'espace colorimétrique en niveaux de gris, et
+      tout canal alpha est abandonné.
+    </simpara>
+   </listitem>
   </varlistentry>
   <varlistentry xml:id="imagick.constants.imgtype-grayscalematte">
    <term>
@@ -1074,6 +1101,10 @@
    </term>
    <listitem>
     <simpara>
+      Des nuances de gris avec un canal alpha.
+      Identique à <constant>imagick::IMGTYPE_GRAYSCALE</constant>, sauf que le
+      canal alpha est conservé, et que si l'image n'en a pas, un canal opaque
+      est ajouté.
     </simpara>
    </listitem>
   </varlistentry>
@@ -1084,6 +1115,10 @@
    </term>
    <listitem>
     <simpara>
+      Couleurs indexées.
+      L'image est convertie en sRGB et, si elle n'est pas déjà indexée ou
+      qu'elle comporte plus de 256 couleurs, elle est quantifiée à 256
+      couleurs ; tout canal alpha est abandonné.
     </simpara>
    </listitem>
   </varlistentry>
@@ -1094,6 +1129,12 @@
    </term>
    <listitem>
     <simpara>
+      Couleurs indexées avec un canal alpha.
+      L'image est convertie en sRGB, le canal alpha est conservé, et si l'image
+      n'en a pas, un canal opaque est ajouté.
+      Contrairement à <constant>imagick::IMGTYPE_PALETTE</constant>, les
+      couleurs sont quantifiées même lorsque l'image est déjà indexée, et le
+      canal alpha est inclus dans la quantification.
     </simpara>
    </listitem>
   </varlistentry>
@@ -1104,6 +1145,9 @@
    </term>
    <listitem>
     <simpara>
+      Couleurs directes : une valeur de rouge, de vert et de bleu par pixel,
+      sans palette.
+      L'image est convertie en sRGB, et tout canal alpha est abandonné.
     </simpara>
    </listitem>
   </varlistentry>
@@ -1114,6 +1158,10 @@
    </term>
    <listitem>
     <simpara>
+      Couleurs directes avec un canal alpha.
+      Identique à <constant>imagick::IMGTYPE_TRUECOLOR</constant>, sauf que le
+      canal alpha est conservé, et que si l'image n'en a pas, un canal opaque
+      est ajouté.
     </simpara>
    </listitem>
   </varlistentry>
@@ -1124,6 +1172,9 @@
    </term>
    <listitem>
     <simpara>
+      Un canal par encre d'impression, sans palette.
+      L'image est convertie vers l'espace colorimétrique CMJN, et tout canal
+      alpha est abandonné.
     </simpara>
    </listitem>
   </varlistentry>
@@ -1134,6 +1185,26 @@
    </term>
    <listitem>
     <simpara>
+      Un canal par encre d'impression, sans palette, plus un canal alpha.
+      Identique à <constant>imagick::IMGTYPE_COLORSEPARATION</constant>, sauf
+      que le canal alpha est conservé, et que si l'image n'en a pas, un canal
+      opaque est ajouté.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="imagick.constants.imgtype-palettebilevelmatte">
+   <term>
+    <constant>imagick::IMGTYPE_PALETTEBILEVELMATTE</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+      Couleurs indexées avec un canal alpha entièrement transparent ou
+      entièrement opaque.
+      L'image est convertie en sRGB, un canal alpha opaque est ajouté si elle
+      n'en a pas, ce canal seul est réduit à deux valeurs, puis les couleurs
+      sont quantifiées.
+      C'est le type d'un PNG utilisant une transparence binaire.
     </simpara>
    </listitem>
   </varlistentry>
@@ -1144,6 +1215,8 @@
    </term>
    <listitem>
     <simpara>
+      <methodname>Imagick::setImageType</methodname> ne convertit rien pour
+      cette valeur, mais l'enregistre tout de même sur l'image.
     </simpara>
    </listitem>
   </varlistentry>

--- a/reference/imagick/imagick/getimagetype.xml
+++ b/reference/imagick/imagick/getimagetype.xml
@@ -1,12 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 65c4446ab35754d2f3cd8abec11302650a150bf9 Maintainer: yannick Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 0aa15a23a0b1457ab2545d7f38eb292fd2f4b66e Maintainer: yannick Status: ready -->
 
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="imagick.getimagetype">
  <refnamediv>
   <refname>Imagick::getImageType</refname>
-  <refpurpose>Lit le type possible d'image</refpurpose>
+  <refpurpose>Lit le type de l'image</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -15,9 +13,13 @@
    <modifier>public</modifier> <type>int</type><methodname>Imagick::getImageType</methodname>
    <void/>
   </methodsynopsis>
-  <para>
-   Retourne le type possible d'image.
-  </para>
+  <simpara>
+   Retourne le type de l'image, déduit de son espace colorimétrique, de sa
+   classe de stockage et de la présence d'un canal alpha. Les pixels
+   eux-mêmes ne sont pas examinés : la valeur reflète donc la façon dont
+   l'image est actuellement stockée, et non le plus petit type auquel elle
+   pourrait être réduite.
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -27,66 +29,59 @@
  
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
-   Lit le type possible d'image.
-   <itemizedlist>
-    <listitem>
-     <simpara>
-      <constant>imagick::IMGTYPE_UNDEFINED</constant>
-     </simpara>
-    </listitem>
-    <listitem>
-     <simpara>
-      <constant>imagick::IMGTYPE_BILEVEL</constant>
-     </simpara>
-    </listitem>
-    <listitem>
-     <simpara>
-      <constant>imagick::IMGTYPE_GRAYSCALE</constant>
-     </simpara>
-    </listitem>
-    <listitem>
-     <simpara>
-      <constant>imagick::IMGTYPE_GRAYSCALEMATTE</constant>
-     </simpara>
-    </listitem>
-    <listitem>
-     <simpara>
-      <constant>imagick::IMGTYPE_PALETTE</constant>
-     </simpara>
-    </listitem>
-    <listitem>
-     <simpara>
-      <constant>imagick::IMGTYPE_PALETTEMATTE</constant>
-     </simpara>
-    </listitem>
-    <listitem>
-     <simpara>
-      <constant>imagick::IMGTYPE_TRUECOLOR</constant>
-     </simpara>
-    </listitem>
-    <listitem>
-     <simpara>
-      <constant>imagick::IMGTYPE_TRUECOLORMATTE</constant>
-     </simpara>
-    </listitem>
-    <listitem>
-     <simpara>
-      <constant>imagick::IMGTYPE_COLORSEPARATION</constant>
-     </simpara>
-    </listitem>
-    <listitem>
-     <simpara>
-      <constant>imagick::IMGTYPE_COLORSEPARATIONMATTE</constant>
-     </simpara>
-    </listitem>
-    <listitem>
-     <simpara>
-      <constant>imagick::IMGTYPE_OPTIMIZE</constant>
-     </simpara>
-    </listitem>
-   </itemizedlist>
-  </para>
+  <simpara>
+   Retourne l'une des constantes
+   <link linkend="imagick.constants.imagetype"><constant>imagick::IMGTYPE_<replaceable>*</replaceable></constant></link>
+   suivantes. <constant>imagick::IMGTYPE_UNDEFINED</constant> et
+   <constant>imagick::IMGTYPE_OPTIMIZE</constant> ne sont jamais retournées.
+  </simpara>
+  <itemizedlist>
+   <listitem>
+    <simpara>
+     <link linkend="imagick.constants.imgtype-bilevel"><constant>imagick::IMGTYPE_BILEVEL</constant></link>
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <link linkend="imagick.constants.imgtype-grayscale"><constant>imagick::IMGTYPE_GRAYSCALE</constant></link>
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <link linkend="imagick.constants.imgtype-grayscalematte"><constant>imagick::IMGTYPE_GRAYSCALEMATTE</constant></link>
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <link linkend="imagick.constants.imgtype-palette"><constant>imagick::IMGTYPE_PALETTE</constant></link>
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <link linkend="imagick.constants.imgtype-palettematte"><constant>imagick::IMGTYPE_PALETTEMATTE</constant></link>
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <link linkend="imagick.constants.imgtype-truecolor"><constant>imagick::IMGTYPE_TRUECOLOR</constant></link>
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <link linkend="imagick.constants.imgtype-truecolormatte"><constant>imagick::IMGTYPE_TRUECOLORMATTE</constant></link>
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <link linkend="imagick.constants.imgtype-colorseparation"><constant>imagick::IMGTYPE_COLORSEPARATION</constant></link>
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     <link linkend="imagick.constants.imgtype-colorseparationmatte"><constant>imagick::IMGTYPE_COLORSEPARATIONMATTE</constant></link>
+    </simpara>
+   </listitem>
+  </itemizedlist>
  </refsect1>
 
  <refsect1 role="errors">

--- a/reference/imagick/imagick/setimagetype.xml
+++ b/reference/imagick/imagick/setimagetype.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 0ffb9c9fc8f4bf1589a1a573644e1c23b6b451d1 Maintainer: yannick Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 0aa15a23a0b1457ab2545d7f38eb292fd2f4b66e Maintainer: yannick Status: ready -->
 
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="imagick.setimagetype">
  <refnamediv>
@@ -15,24 +13,35 @@
    <modifier>public</modifier> <type>bool</type><methodname>Imagick::setImageType</methodname>
    <methodparam><type>int</type><parameter>image_type</parameter></methodparam>
   </methodsynopsis>
-  <para>
-   Configure le type d'image.
-  </para>
+  <simpara>
+   Convertit l'image vers le type donné, qui combine un modèle colorimétrique
+   et la présence ou l'absence d'un canal alpha.
+   Selon le type, cela peut changer l'espace colorimétrique, quantifier les
+   couleurs, ou modifier la présence d'un canal alpha sur l'image.
+  </simpara>
+  <simpara>
+   <methodname>Imagick::setImageType</methodname> modifie l'image elle-même.
+   Pour définir à la place le type avec lequel les images suivantes seront
+   écrites, utiliser <methodname>Imagick::setType</methodname>.
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
   &reftitle.parameters;
-  <para>
-   <variablelist>
-    <varlistentry>
-     <term><parameter>image_type</parameter></term>
-     <listitem>
-      <para>
-      </para>
-     </listitem>
-    </varlistentry>
-   </variablelist>
-  </para>
+  <variablelist>
+   <varlistentry>
+    <term><parameter>image_type</parameter></term>
+    <listitem>
+     <simpara>
+      Une des constantes
+      <link linkend="imagick.constants.imagetype"><constant>imagick::IMGTYPE_<replaceable>*</replaceable></constant></link>.
+      <constant>imagick::IMGTYPE_UNDEFINED</constant> et
+      <constant>imagick::IMGTYPE_OPTIMIZE</constant> ne convertissent rien,
+      mais sont tout de même enregistrées sur l'image.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
  </refsect1>
 
  <refsect1 role="returnvalues">

--- a/reference/imagick/imagick/settype.xml
+++ b/reference/imagick/imagick/settype.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 0ffb9c9fc8f4bf1589a1a573644e1c23b6b451d1 Maintainer: yannick Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 0aa15a23a0b1457ab2545d7f38eb292fd2f4b66e Maintainer: yannick Status: ready -->
 
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="imagick.settype">
  <refnamediv>
@@ -15,24 +13,26 @@
    <modifier>public</modifier> <type>bool</type><methodname>Imagick::setType</methodname>
    <methodparam><type>int</type><parameter>image_type</parameter></methodparam>
   </methodsynopsis>
-  <para>
-   Configure l'attribut de l'image.
-  </para>
+  <simpara>
+   Définit le type d'image appliqué aux images écrites par la suite.
+   Pour convertir l'image courante à la place, utiliser
+   <methodname>Imagick::setImageType</methodname>.
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
   &reftitle.parameters;
-  <para>
-   <variablelist>
-    <varlistentry>
-     <term><parameter>image_type</parameter></term>
-     <listitem>
-      <para>
-      </para>
-     </listitem>
-    </varlistentry>
-   </variablelist>
-  </para>
+  <variablelist>
+   <varlistentry>
+    <term><parameter>image_type</parameter></term>
+    <listitem>
+     <simpara>
+      Une des constantes
+      <link linkend="imagick.constants.imagetype"><constant>imagick::IMGTYPE_<replaceable>*</replaceable></constant></link>.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
  </refsect1>
 
  <refsect1 role="returnvalues">


### PR DESCRIPTION
Translation of php/doc-en#5826 (commit 0aa15a23a0): the `IMGTYPE_*` constants had empty descriptions, so each one now states the conversion `SetImageType()` performs, and the group explains that `MATTE` is the ImageMagick 6 name for the alpha channel. Adds the missing `IMGTYPE_PALETTEBILEVELMATTE` constant, distinguishes `setType()` from `setImageType()`, and corrects `getImageType()`, which described its return value as a "potential" type.

Also drops the leftover `$Revision$` and `Reviewed` markers. EN-Revision updated.

Fixes: #3514