### PR TITLE
[Sync-En] http context: correct the documented default of follow_location

### DIFF
--- a/language/context/http.xml
+++ b/language/context/http.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: aa42c6da04101f58317a901ccc38ee0d1faeab47 Maintainer: jpauli Status: ready -->
+<!-- EN-Revision: 313c83d7c99b46b5d05fdf67e7346719412f522a Maintainer: jpauli Status: ready -->
 
 <refentry xml:id="context.http" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" annotations="verify_info:false" role="stream_context_option">
  <refnamediv>
@@ -129,9 +129,14 @@
        Suit les redirections <literal>Location</literal>.
        À définir à <literal>0</literal> pour désactiver.
       </para>
-      <para>
-       Par défaut, vaut <literal>1</literal>.
-      </para>
+      <simpara>
+       Lorsque cette option n'est pas définie, les redirections ne sont suivies que
+       pour les codes de réponse <literal>300</literal>, <literal>301</literal>,
+       <literal>302</literal>, <literal>303</literal>, <literal>307</literal>
+       et <literal>308</literal>. La définir à <literal>1</literal> n'est pas
+       équivalent : toute réponse portant un en-tête <literal>Location</literal>
+       est alors suivie, quel que soit son code de réponse.
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry xml:id="context.http.max-redirects">


### PR DESCRIPTION
Translation of php/doc-en#5845 (commit 313c83d): leaving follow_location unset
and setting it to 1 are not equivalent, so documenting 1 as the default was
misleading. EN-Revision updated.

Fixes: #3532