### PR TITLE
[Sync-En] fileperms: fix the "Display full permissions" example

### DIFF
--- a/reference/filesystem/functions/fileperms.xml
+++ b/reference/filesystem/functions/fileperms.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 871a231f4a1caa5fb258ae53b1bb7d1fb2a0f949 Maintainer: jpauli Status: ready -->
+<!-- EN-Revision: f5c4950be0ef12e84eea5276b15a7d143885286c Maintainer: jpauli Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.fileperms" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -91,51 +91,35 @@ echo substr(sprintf('%o', fileperms('/etc/passwd')), -4);
 $perms = fileperms('/etc/passwd');
 
 switch ($perms & 0xF000) {
-    case 0xC000: // Socket
-        $info = 's';
-        break;
-    case 0xA000: // Lien symbolique
-        $info = 'l';
-        break;
-    case 0x8000: // Régulier
-        $info = 'r';
-        break;
-    case 0x6000: // Bloc spécial
-        $info = 'b';
-        break;
-    case 0x4000: // dossier
-        $info = 'd';
-        break;
-    case 0x2000: // Caractère spécial
-        $info = 'c';
-        break;
-    case 0x1000: // pipe FIFO
-        $info = 'p';
-        break;
-    default: // Inconnu
-        $info = 'u';
+    case 0x1000: $info = 'p'; break; // pipe FIFO
+    case 0x2000: $info = 'c'; break; // caractère spécial
+    case 0x4000: $info = 'd'; break; // dossier
+    case 0x6000: $info = 'b'; break; // bloc spécial
+    case 0x8000: $info = '-'; break; // régulier
+    case 0xA000: $info = 'l'; break; // lien symbolique (atteignable avec la fonction lstat)
+    case 0xC000: $info = 's'; break; // socket
+
+    // inconnu
+    default: $info = 'u';
 }
 
 // Propriétaire
+$setuid = $perms & 0x0800;
 $info .= (($perms & 0x0100) ? 'r' : '-');
 $info .= (($perms & 0x0080) ? 'w' : '-');
-$info .= (($perms & 0x0040) ?
-            (($perms & 0x0800) ? 's' : 'x' ) :
-            (($perms & 0x0800) ? 'S' : '-'));
+$info .= (($perms & 0x0040) ? ($setuid ? 's' : 'x') : ($setuid ? 'S' : '-'));
 
 // Groupe
+$setgid = $perms & 0x0400;
 $info .= (($perms & 0x0020) ? 'r' : '-');
 $info .= (($perms & 0x0010) ? 'w' : '-');
-$info .= (($perms & 0x0008) ?
-            (($perms & 0x0400) ? 's' : 'x' ) :
-            (($perms & 0x0400) ? 'S' : '-'));
+$info .= (($perms & 0x0008) ? ($setgid ? 's' : 'x') : ($setgid ? 'S' : '-'));
 
 // Tout le monde
+$sticky = $perms & 0x0200;
 $info .= (($perms & 0x0004) ? 'r' : '-');
 $info .= (($perms & 0x0002) ? 'w' : '-');
-$info .= (($perms & 0x0001) ?
-            (($perms & 0x0200) ? 't' : 'x' ) :
-            (($perms & 0x0200) ? 'T' : '-'));
+$info .= (($perms & 0x0001) ? ($sticky ? 't' : 'x') : ($sticky ? 'T' : '-'));
 
 echo $info;
 ?>


### PR DESCRIPTION
Translation of php/doc-en#5842 (commit f5c4950): a regular file is shown with
`-`, not `r`, so the example now produces the output the page announces. The
symbolic link branch is noted as only reachable through lstat. EN-Revision
updated.

Fixes: #3537