### PR TITLE
CI: use the shared check-en-revision.php from doc-base

### DIFF
--- a/.github/workflows/check-en-revision.yml
+++ b/.github/workflows/check-en-revision.yml
@@ -19,7 +19,7 @@ permissions:
 jobs:
   revision:
     name: "Check EN-Revision"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       # fr/, en/ and doc-base/ side by side: this is the layout expected by
       # the doc-base scripts, the same as the one the build workflow uses. The

--- a/.github/workflows/check-en-revision.yml
+++ b/.github/workflows/check-en-revision.yml
@@ -1,7 +1,10 @@
 # https://docs.github.com/en/actions
-# Vérifie que le commentaire EN-Revision des fichiers .xml touchés par une PR
-# pointe le dernier commit doc-en du fichier. Émet une annotation ::error et
-# échoue si le hash est absent, faux, d'un autre fichier, ou en retard.
+# Checks that the EN-Revision tag of the .xml files changed in a PR matches
+# the latest commit hash of the corresponding doc-en file. The script emits
+# its own ::error annotations.
+#
+# The script is the one from doc-base, shared by all translations, and no longer
+# an inline bash snippet local to this workflow.
 
 name: "Structure"
 
@@ -18,36 +21,41 @@ jobs:
     name: "Check EN-Revision"
     runs-on: ubuntu-latest
     steps:
-      # Le ref explicite prend la tête réelle de la PR, et non le commit de
-      # fusion que actions/checkout construit par défaut : ce dernier a master
-      # pour deuxième parent, donc le diff plus bas y verrait aussi tous les
-      # fichiers arrivés sur master depuis le dernier push de la PR.
+      # fr/, en/ and doc-base/ side by side: this is the layout expected by
+      # the doc-base scripts, the same as the one the build workflow uses. The
+      # explicit ref takes the real head of the pull request, not the merge commit
+      # actions/checkout builds by default: that one has master as its second
+      # parent, so the diff below would also list every file landed on master
+      # since the last push of the PR.
 
       - name: "Checkout php/doc-fr"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
+          path: fr
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 
       - name: "Checkout php/doc-en"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           path: en
           repository: php/doc-en
           fetch-depth: 0
 
+      # TEMPORAIRE : le script vit pour l'instant sur la pull request qui
+      # l'ajoute à doc-base. À retirer, avec le ref, une fois celle-ci mergée.
+
+      - name: "Checkout php/doc-base"
+        uses: actions/checkout@v7
+        with:
+          path: doc-base
+          repository: php/doc-base
+          ref: refs/pull/343/head
+
       - name: "Check EN-Revision"
         run: |
           BASE="${{ github.event.pull_request.base.sha }}"
-          git fetch --no-tags --depth=1 origin "$BASE"
-          fail=0
-          while IFS= read -r f; do
-            [ -f "$f" ] && [ -f "en/$f" ] || continue
-            declared=$(grep -oiP 'EN-Revision:\s*\K[0-9a-f]+' "$f" | head -1 || true)
-            latest=$(git -C en log -1 --format=%H -- "$f")
-            if [ "$declared" != "$latest" ]; then
-              echo "::error file=$f::EN-Revision ${declared:-absent} != dernier commit doc-en $latest"
-              fail=1
-            fi
-          done < <(git diff --name-only "$BASE"...HEAD -- '*.xml')
-          exit $fail
+          git -C fr fetch --no-tags --depth=1 origin "$BASE"
+          git -C fr diff --name-only "$BASE"...HEAD -- '*.xml' \
+            | php8.1 doc-base/scripts/translation/check-en-revision.php \
+                --lang=fr --github


### PR DESCRIPTION
Replaces the inline bash logic in `check-en-revision.yml` with the shared `check-en-revision.php` script added in php/doc-base#343, so that every translation runs the same version.

The workflow now checks out `fr`, `en` and `doc-base` side by side, the layout the doc-base scripts expect and the one the build workflow already uses.

Draft until php/doc-base#343 is merged: the revision job cannot find the script before that.