### PR TITLE
[Sync-En] open_basedir: warn that Unix domain sockets are not restricted

### DIFF
--- a/appendices/ini.core.xml
+++ b/appendices/ini.core.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: cf7dcffba0ab8ce14dbfd6019f2861f5a6843ed5 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: f011a5989304239063769239761b5c39c68af12f Maintainer: lacatoire Status: ready -->
 
  <section xml:id="ini.core" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
   <title>Description des directives internes du &php.ini;</title>
@@ -1390,6 +1390,15 @@ include_path = ".:${USER}/pear/php"
          à <literal>0</literal> et ainsi <emphasis>désactive</emphasis> le cache realpath.
         </para>
        </note>
+       <warning>
+        <simpara>
+         <option>open_basedir</option> ne restreint pas l'accès aux sockets de domaine Unix.
+         Les fonctions de socket de PHP telles que <function>stream_socket_client</function>
+         et <function>fsockopen</function> peuvent se connecter à un chemin de socket Unix
+         (par exemple <filename>unix:///var/run/docker.sock</filename>),
+         quelle que soit la valeur de <option>open_basedir</option>.
+        </simpara>
+       </warning>
        <caution>
         <para>
          <literal>open_basedir</literal> est juste une mesure de protection supplémentaire,


### PR DESCRIPTION
Translation of php/doc-en#5846 (commit f011a59): open_basedir does not restrict
access to Unix domain sockets, so socket functions can reach a Unix socket path
regardless of the setting. EN-Revision updated.

Fixes: #3531