### PR TITLE
[Sync-En] context.http: document the uri_parser_class option added in PHP 8.5

### DIFF
--- a/language/context/http.xml
+++ b/language/context/http.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 3abd17e61d5022d503604cc06894254e3281acf5 Maintainer: jpauli Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: aa42c6da04101f58317a901ccc38ee0d1faeab47 Maintainer: jpauli Status: ready -->
 
 <refentry xml:id="context.http" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" annotations="verify_info:false" role="stream_context_option">
  <refnamediv>
@@ -11,12 +10,12 @@
  <refsect1 role="description">
   &reftitle.description;
   <para>
-  Options de contexte pour les protocoles <literal>http://</literal> 
-  et <literal>https://</literal>.
+   Options de contexte pour les protocoles <literal>http://</literal>
+   et <literal>https://</literal>.
   </para>
  </refsect1>
 
- <refsect1 role="options"><!-- {{{ -->
+ <refsect1 role="options">
   &reftitle.options;
   <para>
    <variablelist>
@@ -68,7 +67,7 @@
      <listitem>
       <para>
        Valeur à envoyer avec l'en-tête <literal>User-Agent:</literal>. Cette valeur
-       ne doit être utilisée que si l'agent utilisateur n'est <emphasis>pas</emphasis>
+       ne sera utilisée que si l'agent utilisateur n'est <emphasis>pas</emphasis>
        spécifié dans l'option de contexte <literal>header</literal> ci-dessus.
       </para>
       <para>
@@ -161,7 +160,7 @@
       </para>
       <para>
        Par défaut, vaut <literal>1.1</literal> à partir de PHP 8.0.0 ;
-       antérieur à cette version, la valeur par défaut était <literal>1.0</literal>.
+       avant cette version, la valeur par défaut était <literal>1.0</literal>.
       </para>
      </listitem>
     </varlistentry>
@@ -196,14 +195,56 @@
       </para>
      </listitem>
     </varlistentry>
+    <varlistentry xml:id="context.http.uri-parser-class">
+     <term>
+      <parameter>uri_parser_class</parameter>
+      <type>string</type> ou <type>null</type>
+     </term>
+     <listitem>
+      <simpara>
+       La classe à utiliser pour analyser les URI. Lorsque cette option vaut
+       &null;, le comportement historique fondé sur
+       <function>parse_url</function> est utilisé. Les valeurs acceptées sont
+       <classname>Uri\Rfc3986\Uri</classname> (analyseur conforme à la
+       RFC 3986) et <classname>Uri\WhatWg\Url</classname> (analyseur conforme
+       au standard WHATWG URL). Les implémentations personnalisées écrites en
+       PHP ne sont pas supportées.
+      </simpara>
+      <simpara>
+       Par défaut, vaut &null;.
+      </simpara>
+     </listitem>
+    </varlistentry>
    </variablelist>
   </para>
- </refsect1><!-- }}} -->
+ </refsect1>
 
- <refsect1 role="examples"><!-- {{{ -->
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       L'option <parameter>uri_parser_class</parameter> a été ajoutée.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+
+ <refsect1 role="examples">
   &reftitle.examples;
   <para>
-   <example xml:id="context.http.example-post"><!-- {{{ -->
+   <example xml:id="context.http.example-post">
     <title>Récupération d'une page et envoi de données POST</title>
     <programlisting role="php">
 <![CDATA[
@@ -231,10 +272,10 @@ $result = file_get_contents('http://example.com/submit.php', false, $context);
 ?>
 ]]>
     </programlisting>
-   </example><!-- }}} -->
+   </example>
   </para>
   <para>
-   <example xml:id="context.http.example-fetch-ignore-redirect"><!-- {{{ -->
+   <example xml:id="context.http.example-fetch-ignore-redirect">
     <title>Ignore les redirections mais récupère les en-têtes et le contenu</title>
     <programlisting role="php">
 <![CDATA[
@@ -256,15 +297,15 @@ $stream = fopen($url, 'r', false, $context);
 // informations sur les en-têtes et métadonnées du flux
 var_dump(stream_get_meta_data($stream));
 
-// données actuelles de $url
+// données réelles de $url
 var_dump(stream_get_contents($stream));
 fclose($stream);
 ?>
 ]]>
     </programlisting>
-   </example><!-- }}} -->
+   </example>
   </para>
- </refsect1><!-- }}} -->
+ </refsect1>
 
  <refsect1 role="notes">
   &reftitle.notes;
@@ -284,9 +325,9 @@ fclose($stream);
    <title>Ligne de statut HTTP</title>
    <simpara>
     Lorsque ce gestionnaire de flux suit une redirection,
-    <literal>wrapper_data</literal>, retourné par la fonction
-    <function>stream_get_meta_data</function> ne doit pas contenir
-    obligatoirement la ligne de statut HTTP qui s'applique à des
+    le <literal>wrapper_data</literal> retourné par la fonction
+    <function>stream_get_meta_data</function> ne contient pas
+    nécessairement la ligne de statut HTTP qui s'applique aux
     données de contenu à l'index <literal>0</literal>.
    </simpara>
    <screen>


### PR DESCRIPTION
Translation of php/doc-en#5843 (commit aa42c6d): adds the `uri_parser_class` HTTP context option and the changelog section for PHP 8.5.0. The skeleton comments removed upstream in the meantime are dropped too, since the file now mirrors that revision. EN-Revision updated.

Fixed a few wrong sentences in the same file along the way (a "must not necessarily contain" that reversed the English meaning, an "actual data" translated as "données actuelles", and a couple of agreement issues).

Fixes: #3521