### PR TITLE
[Sync-En] Document the PHP 8.5 new warnings and exceptions

### DIFF
--- a/reference/bzip2/functions/bzcompress.xml
+++ b/reference/bzip2/functions/bzcompress.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 5fdeb11b137c94a6d25cbe98a2e14c00366197cf Maintainer: yannick Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 9ac246c4cf437dae2bf18fd3714545d7a0a51091 Maintainer: yannick Status: ready -->
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.bzcompress">
  <refnamediv>
   <refname>bzcompress</refname>
@@ -62,6 +61,39 @@
    La chaîne compressée ou un numéro d'erreur si une erreur survient.
   </simpara>
  </refsect1>
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simpara>
+   À partir de PHP 8.5.0, une <exceptionname>ValueError</exceptionname> est levée si
+   <parameter>block_size</parameter> n'est pas compris entre 1 et 9, ou si
+   <parameter>work_factor</parameter> n'est pas compris entre 0 et 250.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Une <exceptionname>ValueError</exceptionname> est désormais levée si
+       <parameter>block_size</parameter> n'est pas compris entre 1 et 9, ou si
+       <parameter>work_factor</parameter> n'est pas compris entre 0 et 250.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+
  <refsect1 role="examples">
   &reftitle.examples;
   <example>
@@ -81,6 +113,8 @@ echo $bzstr;
   &reftitle.seealso;
   <simplelist>
    <member><function>bzdecompress</function></member>
+   <member><function>bzopen</function></member>
+   <member><function>gzcompress</function></member>
   </simplelist>
  </refsect1>
 </refentry>

--- a/reference/fileinfo/functions/finfo-file.xml
+++ b/reference/fileinfo/functions/finfo-file.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 82ddd2ec8ad195035dcb57dd8f97d27b83ddc126 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 9ac246c4cf437dae2bf18fd3714545d7a0a51091 Maintainer: yannick Status: ready -->
 <!-- Reviewed: no -->
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.finfo-file">
  <refnamediv>
@@ -75,6 +75,16 @@
   </simpara>
  </refsect1>
 
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simpara>
+   Lève une <exceptionname>ValueError</exceptionname> si
+   <parameter>filename</parameter> contient un octet nul.
+   Avant PHP 8.5.0, une <exceptionname>TypeError</exceptionname> était levée
+   à la place.
+  </simpara>
+ </refsect1>
+
  <refsect1 role="changelog">
   &reftitle.changelog;
   <informaltable>
@@ -86,6 +96,14 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Une <exceptionname>ValueError</exceptionname> est désormais levée à la place
+       d'une <exceptionname>TypeError</exceptionname> lorsque <parameter>filename</parameter>
+       contient un octet nul.
+      </entry>
+     </row>
      &fileinfo.changelog.finfo-object;
      <row>
       <entry>8.0.0</entry>

--- a/reference/mysqli/mysqli/construct.xml
+++ b/reference/mysqli/mysqli/construct.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9dadf74254fa743db43e73ab3f5a3d441c271ab1 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 9ac246c4cf437dae2bf18fd3714545d7a0a51091 Maintainer: yannick Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mysqli.construct" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -143,6 +143,10 @@
  <refsect1 role="errors">
   &reftitle.errors;
   &mysqli.conditionalexception;
+  <simpara>
+   À partir de PHP 8.5.0, appeler le constructeur sur un objet déjà construit
+   lève une <exceptionname>Error</exceptionname>.
+  </simpara>
  </refsect1>
 
  <refsect1 role="changelog">
@@ -157,6 +161,13 @@
       </row>
      </thead>
      <tbody>
+      <row>
+       <entry>8.5.0</entry>
+       <entry>
+        Appeler le constructeur sur un objet déjà construit lève désormais
+        une <exceptionname>Error</exceptionname>.
+       </entry>
+      </row>
       <row>
        <entry>8.1.0</entry>
        <entry>

