### PR TITLE
[Sync-En] htmlspecialchars: add the ENT_IGNORE/ENT_SUBSTITUTE example with invalid UTF-8 bytes

### DIFF
--- a/reference/strings/functions/htmlspecialchars.xml
+++ b/reference/strings/functions/htmlspecialchars.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: eabde0419cf90f596f60db00e31fcb6ebe41ac55 Maintainer: yannick Status: ready -->
-<!-- Reviewed: no -->
+<!-- EN-Revision: a9d052e2db27dd26e5f77b13ca03f0e9d352db5a Maintainer: yannick Status: ready -->
 <refentry xml:id="function.htmlspecialchars" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>htmlspecialchars</refname>
@@ -20,9 +19,9 @@
    Certains caractères ont des significations spéciales en HTML,
    et doivent être remplacés par des entités HTML pour conserver
    leurs significations. Cette fonction retourne une chaîne de caractères
-   avec ces modifications. En cas de besoin que toutes
+   avec ces modifications. S'il faut que toutes
    les sous-chaînes en entrée qui sont associées à des entités
-   nommées soient transformées, utiliser la fonction
+   nommées soient transformées, utiliser plutôt la fonction
    <function>htmlentities</function>.
   </para>
   <para>
@@ -31,10 +30,10 @@
    préparer l'entrée pour une inclusion dans la plupart des contextes
    d'un document HTML. Si cependant, l'entrée peut présenter des caractères
    qui ne sont pas codés dans le jeu de caractères du document final,
-   et que l'on souhaite épargner ces caractères (comme des numériques ou
-   des entités nommées), cette fonction et la fonction <function>htmlentities</function>
+   et que l'on souhaite conserver ces caractères (sous forme d'entités
+   numériques ou nommées), cette fonction et la fonction <function>htmlentities</function>
    (qui n'encode que les sous-chaînes qui ont des entités nommées équivalentes)
-   ne sont pas suffisantes. Il faut utiliser la fonction
+   peuvent ne pas être suffisantes. Il faut alors peut-être utiliser la fonction
    <function>mb_encode_numericentity</function> à la place.
   </para>
   <para>
@@ -54,7 +53,7 @@
       </row>
       <row>
        <entry><literal>&quot;</literal> (double guillemet)</entry>
-       <entry><literal>&amp;quot;</literal> sauf si <constant>ENT_NOQUOTES</constant></entry>
+       <entry><literal>&amp;quot;</literal> sauf si <constant>ENT_NOQUOTES</constant> est défini</entry>
       </row>
       <row>
        <entry><literal>'</literal> (simple guillemet)</entry>
@@ -96,7 +95,7 @@
      <term><parameter>flags</parameter></term>
      <listitem>
       <para>
-       Un masque bit d'un ou plusieurs drapeaux suivants, qui déterminent la façon
+       Un masque de bits d'un ou plusieurs des drapeaux suivants, qui déterminent la façon
        dont les guillemets seront gérés, dont les séquences de code invalide seront
        gérées ainsi que le type du document utilisé. Par défaut, c'est
        <literal>ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401</literal>.
@@ -142,8 +141,8 @@
           <row>
            <entry><constant>ENT_DISALLOWED</constant></entry>
            <entry>
-            Remplace les points du code invalides du document fourni avec
-            un caractère de remplacement Unicode U+FFFD (UTF-8) ou &amp;#xFFFD;
+            Remplace les points de code invalides pour le type de document fourni
+            par un caractère de remplacement Unicode U+FFFD (UTF-8) ou &amp;#xFFFD;
             (sinon) au lieu de les laisser tels quels. Ceci peut être utile pour,
             par exemple, s'assurer du bon formatage de documents XML contenant
             du contenu externe.
@@ -202,7 +201,7 @@
      <listitem>
       <para>
        Lorsque le paramètre <parameter>double_encode</parameter> est désactivé,
-       PHP n'encodera pas les entités html existantes ; par défaut, tout est converti.
+       PHP n'encodera pas les entités HTML existantes ; par défaut, tout est converti.
       </para>
      </listitem>
     </varlistentry>
@@ -262,6 +261,27 @@ echo $new; // &lt;a href=&#039;test&#039;&gt;Test&lt;/a&gt;
     </programlisting>
    </example>
   </para>
+  <para>
+   <example>
+    <title><constant>ENT_IGNORE</constant> et <constant>ENT_SUBSTITUTE</constant> avec des séquences UTF-8 invalides</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+// "\x80" n'est pas une séquence d'octets UTF-8 valide.
+$input = "atta\x80ck";
+
+// ENT_IGNORE supprime silencieusement l'octet invalide - résultat : "attack"
+echo bin2hex(htmlspecialchars($input, ENT_QUOTES | ENT_IGNORE, 'UTF-8')), "\n";
+// 61747461636b
+
+// ENT_SUBSTITUTE remplace l'octet invalide par U+FFFD - résultat : "atta" + caractère de remplacement + "ck"
+echo bin2hex(htmlspecialchars($input, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8')), "\n";
+// 61747461efbfbd636b
+?>
+]]>
+    </programlisting>
+   </example>
+  </para>
  </refsect1>
 
  <refsect1 role="notes">
@@ -284,7 +304,7 @@ echo $new; // &lt;a href=&#039;test&#039;&gt;Test&lt;/a&gt;
       <simpara>
        Quand aucun de <constant>ENT_COMPAT</constant>,
        <constant>ENT_QUOTES</constant>,
-       <constant>ENT_NOQUOTES</constant> est présent,
+       <constant>ENT_NOQUOTES</constant> n'est présent,
        la valeur par défaut est <constant>ENT_NOQUOTES</constant>.
       </simpara>
      </listitem>
@@ -301,7 +321,7 @@ echo $new; // &lt;a href=&#039;test&#039;&gt;Test&lt;/a&gt;
       <simpara>
        Quand aucun de <constant>ENT_HTML401</constant>,
        <constant>ENT_HTML5</constant>,
-       <constant>ENT_XHTML</constant>, <constant>ENT_XML1</constant> est présent,
+       <constant>ENT_XHTML</constant>, <constant>ENT_XML1</constant> n'est présent,
        la valeur par défaut est <constant>ENT_HTML401</constant>.
       </simpara>
      </listitem>


### PR DESCRIPTION
Translation of php/doc-en#5841 (commit a9d052e): adds the second example contrasting `ENT_IGNORE` and `ENT_SUBSTITUTE` on an invalid UTF-8 byte. Output checked against PHP 8.5. EN-Revision updated.

Fixed a few wrong sentences in the same file along the way: "(as numeric or named entities)" had become "comme des numériques ou des entités nommées", "may be insufficient" had lost its modality, "invalid code points for the given document type" had dropped the document type, and two negations were missing their "ne".

Fixes: #3522