### PR TITLE
[Sync-En] get_defined_constants: note that magic constants are excluded

### DIFF
--- a/reference/info/functions/get-defined-constants.xml
+++ b/reference/info/functions/get-defined-constants.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 5367d2fcdf4b710a81806aba52a71c522f082713 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: df4b2be84a0ca22f837f2a921bc40b178be45c66 Maintainer: lacatoire Status: ready -->
 
 <refentry xml:id="function.get-defined-constants" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -13,11 +13,13 @@
    <type>array</type><methodname>get_defined_constants</methodname>
    <methodparam choice="opt"><type>bool</type><parameter>categorize</parameter><initializer>&false;</initializer></methodparam>
   </methodsynopsis>
-  <para>
-   Retourne les noms et valeurs des constantes déjà définies.
-   Cela inclut les constantes créées par les extensions, et celles
-   créées avec la fonction <function>define</function>.
-  </para>
+  <simpara>
+   Retourne les noms et valeurs de toutes les constantes actuellement définies.
+   Cela inclut les constantes définies par les extensions et celles créées avec
+   la fonction <function>define</function>. En revanche, cela exclut les
+   <link linkend="language.constants.magic">constantes magiques</link>, qui sont
+   résolues à la compilation.
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">


### PR DESCRIPTION
Translation of php/doc-en#3109 (commit df4b2be): magic constants resolve at
compile time and are therefore not returned by the function. EN-Revision updated.

Fixes: #3536