--- a/reference/pcntl/functions/pcntl-exec.xml
+++ b/reference/pcntl/functions/pcntl-exec.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 253f4bdd29fc3938030dce22882611ceefa9f74a Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 9ac246c4cf437dae2bf18fd3714545d7a0a51091 Maintainer: lacatoire Status: ready -->
 <refentry xml:id="function.pcntl-exec" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>pcntl_exec</refname>
@@ -65,6 +65,49 @@
    Retourne &false; en cas d'échec. En cas de succès, la fonction ne retourne pas,
    car l'image du processus courant est remplacée par le programme exécuté.
   </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simpara>
+   À partir de PHP 8.5.0, une <exceptionname>ValueError</exceptionname> est levée si
+   une entrée de <parameter>args</parameter> contient un octet nul, ou si une entrée
+   ou une clé de <parameter>env_vars</parameter> contient un octet nul.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Une <exceptionname>ValueError</exceptionname> est désormais levée si une entrée
+       de <parameter>args</parameter> contient un octet nul, ou si une entrée ou une
+       clé de <parameter>env_vars</parameter> contient un octet nul.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>pcntl_fork</function></member>
+   <member><function>pcntl_waitpid</function></member>
+   <member><function>exec</function></member>
+   <member><function>proc_open</function></member>
+  </simplelist>
  </refsect1>
 
 </refentry>

--- a/reference/session/functions/session-start.xml
+++ b/reference/session/functions/session-start.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 151e61773c016edcae8fd4989ad9a86ffd03c283 Maintainer: jpauli Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 9ac246c4cf437dae2bf18fd3714545d7a0a51091 Maintainer: jpauli Status: ready -->
 <refentry xml:id="function.session-start" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>session_start</refname>
@@ -77,6 +76,20 @@
   </para>
  </refsect1>
 
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simpara>
+   À partir de PHP 8.5.0, lève une <exceptionname>ValueError</exceptionname> si
+   <parameter>options</parameter> contient une clé qui n'est pas une chaîne de caractères.
+  </simpara>
+  <simpara>
+   À partir de PHP 8.5.0, lève une <exceptionname>TypeError</exceptionname> si l'option
+   <literal>read_and_close</literal> n'est pas de type <type>string</type>,
+   <type>int</type> ou <type>bool</type>, ou si sa valeur ne peut pas être
+   interprétée comme un <type>int</type>.
+  </simpara>
+ </refsect1>
+
  <refsect1 role="changelog">
   &reftitle.changelog;
   <para>
@@ -89,6 +102,15 @@
       </row>
      </thead>
      <tbody>
+      <row>
+       <entry>8.5.0</entry>
+       <entry>
+        Lève désormais une <exceptionname>ValueError</exceptionname> si le tableau
+        <parameter>options</parameter> contient des clés qui ne sont pas des chaînes
+        de caractères, et une <exceptionname>TypeError</exceptionname> si la valeur de
+        <literal>read_and_close</literal> n'est pas compatible avec <type>int</type>.
+       </entry>
+      </row>
       <row>
        <entry>7.1.0</entry>
        <entry>

--- a/reference/session/functions/session-write-close.xml
+++ b/reference/session/functions/session-write-close.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 35b95a56ccc03b66af7117fc815ac7881e2e0ad3 Maintainer: jpauli Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 9ac246c4cf437dae2bf18fd3714545d7a0a51091 Maintainer: jpauli Status: ready -->
 
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.session-write-close">
  <refnamediv>
@@ -56,6 +55,14 @@
     </thead>
     <tbody>
      <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Si <varname>$_SESSION</varname> contient une clé comportant une barre verticale
+       (<literal>|</literal>), un <constant>E_WARNING</constant> est désormais émis.
+       Auparavant, l'écriture des données de session échouait silencieusement.
+      </entry>
+     </row>
+     <row>
       <entry>7.2.0</entry>
       <entry>
        Le type de retour de cette fonction est désormais &boolean;.
@@ -69,13 +76,11 @@
  
  <refsect1 role="seealso">
   &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member>
-     <function>session_register_shutdown</function>
-    </member>
-   </simplelist>
-  </para>
+  <simplelist>
+   <member><function>session_register_shutdown</function></member>
+   <member><function>session_start</function></member>
+   <member><function>session_abort</function></member>
+  </simplelist>
  </refsect1>
 
 </refentry>

