### PR TITLE
[Sync-En] ext/intl: clarify Locale::getKeywords return values and empty locale

### DIFF
--- a/reference/intl/locale/get-keywords.xml
+++ b/reference/intl/locale/get-keywords.xml
@@ -1,11 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 1976eae0d815797af97a1e16c5cd90ffc2868395 Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: d8de774ae203bccf3ffe02895d8c8fc754377451 Maintainer: yannick Status: ready -->
 <refentry xml:id="locale.getkeywords" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Locale::getKeywords</refname>
   <refname>locale_get_keywords</refname>
-  <refpurpose>Lit les mots-clé de la locale</refpurpose>
+  <refpurpose>Lit les mots-clés de la locale</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -25,7 +24,7 @@
    <methodparam><type>string</type><parameter>locale</parameter></methodparam>
   </methodsynopsis>
   <para>
-   Lit les mots-clé de la locale. 
+   Lit les mots-clés de la locale.
   </para>
  </refsect1>
 
@@ -36,9 +35,11 @@
     <varlistentry>
      <term><parameter>locale</parameter></term>
      <listitem>
-      <para>
-       La locale dont il faut extraire les mots-clé.
-      </para>
+      <simpara>
+       La locale dont il faut extraire les mots-clés. Si une chaîne vide est
+       fournie, la valeur retournée par <function>locale_get_default</function>
+       est utilisée à la place.
+      </simpara>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -47,9 +48,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
-   Un &array; associatif contenant les paires clé-valeur pour cette locale.
-  </para>
+  <simpara>
+   Un &array; associatif contenant les paires clé-valeur pour cette locale,
+   &null; si la locale n'a pas de mots-clés, ou &false; en cas d'échec.
+  </simpara>
   &intl.locale-len.return;
  </refsect1>
 
@@ -61,7 +63,7 @@
 <![CDATA[
 <?php
 $keywords_arr = locale_get_keywords('de_DE@currency=EUR;collation=PHONEBOOK');
-if ($keywords_arr) {
+if (is_array($keywords_arr)) {
     foreach ($keywords_arr as $key => $value) {
         echo "$key = $value\n";
     }
@@ -76,7 +78,7 @@ if ($keywords_arr) {
 <![CDATA[
 <?php
 $keywords_arr = Locale::getKeywords('de_DE@currency=EUR;collation=PHONEBOOK');
-if ($keywords_arr) {
+if (is_array($keywords_arr)) {
     foreach ($keywords_arr as $key => $value) {
         echo "$key = $value\n";
     }
@@ -99,6 +101,8 @@ currency = EUR
   <para>
    <simplelist>
     <member><function>locale_get_all_variants</function></member>
+    <member><function>locale_get_default</function></member>
+    <member><function>locale_set_default</function></member>
    </simplelist>
   </para>
  </refsect1>


### PR DESCRIPTION
Translation of php/doc-en#5844 (commit d8de774): the `locale` parameter now documents the empty string falling back to `locale_get_default()`, the return section mentions `null` and `false`, the examples use `is_array()`, and two entries are added to the see also list. EN-Revision updated.

Also fixed a plural agreement on "mots-clés" and dropped the obsolete `Reviewed` marker in the same file.

Fixes: #3520