### PR TITLE
[Sync-En] pcre: expand the description of the ? meta-character

### DIFF
--- a/reference/pcre/pattern.syntax.xml
+++ b/reference/pcre/pattern.syntax.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: b55141fe2d4f601e32555c33fb00e1f9225c4638 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: c414a81646ee424d1814725f54ec86b9a8f6b434 Maintainer: lacatoire Status: ready -->
 
 <chapter xml:id="reference.pcre.pattern.syntax" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Syntaxe des masques</title>
@@ -76,7 +76,7 @@
     </programlisting>
    </informalexample>
    Les délimiteurs utilisant les crochets n'ont pas besoin d'être échappés lorsqu'ils
-   sont utilisés comme caractères méta dans un masque, mais, comme tout autre opérateur,
+   sont utilisés comme caractères méta dans un masque, mais, comme les autres délimiteurs,
    ils doivent être échappés s'ils sont utilisés comme caractères littéraux.
   </para>
   <para>
@@ -162,8 +162,17 @@
        <entry>)</entry><entry>Caractère de fin de sous-masque</entry>
       </row>
       <row>
-       <entry>?</entry><entry>Étend le sens de (; quantificateur de 0 ou 1; quantificateur de minimisation
-       (Voir les <link linkend="regexp.reference.repetition">répétitions</link>)</entry>
+       <entry>?</entry>
+       <entry>
+        Introduit une construction particulière, comme un groupe non capturant, un
+        sous-masque nommé, une assertion ou une modification d'option, s'il est
+        utilisé comme premier caractère après <literal>(</literal>.
+        Utilisé comme quantificateur, c'est le quantificateur optionnel (équivalent
+        à <literal>{0,1}</literal>).
+        Il transforme également les quantificateurs gourmands en quantificateurs
+        non gourmands
+        (voir les <link linkend="regexp.reference.repetition">répétitions</link>).
+       </entry>
       </row>
       <row>
        <entry>*</entry><entry>Quantificateur de 0 ou plus</entry>
@@ -187,7 +196,7 @@
    les seuls métacaractères autorisés sont :
    
    <table>
-     <title>Meta-characters dans des crochets (<emphasis>classes de caractères</emphasis>)</title>
+     <title>Métacaractères dans des crochets (<emphasis>classes de caractères</emphasis>)</title>
     <tgroup cols="2">
      <thead>
       <row>
@@ -402,7 +411,7 @@
    sur les parenthèses des sous masques.
   </para>
   <para>
-   À l'intérieur d'un caractère de classe ou s'il est plus
+   À l'intérieur d'une classe de caractères ou s'il est plus
    grand que 9, et qu'il n'y a pas eu assez de parenthèses ouvrantes
    auparavant, PCRE lit jusqu'à 3 chiffres octaux à la suite
    de l'antislash, et génère un octet unique, à partir
@@ -441,7 +450,7 @@
      <term><emphasis>\11</emphasis></term>
      <listitem>
       <simpara>
-       peut être une référence de retour,
+       peut être une référence arrière,
        ou une tabulation
       </simpara>
      </listitem>
@@ -466,7 +475,7 @@
      <term><emphasis>\113</emphasis></term>
      <listitem>
       <simpara>
-       est le caractère 113 (étant donné qu'il ne
+       est le caractère de code octal 113 (étant donné qu'il ne
        peut y avoir plus de 99 références arrière)
       </simpara>
      </listitem>
@@ -693,7 +702,7 @@
    l'intérieur d'une classe de caractères).
   </para>
   <para>
-   Une limite de mot est un emplacement dans la chaîne sujet ou un
+   Une limite de mot est un emplacement dans la chaîne sujet où un
    caractère et son suivant ne sont pas en même temps des
    caractères de mot (<literal>\w</literal>), ou le contraire (<literal>\W</literal>)
    (on peut le voir comme <literal>\w\W</literal> ou <literal>\W\w</literal>), ou encore le
@@ -725,7 +734,7 @@
    <literal>\Q</literal> et <literal>\E</literal> peuvent être utilisés
    pour ignorer les métacaractères dans le masque.
    Par exemple : <literal>\w+\Q.$.\E$</literal> recherchera un ou plusieurs
-   caractères suivis par la chaîne littérale <literal>.$.</literal> et ancrés à la
+   caractères de mot suivis par la chaîne littérale <literal>.$.</literal> et ancrés à la
    fin de la chaîne.
    Il est à noter que ceci ne change pas le comportement des délimiteurs ;
    par exemple le masque <literal>#\Q#\E#$</literal> n'est pas valide, car
@@ -733,8 +742,8 @@
    <literal>\E#</literal> est interprété comme un modificateur invalide.
   </para>
   <para>
-   <literal>\K</literal> peut être utilisé pour réinitialiser le résultat
-   Par exemple, le masque <literal>foo\Kbar</literal> trouve
+   <literal>\K</literal> peut être utilisé pour réinitialiser le début de la
+   correspondance. Par exemple, le masque <literal>foo\Kbar</literal> trouve
    "foobar", mais reporte qu'il a trouvé "bar". L'utilisation de
    <literal>\K</literal> n'interfère pas avec la configuration des sous-chaînes capturantes.
    Par exemple, lorsque le masque <literal>(foo)\Kbar</literal>
@@ -1176,7 +1185,7 @@
    pour former un seul glyphe. Dans les faits, cela revient à utiliser
    le caractère <literal>.</literal> sachant qu'il va matcher un
    caractère composé, peu importe le nombre de caractères individuels
-   nécessaire à l'afficher.
+   nécessaires pour l'afficher.
   </para>
   <simpara>
    Dans les versions PCRE inférieures à 8.32 (ce qui correspond aux
@@ -1187,7 +1196,7 @@
    caractères possédant la propriété "mark", et traitait la séquence
    comme un groupe atomique (voir <xref linkend="regexp.reference.onlyonce"/>).
    Les caractères avec la propriété "mark" sont typiquement les lettres
-   accentuées qui affectent le caractère qui la précède.
+   accentuées qui affectent le caractère qui les précède.
   </simpara>
   <para>
    La recherche de caractères par les propriétés Unicode n'est pas la méthode
@@ -1219,15 +1228,11 @@
    <literal>$</literal> est une assertion qui n'est vraie que si elle
    est placée tout en fin de chaîne ou juste avant un
    caractère de nouvelle ligne qui serait le dernier
-   caractère de la chaîne. À l'intérieur d'une
-   classe de caractères, <literal>$</literal> a un tout autre
-   sens (voir ci-dessous).
+   caractère de la chaîne (par défaut).
    <literal>$</literal> n'a pas besoin d'être le dernier
    caractère du masque, si plusieurs alternatives sont
    proposées, mais il doit être placé en dernier
-   dans chaque alternative. Si toutes les alternatives finissent par
-   <literal>$</literal>, alors le masque est dit ancré (il y
-   a une autre construction qui porte cette appellation). <literal>$</literal>
+   dans chaque alternative où il apparaît. <literal>$</literal>
    n'a pas de valeur particulière dans une classe de
    caractères.
   </para>
@@ -1373,7 +1378,7 @@
    <literal>\D</literal>, <literal>\S</literal>, <literal>\s</literal>,
    <literal>\w</literal>, <literal>\W</literal> peuvent aussi intervenir
    dans les classes de caractères. Par exemple,
-   "<literal>[][\^_`wxyzabc][\dABCDEF]</literal>" acceptera n'importe
+   "<literal>[\dABCDEF]</literal>" acceptera n'importe
    quel caractère hexadécimal. Un accent circonflexe peut
    aussi être utilisé pour spécifier adroitement
    des ensembles de caractères plus restrictifs : par exemple
@@ -1382,7 +1387,7 @@
   </para>
   <para>
    Tous les caractères non alphanumériques autres que 
-   <literal>\, -, ^</literal> (placés en début de chaîne) 
+   <literal>\, -, ^</literal> (placé en début de classe)
    et <literal>]</literal> n'ont pas de signification 
    particulière, mais ils ne perdront rien à être protégés.
    Le délimiteur de motif est toujours spécial, et doit être 
@@ -1473,9 +1478,11 @@
   </para>
   <para>
    Les propriétés des caractères Unicode peuvent apparaître à l'intérieur d'une
-   classe de caractère. Ils ne peuvent pas faire partie d'une étendue.
-   Le caractère moins (tiret) après une classe de caractère Unicode satisfera littéralement.
-   Essayer de terminer une étendue avec une propriété de caractère Unicode résultera en un avertissement.
+   classe de caractères. Elles ne peuvent pas faire partie d'un intervalle.
+   Le caractère moins (tiret) placé après une classe de caractères Unicode
+   sera pris littéralement.
+   Essayer de terminer un intervalle par une propriété de caractère Unicode
+   produit un avertissement.
   </para>
  </section>
  
@@ -1483,7 +1490,7 @@
   <title>Alternatives</title>
   <para>
    La barre verticale <literal>|</literal> sert à séparer des
-   alternatives. Par exemple, dans le masque "<literal>/dupont|martin/</literal>"
+   alternatives. Par exemple, le masque "<literal>/dupont|martin/</literal>"
    recherche soit "<literal>dupont</literal>", soit "<literal>martin</literal>".
    Le nombre d'alternatives n'est pas limité, et il est même possible
    d'utiliser la chaîne vide. Lors de la recherche, toutes les alternatives
@@ -1584,7 +1591,8 @@
    linkend="reference.pcre.pattern.modifiers">PCRE_CASELESS</link> n'est pas
    utilisé). Cela signifie que les options permettent d'avoir
    différentes configurations de recherche pour différentes parties du masque.