--- a/reference/simplexml/simplexmlelement/xpath.xml
+++ b/reference/simplexml/simplexmlelement/xpath.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 770c6facae667218f69c8ea2715ea20f6fab32f3 Maintainer: yannick Status: ready -->
+<!-- EN-Revision: 9ac246c4cf437dae2bf18fd3714545d7a0a51091 Maintainer: yannick Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="simplexmlelement.xpath" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -42,6 +42,36 @@
    Retourne un tableau d'objets SimpleXMLElement en cas de succès ou &null;
    ou &false; si une erreur survient.
   </para>
+  <simpara>
+   À partir de PHP 8.5.0, si l'expression XPath retourne autre chose qu'un ensemble
+   de nœuds (par exemple un booléen ou un nombre), un <constant>E_WARNING</constant>
+   est émis et &false; est retourné, au lieu de retourner silencieusement un
+   tableau vide.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Si l'expression XPath retourne autre chose qu'un ensemble de nœuds, un
+       <constant>E_WARNING</constant> est désormais émis et &false; est retourné.
+       Auparavant, un tableau vide était retourné silencieusement.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/tidy/tidy/construct.xml
+++ b/reference/tidy/tidy/construct.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: f02317164cb39512509817e78ef121e3304f6810 Maintainer: yannick Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 9ac246c4cf437dae2bf18fd3714545d7a0a51091 Maintainer: yannick Status: ready -->
 <refentry xml:id="tidy.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>tidy::__construct</refname>
@@ -96,6 +95,16 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Lève désormais une <exceptionname>ValueError</exceptionname> si
+       <parameter>config</parameter> contient une option inconnue ou tente de définir
+       une option en lecture seule, et une <exceptionname>TypeError</exceptionname> si
+       une clé de configuration n'est pas une chaîne de caractères, ou si une option
+       n'accepte pas la valeur fournie.
+      </entry>
+     </row>
      <row>
       <entry>8.4.0</entry>
       <entry>

--- a/reference/tidy/tidy/parsefile.xml
+++ b/reference/tidy/tidy/parsefile.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 9ac246c4cf437dae2bf18fd3714545d7a0a51091 Maintainer: lacatoire Status: ready -->
 <refentry xml:id="tidy.parsefile" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>tidy::parseFile</refname>
@@ -109,6 +109,16 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Lève désormais une <exceptionname>ValueError</exceptionname> si
+       <parameter>config</parameter> contient une option inconnue ou tente de définir
+       une option en lecture seule, et une <exceptionname>TypeError</exceptionname> si
+       une clé de configuration n'est pas une chaîne de caractères, ou si une option
+       n'accepte pas la valeur fournie.
+      </entry>
+     </row>
      <row>
       <entry>8.0.0</entry>
       <entry>

--- a/reference/tidy/tidy/parsestring.xml
+++ b/reference/tidy/tidy/parsestring.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 1cc1b815cd0a2a579fb79bc2ab0c1202574696bc Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 9ac246c4cf437dae2bf18fd3714545d7a0a51091 Maintainer: lacatoire Status: ready -->
 <refentry xml:id="tidy.parsestring" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>tidy::parseString</refname>
@@ -95,6 +95,16 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Lève désormais une <exceptionname>ValueError</exceptionname> si
+       <parameter>config</parameter> contient une option inconnue ou tente de définir
+       une option en lecture seule, et une <exceptionname>TypeError</exceptionname> si
+       une clé de configuration n'est pas une chaîne de caractères, ou si une option
+       n'accepte pas la valeur fournie.
+      </entry>
+     </row>
      <row>
       <entry>8.0.0</entry>
       <entry>


### PR DESCRIPTION
Translation of php/doc-en#5838 (commit 9ac246c): documents the new PHP 8.5
warnings and exceptions on the ten pages concerned, adding an errors section
where the page had none. EN-Revision updated.

Dropped the stale "Reviewed: yes" marker on the files that carried it.

Fixes: #3534