### PR TITLE
[Sync-En] opcache: document huge page use by the shared memory segment

### DIFF
--- a/reference/opcache/ini.xml
+++ b/reference/opcache/ini.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 36d18e7d4a32ecfdacc1eb086276ffb1baf0393c Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 83c44e16897a8f6371b0c652ce9610b396514fb8 Maintainer: lacatoire Status: ready -->
 <sect1 xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="opcache.configuration">
  &reftitle.runtime;
  &extension.runtime;
@@ -409,6 +409,15 @@
      La taille de la mémoire partagée utilisée par OPcache, en mégaoctets.
      La valeur minimale permissible est <literal>"8"</literal>,
      qui est forcé si une valeur plus petite est définie.
+    </simpara>
+    <simpara>
+     Lorsque le JIT est activé, le segment de mémoire partagée contient également
+     le tampon du JIT, de sorte que sa taille totale correspond à cette valeur
+     augmentée de
+     <link linkend="ini.opcache.jit-buffer-size">opcache.jit_buffer_size</link>.
+     OPcache tente d'abord d'allouer le segment en utilisant des HUGE PAGES, et
+     bascule silencieusement sur des pages normales lorsque le système
+     d'exploitation n'en a pas réservé suffisamment.
     </simpara>
    </listitem>
   </varlistentry>
@@ -986,6 +995,11 @@ function getA() { return A; }
      Active ou désactive la copie de code PHP (segment de texte) dans des HUGE PAGES.
      Ceci devrait améliorer les performances, mais nécessite une configuration
      appropriée du système d'exploitation.
+     Seul le segment de texte du binaire PHP est remappé ; le segment de mémoire
+     partagée décrit sous
+     <link linkend="ini.opcache.memory-consumption">opcache.memory_consumption</link>
+     n'est pas concerné par cette directive. Lorsque le remappage échoue, OPcache
+     émet un <constant>E_WARNING</constant>.
      Disponible sur Linux à partir de PHP 7.0.0,
      et sur FreeBSD à partir de PHP 7.4.0.
     </simpara>


### PR DESCRIPTION
Translation of php/doc-en#4861 (commit 83c44e1): the shared memory segment also
holds the JIT buffer and is allocated with huge pages when available, while
opcache.huge_code_pages only remaps the text segment. EN-Revision updated.

Fixes: #3535