-   Une séquence d'options dans une alternative affecte toute l'alternative.
+   Toute option modifiée dans une alternative reste active dans les alternatives
+   suivantes du même sous-masque.
    Par exemple :
    
    <literal>(a(?i)b|c)</literal>
@@ -1626,10 +1634,10 @@
    <listitem>
     <para>
      Cela configure le sous-masque comme capturant. Lorsque tout le motif
-     correspond, la portion de la sous-chaîne qui correspond au sous-masque
-     est passé à l'appelant grâce à l'argument <emphasis>ovector</emphasis>
+     correspond, la portion de la chaîne sujet qui correspond au sous-masque
+     est passée à l'appelant grâce à l'argument <emphasis>ovector</emphasis>
      de <function>pcre_exec</function>. Les parenthèses ouvrantes sont comptées
-     depuis la gauche vers la droite (commençant à 1) jusqu'à obtenir le nombre
+     depuis la gauche vers la droite (en commençant à 1) pour obtenir les numéros
      des sous-masques capturants.
     </para>
    </listitem>
@@ -1651,7 +1659,7 @@
    avec la chaîne "<literal>le prince charmant</literal>", utilisé
    avec le masque
    
-   <literal>Le (( ?:roi|prince) (soleil|charmant))</literal>
+   <literal>Le ((?:roi|prince) (soleil|charmant))</literal>
    
    les chaînes capturées seront "<literal>prince charmant</literal>"
    et "<literal>charmant</literal>", numérotés respectivement 1
@@ -1678,10 +1686,10 @@
   <para>
    captureront exactement les mêmes chaînes. Du fait que les branches
    alternatives sont testées de la gauche vers la droite, et que les
-   options ne sont pas réinitialisées tant que le sous masque n'est pas
-   atteint, une option de configuration d'une branche n'affecte pas
-   les branches sous-jacentes ; ainsi, les 2 masques ci-dessus
-   captureront <literal>"SAMEDI"</literal>, mais aussi 
+   options ne sont pas réinitialisées tant que la fin du sous-masque n'est pas
+   atteinte, une option de configuration d'une branche affecte bien
+   les branches suivantes ; ainsi, les 2 masques ci-dessus
+   acceptent <literal>"DIMANCHE"</literal>, mais aussi
    <literal>"Samedi"</literal>.
   </para>
   <para>
@@ -1701,7 +1709,7 @@
   <para>
    Quelques fois, il est nécessaire d'avoir plusieurs correspondances en alternant
    les sous groupes dans une expression régulière. Normalement, chacun recevra son
-   propre nombre de références arrière même si seulement un d'entre eux ne peut
+   propre numéro de référence arrière alors qu'un seul d'entre eux pourra
    correspondre. Pour éviter cela, la syntaxe <literal>(?|</literal> permet d'autoriser
    les nombres dupliqués. Soit l'expression ci-après utilisée avec la chaîne
    <literal>Sunday</literal>:
@@ -1790,7 +1798,7 @@
    ignorée.
   </para>
   <para>
-   Par convenance (et pour la compatibilité ascendante), les trois
+   Par commodité (et pour la compatibilité historique), les trois
    quantificateurs les plus communs ont une abréviation d'un
    seul caractère :
    <table>
@@ -1878,8 +1886,8 @@
   <para>
    Les quantificateurs suivis par <literal>+</literal> sont "possessifs". Ils
    mangent autant de caractères que possible et ne retournent pas
-   pour chercher le reste du masque. <literal>.*abc</literal> trouvera 
-   <literal>"abc"</literal>, tandis que <literal>.*+abc</literal> ne le trouvera
+   pour chercher le reste du masque. <literal>.*abc</literal> trouvera
+   <literal>"aabc"</literal>, tandis que <literal>.*+abc</literal> ne le trouvera
    pas, car <literal>.*+</literal> accapare totalement la chaîne.
    Les quantificateurs possessifs peuvent être utilisés pour 
    accélérer le traitement.
@@ -1899,7 +1907,7 @@
    lignes par un métacaractère, alors le masque est
    implicitement ancré, car tout ce qui suit va être
    mangé par la première séquence, et se comportera
-   comme si le masque se terminait par le métacaractère
+   comme si le masque était précédé du métacaractère
    <literal>\A</literal>. Dans le cas où on sait d'avance qu'il
    n'y aura pas de caractère de nouvelle ligne, activer l'option
    <link linkend="reference.pcre.pattern.modifiers">PCRE_DOTALL</link> et commencer
@@ -1911,10 +1919,10 @@
    Lorsqu'un sous-masque capturant est répété, la valeur capturée est la
    dernière. Par exemple, après que
    
-   <literal>(inter[net]{3}\s*)+</literal>
+   <literal>(tweedle[dume]{3}\s*)+</literal>
    
-   ait été appliqué à "<literal>internet interne</literal>",
-   la valeur de la chaîne capturée est "<literal>interne</literal>".
+   ait été appliqué à "<literal>tweedledum tweedledee</literal>",
+   la valeur de la chaîne capturée est "<literal>tweedledee</literal>".
    Cependant, s'il y a des sous-masques imbriqués, la valeur
    capturée correspondante peut l'avoir été lors
    des précédentes itérations. Par exemple :
@@ -1931,7 +1939,8 @@
   <para>
    En dehors des classes de caractères, un antislash suivi
    d'un nombre plus grand que 0 (et possiblement plusieurs chiffres)
-   est une référence arrière (c'est-à-dire vers la gauche) dans le masque,
+   est une référence arrière vers un sous-masque capturant situé plus tôt
+   (c'est-à-dire à sa gauche) dans le masque,
    en supposant qu'il y ait
    suffisamment de sous-masques capturants précédents.
   </para>
@@ -1940,14 +1949,13 @@
    plus petit que 10, il sera toujours considéré
    comme une référence arrière, et cela
    générera une erreur si le nombre de captures
-   n'est pas suffisant. En d'autres termes, il faut qu'il existe
-   suffisamment de parenthèses ouvrantes à gauche
-   de la référence, surtout si la référence
-   est inférieure à 10. Une "référence arrière vers l'avant" peut avoir du sens
-   lorsqu'une répétition est isolée et que le sous masque à droite a participé
-   à l'itération précédente. Voir la section sur les
-   <link linkend="regexp.reference.escape">séquences d'échappements</link>
-   pour plus de détails à propos du nombre de chiffres qui suivent l'antislash.
+   n'est pas suffisant. En d'autres termes, pour les nombres inférieurs à 10,
+   les parenthèses référencées n'ont pas besoin de se trouver à gauche
+   de la référence. Une "référence arrière vers l'avant" peut avoir du sens
+   lorsqu'une répétition est en jeu et que le sous-masque situé à droite a
+   participé à une itération précédente. Voir la section sur les
+   <link linkend="regexp.reference.escape">séquences d'échappement</link>
+   pour plus de détails sur le traitement des chiffres qui suivent l'antislash.
   </para>
   <para>
    La référence arrière remplace ce qui a
@@ -2004,7 +2012,7 @@
    "<literal>(a|b\1)+</literal>" pourra convenir pour "<literal>a</literal>",
    "<literal>aba</literal>", "<literal>ababba</literal>", etc.
    À chaque itération du sous-masque, la référence
-   arrière utilise le résultat du dernier sous-masque.
+   arrière utilise la chaîne trouvée à l'itération précédente.
    Pour que cela fonctionne, il faut que la première
    itération n'ait pas besoin d'utiliser la référence
    arrière. Cela arrive avec les alternatives, comme dans
@@ -2017,9 +2025,9 @@
    ou négatif, entouré optionnellement par des accolades. La séquence
    <literal>\1</literal>, <literal>\g1</literal> et <literal>\g{1}</literal>
    sont identiques. L'utilisation de ce masque avec un nombre non signé peut
-   aider à ne pas le confondre lors de l'utilisation de nombre suivi d'un
+   aider à lever l'ambiguïté inhérente aux chiffres qui suivent un
    antislash. Cette séquence aide à distinguer les références arrière
-   lors de l'utilisation de caractères octaux et rend également plus facile
+   des caractères octaux et rend également plus facile
    d'avoir une référence arrière suivie par un nombre littéral, c.-à-d.
    <literal>\g{2}1</literal>.
   </para>
@@ -2027,9 +2035,9 @@
    L'utilisation de la séquence <literal>\g</literal> avec un nombre négatif
    indique une référence relative. Par exemple, <literal>(foo)(bar)\g{-1}</literal>
    trouvera la séquence "foobarbar" et <literal>(foo)(bar)\g{-2}</literal> trouvera
-   la séquence "foobarfoo". Ceci peut être pratique dans ce gros masque
-   comme alternative afin de conserver une trace du nombre de sous-masques
-   afin de référencer un sous-masque précédant spécifique.
+   la séquence "foobarfoo". Ceci peut être pratique dans les longs masques,
+   comme alternative au fait de tenir le compte des sous-masques pour
+   référencer un sous-masque précédent particulier.
   </para>
   <para>
    Les références arrière du sous-masque nommé peuvent être
@@ -2108,12 +2116,12 @@
 
    L'implémentation des assertions arrière déplace
    temporairement le pointeur de position vers l'arrière, et cherche
-   à vérifier l'assertion. Si le nombre de caractères
-   est différent, la position ne sera pas correcte, et l'assertion
-   échouera. La combinaison d'assertions arrière avec des
-   sous-masques peut être particulièrement pratique à
-   fin des chaînes. Un exemple est donné à la fin de
-   cette section.
+   à vérifier l'assertion. S'il n'y a pas assez de caractères avant la
+   position courante, l'assertion échoue.
+   La combinaison d'assertions arrière avec des sous-masques à utilisation
+   unique est particulièrement pratique pour effectuer une recherche en fin
+   de chaîne ; un exemple est donné à la fin de la section sur les
+   sous-masques à utilisation unique.
   </simpara>
   <simpara>
    Avant PHP 8.4.0, qui intègre PCRE2 10.44, le contenu d'une assertion
@@ -2191,12 +2199,13 @@
    Les assertions ne sont pas capturantes, et ne peuvent pas être
    répétées. Si une assertion contient des sous-masques
    capturants en son sein, ils seront compris dans le nombre de sous-masques
-   capturants du masque entier. La capture est réalisée pour
-   les assertions positives, mais cela n'a pas de sens pour les
+   capturants du masque entier. La capture n'est cependant réalisée que pour
+   les assertions positives, car cela n'a pas de sens pour les
    assertions négatives.
   </para>
   <para>
-   200 assertions au maximum sont autorisées.
+   Les assertions comptent dans le maximum de 200 sous-masques entre
+   parenthèses.
   </para>
  </section>
  
@@ -2229,7 +2238,8 @@
    permettrait d'indiquer que lorsqu'une partie du masque est trouvée,
    elle n'a pas besoin d'être réévaluée à chaque tentative. Ceci
    conduirait à ce que la recherche échoue immédiatement après le
-   premier test. Ces assertions ont leur propre notation, commençant avec
+   premier test. Cette notation est un autre type de parenthèse particulière,
+   commençant avec
    <literal>(?&gt;</literal> comme ceci :
    
    <literal>(?&gt;\d+)bar</literal>
@@ -2241,9 +2251,9 @@
    revenir plus loin en arrière.
   </para>
   <para>
-   Une autre description est que les sous-masques de ce type
-   recherchent les chaînes de caractères, et ancre le sous-masque
-   à l'intérieur de la chaîne.
+   Une autre description est que les sous-masques de ce type acceptent
+   la chaîne de caractères qu'accepterait un masque autonome identique,
+   ancré à la position courante dans la chaîne sujet.
   </para>
   <para>
    Les sous-masques uniques ne sont pas capturants. Des cas simples comme
@@ -2325,8 +2335,8 @@
    
    <literal>((?&gt;\D+)|&lt;\d+&gt;)*[!?]</literal>
    
-   les séquences de chiffres ne peuvent pas être
-   trouvées, et l'échec intervient rapidement.
+   les séquences de non-chiffres ne peuvent plus être découpées,
+   et l'échec intervient rapidement.
   </para>
  </section>
  
@@ -2381,13 +2391,13 @@
    Si une parenthèse ouvrante a été trouvée,
    elle a été capturée, et donc la première capture
    existe, et la condition est exécutée. Sinon, elle est
-   ignorée. Ce masque recherche donc une séquence de lettres,
-   éventuellement placées entre parenthèses.
+   ignorée. Ce masque recherche donc une séquence de caractères qui ne sont
+   pas des parenthèses, éventuellement placée entre parenthèses.
   </para>
   <para>
    Si la condition est la chaîne <literal>(R)</literal>, elle sera
    satisfaite si un appel récursif au masque ou au sous-masque
-   a été fait. Au premier appel, la condition n'est pas vérifiée.
+   a été fait. Au niveau le plus haut, la condition est fausse.
   </para>
   <para>
    Si la condition n'est pas une séquence de chiffres, il faut que ce soit
@@ -2406,7 +2416,7 @@
   </informalexample>
   <para>
    La condition est une assertion avant positive, qui recherche une
-   séquence optionnelle de caractères non-lettre. En d'autres
+   séquence optionnelle de caractères non-lettre suivie d'une lettre. En d'autres
    termes, elle teste la présence d'au moins une lettre dans la chaîne
    sujet. Si une lettre est trouvée, la recherche se poursuit avec
    la première alternative, et sinon, avec la seconde. Ce masque
@@ -2499,7 +2509,7 @@ int(1)
   <para>
    Cet exemple particulier contient un nombre illimité de
    répétitions imbriquées, ce qui fait que
-   l'utilisation de sous-chaînes à utilisation unique
+   l'utilisation de sous-masques à utilisation unique
    pour rechercher les séquences de caractères
    non-parenthèses est important, lorsqu'il s'applique à
    une chaîne qui n'est pas valide. Par exemple, si on l'applique
@@ -2507,8 +2517,8 @@ int(1)
    
    <literal>(aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa()</literal>
    
-   la réponse arrive rapidement. Sinon, si les sous-chaînes
-   à utilisation unique ne sont pas utilisées, la
+   la réponse arrive rapidement. En revanche, si les sous-masques
+   à utilisation unique ne sont pas utilisés, la
    recherche peut prendre un temps très long, car il existe
    de très nombreuses combinaisons de <literal>+</literal> et
    <literal>*</literal> à tester avant de conclure à
@@ -2531,7 +2541,7 @@ int(1)
    alors la chaîne capturée est "<literal>ab(cd)ef</literal>",
    c'est-à-dire le contenu de la parenthèse capturante
    de plus haut niveau. S'il y a plus de 15 parenthèses
-   capturantes dans une chaîne, PCRE doit utiliser plus
+   capturantes dans un masque, PCRE doit utiliser plus
    de mémoire pour stocker ces données. S'il ne
    peut obtenir cette mémoire supplémentaire, il ne fait
    que sauver les 15 premières, car il n'y a pas moyen de
@@ -2541,13 +2551,13 @@ int(1)
   <para>
    <literal>(?1)</literal>, <literal>(?2)</literal> et suivants
    peuvent être également utilisés pour les sous masques récursifs. Il est également
-   possible d'utiliser les sous masques nommés : <literal>(?P&gt;foo)</literal> ou
+   possible d'utiliser les sous-masques nommés : <literal>(?P&gt;name)</literal> ou
    <literal>(?&amp;name)</literal>.
   </para>
   <para>
    Si la syntaxe pour une référence de sous-masque récursif (soit par un
-   nombre ou par un nom) est utilisée en dehors des parenthèses à laquelle
-   elle fait référence, il opère comme une sous-routine dans un langage
+   nombre ou par un nom) est utilisée en dehors des parenthèses auxquelles
+   elle fait référence, elle opère comme une sous-routine dans un langage
    de programmation. Un exemple ci-dessus a montré que le masque
    <literal>(sens|respons)e and \1ibility</literal>
    trouvera <literal>"sense and sensibility"</literal> et 
@@ -2578,11 +2588,11 @@ int(1)
    <literal>(a|e|i|o|u)</literal>.
    En général, le masque le plus simple, qui permette
    la recherche désirée est le plus efficace. Le livre
-   de Jeffrey Friedl's contient de nombreuses études à
+   de Jeffrey Friedl contient de nombreuses études à
    propos de l'optimisation des expressions régulières.
   </para>
   <para>
-   Lorsqu'un masque commence par.* et que l'option
+   Lorsqu'un masque commence par <literal>.*</literal> et que l'option
    <link linkend="reference.pcre.pattern.modifiers">PCRE_DOTALL</link> est
    activée, le masque est implicitement ancré par PCRE,
    étant donné qu'il ne peut que rechercher au début
@@ -2596,7 +2606,7 @@ int(1)
    de ces nouvelles lignes, et non pas seulement au début
    de la chaîne sujet. Par exemple, le masque,
    
-   <literal>(.*)second</literal>
+   <literal>(.*) second</literal>
    
    acceptera la chaîne "<literal>premier \net second</literal>"
    (avec "<literal>\n</literal>" qui remplace la nouvelle ligne),


### PR DESCRIPTION
Translation of php/doc-en#3057 (commit c414a81): the `?` row of the meta-characters table now spells out the three roles of the character instead of the one-line summary. EN-Revision updated.

Reading the whole file side by side turned up a number of real defects, fixed in the same commit since the file cannot be split across PRs: several outright contresens (the `$` paragraph claimed dollar has a special meaning inside a character class, options were said *not* to carry into subsequent branches, back references below 10 were described backwards, "200 assertions at most" instead of assertions counting towards the 200 subpattern limit, "sequences of digits cannot be found" instead of non-digits not being split), two broken examples checked against PHP 8.5 (`( ?:roi|prince)` with a stray space, and `(inter[net]{3}\s*)+` which does not capture what the text claims), a garbled character class, an untranslated table title, and a handful of agreement and wording errors.

Fixes: #3523